### PR TITLE
[REEF-83]: maven-javadoc-plugin breaks mvn -Papache-release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@ under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10</version>
+                    <version>2.10.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This addressed the issue by updating the version of maven-javadoc-plugin
to 2.10.1.

JIRA: [REEF-83](https://issues.apache.org/jira/browse/REEF-83)