### PR TITLE
[REEF-54] Creating skeleton of driver configuration files

### DIFF
--- a/reef-bridge-project/reef-bridge-java/pom.xml
+++ b/reef-bridge-project/reef-bridge-java/pom.xml
@@ -111,6 +111,24 @@ under the License.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>process-classes</phase>
+                <goals>
+                  <goal>java</goal>
+                </goals>
+                <configuration>
+                  <mainClass>org.apache.reef.javabridge.generic.DriverConfigCreator</mainClass>
+                  <arguments>
+                    <argument>true</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+            </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/reef-bridge-project/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/DriverConfigBuilder.java
+++ b/reef-bridge-project/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/DriverConfigBuilder.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.javabridge.generic;
+
+import org.apache.reef.driver.parameters.*;
+import org.apache.reef.tang.*;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.apache.reef.tang.formats.AvroConfigurationSerializer;
+import org.apache.reef.tang.formats.ConfigurationSerializer;
+import org.apache.reef.tang.implementation.protobuf.ProtocolBufferClassHierarchy;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Build driver configuration files
+ */
+public class DriverConfigBuilder {
+  /**
+   * Standard java logger.
+   */
+  private static final Logger LOG = Logger.getLogger(JobClient.class.getName());
+
+  private static final String USER_DIR = "user.dir";
+  private static final String JOB_DRIVER_CONFIG_FILE = "jobDriver.config";
+  private static final String HTTP_SERVER_CONFIG_FILE = "httpServer.config";
+  private static final String NAME_SERVER_CONFIG_FILE = "nameServer.config";
+  private static final String DRIVER_CH_FILE = "driverClassHierarchy.bin";
+  private static final String REEF_BRIDGE_PROJECT_DIR = "\\reef-bridge-project";
+  private static final String REEF_BRIDGE_JAVA_DIR = "\\reef-bridge-java";
+  private static final String TARGET_DIR = "\\target\\classes\\";
+
+  /**
+   * Build driver config, httpServer config and Name server config files with java bindings
+   * @param driverConfiguration
+   */
+  public static void buildDriverConfigurationFiles(final Configuration driverConfiguration) throws IOException {
+    //make the classes available in the class hierarchy so that clients can bind values to the configuration
+    final ClassHierarchy ns = driverConfiguration.getClassHierarchy();
+    ns.getNode(JobGlobalFiles.class.getName());
+    ns.getNode(JobGlobalLibraries.class.getName());
+    ns.getNode(DriverMemory.class.getName());
+    ns.getNode(DriverIdentifier.class.getName());
+    ns.getNode(DriverJobSubmissionDirectory.class.getName());
+
+    serializeConfigFile(new File(getConfigFileFolder(JOB_DRIVER_CONFIG_FILE)), driverConfiguration);
+    serializeConfigFile(new File(getConfigFileFolder(HTTP_SERVER_CONFIG_FILE)), JobClient.getHTTPConfiguration());
+    serializeConfigFile(new File(getConfigFileFolder(NAME_SERVER_CONFIG_FILE)), JobClient.getNameServerConfiguration());
+
+    //do this at the end to ensure all nodes are in the class hierarchy
+    //serializeClassHierarchy(DRIVER_CH_FILE, driverConfiguration);
+    final File classHierarchyFile = new File(getConfigFileFolder(DRIVER_CH_FILE));
+    ProtocolBufferClassHierarchy.serialize(classHierarchyFile, ns);
+  }
+
+  /**
+   * Serialize Configuration object into a file with configFileName
+   * @param configFile
+   * @param conf
+   */
+  private static void serializeConfigFile(final File configFile, final Configuration conf) throws IOException {
+    try {
+      final Injector i = Tang.Factory.getTang().newInjector(Tang.Factory.getTang().newConfigurationBuilder().build());
+      final ConfigurationSerializer serializer = i.getInstance(ConfigurationSerializer.class);
+      serializer.toFile(conf, configFile);
+    } catch (final InjectionException e) {
+      throw new RuntimeException("Cannot inject ConfigurationSerializer.");
+    }
+  }
+
+  /**
+   * Return folder reef-bridge-project\reef-bridge-java\target\classes
+   * @param fileName
+   * @return
+   */
+  public static String getConfigFileFolder(final String fileName) {
+    final String userDir = System.getProperty(USER_DIR);
+    if (userDir.endsWith(REEF_BRIDGE_PROJECT_DIR)) {
+      return new StringBuilder().append(userDir).append(REEF_BRIDGE_JAVA_DIR).append(TARGET_DIR).append(fileName).toString();
+    }
+    if (userDir.endsWith(REEF_BRIDGE_JAVA_DIR)) {
+      return new StringBuilder().append(userDir).append(TARGET_DIR).append(fileName).toString();
+    }
+    return new StringBuilder().append(userDir).append(REEF_BRIDGE_PROJECT_DIR).append(REEF_BRIDGE_JAVA_DIR).append(TARGET_DIR).append(fileName).toString();
+  }
+}

--- a/reef-bridge-project/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/DriverConfigCreator.java
+++ b/reef-bridge-project/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/DriverConfigCreator.java
@@ -54,8 +54,7 @@ public class DriverConfigCreator {
     LOG.log(Level.INFO, "Entering DriverConfigCreator");
 
     final boolean isLocal;
-    if (args.length > 0)
-    {
+    if (args.length > 0) {
       isLocal = Boolean.valueOf(args[0]);
     } else {
       isLocal = true;

--- a/reef-bridge-project/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/DriverConfigCreator.java
+++ b/reef-bridge-project/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/DriverConfigCreator.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.javabridge.generic;
+
+import org.apache.reef.client.ClientConfiguration;
+import org.apache.reef.runtime.local.client.LocalRuntimeConfiguration;
+import org.apache.reef.runtime.yarn.client.YarnClientConfiguration;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Configurations;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.formats.ConfigurationModule;
+
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * DriverConfigCreator
+ */
+public class DriverConfigCreator {
+  /**
+   * Standard Java logger
+   */
+  private static final Logger LOG = Logger.getLogger(Launch.class.getName());
+
+  /**
+   * Number of REEF worker threads in local mode. We assume maximum 10 evaluators can be requested on local runtime
+   */
+  private static final int NUM_LOCAL_THREADS = 10;
+
+  /**
+   * This program is used to generate JobDriver.config, HttpConfig.config and nameServer.config. It runs when the project is build. The config files are
+   * dropped at the class folder and then packed into the jar file.
+   * @param args
+   */
+  public static void main(final String[] args) throws IOException{
+    LOG.log(Level.INFO, "Entering DriverConfigCreator");
+
+    final boolean isLocal;
+    if (args.length > 0)
+    {
+      isLocal = Boolean.valueOf(args[0]);
+    } else {
+      isLocal = true;
+    }
+
+    final Configuration clientConfig = getClientConfiguration(isLocal);
+    final ConfigurationModule driverConfigModule = JobClient.getDriverConfiguration();
+    final Configuration driverConfig = Configurations.merge(driverConfigModule.build(), clientConfig);
+
+    try {
+      DriverConfigBuilder.buildDriverConfigurationFiles(driverConfig);
+    } catch (IOException e) {
+      LOG.log(Level.SEVERE, "Failed to buildDriverConfigurationFiles.", e);
+      throw e;
+    }
+    LOG.log(Level.INFO, "Driver config files are created.");
+  }
+
+  /**
+   * get ClientConfigurations
+   * @param isLocal
+   * @return
+   */
+  private static Configuration getClientConfiguration(boolean isLocal) {
+    final Configuration clientConfiguration = ClientConfiguration.CONF
+        .set(ClientConfiguration.ON_JOB_COMPLETED, JobClient.CompletedJobHandler.class)
+        .set(ClientConfiguration.ON_JOB_FAILED, JobClient.FailedJobHandler.class)
+        .set(ClientConfiguration.ON_RUNTIME_ERROR, JobClient.RuntimeErrorHandler.class)
+        .build();
+
+    final Configuration runtimeConfiguration;
+
+    if (isLocal) {
+      LOG.log(Level.INFO, "Running on the local runtime");
+      runtimeConfiguration = LocalRuntimeConfiguration.CONF
+          .set(LocalRuntimeConfiguration.NUMBER_OF_THREADS, NUM_LOCAL_THREADS)
+          .build();
+    } else {
+      LOG.log(Level.INFO, "Running on YARN");
+      runtimeConfiguration = YarnClientConfiguration.CONF.build();
+    }
+
+    return Tang.Factory.getTang()
+        .newConfigurationBuilder(Configurations.merge(runtimeConfiguration, clientConfiguration))
+        .build();
+  }
+}

--- a/reef-bridge-project/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobClient.java
+++ b/reef-bridge-project/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobClient.java
@@ -92,7 +92,7 @@ public class JobClient {
   /**
    *  ConfigurationSerializer
    */
-  ConfigurationSerializer configurationSerializer;
+  private final ConfigurationSerializer configurationSerializer;
 
   /**
    * Clr Bridge client.

--- a/reef-bridge-project/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
+++ b/reef-bridge-project/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
@@ -285,8 +285,8 @@ public final class JobDriver {
       }
 
       LOG.log(Level.INFO, "StartTime: {0}", new Object[]{startTime});
-      Optional<String> portNumber = httpServer.isPresent() ? Optional.of(Integer.toString((httpServer.get().getPort()))) : Optional.<String>empty();
-      long[] handlers = NativeInterop.CallClrSystemOnStartHandler(startTime.toString(), portNumber.get());
+      final Optional<String> portNumber = httpServer.isPresent() ? Optional.of(Integer.toString((httpServer.get().getPort()))) : Optional.<String>empty();
+      final long[] handlers = NativeInterop.CallClrSystemOnStartHandler(startTime.toString(), portNumber.get());
       if (handlers != null) {
         if (handlers.length != NativeInterop.nHandlers) {
           throw new RuntimeException(

--- a/reef-bridge-project/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/Launch.java
+++ b/reef-bridge-project/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/Launch.java
@@ -169,7 +169,6 @@ public final class Launch {
         client.waitForCompletion(0);
       }
 
-
       LOG.info("Done!");
     } catch (final BindException | InjectionException | IOException ex) {
       LOG.log(Level.SEVERE, "Job configuration error", ex);

--- a/reef-bridge-project/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/Launch.java
+++ b/reef-bridge-project/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/Launch.java
@@ -169,6 +169,7 @@ public final class Launch {
         client.waitForCompletion(0);
       }
 
+
       LOG.info("Done!");
     } catch (final BindException | InjectionException | IOException ex) {
       LOG.log(Level.SEVERE, "Job configuration error", ex);


### PR DESCRIPTION
Today SAS uses Launch/JobClient in bridge project to generate driver config file, and submit it to REEF Launcher. This requires the clients to run Java bridge Launch offline with their configuration parameters. It is easy to cause out of sync for driver configuration settings.

This PR is to generate a skeleton of  driver configuration at Java side with Java bridge JobDriver configuration settings only.  This would leave the flexibility to the client so that they can deserialize the driver configuration, and set additional parameters and then serialize the result into driver config file again.  And we have provided an API for it.

To make the configuration modularized, this PR also separated HttpServer configuration and NameServer configuration from driver configuration file when creating the skeletons. They would become building blocks. Client can choose what they want in the driver and merge them as need. This would make Http Server and Name server become optional instead of build-in in a .Net/Java hybrid driver.

The driver skeleton configuration creation has been put as part of the build and the configuration files are packed into the jar file.

There are still some static and dynamic portion of driver configurations set at Reef Runtime. We need to abstract them out and add them into the config file so that clients can call REST API directly with the complete driver config. This work is not covered in this PL.

This is to resolve issue #54. https://issues.apache.org/jira/i#browse/REEF-54

Author: Julia Wang
email: jwang98052@yahoo.com