### PR TITLE
[REEF-88]: Upgrade version in POMs to 0.11.0-incubating-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ contains only basic setup instructions.
 
 ## Building REEF
 
-REEF is built using [Apache Maven](http://maven.apache.org/).
+Requirements
+
+* Java 7 Development Kit
+* [Apache Maven](http://maven.apache.org) 3 or newer. Make sure that mvn is in your PATH.
+* [Protocol Buffers](https://code.google.com/p/protobuf/) Compiler (protoc) 2.5. Make sure that protoc is in your PATH.
+
+REEF is built using Apache Maven.
 To build REEF and its example programs, run:
 
     mvn -DskipTests clean install

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@ under the License.
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.reef</groupId>
-    <version>0.10.0-incubating-SNAPSHOT</version>
+    <version>0.11.0-incubating-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>REEF</name>
     <artifactId>reef-project</artifactId>

--- a/reef-annotations/pom.xml
+++ b/reef-annotations/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>reef-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
 
     <artifactId>reef-annotations</artifactId>

--- a/reef-bridge-project/pom.xml
+++ b/reef-bridge-project/pom.xml
@@ -29,7 +29,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>reef-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
 
 

--- a/reef-bridge-project/reef-bridge-clr/pom.xml
+++ b/reef-bridge-project/reef-bridge-clr/pom.xml
@@ -28,7 +28,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>reef-bridge-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
 
 

--- a/reef-bridge-project/reef-bridge-java/pom.xml
+++ b/reef-bridge-project/reef-bridge-java/pom.xml
@@ -28,7 +28,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>reef-bridge-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/reef-bridge-project/reef-bridge/pom.xml
+++ b/reef-bridge-project/reef-bridge/pom.xml
@@ -28,7 +28,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>reef-bridge-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
 
 

--- a/reef-checkpoint/pom.xml
+++ b/reef-checkpoint/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>reef-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
     <artifactId>reef-checkpoint</artifactId>
     <name>REEF Checkpoint</name>

--- a/reef-common/pom.xml
+++ b/reef-common/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>reef-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
 
     <artifactId>reef-common</artifactId>

--- a/reef-examples-clr/pom.xml
+++ b/reef-examples-clr/pom.xml
@@ -27,7 +27,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>reef-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/reef-examples-hdinsight/pom.xml
+++ b/reef-examples-hdinsight/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>reef-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/reef-examples/pom.xml
+++ b/reef-examples/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>reef-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/reef-io/pom.xml
+++ b/reef-io/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>reef-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
     <artifactId>reef-io</artifactId>
     <name>REEF IO</name>

--- a/reef-poison/pom.xml
+++ b/reef-poison/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>reef-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
 
     <artifactId>reef-poison</artifactId>

--- a/reef-runtime-hdinsight/pom.xml
+++ b/reef-runtime-hdinsight/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>reef-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
     <name>REEF Runtime for HDInsight</name>
     <artifactId>reef-runtime-hdinsight</artifactId>

--- a/reef-runtime-local/pom.xml
+++ b/reef-runtime-local/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>reef-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
 
     <artifactId>reef-runtime-local</artifactId>

--- a/reef-runtime-yarn/pom.xml
+++ b/reef-runtime-yarn/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>reef-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
     <name>REEF Runtime for YARN</name>
     <artifactId>reef-runtime-yarn</artifactId>

--- a/reef-tang/pom.xml
+++ b/reef-tang/pom.xml
@@ -27,7 +27,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>reef-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/reef-tang/tang-test-jarA/pom.xml
+++ b/reef-tang/tang-test-jarA/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>tang-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
 
     <artifactId>tang-test-jarA</artifactId>

--- a/reef-tang/tang-test-jarAB/pom.xml
+++ b/reef-tang/tang-test-jarAB/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>tang-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
 
     <artifactId>tang-test-jarAB</artifactId>

--- a/reef-tang/tang-test-jarB-conflictA/pom.xml
+++ b/reef-tang/tang-test-jarB-conflictA/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>tang-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
 
     <artifactId>tang-test-jarB-conflictA</artifactId>

--- a/reef-tang/tang-test-jarB/pom.xml
+++ b/reef-tang/tang-test-jarB/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>tang-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
 
     <artifactId>tang-test-jarB</artifactId>

--- a/reef-tang/tang/pom.xml
+++ b/reef-tang/tang/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>tang-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
 
     <artifactId>tang</artifactId>

--- a/reef-tests/pom.xml
+++ b/reef-tests/pom.xml
@@ -28,7 +28,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>reef-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
 
 

--- a/reef-utils-hadoop/pom.xml
+++ b/reef-utils-hadoop/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>reef-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
 
     <artifactId>reef-utils-hadoop</artifactId>

--- a/reef-utils/pom.xml
+++ b/reef-utils/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>reef-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
 
     <artifactId>reef-utils</artifactId>

--- a/reef-wake/pom.xml
+++ b/reef-wake/pom.xml
@@ -28,7 +28,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>reef-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/reef-wake/wake/pom.xml
+++ b/reef-wake/wake/pom.xml
@@ -27,7 +27,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>wake-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/reef-webserver/pom.xml
+++ b/reef-webserver/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <groupId>org.apache.reef</groupId>
         <artifactId>reef-project</artifactId>
-        <version>0.10.0-incubating-SNAPSHOT</version>
+        <version>0.11.0-incubating-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>reef-webserver</artifactId>


### PR DESCRIPTION
This addressed the issue by upgrading version in POMs. In addition,
the requirements for compiling REEF are added in README.md.

JIRA: [REEF-88](https://issues.apache.org/jira/browse/REEF-88)