### PR TITLE
[REEF-127]  Remove dot-net build dependency from reef-bridge-clr

### DIFF
--- a/lang/cpp/reef-bridge-clr/pom.xml
+++ b/lang/cpp/reef-bridge-clr/pom.xml
@@ -61,11 +61,6 @@ under the License.
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>reef-dotnet</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
             <artifactId>reef-bridge-java</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
Dotnet project dependency from reef-bridge-clr project was accidently pushed in. This PR is to remove this dependency for now before the dotnet build is integrated.

JIRA: Reef-127. (https://issues.apache.org/jira/browse/REEF-127)
Author: Julia Wang  Email: jwang98052@yahoo.com