### PR TITLE
[REEF-149] Fix a path in the scripts for running reef-tests on YARN/Mesos

### DIFF
--- a/bin/runmesostests.sh
+++ b/bin/runmesostests.sh
@@ -26,7 +26,7 @@ fi
 export REEF_TEST_MESOS=true
 export REEF_TEST_MESOS_MASTER_IP=$1
 
-DEPENDENCY_JAR=`echo $REEF_HOME/reef-tests/target/reef-tests-*-test-jar-with-dependencies.jar`
+DEPENDENCY_JAR=`echo $REEF_HOME/lang/java/reef-tests/target/reef-tests-*-test-jar-with-dependencies.jar`
 CLASSPATH=`hadoop classpath`
 
 CMD="java -cp $DEPENDENCY_JAR:$CLASSPATH org.junit.runner.JUnitCore org.apache.reef.tests.AllTestsSuite"

--- a/bin/runyarntests.sh
+++ b/bin/runyarntests.sh
@@ -19,7 +19,7 @@
 #
 
 export REEF_TEST_YARN=true
-DEPENDENCY_JAR=`echo $REEF_HOME/reef-tests/target/reef-tests-*-test-jar-with-dependencies.jar`
+DEPENDENCY_JAR=`echo $REEF_HOME/lang/java/reef-tests/target/reef-tests-*-test-jar-with-dependencies.jar`
 CLASSPATH=`yarn classpath`
 
 CMD="java -cp $YARN_CONF_DIR:$DEPENDENCY_JAR:$CLASSPATH org.junit.runner.JUnitCore org.apache.reef.tests.AllTestsSuite $*" 


### PR DESCRIPTION
Fixes the path of DEPENDENCY_JAR to reflect the changes in the directory structure

JIRA: [REEF-149] https://issues.apache.org/jira/browse/REEF-149