### PR TITLE
[REEF-138] Excludes for Apache-RAT for the new .NET project structure

### DIFF
--- a/lang/cpp/reef-bridge-clr/pom.xml
+++ b/lang/cpp/reef-bridge-clr/pom.xml
@@ -75,24 +75,6 @@ under the License.
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.rat</groupId>
-                <artifactId>apache-rat-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <!-- Build files are frequently overwritten by Visual Studio -->
-                        <exclude>src/main/Cpp/CppBridge/JavaClrBridge/JavaClrBridge.sln</exclude>
-                        <exclude>src/main/Cpp/CppBridge/JavaClrBridge/JavaClrBridge.vcxproj</exclude>
-                        <exclude>src/main/Cpp/CppBridge/JavaClrBridge/JavaClrBridge.vcxproj.filters</exclude>
-                        <exclude>src/main/CSharp/CSharp/ClrHandler/ClrHandler.csproj</exclude>
-                        <!--End of Visual Studio build files-->
-                    </excludes>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
     <profiles>
         <profile>
             <id>Bridge</id>

--- a/lang/cs/Org.Apache.REEF.Evaluator/NugetExeFix.txt
+++ b/lang/cs/Org.Apache.REEF.Evaluator/NugetExeFix.txt
@@ -1,1 +1,19 @@
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+
 Nuget hack, don't delete this

--- a/pom.xml
+++ b/pom.xml
@@ -239,27 +239,30 @@ under the License.
                             <exclude>lang/java/.idea/**</exclude>                            
                             <exclude>**/*.iml</exclude>
                             <exclude>**/target/**</exclude>
-			    <exclude>**/README.*</exclude>
+			                      <exclude>**/README.*</exclude>
                             <!-- The below are sometimes created during tests -->
                             <exclude>REEF_LOCAL_RUNTIME/**</exclude>
                             <!-- The Visual Studio build files -->
-                            <exclude>*.sln</exclude>
-                            <exclude>**/*.csproj.user</exclude>
+                            <exclude>**/*.sln*</exclude>
+                            <exclude>**/*.vcxproj*</exclude>
+                            <exclude>**/*.csproj*</exclude>
                             <!-- The below are auto generated during the .Net build -->                            
                             <exclude>**/bin/**</exclude>
                             <exclude>**/obj/**</exclude>
                             <exclude>**/Release/**</exclude>
                             <exclude>**/Debug/**</exclude>
                             <exclude>**/TestResults/**</exclude>
+                            <exclude>**/x64/**</exclude>
+                            
                             <!-- NuGet dependencies downloaded as part of the build -->
                             <exclude>**/packages/**</exclude>
                             <!-- The below are auto generated files for serialization -->
-                            <exclude>**/Org.Apache.REEF.Common/protobuf/cs/*</exclude>
-                            <exclude>**/Org.Apache.REEF.Common/avro/*</exclude>
+                            <exclude>Org.Apache.REEF.Common/Protobuf/ReefProtocol/*</exclude>
+                            <exclude>Org.Apache.REEF.Common/Avro/*</exclude>
                             <!-- The below are binary data files used in tests -->
-                            <exclude>**/ConfigFiles/evaluator.conf</exclude>
-                            <exclude>**/TangTests/evaluator.conf</exclude>
-                            <exclude>**/TangTests/simpleConstructorJavaProto.bin</exclude>
+                            <exclude>Org.Apache.REEF.Tests/ConfigFiles/evaluator.conf</exclude>
+                            <exclude>Org.Apache.REEF.Tang.Tests/evaluator.conf</exclude>
+                            <exclude>Org.Apache.REEF.Tang.Tests/simpleConstructorJavaProto.bin</exclude>
                         </excludes>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
Update excludes with the new folder structures

IIRA: Reef-138. (https://issues.apache.org/jira/browse/REEF-138)

Author Julia wang
email: jwang98052@yahoo.com