### PR TITLE
[REEF-166] Adding tree topology for group communication

### DIFF
--- a/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/KMeansDriverHandlers.cs
+++ b/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/KMeansDriverHandlers.cs
@@ -58,6 +58,7 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
         // TODO: we may want to make this injectable
         private readonly int _partitionsNumber = 2;
         private readonly int _clustersNumber = 3;
+        private readonly int _fanOut = 2;
         private readonly int _totalEvaluators;
         private int _partitionInex = 0;
         private readonly IMpiDriver _mpiDriver;
@@ -78,7 +79,7 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
                 _executionDirectory); 
 
             _totalEvaluators = _partitionsNumber + 1;
-            _mpiDriver = new MpiDriver(Identifier, Constants.MasterTaskId, new AvroConfigurationSerializer());
+            _mpiDriver = new MpiDriver(Identifier, Constants.MasterTaskId, _fanOut, new AvroConfigurationSerializer());
 
             _commGroup = _mpiDriver.NewCommunicationGroup(
                Constants.KMeansCommunicationGroupName,

--- a/lang/cs/Org.Apache.REEF.Network/Group/Config/MpiConfigurationOptions.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Config/MpiConfigurationOptions.cs
@@ -44,6 +44,11 @@ namespace Org.Apache.REEF.Network.Group.Config
         {
         }
 
+        [NamedParameter("with of the tree in typology")]
+        public class FanOut : Name<int>
+        {
+        }
+
         [NamedParameter("Serialized communication group configuration")]
         public class SerializedGroupConfigs : Name<ISet<string>>
         {

--- a/lang/cs/Org.Apache.REEF.Network/Group/Config/MpiConfigurationOptions.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Config/MpiConfigurationOptions.cs
@@ -39,6 +39,16 @@ namespace Org.Apache.REEF.Network.Group.Config
         {
         }
 
+        [NamedParameter("Timeout for receiving data", defaultValue: "50000")]
+        public class Timeout : Name<int>
+        {
+        }
+
+        [NamedParameter("Retry times", defaultValue: "5")]
+        public class RetryCount : Name<int>
+        {
+        }
+
         [NamedParameter("Master task identifier")]
         public class MasterTaskId : Name<string>
         {

--- a/lang/cs/Org.Apache.REEF.Network/Group/Config/MpiConfigurationOptions.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Config/MpiConfigurationOptions.cs
@@ -44,7 +44,7 @@ namespace Org.Apache.REEF.Network.Group.Config
         {
         }
 
-        [NamedParameter("with of the tree in typology")]
+        [NamedParameter("with of the tree in topology", defaultValue:"2")]
         public class FanOut : Name<int>
         {
         }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Driver/ICommunicationGroupDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Driver/ICommunicationGroupDriver.cs
@@ -19,6 +19,7 @@
 
 using System.Collections.Generic;
 using Org.Apache.REEF.Network.Group.Operators.Impl;
+using Org.Apache.REEF.Network.Group.Topology;
 using Org.Apache.REEF.Tang.Interface;
 
 namespace Org.Apache.REEF.Network.Group.Driver
@@ -42,7 +43,7 @@ namespace Org.Apache.REEF.Network.Group.Driver
         /// <param name="operatorName">The name of the broadcast operator</param>
         /// <param name="spec">The specification that defines the Broadcast operator</param>
         /// <returns>The same CommunicationGroupDriver with the added Broadcast operator info</returns>
-        ICommunicationGroupDriver AddBroadcast<T>(string operatorName, BroadcastOperatorSpec<T> spec);
+        ICommunicationGroupDriver AddBroadcast<T>(string operatorName, BroadcastOperatorSpec<T> spec, TopologyTypes topologyType = TopologyTypes.Flat);
 
         /// <summary>
         /// Adds the Reduce MPI operator to the communication group.
@@ -51,7 +52,7 @@ namespace Org.Apache.REEF.Network.Group.Driver
         /// <param name="operatorName">The name of the reduce operator</param>
         /// <param name="spec">The specification that defines the Reduce operator</param>
         /// <returns>The same CommunicationGroupDriver with the added Reduce operator info</returns>
-        ICommunicationGroupDriver AddReduce<T>(string operatorName, ReduceOperatorSpec<T> spec);
+        ICommunicationGroupDriver AddReduce<T>(string operatorName, ReduceOperatorSpec<T> spec, TopologyTypes topologyType = TopologyTypes.Flat);
 
         /// <summary>
         /// Adds the Scatter MPI operator to the communication group.
@@ -59,8 +60,9 @@ namespace Org.Apache.REEF.Network.Group.Driver
         /// <typeparam name="T">The type of messages that operators will send</typeparam>
         /// <param name="operatorName">The name of the scatter operator</param>
         /// <param name="spec">The specification that defines the Scatter operator</param>
+        /// <param name="topologyType">type of topology used in the operaor</param>
         /// <returns>The same CommunicationGroupDriver with the added Scatter operator info</returns>
-        ICommunicationGroupDriver AddScatter<T>(string operatorName, ScatterOperatorSpec<T> spec);
+        ICommunicationGroupDriver AddScatter<T>(string operatorName, ScatterOperatorSpec<T> spec, TopologyTypes topologyType = TopologyTypes.Flat);
 
         /// <summary>
         /// Finalizes the CommunicationGroupDriver.

--- a/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/CommunicationGroupDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/CommunicationGroupDriver.cs
@@ -45,6 +45,7 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
         private readonly int _numTasks;
         private int _tasksAdded;
         private bool _finalized;
+        private int _fanOut;
 
         private readonly AvroConfigurationSerializer _confSerializer;
 
@@ -63,6 +64,7 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
             string groupName,
             string driverId, 
             int numTasks,
+            int fanOut,
             AvroConfigurationSerializer confSerializer)
         {
             _confSerializer = confSerializer;
@@ -71,6 +73,7 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
             _numTasks = numTasks;
             _tasksAdded = 0;
             _finalized = false;
+            _fanOut = fanOut;
 
             _topologyLock = new object();
 
@@ -100,7 +103,8 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
                 throw new IllegalStateException("Can't add operators once the spec has been built.");
             }
 
-            ITopology<T> topology = new FlatTopology<T>(operatorName, _groupName, spec.SenderId, _driverId, spec);
+            //ITopology<T> topology = new FlatTopology<T>(operatorName, _groupName, spec.SenderId, _driverId, spec);
+            ITopology<T> topology = new TreeTopology<T>(operatorName, _groupName, spec.SenderId, _driverId, spec, _fanOut);
             _topologies[operatorName] = topology;
             _operatorSpecs[operatorName] = spec;
 
@@ -123,7 +127,8 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
                 throw new IllegalStateException("Can't add operators once the spec has been built.");
             }
 
-            ITopology<T> topology = new FlatTopology<T>(operatorName, _groupName, spec.ReceiverId, _driverId, spec);
+            //ITopology<T> topology = new FlatTopology<T>(operatorName, _groupName, spec.ReceiverId, _driverId, spec);
+            ITopology<T> topology = new TreeTopology<T>(operatorName, _groupName, spec.ReceiverId, _driverId, spec, _fanOut);
             _topologies[operatorName] = topology;
             _operatorSpecs[operatorName] = spec;
 

--- a/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/CommunicationGroupDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/CommunicationGroupDriver.cs
@@ -45,7 +45,7 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
         private readonly int _numTasks;
         private int _tasksAdded;
         private bool _finalized;
-        private int _fanOut;
+        private readonly int _fanOut;
 
         private readonly AvroConfigurationSerializer _confSerializer;
 
@@ -62,7 +62,7 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
         /// <param name="confSerializer">Used to serialize task configuration</param>
         public CommunicationGroupDriver(
             string groupName,
-            string driverId, 
+            string driverId,
             int numTasks,
             int fanOut,
             AvroConfigurationSerializer confSerializer)
@@ -85,7 +85,7 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
         /// <summary>
         /// Returns the list of task ids that belong to this Communication Group
         /// </summary>
-        public List<string> TaskIds { get; private set; } 
+        public List<string> TaskIds { get; private set; }
 
         /// <summary>
         /// Adds the Broadcast MPI operator to the communication group.
@@ -95,16 +95,26 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
         /// <param name="spec">The specification that defines the Broadcast operator</param>
         /// <returns>The same CommunicationGroupDriver with the added Broadcast operator info</returns>
         public ICommunicationGroupDriver AddBroadcast<T>(
-            string operatorName, 
-            BroadcastOperatorSpec<T> spec)
+            string operatorName,
+            BroadcastOperatorSpec<T> spec,
+            TopologyTypes topologyType = TopologyTypes.Flat)
         {
             if (_finalized)
             {
                 throw new IllegalStateException("Can't add operators once the spec has been built.");
             }
 
-            //ITopology<T> topology = new FlatTopology<T>(operatorName, _groupName, spec.SenderId, _driverId, spec);
-            ITopology<T> topology = new TreeTopology<T>(operatorName, _groupName, spec.SenderId, _driverId, spec, _fanOut);
+            ITopology<T> topology;
+
+            if (topologyType == TopologyTypes.Flat)
+            {
+                topology = new FlatTopology<T>(operatorName, _groupName, spec.SenderId, _driverId, spec);
+            }
+            else
+            {
+                topology = new TreeTopology<T>(operatorName, _groupName, spec.SenderId, _driverId, spec,
+                    _fanOut);
+            }
             _topologies[operatorName] = topology;
             _operatorSpecs[operatorName] = spec;
 
@@ -119,16 +129,26 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
         /// <param name="spec">The specification that defines the Reduce operator</param>
         /// <returns>The same CommunicationGroupDriver with the added Reduce operator info</returns>
         public ICommunicationGroupDriver AddReduce<T>(
-            string operatorName, 
-            ReduceOperatorSpec<T> spec)
+            string operatorName,
+            ReduceOperatorSpec<T> spec,
+            TopologyTypes topologyType = TopologyTypes.Flat)
         {
             if (_finalized)
             {
                 throw new IllegalStateException("Can't add operators once the spec has been built.");
             }
 
-            //ITopology<T> topology = new FlatTopology<T>(operatorName, _groupName, spec.ReceiverId, _driverId, spec);
-            ITopology<T> topology = new TreeTopology<T>(operatorName, _groupName, spec.ReceiverId, _driverId, spec, _fanOut);
+            ITopology<T> topology;
+
+            if (topologyType == TopologyTypes.Flat)
+            {
+                topology = new FlatTopology<T>(operatorName, _groupName, spec.ReceiverId, _driverId, spec);
+            }
+            else
+            {
+                topology = new TreeTopology<T>(operatorName, _groupName, spec.ReceiverId, _driverId, spec,
+                    _fanOut);
+            }
             _topologies[operatorName] = topology;
             _operatorSpecs[operatorName] = spec;
 
@@ -142,14 +162,24 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
         /// <param name="operatorName">The name of the scatter operator</param>
         /// <param name="spec">The specification that defines the Scatter operator</param>
         /// <returns>The same CommunicationGroupDriver with the added Scatter operator info</returns>
-        public ICommunicationGroupDriver AddScatter<T>(string operatorName, ScatterOperatorSpec<T> spec)
+        public ICommunicationGroupDriver AddScatter<T>(string operatorName, ScatterOperatorSpec<T> spec, TopologyTypes topologyType = TopologyTypes.Flat)
         {
             if (_finalized)
             {
                 throw new IllegalStateException("Can't add operators once the spec has been built.");
             }
 
-            ITopology<T> topology = new FlatTopology<T>(operatorName, _groupName, spec.SenderId, _driverId, spec);
+            ITopology<T> topology; 
+
+            if (topologyType == TopologyTypes.Flat)
+            {
+                topology = new FlatTopology<T>(operatorName, _groupName, spec.SenderId, _driverId, spec);
+            }
+            else
+            {
+                topology = new TreeTopology<T>(operatorName, _groupName, spec.SenderId, _driverId, spec,
+                    _fanOut);
+            }
             _topologies[operatorName] = topology;
             _operatorSpecs[operatorName] = spec;
 
@@ -250,14 +280,14 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
         {
             var topology = _topologies[operatorName];
             MethodInfo info = topology.GetType().GetMethod("AddTask");
-            info.Invoke(topology, new[] { (object) taskId });
+            info.Invoke(topology, new[] { (object)taskId });
         }
 
         private IConfiguration GetOperatorConfiguration(string operatorName, string taskId)
         {
             var topology = _topologies[operatorName];
             MethodInfo info = topology.GetType().GetMethod("GetTaskConfiguration");
-            return (IConfiguration) info.Invoke(topology, new[] { (object) taskId });
+            return (IConfiguration)info.Invoke(topology, new[] { (object)taskId });
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/MpiDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/MpiDriver.cs
@@ -55,6 +55,7 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
         private readonly string _nameServerAddr;
         private readonly int _nameServerPort;
         private int _contextIds;
+        private int _fanOut;
 
         private readonly Dictionary<string, ICommunicationGroupDriver> _commGroups; 
         private readonly AvroConfigurationSerializer _configSerializer;
@@ -70,10 +71,12 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
         public MpiDriver(
             [Parameter(typeof(MpiConfigurationOptions.DriverId))] string driverId,
             [Parameter(typeof(MpiConfigurationOptions.MasterTaskId))] string masterTaskId,
+            [Parameter(typeof(MpiConfigurationOptions.FanOut))] int fanOut,
             AvroConfigurationSerializer configSerializer)
         {
             _driverId = driverId;
             _contextIds = -1;
+            _fanOut = fanOut;
             MasterTaskId = masterTaskId;
 
             _configSerializer = configSerializer;
@@ -111,7 +114,7 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
                 throw new ArgumentException("Group Name already registered with MpiDriver");
             }
 
-            var commGroup = new CommunicationGroupDriver(groupName, _driverId, numTasks, _configSerializer);
+            var commGroup = new CommunicationGroupDriver(groupName, _driverId, numTasks, _fanOut, _configSerializer);
             _commGroups[groupName] = commGroup;
             return commGroup;
         }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/IReduceSender.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/IReduceSender.cs
@@ -30,10 +30,5 @@ namespace Org.Apache.REEF.Network.Group.Operators
         /// </summary>
         /// <param name="data">The data to send</param>
         void Send(T data);
-
-        /// <summary>
-        /// Get reduced data from children, then send it parent
-        /// </summary>
-        void Send();
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/BroadcastReceiver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/BroadcastReceiver.cs
@@ -85,7 +85,9 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         /// <returns>The incoming message</returns>
         public T Receive()
         {
-            return _topology.ReceiveFromParent();
+            var data = _topology.ReceiveFromParent();
+            _topology.SendToChildren(data, MessageType.Data);
+            return data;
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/BroadcastReceiver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/BroadcastReceiver.cs
@@ -86,7 +86,10 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         public T Receive()
         {
             var data = _topology.ReceiveFromParent();
-            _topology.SendToChildren(data, MessageType.Data);
+            if (_topology.HasChildren())
+            {
+                _topology.SendToChildren(data, MessageType.Data);
+            }
             return data;
         }
     }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceSender.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceSender.cs
@@ -18,6 +18,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Reactive;
 using Org.Apache.REEF.Network.Group.Config;
 using Org.Apache.REEF.Network.Group.Driver.Impl;
@@ -37,6 +38,7 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
 
         private readonly ICommunicationGroupNetworkObserver _networkHandler;
         private readonly OperatorTopology<T> _topology;
+        private IReduceFunction<T> _reduceFunction;
 
         /// <summary>
         /// Creates a new ReduceSender.
@@ -50,12 +52,13 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
             [Parameter(typeof(MpiConfigurationOptions.OperatorName))] string operatorName,
             [Parameter(typeof(MpiConfigurationOptions.CommunicationGroupName))] string groupName,
             OperatorTopology<T> topology, 
-            ICommunicationGroupNetworkObserver networkHandler)
+            ICommunicationGroupNetworkObserver networkHandler,
+            IReduceFunction<T> reduceFunction)
         {
             OperatorName = operatorName;
             GroupName = groupName;
             Version = DefaultVersion;
-
+            _reduceFunction = reduceFunction;
             _networkHandler = networkHandler;
             _topology = topology;
             _topology.Initialize();
@@ -90,7 +93,17 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
                 throw new ArgumentNullException("data");    
             }
 
-            _topology.SendToParent(data, MessageType.Data);
+            var reducedValueOfChildren = _topology.ReceiveFromChildren(_reduceFunction);
+            var mergeddData = new List<T>();
+            mergeddData.Add(data);
+            if (reducedValueOfChildren != null)
+            {
+                mergeddData.Add(reducedValueOfChildren);
+            }
+            T reducedValue = _reduceFunction.Reduce(mergeddData);
+
+            _topology.SendToParent(reducedValue, MessageType.Data);
+            //_topology.SendToParent(data, MessageType.Data);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceSender.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceSender.cs
@@ -38,7 +38,7 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
 
         private readonly ICommunicationGroupNetworkObserver _networkHandler;
         private readonly OperatorTopology<T> _topology;
-        private IReduceFunction<T> _reduceFunction;
+        private readonly IReduceFunction<T> _reduceFunction;
 
         /// <summary>
         /// Creates a new ReduceSender.

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceSender.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceSender.cs
@@ -93,26 +93,26 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
                 throw new ArgumentNullException("data");    
             }
 
-            var reducedValueOfChildren = _topology.ReceiveFromChildren(_reduceFunction);
-
-            var mergeddData = new List<T>();
-            mergeddData.Add(data);
-            if (reducedValueOfChildren != null)
+            //middle notes
+            if (_topology.HasChildren())
             {
-                mergeddData.Add(reducedValueOfChildren);
+                var reducedValueOfChildren = _topology.ReceiveFromChildren(_reduceFunction);
+
+                var mergeddData = new List<T>();
+                mergeddData.Add(data);
+                if (reducedValueOfChildren != null)
+                {
+                    mergeddData.Add(reducedValueOfChildren);
+                }
+                T reducedValue = _reduceFunction.Reduce(mergeddData);
+
+                _topology.SendToParent(reducedValue, MessageType.Data);
             }
-            T reducedValue = _reduceFunction.Reduce(mergeddData);
-
-            _topology.SendToParent(reducedValue, MessageType.Data);
-        }
-
-        /// <summary>
-        /// Get reduced data from children, then send it parent
-        /// </summary>
-        public void Send()
-        {
-            var reducedValueOfChildren = _topology.ReceiveFromChildren(_reduceFunction);
-            _topology.SendToParent(reducedValueOfChildren, MessageType.Data);
+            else
+            {
+                //leaf node
+                _topology.SendToParent(data, MessageType.Data);
+            }
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceSender.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceSender.cs
@@ -83,7 +83,7 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         public int Version { get; private set; }
 
         /// <summary>
-        /// Get reduced data from children, reduce with the data given, then sends reduced data to parent
+        /// Sends data to the operator's ReduceReceiver to be aggregated.
         /// </summary>
         /// <param name="data">The data to send</param>
         public void Send(T data)

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceSender.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceSender.cs
@@ -83,7 +83,7 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         public int Version { get; private set; }
 
         /// <summary>
-        /// Sends the data to the operator's ReduceReceiver to be aggregated.
+        /// Get reduced data from children, reduce with the data given, then sends reduced data to parent
         /// </summary>
         /// <param name="data">The data to send</param>
         public void Send(T data)
@@ -94,6 +94,7 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
             }
 
             var reducedValueOfChildren = _topology.ReceiveFromChildren(_reduceFunction);
+
             var mergeddData = new List<T>();
             mergeddData.Add(data);
             if (reducedValueOfChildren != null)
@@ -103,7 +104,15 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
             T reducedValue = _reduceFunction.Reduce(mergeddData);
 
             _topology.SendToParent(reducedValue, MessageType.Data);
-            //_topology.SendToParent(data, MessageType.Data);
+        }
+
+        /// <summary>
+        /// Get reduced data from children, then send it parent
+        /// </summary>
+        public void Send()
+        {
+            var reducedValueOfChildren = _topology.ReceiveFromChildren(_reduceFunction);
+            _topology.SendToParent(reducedValueOfChildren, MessageType.Data);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ScatterReceiver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ScatterReceiver.cs
@@ -91,7 +91,9 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         /// <returns>The sublist of messages</returns>
         public List<T> Receive()
         {
-            return _topology.ReceiveListFromParent();
+            List<T> elements = _topology.ReceiveListFromParent();
+            _topology.ScatterToChildren(elements, MessageType.Data);
+            return elements;
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/OperatorTopology.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/OperatorTopology.cs
@@ -213,7 +213,6 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
             if (_children.Count <= 0)
             {
                 return;
-                //throw new ArgumentException("Cannot scatter, no children available");
             }
 
             int count = (int) Math.Ceiling(((double) messages.Count) / _children.Count);
@@ -343,6 +342,11 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
 
         public void OnCompleted()
         {
+        }
+
+        public bool HasChildren()
+        {
+            return _children.Count > 0 ? true : false;
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/OperatorTopology.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/OperatorTopology.cs
@@ -98,20 +98,37 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
             _children = new List<NodeStruct>();
             _idToNodeMap = new Dictionary<string, NodeStruct>();
 
+            //if (rootId != null)
+            //{
+            //    _parent = new NodeStruct(rootId);
+            //    _idToNodeMap[rootId] = _parent;
+            //}
+            //else
+            //{
+            //    _parent = null;
+            //}
+
+            //foreach (string childId in childIds)
+            //{
+            //    NodeStruct node = new NodeStruct(childId);
+            //    _children.Add(node);
+            //    _idToNodeMap[childId] = node;
+            //}
+
             if (_selfId.Equals(rootId))
             {
                 _parent = null;
-                foreach (string childId in childIds)
-                {
-                    NodeStruct node = new NodeStruct(childId);
-                    _children.Add(node);
-                    _idToNodeMap[childId] = node;
-                }
             }
             else
             {
                 _parent = new NodeStruct(rootId);
                 _idToNodeMap[rootId] = _parent;
+            }
+            foreach (string childId in childIds)
+            {
+                NodeStruct node = new NodeStruct(childId);
+                _children.Add(node);
+                _idToNodeMap[childId] = node;
             }
         }
 

--- a/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/OperatorTopology.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/OperatorTopology.cs
@@ -98,23 +98,6 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
             _children = new List<NodeStruct>();
             _idToNodeMap = new Dictionary<string, NodeStruct>();
 
-            //if (rootId != null)
-            //{
-            //    _parent = new NodeStruct(rootId);
-            //    _idToNodeMap[rootId] = _parent;
-            //}
-            //else
-            //{
-            //    _parent = null;
-            //}
-
-            //foreach (string childId in childIds)
-            //{
-            //    NodeStruct node = new NodeStruct(childId);
-            //    _children.Add(node);
-            //    _idToNodeMap[childId] = node;
-            //}
-
             if (_selfId.Equals(rootId))
             {
                 _parent = null;

--- a/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/OperatorTopology.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/OperatorTopology.cs
@@ -45,8 +45,8 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
     /// <typeparam name="T">The message type</typeparam>
     public class OperatorTopology<T> : IObserver<GroupCommunicationMessage>
     {
-        private const int DefaultTimeout = 10000;
-        private const int RetryCount = 5;
+        private const int DefaultTimeout = 50000;
+        private const int RetryCount = 10;
 
         private static readonly Logger LOGGER = Logger.GetLogger(typeof(OperatorTopology<>));
 
@@ -212,7 +212,8 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
             }
             if (_children.Count <= 0)
             {
-                throw new ArgumentException("Cannot scatter, no children available");
+                return;
+                //throw new ArgumentException("Cannot scatter, no children available");
             }
 
             int count = (int) Math.Ceiling(((double) messages.Count) / _children.Count);

--- a/lang/cs/Org.Apache.REEF.Network/Group/Topology/FlatTopology.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Topology/FlatTopology.cs
@@ -82,39 +82,6 @@ namespace Org.Apache.REEF.Network.Group.Topology
         /// <returns>The task configuration</returns>
         public IConfiguration GetTaskConfiguration(string taskId)
         {
-            //ICsConfigurationBuilder confBuilder;
-
-            //if (taskId.Equals(_rootId))
-            //{
-            //    //parent is null
-            //    confBuilder = TangFactory.GetTang().NewConfigurationBuilder()
-            //        .BindImplementation(typeof(ICodec<T>), OperatorSpec.Codec.GetType())
-            //        .BindNamedParameter<MpiConfigurationOptions.TopologyRootTaskId, string>(
-            //            GenericType<MpiConfigurationOptions.TopologyRootTaskId>.Class,
-            //            null);
-            //    //all chidrean are its children
-            //    foreach (string tId in _nodes.Keys)
-            //    {
-            //        if (!tId.Equals(_rootId))
-            //        {
-            //            confBuilder.BindSetEntry<MpiConfigurationOptions.TopologyChildTaskIds, string>(
-            //                GenericType<MpiConfigurationOptions.TopologyChildTaskIds>.Class,
-            //                tId);
-            //        }
-            //    }
-            //}
-            //else
-            //{
-            //    //parent is root
-            //    confBuilder = TangFactory.GetTang().NewConfigurationBuilder()
-            //        .BindImplementation(typeof(ICodec<T>), OperatorSpec.Codec.GetType())
-            //        .BindNamedParameter<MpiConfigurationOptions.TopologyRootTaskId, string>(
-            //            GenericType<MpiConfigurationOptions.TopologyRootTaskId>.Class,
-            //            _rootId);
-
-            //    //no children
-            //}
-
             var confBuilder = TangFactory.GetTang().NewConfigurationBuilder()
                 .BindImplementation(typeof(ICodec<T>), OperatorSpec.Codec.GetType())
                 .BindNamedParameter<MpiConfigurationOptions.TopologyRootTaskId, string>(
@@ -134,22 +101,6 @@ namespace Org.Apache.REEF.Network.Group.Topology
                 }
             }
 
-            //var confBuilder = TangFactory.GetTang().NewConfigurationBuilder()
-            //    .BindImplementation(typeof(ICodec<T>), OperatorSpec.Codec.GetType())
-            //    .BindNamedParameter<MpiConfigurationOptions.TopologyRootTaskId, string>(
-            //        GenericType<MpiConfigurationOptions.TopologyRootTaskId>.Class,
-            //        _rootId);
-
-            //foreach (string tId in _nodes.Keys)
-            //{
-            //    if (!tId.Equals(_rootId))
-            //    {
-            //        confBuilder.BindSetEntry<MpiConfigurationOptions.TopologyChildTaskIds, string>(
-            //            GenericType<MpiConfigurationOptions.TopologyChildTaskIds>.Class,
-            //            tId);
-            //    }
-            //}
-            
             if (OperatorSpec is BroadcastOperatorSpec<T>)
             {
                 BroadcastOperatorSpec<T> broadcastSpec = OperatorSpec as BroadcastOperatorSpec<T>;
@@ -229,7 +180,7 @@ namespace Org.Apache.REEF.Network.Group.Topology
             foreach (TaskNode childNode in _nodes.Values)
             {
                 rootNode.AddChild(childNode);
-                childNode.SetParent(rootNode);
+                childNode.Parent = rootNode;
             }
         }
 
@@ -241,7 +192,7 @@ namespace Org.Apache.REEF.Network.Group.Topology
             if (_root != null)
             {
                 _root.AddChild(childNode);
-                childNode.SetParent(_root);
+                childNode.Parent = _root;
             }
         }
     }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Topology/TaskNode.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Topology/TaskNode.cs
@@ -32,7 +32,7 @@ namespace Org.Apache.REEF.Network.Group.Topology
         private string _driverId;
 
         private TaskNode _parent;
-        private TaskNode _sibling;
+        private TaskNode _successor;
         private bool _isRoot;
 
         private readonly List<TaskNode> _children;
@@ -59,29 +59,21 @@ namespace Org.Apache.REEF.Network.Group.Topology
             private set { _taskId = value;  }
         }
 
-        public void SetSibling(TaskNode leaf) 
+        public TaskNode Successor
         {
-            _sibling = leaf;
+            get { return _successor; }
+            set { _successor = value; }
+        }
+
+        public TaskNode Parent
+        {
+            get { return _parent; }
+            set { _parent = value; }
         }
 
         public void AddChild(TaskNode child)
         {
             _children.Add(child);
-        }
-
-        public void SetParent(TaskNode parent)
-        {
-            _parent = parent;
-        }
-
-        public TaskNode GetParent()
-        {
-            return _parent;
-        }
-
-        public TaskNode Successor()
-        {           
-            return _sibling;
         }
 
         public int GetNumberOfChildren() {

--- a/lang/cs/Org.Apache.REEF.Network/Group/Topology/TaskNode.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Topology/TaskNode.cs
@@ -32,23 +32,37 @@ namespace Org.Apache.REEF.Network.Group.Topology
         private string _driverId;
 
         private TaskNode _parent;
+        private TaskNode _sibling;
+        private bool _isRoot;
+
         private readonly List<TaskNode> _children;
 
         public TaskNode(
             string groupName, 
             string operatorName, 
             string taskId, 
-            string driverId)
+            string driverId,
+            bool isRoot)
         {
             _groupName = groupName;
             _operatorName = operatorName;
             _taskId = taskId;
             _driverId = driverId;
+            _isRoot = isRoot;
 
             _children = new List<TaskNode>();
         }
 
-        public string TaskId { get; private set; }
+        public string TaskId
+        {
+            get { return _taskId; } 
+            private set { _taskId = value;  }
+        }
+
+        public void SetSibling(TaskNode leaf) 
+        {
+            _sibling = leaf;
+        }
 
         public void AddChild(TaskNode child)
         {
@@ -59,5 +73,24 @@ namespace Org.Apache.REEF.Network.Group.Topology
         {
             _parent = parent;
         }
+
+        public TaskNode GetParent()
+        {
+            return _parent;
+        }
+
+        public TaskNode Successor()
+        {           
+            return _sibling;
+        }
+
+        public int GetNumberOfChildren() {
+            return _children.Count;
+        }
+
+        public IList<TaskNode> GetChildren()
+        {
+            return _children;
+        } 
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Topology/TopologyTypes.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Topology/TopologyTypes.cs
@@ -17,23 +17,11 @@
  * under the License.
  */
 
-namespace Org.Apache.REEF.Network.Group.Operators
+namespace Org.Apache.REEF.Network.Group.Topology
 {
-    /// <summary>
-    /// MPI Operator used to send messages to be reduced by the ReduceReceiver.
-    /// </summary>
-    /// <typeparam name="T">The message type</typeparam>
-    public interface IReduceSender<T> : IMpiOperator<T>
+    public enum TopologyTypes
     {
-        /// <summary>
-        /// Get reduced data from children, reduce with the data given, then sends reduced data to parent
-        /// </summary>
-        /// <param name="data">The data to send</param>
-        void Send(T data);
-
-        /// <summary>
-        /// Get reduced data from children, then send it parent
-        /// </summary>
-        void Send();
+        Flat = 0,
+        Tree = 1
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
+++ b/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
@@ -93,9 +93,7 @@ under the License.
     <Compile Include="Group\Topology\FlatTopology.cs" />
     <Compile Include="Group\Topology\ITopology.cs" />
     <Compile Include="Group\Topology\TaskNode.cs" />
-    <Compile Include="Group\Topology\TreeTopology.cs">
-      <SubType>Code</SubType>
-    </Compile>
+    <Compile Include="Group\Topology\TreeTopology.cs" />
     <Compile Include="Naming\Codec\NamingLookupRequestCodec.cs" />
     <Compile Include="Naming\Codec\NamingLookupResponseCodec.cs" />
     <Compile Include="Naming\Codec\NamingRegisterRequestCodec.cs" />

--- a/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
+++ b/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
@@ -93,6 +93,7 @@ under the License.
     <Compile Include="Group\Topology\FlatTopology.cs" />
     <Compile Include="Group\Topology\ITopology.cs" />
     <Compile Include="Group\Topology\TaskNode.cs" />
+    <Compile Include="Group\Topology\TopologyTypes.cs" />
     <Compile Include="Group\Topology\TreeTopology.cs" />
     <Compile Include="Naming\Codec\NamingLookupRequestCodec.cs" />
     <Compile Include="Naming\Codec\NamingLookupResponseCodec.cs" />

--- a/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
+++ b/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
@@ -93,6 +93,9 @@ under the License.
     <Compile Include="Group\Topology\FlatTopology.cs" />
     <Compile Include="Group\Topology\ITopology.cs" />
     <Compile Include="Group\Topology\TaskNode.cs" />
+    <Compile Include="Group\Topology\TreeTopology.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Naming\Codec\NamingLookupRequestCodec.cs" />
     <Compile Include="Naming\Codec\NamingLookupResponseCodec.cs" />
     <Compile Include="Naming\Codec\NamingRegisterRequestCodec.cs" />

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/BroadcastReduceTest/BroadcastReduceDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/BroadcastReduceTest/BroadcastReduceDriver.cs
@@ -57,6 +57,7 @@ namespace Org.Apache.REEF.Tests.Functional.MPI.BroadcastReduceTest
         public BroadcastReduceDriver(
             [Parameter(typeof(MpiTestConfig.NumEvaluators))] int numEvaluators,
             [Parameter(typeof(MpiTestConfig.NumIterations))] int numIterations,
+            [Parameter(typeof(MpiTestConfig.FanOut))] int fanOut,
             AvroConfigurationSerializer confSerializer)
         {
             Identifier = "BroadcastStartHandler";
@@ -66,6 +67,7 @@ namespace Org.Apache.REEF.Tests.Functional.MPI.BroadcastReduceTest
             _mpiDriver = new MpiDriver(
                 MpiTestConstants.DriverId,
                 MpiTestConstants.MasterTaskId,
+                fanOut,
                 confSerializer);
 
             _commGroup = _mpiDriver.NewCommunicationGroup(

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/BroadcastReduceTest/BroadcastReduceTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/BroadcastReduceTest/BroadcastReduceTest.cs
@@ -64,6 +64,9 @@ namespace Org.Apache.REEF.Tests.Functional.MPI.BroadcastReduceTest
                 .BindNamedParameter<MpiTestConfig.NumIterations, int>(
                     GenericType<MpiTestConfig.NumIterations>.Class,
                     MpiTestConstants.NumIterations.ToString(CultureInfo.InvariantCulture))
+                .BindNamedParameter<MpiTestConfig.FanOut, int>(
+                    GenericType<MpiTestConfig.FanOut>.Class,
+                    MpiTestConstants.FanOut.ToString(CultureInfo.InvariantCulture))
                 .BindNamedParameter<MpiTestConfig.NumEvaluators, int>(
                     GenericType<MpiTestConfig.NumEvaluators>.Class,
                     numTasks.ToString(CultureInfo.InvariantCulture))

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/MpiTestConfig.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/MpiTestConfig.cs
@@ -32,5 +32,10 @@ namespace Org.Apache.REEF.Tests.Functional.MPI
         public class NumEvaluators : Name<int>
         {
         }
+
+        [NamedParameter("tree width")]
+        public class FanOut : Name<int>
+        {
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/MpiTestConstants.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/MpiTestConstants.cs
@@ -29,5 +29,6 @@ namespace Org.Apache.REEF.Tests.Functional.MPI
         public const string MasterTaskId = "MasterTask";
         public const string SlaveTaskId = "SlaveTask-";
         public const int NumIterations = 10;
+        public const int FanOut = 2;
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/ScatterReduceTest/MasterTask.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/ScatterReduceTest/MasterTask.cs
@@ -50,7 +50,6 @@ namespace Org.Apache.REEF.Tests.Functional.MPI.ScatterReduceTest
         public byte[] Call(byte[] memento)
         {
             List<int> data = Enumerable.Range(1, 100).ToList();
-            //List<string> order = GetScatterOrder();
             _scatterSender.Send(data);
 
             int sum = _sumReducer.Reduce();

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/ScatterReduceTest/MasterTask.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/ScatterReduceTest/MasterTask.cs
@@ -50,8 +50,8 @@ namespace Org.Apache.REEF.Tests.Functional.MPI.ScatterReduceTest
         public byte[] Call(byte[] memento)
         {
             List<int> data = Enumerable.Range(1, 100).ToList();
-            List<string> order = GetScatterOrder();
-            _scatterSender.Send(data, order);
+            //List<string> order = GetScatterOrder();
+            _scatterSender.Send(data);
 
             int sum = _sumReducer.Reduce();
             _logger.Log(Level.Info, "Received sum: {0}", sum);

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/ScatterReduceTest/ScatterReduceDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/ScatterReduceTest/ScatterReduceDriver.cs
@@ -53,6 +53,7 @@ namespace Org.Apache.REEF.Tests.Functional.MPI.ScatterReduceTest
         [Inject]
         public ScatterReduceDriver(
             [Parameter(typeof(MpiTestConfig.NumEvaluators))] int numEvaluators,
+            [Parameter(typeof(MpiTestConfig.FanOut))] int fanOut,
             AvroConfigurationSerializer confSerializer)
         {
             Identifier = "BroadcastStartHandler";
@@ -61,6 +62,7 @@ namespace Org.Apache.REEF.Tests.Functional.MPI.ScatterReduceTest
             _mpiDriver = new MpiDriver(
                 MpiTestConstants.DriverId,
                 MpiTestConstants.MasterTaskId,
+                fanOut,
                 confSerializer);
 
             _commGroup = _mpiDriver.NewCommunicationGroup(

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/ScatterReduceTest/ScatterReduceDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/ScatterReduceTest/ScatterReduceDriver.cs
@@ -30,6 +30,7 @@ using Org.Apache.REEF.Network.Group.Driver;
 using Org.Apache.REEF.Network.Group.Driver.Impl;
 using Org.Apache.REEF.Network.Group.Operators;
 using Org.Apache.REEF.Network.Group.Operators.Impl;
+using Org.Apache.REEF.Network.Group.Topology;
 using Org.Apache.REEF.Network.NetworkService;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Formats;
@@ -72,7 +73,8 @@ namespace Org.Apache.REEF.Tests.Functional.MPI.ScatterReduceTest
                         MpiTestConstants.ScatterOperatorName,
                         new ScatterOperatorSpec<int>(
                             MpiTestConstants.MasterTaskId,
-                            new IntCodec()))
+                            new IntCodec()),
+                            TopologyTypes.Tree)
                     .AddReduce(
                         MpiTestConstants.ReduceOperatorName,
                         new ReduceOperatorSpec<int>(

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/ScatterReduceTest/ScatterReduceTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/ScatterReduceTest/ScatterReduceTest.cs
@@ -64,6 +64,9 @@ namespace Org.Apache.REEF.Tests.Functional.MPI.ScatterReduceTest
                 .BindNamedParameter<MpiTestConfig.NumEvaluators, int>(
                     GenericType<MpiTestConfig.NumEvaluators>.Class,
                     numTasks.ToString(CultureInfo.InvariantCulture))
+                .BindNamedParameter<MpiTestConfig.FanOut, int>(
+                    GenericType<MpiTestConfig.FanOut>.Class,
+                    MpiTestConstants.FanOut.ToString(CultureInfo.InvariantCulture))
                 .Build();
                     
             HashSet<string> appDlls = new HashSet<string>();

--- a/lang/cs/Org.Apache.REEF.Tests/Network/GroupCommunicationTests.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Network/GroupCommunicationTests.cs
@@ -156,14 +156,14 @@ namespace Org.Apache.REEF.Tests.Network
             IBroadcastReceiver<int> broadcastReceiver2 = commGroups[2].GetBroadcastReceiver<int>(broadcastOperatorName);
             IReduceSender<int> triangleNumberSender2 = commGroups[2].GetReduceSender<int>(reduceOperatorName);
 
-            for (int i = 1; i <= 10; i++)
+            for (int j = 1; j <= 10; j++)
             {
-                broadcastSender.Send(i);
+                broadcastSender.Send(j);
 
                 int n1 = broadcastReceiver1.Receive();
                 int n2 = broadcastReceiver2.Receive();
-                Assert.AreEqual(i, n1);
-                Assert.AreEqual(i, n2);
+                Assert.AreEqual(j, n1);
+                Assert.AreEqual(j, n2);
 
                 int triangleNum1 = TriangleNumber(n1);
                 triangleNumberSender1.Send(triangleNum1);
@@ -171,151 +171,7 @@ namespace Org.Apache.REEF.Tests.Network
                 triangleNumberSender2.Send(triangleNum2);
 
                 int sum = sumReducer.Reduce();
-                int expected = TriangleNumber(i) * (numTasks - 1);
-                Assert.AreEqual(sum, expected);
-            }
-        }
-
-        [TestMethod]
-        public void TestBroadcastReduceOperatorsForTree()
-        {
-            string groupName = "group1";
-            string broadcastOperatorName = "broadcast";
-            string reduceOperatorName = "reduce";
-            string masterTaskId = "task0";
-            string driverId = "Driver Id";
-            int numTasks = 10;
-            int fanOut = 3;
-
-            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, fanOut, new AvroConfigurationSerializer());
-
-            ICommunicationGroupDriver commGroup = mpiDriver.NewCommunicationGroup(
-                groupName,
-                numTasks)
-                .AddBroadcast(
-                    broadcastOperatorName,
-                    new BroadcastOperatorSpec<int>(
-                    masterTaskId,
-                    new IntCodec()))
-                .AddReduce(
-                    reduceOperatorName,
-                    new ReduceOperatorSpec<int>(
-                    masterTaskId,
-                    new IntCodec(),
-                    new SumFunction()))
-                .Build();
-
-            List<ICommunicationGroupClient> commGroups = new List<ICommunicationGroupClient>();
-            IConfiguration serviceConfig = mpiDriver.GetServiceConfiguration();
-
-            List<IConfiguration> partialConfigs = new List<IConfiguration>();
-            for (int i = 0; i < numTasks; i++)
-            {
-                string taskId = "task" + i;
-                IConfiguration partialTaskConfig = TangFactory.GetTang().NewConfigurationBuilder(
-                    TaskConfiguration.ConfigurationModule
-                        .Set(TaskConfiguration.Identifier, taskId)
-                        .Set(TaskConfiguration.Task, GenericType<MyTask>.Class)
-                        .Build())
-                    .Build();
-                commGroup.AddTask(taskId);
-                partialConfigs.Add(partialTaskConfig);
-            }
-
-            for (int i = 0; i < numTasks; i++)
-            {
-                string taskId = "task" + i;
-                IConfiguration mpiTaskConfig = mpiDriver.GetMpiTaskConfiguration(taskId);
-                IConfiguration mergedConf = Configurations.Merge(mpiTaskConfig, partialConfigs[i], serviceConfig);
-                IInjector injector = TangFactory.GetTang().NewInjector(mergedConf);
-
-                IMpiClient mpiClient = injector.GetInstance<IMpiClient>();
-                commGroups.Add(mpiClient.GetCommunicationGroup(groupName));
-            }
-
-            //for master task
-            IBroadcastSender<int> broadcastSender = commGroups[0].GetBroadcastSender<int>(broadcastOperatorName);
-            IReduceReceiver<int> sumReducer = commGroups[0].GetReduceReceiver<int>(reduceOperatorName);
-
-            IBroadcastReceiver<int> broadcastReceiver1 = commGroups[1].GetBroadcastReceiver<int>(broadcastOperatorName);
-            IReduceSender<int> triangleNumberSender1 = commGroups[1].GetReduceSender<int>(reduceOperatorName);
-
-            IBroadcastReceiver<int> broadcastReceiver2 = commGroups[2].GetBroadcastReceiver<int>(broadcastOperatorName);
-            IReduceSender<int> triangleNumberSender2 = commGroups[2].GetReduceSender<int>(reduceOperatorName);
-
-            IBroadcastReceiver<int> broadcastReceiver3 = commGroups[3].GetBroadcastReceiver<int>(broadcastOperatorName);
-            IReduceSender<int> triangleNumberSender3 = commGroups[3].GetReduceSender<int>(reduceOperatorName);
-
-            IBroadcastReceiver<int> broadcastReceiver4 = commGroups[4].GetBroadcastReceiver<int>(broadcastOperatorName);
-            IReduceSender<int> triangleNumberSender4 = commGroups[4].GetReduceSender<int>(reduceOperatorName);
-
-            IBroadcastReceiver<int> broadcastReceiver5 = commGroups[5].GetBroadcastReceiver<int>(broadcastOperatorName);
-            IReduceSender<int> triangleNumberSender5 = commGroups[5].GetReduceSender<int>(reduceOperatorName);
-
-            IBroadcastReceiver<int> broadcastReceiver6 = commGroups[6].GetBroadcastReceiver<int>(broadcastOperatorName);
-            IReduceSender<int> triangleNumberSender6 = commGroups[6].GetReduceSender<int>(reduceOperatorName);
-
-            IBroadcastReceiver<int> broadcastReceiver7 = commGroups[7].GetBroadcastReceiver<int>(broadcastOperatorName);
-            IReduceSender<int> triangleNumberSender7 = commGroups[7].GetReduceSender<int>(reduceOperatorName);
-
-            IBroadcastReceiver<int> broadcastReceiver8 = commGroups[8].GetBroadcastReceiver<int>(broadcastOperatorName);
-            IReduceSender<int> triangleNumberSender8 = commGroups[8].GetReduceSender<int>(reduceOperatorName);
-
-            IBroadcastReceiver<int> broadcastReceiver9 = commGroups[9].GetBroadcastReceiver<int>(broadcastOperatorName);
-            IReduceSender<int> triangleNumberSender9 = commGroups[9].GetReduceSender<int>(reduceOperatorName);
-
-            for (int i = 1; i <= 10; i++)
-            {
-                broadcastSender.Send(i);
-
-                int n1 = broadcastReceiver1.Receive();
-                int n2 = broadcastReceiver2.Receive();
-                int n3 = broadcastReceiver3.Receive();
-                int n4 = broadcastReceiver4.Receive();
-                int n5 = broadcastReceiver5.Receive();
-                int n6 = broadcastReceiver6.Receive();
-                int n7 = broadcastReceiver7.Receive();
-                int n8 = broadcastReceiver8.Receive();
-                int n9 = broadcastReceiver9.Receive();
-                Assert.AreEqual(i, n1);
-                Assert.AreEqual(i, n2);
-                Assert.AreEqual(i, n3);
-                Assert.AreEqual(i, n4);
-                Assert.AreEqual(i, n5);
-                Assert.AreEqual(i, n6);
-                Assert.AreEqual(i, n7);
-                Assert.AreEqual(i, n8);
-                Assert.AreEqual(i, n9);
-
-                int triangleNum9 = TriangleNumber(n9);
-                triangleNumberSender9.Send(triangleNum9);
-
-                int triangleNum8 = TriangleNumber(n8);
-                triangleNumberSender8.Send(triangleNum8);
-
-                int triangleNum7 = TriangleNumber(n7);
-                triangleNumberSender7.Send(triangleNum7);
-
-                int triangleNum6 = TriangleNumber(n6);
-                triangleNumberSender6.Send(triangleNum6);
-
-                int triangleNum5 = TriangleNumber(n5);
-                triangleNumberSender5.Send(triangleNum5);
-
-                int triangleNum4 = TriangleNumber(n4);
-                triangleNumberSender4.Send(triangleNum4);
-
-                int triangleNum3 = TriangleNumber(n3);
-                triangleNumberSender3.Send(triangleNum3);
-
-                int triangleNum2 = TriangleNumber(n2);
-                triangleNumberSender2.Send(triangleNum2);
-
-                int triangleNum1 = TriangleNumber(n1);
-                triangleNumberSender1.Send(triangleNum1);
-
-                int sum = sumReducer.Reduce();
-                int expected = TriangleNumber(i) * (numTasks - 1);
+                int expected = TriangleNumber(j) * (numTasks - 1);
                 Assert.AreEqual(sum, expected);
             }
         }
@@ -562,110 +418,6 @@ namespace Org.Apache.REEF.Tests.Network
         }
 
         [TestMethod]
-        public void TestBroadcastOperatorForTree()
-        {
-            string groupName = "group1";
-            string operatorName = "broadcast";
-            string driverId = "driverId";
-            string masterTaskId = "task0";
-            int numTasks = 10;
-            int value1 = 1337;
-            int value2 = 42;
-            int value3 = 99;
-            int fanOut = 3;
-
-            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, fanOut, new AvroConfigurationSerializer());
-
-            var commGroup = mpiDriver.NewCommunicationGroup(groupName, numTasks)
-                .AddBroadcast(operatorName, new BroadcastOperatorSpec<int>(masterTaskId, new IntCodec()))
-                .Build();
-
-            List<IConfiguration> partialConfigs = new List<IConfiguration>();
-            for (int i = 0; i < numTasks; i++)
-            {
-                string taskId = "task" + i;
-                IConfiguration partialTaskConfig = TangFactory.GetTang().NewConfigurationBuilder(
-                    TaskConfiguration.ConfigurationModule
-                        .Set(TaskConfiguration.Identifier, taskId)
-                        .Set(TaskConfiguration.Task, GenericType<MyTask>.Class)
-                        .Build())
-                    .Build();
-
-                commGroup.AddTask(taskId);
-                partialConfigs.Add(partialTaskConfig);
-            }
-
-            IConfiguration serviceConfig = mpiDriver.GetServiceConfiguration();
-
-            IList<ICommunicationGroupClient> commGroups = new List<ICommunicationGroupClient>();
-            for (int i = 0; i < numTasks; i++)
-            {
-                string taskId = "task" + i;
-                IConfiguration mpiTaskConfig = mpiDriver.GetMpiTaskConfiguration(taskId);
-                IConfiguration mergedConf = Configurations.Merge(mpiTaskConfig, partialConfigs[i], serviceConfig);
-                IInjector injector = TangFactory.GetTang().NewInjector(mergedConf);
-
-                IMpiClient mpiClient = injector.GetInstance<IMpiClient>();
-                commGroups.Add(mpiClient.GetCommunicationGroup(groupName));
-            }
-
-            IBroadcastSender<int> sender = commGroups[0].GetBroadcastSender<int>(operatorName);
-            IBroadcastReceiver<int> receiver1 = commGroups[1].GetBroadcastReceiver<int>(operatorName);
-            IBroadcastReceiver<int> receiver2 = commGroups[2].GetBroadcastReceiver<int>(operatorName);
-            IBroadcastReceiver<int> receiver3 = commGroups[3].GetBroadcastReceiver<int>(operatorName);
-            IBroadcastReceiver<int> receiver4 = commGroups[4].GetBroadcastReceiver<int>(operatorName);
-            IBroadcastReceiver<int> receiver5 = commGroups[5].GetBroadcastReceiver<int>(operatorName);
-            IBroadcastReceiver<int> receiver6 = commGroups[6].GetBroadcastReceiver<int>(operatorName);
-            IBroadcastReceiver<int> receiver7 = commGroups[7].GetBroadcastReceiver<int>(operatorName);
-            IBroadcastReceiver<int> receiver8 = commGroups[8].GetBroadcastReceiver<int>(operatorName);
-            IBroadcastReceiver<int> receiver9 = commGroups[9].GetBroadcastReceiver<int>(operatorName);
-
-            Assert.IsNotNull(sender);
-            Assert.IsNotNull(receiver1);
-            Assert.IsNotNull(receiver2);
-            Assert.IsNotNull(receiver3);
-            Assert.IsNotNull(receiver4);
-            Assert.IsNotNull(receiver5);
-            Assert.IsNotNull(receiver6);
-            Assert.IsNotNull(receiver7);
-            Assert.IsNotNull(receiver8);
-            Assert.IsNotNull(receiver9);
-
-            sender.Send(value1);
-            Assert.AreEqual(value1, receiver1.Receive());
-            Assert.AreEqual(value1, receiver2.Receive());
-            Assert.AreEqual(value1, receiver3.Receive());
-            Assert.AreEqual(value1, receiver4.Receive());
-            Assert.AreEqual(value1, receiver5.Receive());
-            Assert.AreEqual(value1, receiver6.Receive());
-            Assert.AreEqual(value1, receiver7.Receive());
-            Assert.AreEqual(value1, receiver8.Receive());
-            Assert.AreEqual(value1, receiver9.Receive());
-
-            sender.Send(value2);
-            Assert.AreEqual(value2, receiver1.Receive());
-            Assert.AreEqual(value2, receiver2.Receive());
-            Assert.AreEqual(value2, receiver3.Receive());
-            Assert.AreEqual(value2, receiver4.Receive());
-            Assert.AreEqual(value2, receiver5.Receive());
-            Assert.AreEqual(value2, receiver6.Receive());
-            Assert.AreEqual(value2, receiver7.Receive());
-            Assert.AreEqual(value2, receiver8.Receive());
-            Assert.AreEqual(value2, receiver9.Receive());
-
-            sender.Send(value3);
-            Assert.AreEqual(value3, receiver1.Receive());
-            Assert.AreEqual(value3, receiver2.Receive());
-            Assert.AreEqual(value3, receiver3.Receive());
-            Assert.AreEqual(value3, receiver4.Receive());
-            Assert.AreEqual(value3, receiver5.Receive());
-            Assert.AreEqual(value3, receiver6.Receive());
-            Assert.AreEqual(value3, receiver7.Receive());
-            Assert.AreEqual(value3, receiver8.Receive());
-            Assert.AreEqual(value3, receiver9.Receive());
-        }
-
-        [TestMethod]
         public void TestReduceOperator()
         {
             string groupName = "group1";
@@ -721,83 +473,6 @@ namespace Org.Apache.REEF.Tests.Network
 
             Assert.AreEqual(9, receiver.Reduce());
         }
-
-        [TestMethod]
-        public void TestReduceOperatorForTree()
-        {
-            string groupName = "group1";
-            string operatorName = "reduce";
-            int numTasks = 10;
-            int fanOut = 3;
-            IMpiDriver mpiDriver = new MpiDriver("driverid", "task0", fanOut, new AvroConfigurationSerializer());
-
-            var commGroup = mpiDriver.NewCommunicationGroup(groupName, numTasks)
-                .AddReduce(operatorName, new ReduceOperatorSpec<int>("task0", new IntCodec(), new SumFunction()))
-                .Build();
-
-            List<IConfiguration> partialConfigs = new List<IConfiguration>();
-            for (int i = 0; i < numTasks; i++)
-            {
-                string taskId = "task" + i;
-                IConfiguration partialTaskConfig = TangFactory.GetTang().NewConfigurationBuilder(
-                    TaskConfiguration.ConfigurationModule
-                        .Set(TaskConfiguration.Identifier, taskId)
-                        .Set(TaskConfiguration.Task, GenericType<MyTask>.Class)
-                        .Build())
-                    .Build();
-                commGroup.AddTask(taskId);
-                partialConfigs.Add(partialTaskConfig);
-            }
-
-            IConfiguration serviceConfig = mpiDriver.GetServiceConfiguration();
-            IList<ICommunicationGroupClient> commGroups = new List<ICommunicationGroupClient>();
-
-            for (int i = 0; i < numTasks; i++)
-            {
-                string taskId = "task" + i;
-                IConfiguration taskConfig = mpiDriver.GetMpiTaskConfiguration(taskId);
-                IConfiguration mergedConf = Configurations.Merge(taskConfig, partialConfigs[i], serviceConfig);
-                IInjector injector = TangFactory.GetTang().NewInjector(mergedConf);
-
-                IMpiClient mpiClient = injector.GetInstance<IMpiClient>();
-                commGroups.Add(mpiClient.GetCommunicationGroup(groupName));
-            }
-
-            IReduceReceiver<int> receiver = commGroups[0].GetReduceReceiver<int>(operatorName);
-            IReduceSender<int> sender1 = commGroups[1].GetReduceSender<int>(operatorName);
-            IReduceSender<int> sender2 = commGroups[2].GetReduceSender<int>(operatorName);
-            IReduceSender<int> sender3 = commGroups[3].GetReduceSender<int>(operatorName);
-            IReduceSender<int> sender4 = commGroups[4].GetReduceSender<int>(operatorName);
-            IReduceSender<int> sender5 = commGroups[5].GetReduceSender<int>(operatorName);
-            IReduceSender<int> sender6 = commGroups[6].GetReduceSender<int>(operatorName);
-            IReduceSender<int> sender7 = commGroups[7].GetReduceSender<int>(operatorName);
-            IReduceSender<int> sender8 = commGroups[8].GetReduceSender<int>(operatorName);
-            IReduceSender<int> sender9 = commGroups[9].GetReduceSender<int>(operatorName);
-
-            Assert.IsNotNull(receiver);
-            Assert.IsNotNull(sender1);
-            Assert.IsNotNull(sender2);
-            Assert.IsNotNull(sender3);
-            Assert.IsNotNull(sender4);
-            Assert.IsNotNull(sender5);
-            Assert.IsNotNull(sender6);
-            Assert.IsNotNull(sender7);
-            Assert.IsNotNull(sender8);
-            Assert.IsNotNull(sender9);
-
-            sender9.Send(9);
-            sender8.Send(8);
-            sender7.Send(7);
-            sender6.Send(6);
-            sender5.Send(5);
-            sender4.Send(4);
-            sender3.Send(3);
-            sender2.Send(2);
-            sender1.Send(1);
-
-            Assert.AreEqual(45, receiver.Reduce());
-        }
-
 
         [TestMethod]
         public void TestReduceOperator2()
@@ -1175,23 +850,6 @@ namespace Org.Apache.REEF.Tests.Network
 
             ICodec<int> codec = TangFactory.GetTang().NewInjector(conf).GetInstance<ICodec<int>>();
             Assert.AreEqual(3, codec.Decode(codec.Encode(3)));
-        }
-
-        [TestMethod]
-        public void TestTreeTopology()
-        {
-            TreeTopology<int> topology = new TreeTopology<int>("Operator", "Operator", "task1", "driverid",
-                new BroadcastOperatorSpec<int>("task1", new IntCodec()), 2);
-            for (int i = 1; i < 8; i++)
-            {
-                string taskid = "task" + i;
-                topology.AddTask(taskid);
-            }
-
-            for (int i = 1; i < 8; i++)
-            {
-                var conf = topology.GetTaskConfiguration("task" + i);
-            }
         }
 
         [TestMethod]

--- a/lang/cs/Org.Apache.REEF.Tests/Network/GroupCommunicationTests.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Network/GroupCommunicationTests.cs
@@ -98,7 +98,6 @@ namespace Org.Apache.REEF.Tests.Network
             string masterTaskId = "task0";
             string driverId = "Driver Id";
             int numTasks = 3;
-            int value = 1;
             int fanOut = 2;
 
             IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, fanOut, new AvroConfigurationSerializer());
@@ -186,7 +185,6 @@ namespace Org.Apache.REEF.Tests.Network
             string masterTaskId = "task0";
             string driverId = "Driver Id";
             int numTasks = 10;
-            int value = 1;
             int fanOut = 3;
 
             IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, fanOut, new AvroConfigurationSerializer());
@@ -331,7 +329,6 @@ namespace Org.Apache.REEF.Tests.Network
             string masterTaskId = "task0";
             string driverId = "Driver Id";
             int numTasks = 5;
-            int value = 1;
             int fanOut = 2;
 
             IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, fanOut, new AvroConfigurationSerializer());

--- a/lang/cs/Org.Apache.REEF.Tests/Network/GroupCommunicationTests.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Network/GroupCommunicationTests.cs
@@ -99,8 +99,9 @@ namespace Org.Apache.REEF.Tests.Network
             string driverId = "Driver Id";
             int numTasks = 3;
             int value = 1;
+            int fanOut = 2;
 
-            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, new AvroConfigurationSerializer());
+            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, fanOut, new AvroConfigurationSerializer());
 
             ICommunicationGroupDriver commGroup = mpiDriver.NewCommunicationGroup(
                 groupName,
@@ -177,6 +178,151 @@ namespace Org.Apache.REEF.Tests.Network
         }
 
         [TestMethod]
+        public void TestBroadcastReduceOperatorsForTree()
+        {
+            string groupName = "group1";
+            string broadcastOperatorName = "broadcast";
+            string reduceOperatorName = "reduce";
+            string masterTaskId = "task0";
+            string driverId = "Driver Id";
+            int numTasks = 10;
+            int value = 1;
+            int fanOut = 3;
+
+            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, fanOut, new AvroConfigurationSerializer());
+
+            ICommunicationGroupDriver commGroup = mpiDriver.NewCommunicationGroup(
+                groupName,
+                numTasks)
+                .AddBroadcast(
+                    broadcastOperatorName,
+                    new BroadcastOperatorSpec<int>(
+                    masterTaskId,
+                    new IntCodec()))
+                .AddReduce(
+                    reduceOperatorName,
+                    new ReduceOperatorSpec<int>(
+                    masterTaskId,
+                    new IntCodec(),
+                    new SumFunction()))
+                .Build();
+
+            List<ICommunicationGroupClient> commGroups = new List<ICommunicationGroupClient>();
+            IConfiguration serviceConfig = mpiDriver.GetServiceConfiguration();
+
+            List<IConfiguration> partialConfigs = new List<IConfiguration>();
+            for (int i = 0; i < numTasks; i++)
+            {
+                string taskId = "task" + i;
+                IConfiguration partialTaskConfig = TangFactory.GetTang().NewConfigurationBuilder(
+                    TaskConfiguration.ConfigurationModule
+                        .Set(TaskConfiguration.Identifier, taskId)
+                        .Set(TaskConfiguration.Task, GenericType<MyTask>.Class)
+                        .Build())
+                    .Build();
+                commGroup.AddTask(taskId);
+                partialConfigs.Add(partialTaskConfig);
+            }
+
+            for (int i = 0; i < numTasks; i++)
+            {
+                string taskId = "task" + i;
+                IConfiguration mpiTaskConfig = mpiDriver.GetMpiTaskConfiguration(taskId);
+                IConfiguration mergedConf = Configurations.Merge(mpiTaskConfig, partialConfigs[i], serviceConfig);
+                IInjector injector = TangFactory.GetTang().NewInjector(mergedConf);
+
+                IMpiClient mpiClient = injector.GetInstance<IMpiClient>();
+                commGroups.Add(mpiClient.GetCommunicationGroup(groupName));
+            }
+
+            //for master task
+            IBroadcastSender<int> broadcastSender = commGroups[0].GetBroadcastSender<int>(broadcastOperatorName);
+            IReduceReceiver<int> sumReducer = commGroups[0].GetReduceReceiver<int>(reduceOperatorName);
+
+            IBroadcastReceiver<int> broadcastReceiver1 = commGroups[1].GetBroadcastReceiver<int>(broadcastOperatorName);
+            IReduceSender<int> triangleNumberSender1 = commGroups[1].GetReduceSender<int>(reduceOperatorName);
+
+            IBroadcastReceiver<int> broadcastReceiver2 = commGroups[2].GetBroadcastReceiver<int>(broadcastOperatorName);
+            IReduceSender<int> triangleNumberSender2 = commGroups[2].GetReduceSender<int>(reduceOperatorName);
+
+            IBroadcastReceiver<int> broadcastReceiver3 = commGroups[3].GetBroadcastReceiver<int>(broadcastOperatorName);
+            IReduceSender<int> triangleNumberSender3 = commGroups[3].GetReduceSender<int>(reduceOperatorName);
+
+            IBroadcastReceiver<int> broadcastReceiver4 = commGroups[4].GetBroadcastReceiver<int>(broadcastOperatorName);
+            IReduceSender<int> triangleNumberSender4 = commGroups[4].GetReduceSender<int>(reduceOperatorName);
+
+            IBroadcastReceiver<int> broadcastReceiver5 = commGroups[5].GetBroadcastReceiver<int>(broadcastOperatorName);
+            IReduceSender<int> triangleNumberSender5 = commGroups[5].GetReduceSender<int>(reduceOperatorName);
+
+            IBroadcastReceiver<int> broadcastReceiver6 = commGroups[6].GetBroadcastReceiver<int>(broadcastOperatorName);
+            IReduceSender<int> triangleNumberSender6 = commGroups[6].GetReduceSender<int>(reduceOperatorName);
+
+            IBroadcastReceiver<int> broadcastReceiver7 = commGroups[7].GetBroadcastReceiver<int>(broadcastOperatorName);
+            IReduceSender<int> triangleNumberSender7 = commGroups[7].GetReduceSender<int>(reduceOperatorName);
+
+            IBroadcastReceiver<int> broadcastReceiver8 = commGroups[8].GetBroadcastReceiver<int>(broadcastOperatorName);
+            IReduceSender<int> triangleNumberSender8 = commGroups[8].GetReduceSender<int>(reduceOperatorName);
+
+            IBroadcastReceiver<int> broadcastReceiver9 = commGroups[9].GetBroadcastReceiver<int>(broadcastOperatorName);
+            IReduceSender<int> triangleNumberSender9 = commGroups[9].GetReduceSender<int>(reduceOperatorName);
+
+            for (int i = 1; i <= 10; i++)
+            {
+                broadcastSender.Send(i);
+
+                int n1 = broadcastReceiver1.Receive();
+                int n2 = broadcastReceiver2.Receive();
+                int n3 = broadcastReceiver3.Receive();
+                int n4 = broadcastReceiver4.Receive();
+                int n5 = broadcastReceiver5.Receive();
+                int n6 = broadcastReceiver6.Receive();
+                int n7 = broadcastReceiver7.Receive();
+                int n8 = broadcastReceiver8.Receive();
+                int n9 = broadcastReceiver9.Receive();
+                Assert.AreEqual(i, n1);
+                Assert.AreEqual(i, n2);
+                Assert.AreEqual(i, n3);
+                Assert.AreEqual(i, n4);
+                Assert.AreEqual(i, n5);
+                Assert.AreEqual(i, n6);
+                Assert.AreEqual(i, n7);
+                Assert.AreEqual(i, n8);
+                Assert.AreEqual(i, n9);
+
+                int triangleNum9 = TriangleNumber(n9);
+                triangleNumberSender9.Send(triangleNum9);
+
+                int triangleNum8 = TriangleNumber(n8);
+                triangleNumberSender8.Send(triangleNum8);
+
+                int triangleNum7 = TriangleNumber(n7);
+                triangleNumberSender7.Send(triangleNum7);
+
+                int triangleNum6 = TriangleNumber(n6);
+                triangleNumberSender6.Send(triangleNum6);
+
+                int triangleNum5 = TriangleNumber(n5);
+                triangleNumberSender5.Send(triangleNum5);
+
+                int triangleNum4 = TriangleNumber(n4);
+                triangleNumberSender4.Send(triangleNum4);
+
+                int triangleNum3 = TriangleNumber(n3);
+                triangleNumberSender3.Send(triangleNum3);
+
+                int triangleNum2 = TriangleNumber(n2);
+                triangleNumberSender2.Send(triangleNum2);
+
+                int triangleNum1 = TriangleNumber(n1);
+                triangleNumberSender1.Send(triangleNum1);
+
+                int sum = sumReducer.Reduce();
+                int expected = TriangleNumber(i) * (numTasks - 1);
+                Assert.AreEqual(sum, expected);
+            }
+        }
+
+        [TestMethod]
         public void TestScatterReduceOperators()
         {
             string groupName = "group1";
@@ -186,8 +332,9 @@ namespace Org.Apache.REEF.Tests.Network
             string driverId = "Driver Id";
             int numTasks = 5;
             int value = 1;
+            int fanOut = 2;
 
-            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, new AvroConfigurationSerializer());
+            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, fanOut, new AvroConfigurationSerializer());
 
             ICommunicationGroupDriver commGroup = mpiDriver.NewCommunicationGroup(
                 groupName,
@@ -260,10 +407,10 @@ namespace Org.Apache.REEF.Tests.Network
 
             sender.Send(data, order);
 
-            ScatterReceiveReduce(receiver1, sumSender1);
-            ScatterReceiveReduce(receiver2, sumSender2);
-            ScatterReceiveReduce(receiver3, sumSender3);
             ScatterReceiveReduce(receiver4, sumSender4);
+            ScatterReceiveReduce(receiver3, sumSender3);
+            ScatterReceiveReduce(receiver2, sumSender2);
+            ScatterReceiveReduce(receiver1, sumSender1);
 
             int sum = sumReducer.Reduce();
 
@@ -291,10 +438,11 @@ namespace Org.Apache.REEF.Tests.Network
             string operatorName = "broadcast";
             string masterTaskId = "task0";
             string driverId = "Driver Id";
-            int numTasks = 3;
+            int numTasks = 10;
             int value = 1337;
+            int fanOut = 3;
 
-            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, new AvroConfigurationSerializer());
+            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, fanOut, new AvroConfigurationSerializer());
 
             var commGroup = mpiDriver.NewCommunicationGroup(groupName, numTasks)
                 .AddBroadcast(operatorName, new BroadcastOperatorSpec<int>(masterTaskId, new IntCodec()))
@@ -358,8 +506,9 @@ namespace Org.Apache.REEF.Tests.Network
             int value1 = 1337;
             int value2 = 42;
             int value3 = 99;
+            int fanOut = 2;
 
-            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, new AvroConfigurationSerializer());
+            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, fanOut, new AvroConfigurationSerializer());
 
             var commGroup = mpiDriver.NewCommunicationGroup(groupName, numTasks)
                 .AddBroadcast(operatorName, new BroadcastOperatorSpec<int>(masterTaskId, new IntCodec()))
@@ -416,23 +565,120 @@ namespace Org.Apache.REEF.Tests.Network
         }
 
         [TestMethod]
+        public void TestBroadcastOperatorForTree()
+        {
+            string groupName = "group1";
+            string operatorName = "broadcast";
+            string driverId = "driverId";
+            string masterTaskId = "task0";
+            int numTasks = 10;
+            int value1 = 1337;
+            int value2 = 42;
+            int value3 = 99;
+            int fanOut = 3;
+
+            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, fanOut, new AvroConfigurationSerializer());
+
+            var commGroup = mpiDriver.NewCommunicationGroup(groupName, numTasks)
+                .AddBroadcast(operatorName, new BroadcastOperatorSpec<int>(masterTaskId, new IntCodec()))
+                .Build();
+
+            List<IConfiguration> partialConfigs = new List<IConfiguration>();
+            for (int i = 0; i < numTasks; i++)
+            {
+                string taskId = "task" + i;
+                IConfiguration partialTaskConfig = TangFactory.GetTang().NewConfigurationBuilder(
+                    TaskConfiguration.ConfigurationModule
+                        .Set(TaskConfiguration.Identifier, taskId)
+                        .Set(TaskConfiguration.Task, GenericType<MyTask>.Class)
+                        .Build())
+                    .Build();
+
+                commGroup.AddTask(taskId);
+                partialConfigs.Add(partialTaskConfig);
+            }
+
+            IConfiguration serviceConfig = mpiDriver.GetServiceConfiguration();
+
+            IList<ICommunicationGroupClient> commGroups = new List<ICommunicationGroupClient>();
+            for (int i = 0; i < numTasks; i++)
+            {
+                string taskId = "task" + i;
+                IConfiguration mpiTaskConfig = mpiDriver.GetMpiTaskConfiguration(taskId);
+                IConfiguration mergedConf = Configurations.Merge(mpiTaskConfig, partialConfigs[i], serviceConfig);
+                IInjector injector = TangFactory.GetTang().NewInjector(mergedConf);
+
+                IMpiClient mpiClient = injector.GetInstance<IMpiClient>();
+                commGroups.Add(mpiClient.GetCommunicationGroup(groupName));
+            }
+
+            IBroadcastSender<int> sender = commGroups[0].GetBroadcastSender<int>(operatorName);
+            IBroadcastReceiver<int> receiver1 = commGroups[1].GetBroadcastReceiver<int>(operatorName);
+            IBroadcastReceiver<int> receiver2 = commGroups[2].GetBroadcastReceiver<int>(operatorName);
+            IBroadcastReceiver<int> receiver3 = commGroups[3].GetBroadcastReceiver<int>(operatorName);
+            IBroadcastReceiver<int> receiver4 = commGroups[4].GetBroadcastReceiver<int>(operatorName);
+            IBroadcastReceiver<int> receiver5 = commGroups[5].GetBroadcastReceiver<int>(operatorName);
+            IBroadcastReceiver<int> receiver6 = commGroups[6].GetBroadcastReceiver<int>(operatorName);
+            IBroadcastReceiver<int> receiver7 = commGroups[7].GetBroadcastReceiver<int>(operatorName);
+            IBroadcastReceiver<int> receiver8 = commGroups[8].GetBroadcastReceiver<int>(operatorName);
+            IBroadcastReceiver<int> receiver9 = commGroups[9].GetBroadcastReceiver<int>(operatorName);
+
+            Assert.IsNotNull(sender);
+            Assert.IsNotNull(receiver1);
+            Assert.IsNotNull(receiver2);
+            Assert.IsNotNull(receiver3);
+            Assert.IsNotNull(receiver4);
+            Assert.IsNotNull(receiver5);
+            Assert.IsNotNull(receiver6);
+            Assert.IsNotNull(receiver7);
+            Assert.IsNotNull(receiver8);
+            Assert.IsNotNull(receiver9);
+
+            sender.Send(value1);
+            Assert.AreEqual(value1, receiver1.Receive());
+            Assert.AreEqual(value1, receiver2.Receive());
+            Assert.AreEqual(value1, receiver3.Receive());
+            Assert.AreEqual(value1, receiver4.Receive());
+            Assert.AreEqual(value1, receiver5.Receive());
+            Assert.AreEqual(value1, receiver6.Receive());
+            Assert.AreEqual(value1, receiver7.Receive());
+            Assert.AreEqual(value1, receiver8.Receive());
+            Assert.AreEqual(value1, receiver9.Receive());
+
+            sender.Send(value2);
+            Assert.AreEqual(value2, receiver1.Receive());
+            Assert.AreEqual(value2, receiver2.Receive());
+            Assert.AreEqual(value2, receiver3.Receive());
+            Assert.AreEqual(value2, receiver4.Receive());
+            Assert.AreEqual(value2, receiver5.Receive());
+            Assert.AreEqual(value2, receiver6.Receive());
+            Assert.AreEqual(value2, receiver7.Receive());
+            Assert.AreEqual(value2, receiver8.Receive());
+            Assert.AreEqual(value2, receiver9.Receive());
+
+            sender.Send(value3);
+            Assert.AreEqual(value3, receiver1.Receive());
+            Assert.AreEqual(value3, receiver2.Receive());
+            Assert.AreEqual(value3, receiver3.Receive());
+            Assert.AreEqual(value3, receiver4.Receive());
+            Assert.AreEqual(value3, receiver5.Receive());
+            Assert.AreEqual(value3, receiver6.Receive());
+            Assert.AreEqual(value3, receiver7.Receive());
+            Assert.AreEqual(value3, receiver8.Receive());
+            Assert.AreEqual(value3, receiver9.Receive());
+        }
+
+        [TestMethod]
         public void TestReduceOperator()
         {
-            //NameServer nameServer = new NameServer(0);
-
             string groupName = "group1";
             string operatorName = "reduce";
             int numTasks = 4;
-            IMpiDriver mpiDriver = new MpiDriver("driverid", "task0", new AvroConfigurationSerializer());
+            IMpiDriver mpiDriver = new MpiDriver("driverid", "task0", 2, new AvroConfigurationSerializer());
 
             var commGroup = mpiDriver.NewCommunicationGroup(groupName, numTasks)
                 .AddReduce(operatorName, new ReduceOperatorSpec<int>("task0", new IntCodec(), new SumFunction()))
                 .Build();
-
-            //for (int i = 0; i < numTasks; i++)
-            //{
-            //    nameServer.Register("task" + i, new IPEndPoint(IPAddress.Parse("127.0.0.1"), 21));
-            //}
 
             List<IConfiguration> partialConfigs = new List<IConfiguration>();
             for (int i = 0; i < numTasks; i++)
@@ -472,12 +718,89 @@ namespace Org.Apache.REEF.Tests.Network
             Assert.IsNotNull(sender2);
             Assert.IsNotNull(sender3);
 
+            sender3.Send(5);
             sender1.Send(1);
             sender2.Send(3);
-            sender3.Send(5);
 
             Assert.AreEqual(9, receiver.Reduce());
         }
+
+        [TestMethod]
+        public void TestReduceOperatorForTree()
+        {
+            string groupName = "group1";
+            string operatorName = "reduce";
+            int numTasks = 10;
+            int fanOut = 3;
+            IMpiDriver mpiDriver = new MpiDriver("driverid", "task0", fanOut, new AvroConfigurationSerializer());
+
+            var commGroup = mpiDriver.NewCommunicationGroup(groupName, numTasks)
+                .AddReduce(operatorName, new ReduceOperatorSpec<int>("task0", new IntCodec(), new SumFunction()))
+                .Build();
+
+            List<IConfiguration> partialConfigs = new List<IConfiguration>();
+            for (int i = 0; i < numTasks; i++)
+            {
+                string taskId = "task" + i;
+                IConfiguration partialTaskConfig = TangFactory.GetTang().NewConfigurationBuilder(
+                    TaskConfiguration.ConfigurationModule
+                        .Set(TaskConfiguration.Identifier, taskId)
+                        .Set(TaskConfiguration.Task, GenericType<MyTask>.Class)
+                        .Build())
+                    .Build();
+                commGroup.AddTask(taskId);
+                partialConfigs.Add(partialTaskConfig);
+            }
+
+            IConfiguration serviceConfig = mpiDriver.GetServiceConfiguration();
+            IList<ICommunicationGroupClient> commGroups = new List<ICommunicationGroupClient>();
+
+            for (int i = 0; i < numTasks; i++)
+            {
+                string taskId = "task" + i;
+                IConfiguration taskConfig = mpiDriver.GetMpiTaskConfiguration(taskId);
+                IConfiguration mergedConf = Configurations.Merge(taskConfig, partialConfigs[i], serviceConfig);
+                IInjector injector = TangFactory.GetTang().NewInjector(mergedConf);
+
+                IMpiClient mpiClient = injector.GetInstance<IMpiClient>();
+                commGroups.Add(mpiClient.GetCommunicationGroup(groupName));
+            }
+
+            IReduceReceiver<int> receiver = commGroups[0].GetReduceReceiver<int>(operatorName);
+            IReduceSender<int> sender1 = commGroups[1].GetReduceSender<int>(operatorName);
+            IReduceSender<int> sender2 = commGroups[2].GetReduceSender<int>(operatorName);
+            IReduceSender<int> sender3 = commGroups[3].GetReduceSender<int>(operatorName);
+            IReduceSender<int> sender4 = commGroups[4].GetReduceSender<int>(operatorName);
+            IReduceSender<int> sender5 = commGroups[5].GetReduceSender<int>(operatorName);
+            IReduceSender<int> sender6 = commGroups[6].GetReduceSender<int>(operatorName);
+            IReduceSender<int> sender7 = commGroups[7].GetReduceSender<int>(operatorName);
+            IReduceSender<int> sender8 = commGroups[8].GetReduceSender<int>(operatorName);
+            IReduceSender<int> sender9 = commGroups[9].GetReduceSender<int>(operatorName);
+
+            Assert.IsNotNull(receiver);
+            Assert.IsNotNull(sender1);
+            Assert.IsNotNull(sender2);
+            Assert.IsNotNull(sender3);
+            Assert.IsNotNull(sender4);
+            Assert.IsNotNull(sender5);
+            Assert.IsNotNull(sender6);
+            Assert.IsNotNull(sender7);
+            Assert.IsNotNull(sender8);
+            Assert.IsNotNull(sender9);
+
+            sender9.Send(9);
+            sender8.Send(8);
+            sender7.Send(7);
+            sender6.Send(6);
+            sender5.Send(5);
+            sender4.Send(4);
+            sender3.Send(3);
+            sender2.Send(2);
+            sender1.Send(1);
+
+            Assert.AreEqual(45, receiver.Reduce());
+        }
+
 
         [TestMethod]
         public void TestReduceOperator2()
@@ -485,7 +808,7 @@ namespace Org.Apache.REEF.Tests.Network
             string groupName = "group1";
             string operatorName = "reduce";
             int numTasks = 4;
-            IMpiDriver mpiDriver = new MpiDriver("driverid", "task0", new AvroConfigurationSerializer());
+            IMpiDriver mpiDriver = new MpiDriver("driverid", "task0", 2, new AvroConfigurationSerializer());
 
             var commGroup = mpiDriver.NewCommunicationGroup(groupName, numTasks)
                 .AddReduce(operatorName, new ReduceOperatorSpec<int>("task0", new IntCodec(), new SumFunction()))
@@ -529,19 +852,19 @@ namespace Org.Apache.REEF.Tests.Network
             Assert.IsNotNull(sender2);
             Assert.IsNotNull(sender3);
 
+            sender3.Send(5);
             sender1.Send(1);
             sender2.Send(3);
-            sender3.Send(5);
             Assert.AreEqual(9, receiver.Reduce());
 
+            sender3.Send(6);
             sender1.Send(2);
             sender2.Send(4);
-            sender3.Send(6);
             Assert.AreEqual(12, receiver.Reduce());
 
+            sender3.Send(9);
             sender1.Send(3);
             sender2.Send(6);
-            sender3.Send(9);
             Assert.AreEqual(18, receiver.Reduce());
         }
 
@@ -555,8 +878,9 @@ namespace Org.Apache.REEF.Tests.Network
             string masterTaskId = "task0";
             string driverId = "Driver Id";
             int numTasks = 5;
+            int fanOut = 2;
 
-            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, new AvroConfigurationSerializer());
+            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, fanOut, new AvroConfigurationSerializer());
 
             var commGroup = mpiDriver.NewCommunicationGroup(groupName, numTasks)
                 .AddScatter(operatorName, new ScatterOperatorSpec<int>(masterTaskId, new IntCodec()))
@@ -620,24 +944,18 @@ namespace Org.Apache.REEF.Tests.Network
         [TestMethod]
         public void TestScatterOperator2()
         {
-            //NameServer nameServer = new NameServer(0);
-
             string groupName = "group1";
             string operatorName = "scatter";
             string masterTaskId = "task0";
             string driverId = "Driver Id";
             int numTasks = 5;
+            int fanOut = 2;
 
-            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, new AvroConfigurationSerializer());
+            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, fanOut, new AvroConfigurationSerializer());
 
             var commGroup = mpiDriver.NewCommunicationGroup(groupName, numTasks)
                 .AddScatter(operatorName, new ScatterOperatorSpec<int>(masterTaskId, new IntCodec()))
                 .Build();
-
-            //for (int i = 0; i < numTasks; i++)
-            //{
-            //    nameServer.Register("task" + i, new IPEndPoint(IPAddress.Parse("127.0.0.1"), 21));
-            //}
 
             List<IConfiguration> partialConfigs = new List<IConfiguration>();
             for (int i = 0; i < numTasks; i++)
@@ -703,24 +1021,18 @@ namespace Org.Apache.REEF.Tests.Network
         [TestMethod]
         public void TestScatterOperator3()
         {
-            //NameServer nameServer = new NameServer(0);
-
             string groupName = "group1";
             string operatorName = "scatter";
             string masterTaskId = "task0";
             string driverId = "Driver Id";
             int numTasks = 4;
+            int fanOut = 2;
 
-            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, new AvroConfigurationSerializer());
+            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, fanOut, new AvroConfigurationSerializer());
 
             var commGroup = mpiDriver.NewCommunicationGroup(groupName, numTasks)
                 .AddScatter(operatorName, new ScatterOperatorSpec<int>(masterTaskId, new IntCodec()))
                 .Build();
-
-            //for (int i = 0; i < numTasks; i++)
-            //{
-            //    nameServer.Register("task" + i, new IPEndPoint(IPAddress.Parse("127.0.0.1"), 21));
-            //}
 
             List<IConfiguration> partialConfigs = new List<IConfiguration>();
             for (int i = 0; i < numTasks; i++)
@@ -783,24 +1095,18 @@ namespace Org.Apache.REEF.Tests.Network
         [TestMethod]
         public void TestScatterOperator4()
         {
-            //NameServer nameServer = new NameServer(0);
-
             string groupName = "group1";
             string operatorName = "scatter";
             string masterTaskId = "task0";
             string driverId = "Driver Id";
             int numTasks = 4;
+            int fanOut = 2;
 
-            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, new AvroConfigurationSerializer());
+            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, fanOut, new AvroConfigurationSerializer());
 
             var commGroup = mpiDriver.NewCommunicationGroup(groupName, numTasks)
                 .AddScatter(operatorName, new ScatterOperatorSpec<int>(masterTaskId, new IntCodec()))
                 .Build();
-
-            //for (int i = 0; i < numTasks; i++)
-            //{
-            //    nameServer.Register("task" + i, new IPEndPoint(IPAddress.Parse("127.0.0.1"), 21));
-            //}
 
             List<IConfiguration> partialConfigs = new List<IConfiguration>();
             for (int i = 0; i < numTasks; i++)
@@ -872,6 +1178,23 @@ namespace Org.Apache.REEF.Tests.Network
 
             ICodec<int> codec = TangFactory.GetTang().NewInjector(conf).GetInstance<ICodec<int>>();
             Assert.AreEqual(3, codec.Decode(codec.Encode(3)));
+        }
+
+        [TestMethod]
+        public void TestTreeTopology()
+        {
+            TreeTopology<int> topology = new TreeTopology<int>("Operator", "Operator", "task1", "driverid",
+                new BroadcastOperatorSpec<int>("task1", new IntCodec()), 2);
+            for (int i = 1; i < 8; i++)
+            {
+                string taskid = "task" + i;
+                topology.AddTask(taskid);
+            }
+
+            for (int i = 1; i < 8; i++)
+            {
+                var conf = topology.GetTaskConfiguration("task" + i);
+            }
         }
 
         [TestMethod]

--- a/lang/cs/Org.Apache.REEF.Tests/Network/GroupCommunicationTests.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Network/GroupCommunicationTests.cs
@@ -301,11 +301,6 @@ namespace Org.Apache.REEF.Tests.Network
                 .AddBroadcast(operatorName, new BroadcastOperatorSpec<int>(masterTaskId, new IntCodec()))
                 .Build();
 
-            //for (int i = 0; i < numTasks; i++)
-            //{
-            //    nameServer.Register("task" + i, new IPEndPoint(IPAddress.Parse("127.0.0.1"), 21));
-            //}
-
             List<IConfiguration> partialConfigs = new List<IConfiguration>();
             for (int i = 0; i < numTasks; i++)
             {
@@ -543,8 +538,6 @@ namespace Org.Apache.REEF.Tests.Network
         [TestMethod]
         public void TestScatterOperator()
         {
-            //NameServer nameServer = new NameServer(0);
-
             string groupName = "group1";
             string operatorName = "scatter";
             string masterTaskId = "task0";
@@ -557,11 +550,6 @@ namespace Org.Apache.REEF.Tests.Network
             var commGroup = mpiDriver.NewCommunicationGroup(groupName, numTasks)
                 .AddScatter(operatorName, new ScatterOperatorSpec<int>(masterTaskId, new IntCodec()))
                 .Build();
-
-            //for (int i = 0; i < numTasks; i++)
-            //{
-            //    nameServer.Register("task" + i, new IPEndPoint(IPAddress.Parse("127.0.0.1"), 21));
-            //}
 
             List<IConfiguration> partialConfigs = new List<IConfiguration>();
             for (int i = 0; i < numTasks; i++)
@@ -873,7 +861,7 @@ namespace Org.Apache.REEF.Tests.Network
                 handler, new StringIdentifierFactory(), new GroupCommunicationMessageCodec());
         }
 
-        private GroupCommunicationMessage CreateGcm(string message, string from, string to)
+       private GroupCommunicationMessage CreateGcm(string message, string from, string to)
         {
             byte[] data = Encoding.UTF8.GetBytes(message);
             return new GroupCommunicationMessage("g1", "op1", from, to, data, MessageType.Data);

--- a/lang/cs/Org.Apache.REEF.Tests/Network/GroupCommunicationTreeTopologyTests.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Network/GroupCommunicationTreeTopologyTests.cs
@@ -1,0 +1,935 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Org.Apache.REEF.Common.Tasks;
+using Org.Apache.REEF.Network.Group.Driver;
+using Org.Apache.REEF.Network.Group.Driver.Impl;
+using Org.Apache.REEF.Network.Group.Operators;
+using Org.Apache.REEF.Network.Group.Operators.Impl;
+using Org.Apache.REEF.Network.Group.Task;
+using Org.Apache.REEF.Network.Group.Topology;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Tang.Formats;
+using Org.Apache.REEF.Tang.Implementations.Configuration;
+using Org.Apache.REEF.Tang.Implementations.Tang;
+using Org.Apache.REEF.Tang.Interface;
+using Org.Apache.REEF.Tang.Util;
+using Org.Apache.REEF.Wake.Remote.Impl;
+
+namespace Org.Apache.REEF.Tests.Network
+{
+    [TestClass]
+    public class GroupCommunicationTreeTopologyTests
+    {
+        [TestMethod]
+        public void TestTreeTopology()
+        {
+            TreeTopology<int> topology = new TreeTopology<int>("Operator", "Operator", "task1", "driverid",
+                new BroadcastOperatorSpec<int>("task1", new IntCodec()), 2);
+            for (int i = 1; i < 8; i++)
+            {
+                string taskid = "task" + i;
+                topology.AddTask(taskid);
+            }
+
+            for (int i = 1; i < 8; i++)
+            {
+                var conf = topology.GetTaskConfiguration("task" + i);
+            }
+        }
+
+        [TestMethod]
+        public void TestReduceOperator()
+        {
+            string groupName = "group1";
+            string operatorName = "reduce";
+            int numTasks = 10;
+            int fanOut = 3;
+            IMpiDriver mpiDriver = new MpiDriver("driverid", "task0", fanOut, new AvroConfigurationSerializer());
+
+            var commGroup = mpiDriver.NewCommunicationGroup(groupName, numTasks)
+                .AddReduce(operatorName, new ReduceOperatorSpec<int>("task0", new IntCodec(), new SumFunction()), TopologyTypes.Tree)
+                .Build();
+
+            List<IConfiguration> partialConfigs = new List<IConfiguration>();
+            for (int i = 0; i < numTasks; i++)
+            {
+                string taskId = "task" + i;
+                IConfiguration partialTaskConfig = TangFactory.GetTang().NewConfigurationBuilder(
+                    TaskConfiguration.ConfigurationModule
+                        .Set(TaskConfiguration.Identifier, taskId)
+                        .Set(TaskConfiguration.Task, GenericType<MyTask>.Class)
+                        .Build())
+                    .Build();
+                commGroup.AddTask(taskId);
+                partialConfigs.Add(partialTaskConfig);
+            }
+
+            IConfiguration serviceConfig = mpiDriver.GetServiceConfiguration();
+            IList<ICommunicationGroupClient> commGroups = new List<ICommunicationGroupClient>();
+
+            for (int i = 0; i < numTasks; i++)
+            {
+                string taskId = "task" + i;
+                IConfiguration taskConfig = mpiDriver.GetMpiTaskConfiguration(taskId);
+                IConfiguration mergedConf = Configurations.Merge(taskConfig, partialConfigs[i], serviceConfig);
+                IInjector injector = TangFactory.GetTang().NewInjector(mergedConf);
+
+                IMpiClient mpiClient = injector.GetInstance<IMpiClient>();
+                commGroups.Add(mpiClient.GetCommunicationGroup(groupName));
+            }
+
+            IReduceReceiver<int> receiver = commGroups[0].GetReduceReceiver<int>(operatorName);
+            IReduceSender<int> sender1 = commGroups[1].GetReduceSender<int>(operatorName);
+            IReduceSender<int> sender2 = commGroups[2].GetReduceSender<int>(operatorName);
+            IReduceSender<int> sender3 = commGroups[3].GetReduceSender<int>(operatorName);
+            IReduceSender<int> sender4 = commGroups[4].GetReduceSender<int>(operatorName);
+            IReduceSender<int> sender5 = commGroups[5].GetReduceSender<int>(operatorName);
+            IReduceSender<int> sender6 = commGroups[6].GetReduceSender<int>(operatorName);
+            IReduceSender<int> sender7 = commGroups[7].GetReduceSender<int>(operatorName);
+            IReduceSender<int> sender8 = commGroups[8].GetReduceSender<int>(operatorName);
+            IReduceSender<int> sender9 = commGroups[9].GetReduceSender<int>(operatorName);
+
+            Assert.IsNotNull(receiver);
+            Assert.IsNotNull(sender1);
+            Assert.IsNotNull(sender2);
+            Assert.IsNotNull(sender3);
+            Assert.IsNotNull(sender4);
+            Assert.IsNotNull(sender5);
+            Assert.IsNotNull(sender6);
+            Assert.IsNotNull(sender7);
+            Assert.IsNotNull(sender8);
+            Assert.IsNotNull(sender9);
+
+            sender9.Send(9);
+            sender8.Send(8);
+            sender7.Send(7);
+            sender6.Send(6);
+            sender5.Send(5);
+            sender4.Send(4);
+            sender3.Send(3);
+            sender2.Send(2);
+            sender1.Send(1);
+
+            Assert.AreEqual(45, receiver.Reduce());
+        }
+
+        [TestMethod]
+        public void TestBroadcastOperator()
+        {
+            string groupName = "group1";
+            string operatorName = "broadcast";
+            string driverId = "driverId";
+            string masterTaskId = "task0";
+            int numTasks = 10;
+            int value1 = 1337;
+            int value2 = 42;
+            int value3 = 99;
+            int fanOut = 3;
+
+            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, fanOut, new AvroConfigurationSerializer());
+
+            var commGroup = mpiDriver.NewCommunicationGroup(groupName, numTasks)
+                .AddBroadcast(operatorName, new BroadcastOperatorSpec<int>(masterTaskId, new IntCodec()), TopologyTypes.Tree)
+                .Build();
+
+            List<IConfiguration> partialConfigs = new List<IConfiguration>();
+            for (int i = 0; i < numTasks; i++)
+            {
+                string taskId = "task" + i;
+                IConfiguration partialTaskConfig = TangFactory.GetTang().NewConfigurationBuilder(
+                    TaskConfiguration.ConfigurationModule
+                        .Set(TaskConfiguration.Identifier, taskId)
+                        .Set(TaskConfiguration.Task, GenericType<GroupCommunicationTreeTopologyTests.MyTask>.Class)
+                        .Build())
+                    .Build();
+
+                commGroup.AddTask(taskId);
+                partialConfigs.Add(partialTaskConfig);
+            }
+
+            IConfiguration serviceConfig = mpiDriver.GetServiceConfiguration();
+
+            IList<ICommunicationGroupClient> commGroups = new List<ICommunicationGroupClient>();
+            for (int i = 0; i < numTasks; i++)
+            {
+                string taskId = "task" + i;
+                IConfiguration mpiTaskConfig = mpiDriver.GetMpiTaskConfiguration(taskId);
+                IConfiguration mergedConf = Configurations.Merge(mpiTaskConfig, partialConfigs[i], serviceConfig);
+                IInjector injector = TangFactory.GetTang().NewInjector(mergedConf);
+
+                IMpiClient mpiClient = injector.GetInstance<IMpiClient>();
+                commGroups.Add(mpiClient.GetCommunicationGroup(groupName));
+            }
+
+            IBroadcastSender<int> sender = commGroups[0].GetBroadcastSender<int>(operatorName);
+            IBroadcastReceiver<int> receiver1 = commGroups[1].GetBroadcastReceiver<int>(operatorName);
+            IBroadcastReceiver<int> receiver2 = commGroups[2].GetBroadcastReceiver<int>(operatorName);
+            IBroadcastReceiver<int> receiver3 = commGroups[3].GetBroadcastReceiver<int>(operatorName);
+            IBroadcastReceiver<int> receiver4 = commGroups[4].GetBroadcastReceiver<int>(operatorName);
+            IBroadcastReceiver<int> receiver5 = commGroups[5].GetBroadcastReceiver<int>(operatorName);
+            IBroadcastReceiver<int> receiver6 = commGroups[6].GetBroadcastReceiver<int>(operatorName);
+            IBroadcastReceiver<int> receiver7 = commGroups[7].GetBroadcastReceiver<int>(operatorName);
+            IBroadcastReceiver<int> receiver8 = commGroups[8].GetBroadcastReceiver<int>(operatorName);
+            IBroadcastReceiver<int> receiver9 = commGroups[9].GetBroadcastReceiver<int>(operatorName);
+
+            Assert.IsNotNull(sender);
+            Assert.IsNotNull(receiver1);
+            Assert.IsNotNull(receiver2);
+            Assert.IsNotNull(receiver3);
+            Assert.IsNotNull(receiver4);
+            Assert.IsNotNull(receiver5);
+            Assert.IsNotNull(receiver6);
+            Assert.IsNotNull(receiver7);
+            Assert.IsNotNull(receiver8);
+            Assert.IsNotNull(receiver9);
+
+            sender.Send(value1);
+            Assert.AreEqual(value1, receiver1.Receive());
+            Assert.AreEqual(value1, receiver2.Receive());
+            Assert.AreEqual(value1, receiver3.Receive());
+            Assert.AreEqual(value1, receiver4.Receive());
+            Assert.AreEqual(value1, receiver5.Receive());
+            Assert.AreEqual(value1, receiver6.Receive());
+            Assert.AreEqual(value1, receiver7.Receive());
+            Assert.AreEqual(value1, receiver8.Receive());
+            Assert.AreEqual(value1, receiver9.Receive());
+
+            sender.Send(value2);
+            Assert.AreEqual(value2, receiver1.Receive());
+            Assert.AreEqual(value2, receiver2.Receive());
+            Assert.AreEqual(value2, receiver3.Receive());
+            Assert.AreEqual(value2, receiver4.Receive());
+            Assert.AreEqual(value2, receiver5.Receive());
+            Assert.AreEqual(value2, receiver6.Receive());
+            Assert.AreEqual(value2, receiver7.Receive());
+            Assert.AreEqual(value2, receiver8.Receive());
+            Assert.AreEqual(value2, receiver9.Receive());
+
+            sender.Send(value3);
+            Assert.AreEqual(value3, receiver1.Receive());
+            Assert.AreEqual(value3, receiver2.Receive());
+            Assert.AreEqual(value3, receiver3.Receive());
+            Assert.AreEqual(value3, receiver4.Receive());
+            Assert.AreEqual(value3, receiver5.Receive());
+            Assert.AreEqual(value3, receiver6.Receive());
+            Assert.AreEqual(value3, receiver7.Receive());
+            Assert.AreEqual(value3, receiver8.Receive());
+            Assert.AreEqual(value3, receiver9.Receive());
+        }
+
+
+        [TestMethod]
+        public void TestBroadcastReduceOperators()
+        {
+            string groupName = "group1";
+            string broadcastOperatorName = "broadcast";
+            string reduceOperatorName = "reduce";
+            string masterTaskId = "task0";
+            string driverId = "Driver Id";
+            int numTasks = 10;
+            int fanOut = 3;
+
+            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, fanOut, new AvroConfigurationSerializer());
+
+            ICommunicationGroupDriver commGroup = mpiDriver.NewCommunicationGroup(
+                groupName,
+                numTasks)
+                .AddBroadcast(
+                    broadcastOperatorName,
+                    new BroadcastOperatorSpec<int>(
+                    masterTaskId,
+                    new IntCodec()), 
+                    TopologyTypes.Tree)
+                .AddReduce(
+                    reduceOperatorName,
+                    new ReduceOperatorSpec<int>(
+                    masterTaskId,
+                    new IntCodec(),
+                    new SumFunction()),
+                    TopologyTypes.Tree)
+                .Build();
+
+            List<ICommunicationGroupClient> commGroups = new List<ICommunicationGroupClient>();
+            IConfiguration serviceConfig = mpiDriver.GetServiceConfiguration();
+
+            List<IConfiguration> partialConfigs = new List<IConfiguration>();
+            for (int i = 0; i < numTasks; i++)
+            {
+                string taskId = "task" + i;
+                IConfiguration partialTaskConfig = TangFactory.GetTang().NewConfigurationBuilder(
+                    TaskConfiguration.ConfigurationModule
+                        .Set(TaskConfiguration.Identifier, taskId)
+                        .Set(TaskConfiguration.Task, GenericType<MyTask>.Class)
+                        .Build())
+                    .Build();
+                commGroup.AddTask(taskId);
+                partialConfigs.Add(partialTaskConfig);
+            }
+
+            for (int i = 0; i < numTasks; i++)
+            {
+                string taskId = "task" + i;
+                IConfiguration mpiTaskConfig = mpiDriver.GetMpiTaskConfiguration(taskId);
+                IConfiguration mergedConf = Configurations.Merge(mpiTaskConfig, partialConfigs[i], serviceConfig);
+                IInjector injector = TangFactory.GetTang().NewInjector(mergedConf);
+
+                IMpiClient mpiClient = injector.GetInstance<IMpiClient>();
+                commGroups.Add(mpiClient.GetCommunicationGroup(groupName));
+            }
+
+            //for master task
+            IBroadcastSender<int> broadcastSender = commGroups[0].GetBroadcastSender<int>(broadcastOperatorName);
+            IReduceReceiver<int> sumReducer = commGroups[0].GetReduceReceiver<int>(reduceOperatorName);
+
+            IBroadcastReceiver<int> broadcastReceiver1 = commGroups[1].GetBroadcastReceiver<int>(broadcastOperatorName);
+            IReduceSender<int> triangleNumberSender1 = commGroups[1].GetReduceSender<int>(reduceOperatorName);
+
+            IBroadcastReceiver<int> broadcastReceiver2 = commGroups[2].GetBroadcastReceiver<int>(broadcastOperatorName);
+            IReduceSender<int> triangleNumberSender2 = commGroups[2].GetReduceSender<int>(reduceOperatorName);
+
+            IBroadcastReceiver<int> broadcastReceiver3 = commGroups[3].GetBroadcastReceiver<int>(broadcastOperatorName);
+            IReduceSender<int> triangleNumberSender3 = commGroups[3].GetReduceSender<int>(reduceOperatorName);
+
+            IBroadcastReceiver<int> broadcastReceiver4 = commGroups[4].GetBroadcastReceiver<int>(broadcastOperatorName);
+            IReduceSender<int> triangleNumberSender4 = commGroups[4].GetReduceSender<int>(reduceOperatorName);
+
+            IBroadcastReceiver<int> broadcastReceiver5 = commGroups[5].GetBroadcastReceiver<int>(broadcastOperatorName);
+            IReduceSender<int> triangleNumberSender5 = commGroups[5].GetReduceSender<int>(reduceOperatorName);
+
+            IBroadcastReceiver<int> broadcastReceiver6 = commGroups[6].GetBroadcastReceiver<int>(broadcastOperatorName);
+            IReduceSender<int> triangleNumberSender6 = commGroups[6].GetReduceSender<int>(reduceOperatorName);
+
+            IBroadcastReceiver<int> broadcastReceiver7 = commGroups[7].GetBroadcastReceiver<int>(broadcastOperatorName);
+            IReduceSender<int> triangleNumberSender7 = commGroups[7].GetReduceSender<int>(reduceOperatorName);
+
+            IBroadcastReceiver<int> broadcastReceiver8 = commGroups[8].GetBroadcastReceiver<int>(broadcastOperatorName);
+            IReduceSender<int> triangleNumberSender8 = commGroups[8].GetReduceSender<int>(reduceOperatorName);
+
+            IBroadcastReceiver<int> broadcastReceiver9 = commGroups[9].GetBroadcastReceiver<int>(broadcastOperatorName);
+            IReduceSender<int> triangleNumberSender9 = commGroups[9].GetReduceSender<int>(reduceOperatorName);
+
+            for (int i = 1; i <= 10; i++)
+            {
+                broadcastSender.Send(i);
+
+                int n1 = broadcastReceiver1.Receive();
+                int n2 = broadcastReceiver2.Receive();
+                int n3 = broadcastReceiver3.Receive();
+                int n4 = broadcastReceiver4.Receive();
+                int n5 = broadcastReceiver5.Receive();
+                int n6 = broadcastReceiver6.Receive();
+                int n7 = broadcastReceiver7.Receive();
+                int n8 = broadcastReceiver8.Receive();
+                int n9 = broadcastReceiver9.Receive();
+                Assert.AreEqual(i, n1);
+                Assert.AreEqual(i, n2);
+                Assert.AreEqual(i, n3);
+                Assert.AreEqual(i, n4);
+                Assert.AreEqual(i, n5);
+                Assert.AreEqual(i, n6);
+                Assert.AreEqual(i, n7);
+                Assert.AreEqual(i, n8);
+                Assert.AreEqual(i, n9);
+
+                int triangleNum9 = TriangleNumber(n9);
+                triangleNumberSender9.Send(triangleNum9);
+
+                int triangleNum8 = TriangleNumber(n8);
+                triangleNumberSender8.Send(triangleNum8);
+
+                int triangleNum7 = TriangleNumber(n7);
+                triangleNumberSender7.Send(triangleNum7);
+
+                int triangleNum6 = TriangleNumber(n6);
+                triangleNumberSender6.Send(triangleNum6);
+
+                int triangleNum5 = TriangleNumber(n5);
+                triangleNumberSender5.Send(triangleNum5);
+
+                int triangleNum4 = TriangleNumber(n4);
+                triangleNumberSender4.Send(triangleNum4);
+
+                int triangleNum3 = TriangleNumber(n3);
+                triangleNumberSender3.Send(triangleNum3);
+
+                int triangleNum2 = TriangleNumber(n2);
+                triangleNumberSender2.Send(triangleNum2);
+
+                int triangleNum1 = TriangleNumber(n1);
+                triangleNumberSender1.Send(triangleNum1);
+
+                int sum = sumReducer.Reduce();
+                int expected = TriangleNumber(i) * (numTasks - 1);
+                Assert.AreEqual(sum, expected);
+            }
+        }
+
+        [TestMethod]
+        public void TestScatterOperator()
+        {
+            string groupName = "group1";
+            string operatorName = "scatter";
+            string masterTaskId = "task0";
+            string driverId = "Driver Id";
+            int numTasks = 5;
+            int fanOut = 2;
+
+            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, fanOut, new AvroConfigurationSerializer());
+
+            var commGroup = mpiDriver.NewCommunicationGroup(groupName, numTasks)
+                .AddScatter(operatorName, new ScatterOperatorSpec<int>(masterTaskId, new IntCodec()), TopologyTypes.Tree)
+                .Build();
+
+            List<IConfiguration> partialConfigs = new List<IConfiguration>();
+            for (int i = 0; i < numTasks; i++)
+            {
+                string taskId = "task" + i;
+                IConfiguration partialTaskConfig = TangFactory.GetTang().NewConfigurationBuilder(
+                    TaskConfiguration.ConfigurationModule
+                        .Set(TaskConfiguration.Identifier, taskId)
+                        .Set(TaskConfiguration.Task, GenericType<GroupCommunicationTreeTopologyTests.MyTask>.Class)
+                        .Build())
+                    .Build();
+                commGroup.AddTask(taskId);
+                partialConfigs.Add(partialTaskConfig);
+            }
+
+            IConfiguration serviceConfig = mpiDriver.GetServiceConfiguration();
+
+            List<ICommunicationGroupClient> commGroups = new List<ICommunicationGroupClient>();
+
+            for (int i = 0; i < numTasks; i++)
+            {
+                string taskId = "task" + i;
+                IConfiguration mpiTaskConfig = mpiDriver.GetMpiTaskConfiguration(taskId);
+                IConfiguration mergedConf = Configurations.Merge(mpiTaskConfig, partialConfigs[i], serviceConfig);
+                IInjector injector = TangFactory.GetTang().NewInjector(mergedConf);
+
+                IMpiClient mpiClient = injector.GetInstance<IMpiClient>();
+                commGroups.Add(mpiClient.GetCommunicationGroup(groupName));
+            }
+
+            IScatterSender<int> sender = commGroups[0].GetScatterSender<int>(operatorName);
+            IScatterReceiver<int> receiver1 = commGroups[1].GetScatterReceiver<int>(operatorName);
+            IScatterReceiver<int> receiver2 = commGroups[2].GetScatterReceiver<int>(operatorName);
+            IScatterReceiver<int> receiver3 = commGroups[3].GetScatterReceiver<int>(operatorName);
+            IScatterReceiver<int> receiver4 = commGroups[4].GetScatterReceiver<int>(operatorName);
+
+            Assert.IsNotNull(sender);
+            Assert.IsNotNull(receiver1);
+            Assert.IsNotNull(receiver2);
+            Assert.IsNotNull(receiver3);
+            Assert.IsNotNull(receiver4);
+
+            List<int> data = new List<int> { 1, 2, 3, 4 };
+
+            sender.Send(data);
+            var receved1 = receiver1.Receive().ToArray();
+            Assert.AreEqual(1, receved1[0]);
+            Assert.AreEqual(2, receved1[1]);
+
+            var receved2 = receiver2.Receive().ToArray();
+            Assert.AreEqual(3, receved2[0]);
+            Assert.AreEqual(4, receved2[1]);
+
+            Assert.AreEqual(1, receiver3.Receive().Single());
+            Assert.AreEqual(2, receiver4.Receive().Single());
+        }
+
+        [TestMethod]
+        public void TestScatterOperator2()
+        {
+            string groupName = "group1";
+            string operatorName = "scatter";
+            string masterTaskId = "task0";
+            string driverId = "Driver Id";
+            int numTasks = 5;
+            int fanOut = 2;
+
+            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, fanOut, new AvroConfigurationSerializer());
+
+            var commGroup = mpiDriver.NewCommunicationGroup(groupName, numTasks)
+                .AddScatter(operatorName, new ScatterOperatorSpec<int>(masterTaskId, new IntCodec()), TopologyTypes.Tree)
+                .Build();
+
+            List<IConfiguration> partialConfigs = new List<IConfiguration>();
+            for (int i = 0; i < numTasks; i++)
+            {
+                string taskId = "task" + i;
+                IConfiguration partialTaskConfig = TangFactory.GetTang().NewConfigurationBuilder(
+                    TaskConfiguration.ConfigurationModule
+                        .Set(TaskConfiguration.Identifier, taskId)
+                        .Set(TaskConfiguration.Task, GenericType<MyTask>.Class)
+                        .Build())
+                    .Build();
+                commGroup.AddTask(taskId);
+                partialConfigs.Add(partialTaskConfig);
+            }
+
+            IConfiguration serviceConfig = mpiDriver.GetServiceConfiguration();
+
+            List<ICommunicationGroupClient> commGroups = new List<ICommunicationGroupClient>();
+
+            for (int i = 0; i < numTasks; i++)
+            {
+                string taskId = "task" + i;
+                IConfiguration mpiTaskConfig = mpiDriver.GetMpiTaskConfiguration(taskId);
+                IConfiguration mergedConf = Configurations.Merge(mpiTaskConfig, partialConfigs[i], serviceConfig);
+                IInjector injector = TangFactory.GetTang().NewInjector(mergedConf);
+
+                IMpiClient mpiClient = injector.GetInstance<IMpiClient>();
+                commGroups.Add(mpiClient.GetCommunicationGroup(groupName));
+            }
+
+            IScatterSender<int> sender = commGroups[0].GetScatterSender<int>(operatorName);
+            IScatterReceiver<int> receiver1 = commGroups[1].GetScatterReceiver<int>(operatorName);
+            IScatterReceiver<int> receiver2 = commGroups[2].GetScatterReceiver<int>(operatorName);
+            IScatterReceiver<int> receiver3 = commGroups[3].GetScatterReceiver<int>(operatorName);
+            IScatterReceiver<int> receiver4 = commGroups[4].GetScatterReceiver<int>(operatorName);
+
+            Assert.IsNotNull(sender);
+            Assert.IsNotNull(receiver1);
+            Assert.IsNotNull(receiver2);
+            Assert.IsNotNull(receiver3);
+            Assert.IsNotNull(receiver4);
+
+            List<int> data = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+            sender.Send(data);
+            var data1 = receiver1.Receive().ToArray();
+            Assert.AreEqual(1, data1[0]);
+            Assert.AreEqual(2, data1[1]);
+            Assert.AreEqual(3, data1[2]);
+            Assert.AreEqual(4, data1[3]);
+
+            var data2 = receiver2.Receive().ToArray();
+            Assert.AreEqual(5, data2[0]);
+            Assert.AreEqual(6, data2[1]);
+            Assert.AreEqual(7, data2[2]);
+            Assert.AreEqual(8, data2[3]);
+
+            var data3 = receiver3.Receive();
+            Assert.AreEqual(1, data3.First());
+            Assert.AreEqual(2, data3.Last());
+
+            var data4 = receiver4.Receive();
+            Assert.AreEqual(3, data4.First());
+            Assert.AreEqual(4, data4.Last());
+        }
+
+        [TestMethod]
+        public void TestScatterOperator3()
+        {
+            string groupName = "group1";
+            string operatorName = "scatter";
+            string masterTaskId = "task0";
+            string driverId = "Driver Id";
+            int numTasks = 4;
+            int fanOut = 2;
+
+            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, fanOut, new AvroConfigurationSerializer());
+
+            var commGroup = mpiDriver.NewCommunicationGroup(groupName, numTasks)
+                .AddScatter(operatorName, new ScatterOperatorSpec<int>(masterTaskId, new IntCodec()), TopologyTypes.Tree)
+                .Build();
+
+            List<IConfiguration> partialConfigs = new List<IConfiguration>();
+            for (int i = 0; i < numTasks; i++)
+            {
+                string taskId = "task" + i;
+                IConfiguration partialTaskConfig = TangFactory.GetTang().NewConfigurationBuilder(
+                    TaskConfiguration.ConfigurationModule
+                        .Set(TaskConfiguration.Identifier, taskId)
+                        .Set(TaskConfiguration.Task, GenericType<MyTask>.Class)
+                        .Build())
+                    .Build();
+                commGroup.AddTask(taskId);
+                partialConfigs.Add(partialTaskConfig);
+            }
+
+            IConfiguration serviceConfig = mpiDriver.GetServiceConfiguration();
+
+            List<ICommunicationGroupClient> commGroups = new List<ICommunicationGroupClient>();
+
+            for (int i = 0; i < numTasks; i++)
+            {
+                string taskId = "task" + i;
+                IConfiguration mpiTaskConfig = mpiDriver.GetMpiTaskConfiguration(taskId);
+                IConfiguration mergedConf = Configurations.Merge(mpiTaskConfig, partialConfigs[i], serviceConfig);
+                IInjector injector = TangFactory.GetTang().NewInjector(mergedConf);
+
+                IMpiClient mpiClient = injector.GetInstance<IMpiClient>();
+                commGroups.Add(mpiClient.GetCommunicationGroup(groupName));
+            }
+
+            IScatterSender<int> sender = commGroups[0].GetScatterSender<int>(operatorName);
+            IScatterReceiver<int> receiver1 = commGroups[1].GetScatterReceiver<int>(operatorName);
+            IScatterReceiver<int> receiver2 = commGroups[2].GetScatterReceiver<int>(operatorName);
+            IScatterReceiver<int> receiver3 = commGroups[3].GetScatterReceiver<int>(operatorName);
+
+            Assert.IsNotNull(sender);
+            Assert.IsNotNull(receiver1);
+            Assert.IsNotNull(receiver2);
+            Assert.IsNotNull(receiver3);
+
+            List<int> data = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+            sender.Send(data);
+
+            var data1 = receiver1.Receive().ToArray();
+            Assert.AreEqual(1, data1[0]);
+            Assert.AreEqual(2, data1[1]);
+            Assert.AreEqual(3, data1[2]);
+            Assert.AreEqual(4, data1[3]);
+
+            var data2 = receiver2.Receive().ToArray();
+            Assert.AreEqual(5, data2[0]);
+            Assert.AreEqual(6, data2[1]);
+            Assert.AreEqual(7, data2[2]);
+            Assert.AreEqual(8, data2[3]);
+
+            var data3 = receiver3.Receive().ToArray();
+            Assert.AreEqual(1, data3[0]);
+            Assert.AreEqual(2, data3[1]);
+            Assert.AreEqual(3, data3[2]);
+            Assert.AreEqual(4, data3[3]);
+        }
+
+        [TestMethod]
+        public void TestScatterOperator4()
+        {
+            string groupName = "group1";
+            string operatorName = "scatter";
+            string masterTaskId = "task0";
+            string driverId = "Driver Id";
+            int numTasks = 4;
+            int fanOut = 2;
+
+            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, fanOut, new AvroConfigurationSerializer());
+
+            var commGroup = mpiDriver.NewCommunicationGroup(groupName, numTasks)
+                .AddScatter(operatorName, new ScatterOperatorSpec<int>(masterTaskId, new IntCodec()), TopologyTypes.Tree)
+                .Build();
+
+            List<IConfiguration> partialConfigs = new List<IConfiguration>();
+            for (int i = 0; i < numTasks; i++)
+            {
+                string taskId = "task" + i;
+                IConfiguration partialTaskConfig = TangFactory.GetTang().NewConfigurationBuilder(
+                    TaskConfiguration.ConfigurationModule
+                        .Set(TaskConfiguration.Identifier, taskId)
+                        .Set(TaskConfiguration.Task, GenericType<MyTask>.Class)
+                        .Build())
+                    .Build();
+                commGroup.AddTask(taskId);
+                partialConfigs.Add(partialTaskConfig);
+            }
+
+            IConfiguration serviceConfig = mpiDriver.GetServiceConfiguration();
+
+            List<ICommunicationGroupClient> commGroups = new List<ICommunicationGroupClient>();
+
+            for (int i = 0; i < numTasks; i++)
+            {
+                string taskId = "task" + i;
+                IConfiguration mpiTaskConfig = mpiDriver.GetMpiTaskConfiguration(taskId);
+                IConfiguration mergedConf = Configurations.Merge(mpiTaskConfig, partialConfigs[i], serviceConfig);
+                IInjector injector = TangFactory.GetTang().NewInjector(mergedConf);
+
+                IMpiClient mpiClient = injector.GetInstance<IMpiClient>();
+                commGroups.Add(mpiClient.GetCommunicationGroup(groupName));
+            }
+
+            IScatterSender<int> sender = commGroups[0].GetScatterSender<int>(operatorName);
+            IScatterReceiver<int> receiver1 = commGroups[1].GetScatterReceiver<int>(operatorName);
+            IScatterReceiver<int> receiver2 = commGroups[2].GetScatterReceiver<int>(operatorName);
+            IScatterReceiver<int> receiver3 = commGroups[3].GetScatterReceiver<int>(operatorName);
+
+            Assert.IsNotNull(sender);
+            Assert.IsNotNull(receiver1);
+            Assert.IsNotNull(receiver2);
+            Assert.IsNotNull(receiver3);
+
+            List<int> data = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8 };
+            List<string> order = new List<string> { "task2", "task1" };
+
+            sender.Send(data, order);
+
+            var data2 = receiver2.Receive().ToArray();
+            Assert.AreEqual(1, data2[0]);
+            Assert.AreEqual(2, data2[1]);
+            Assert.AreEqual(3, data2[2]);
+            Assert.AreEqual(4, data2[3]);
+
+            var data1 = receiver1.Receive().ToArray();
+            Assert.AreEqual(5, data1[0]);
+            Assert.AreEqual(6, data1[1]);
+            Assert.AreEqual(7, data1[2]);
+            Assert.AreEqual(8, data1[3]);
+
+            var data3 = receiver3.Receive().ToArray();
+            Assert.AreEqual(5, data3[0]);
+            Assert.AreEqual(6, data3[1]);
+            Assert.AreEqual(7, data3[2]);
+            Assert.AreEqual(8, data3[3]);
+        }
+
+
+        [TestMethod]
+        public void TestScatterOperator5()
+        {
+            string groupName = "group1";
+            string operatorName = "scatter";
+            string masterTaskId = "task0";
+            string driverId = "Driver Id";
+            int numTasks = 6;
+            int fanOut = 2;
+
+            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, fanOut, new AvroConfigurationSerializer());
+
+            var commGroup = mpiDriver.NewCommunicationGroup(groupName, numTasks)
+                .AddScatter(operatorName, new ScatterOperatorSpec<int>(masterTaskId, new IntCodec()), TopologyTypes.Tree)
+                .Build();
+
+            List<IConfiguration> partialConfigs = new List<IConfiguration>();
+            for (int i = 0; i < numTasks; i++)
+            {
+                string taskId = "task" + i;
+                IConfiguration partialTaskConfig = TangFactory.GetTang().NewConfigurationBuilder(
+                    TaskConfiguration.ConfigurationModule
+                        .Set(TaskConfiguration.Identifier, taskId)
+                        .Set(TaskConfiguration.Task, GenericType<MyTask>.Class)
+                        .Build())
+                    .Build();
+                commGroup.AddTask(taskId);
+                partialConfigs.Add(partialTaskConfig);
+            }
+
+            IConfiguration serviceConfig = mpiDriver.GetServiceConfiguration();
+
+            List<ICommunicationGroupClient> commGroups = new List<ICommunicationGroupClient>();
+
+            for (int i = 0; i < numTasks; i++)
+            {
+                string taskId = "task" + i;
+                IConfiguration mpiTaskConfig = mpiDriver.GetMpiTaskConfiguration(taskId);
+                IConfiguration mergedConf = Configurations.Merge(mpiTaskConfig, partialConfigs[i], serviceConfig);
+                IInjector injector = TangFactory.GetTang().NewInjector(mergedConf);
+
+                IMpiClient mpiClient = injector.GetInstance<IMpiClient>();
+                commGroups.Add(mpiClient.GetCommunicationGroup(groupName));
+            }
+
+            IScatterSender<int> sender = commGroups[0].GetScatterSender<int>(operatorName);
+            IScatterReceiver<int> receiver1 = commGroups[1].GetScatterReceiver<int>(operatorName);
+            IScatterReceiver<int> receiver2 = commGroups[2].GetScatterReceiver<int>(operatorName);
+            IScatterReceiver<int> receiver3 = commGroups[3].GetScatterReceiver<int>(operatorName);
+            IScatterReceiver<int> receiver4 = commGroups[4].GetScatterReceiver<int>(operatorName);
+            IScatterReceiver<int> receiver5 = commGroups[5].GetScatterReceiver<int>(operatorName);
+
+            Assert.IsNotNull(sender);
+            Assert.IsNotNull(receiver1);
+            Assert.IsNotNull(receiver2);
+            Assert.IsNotNull(receiver3);
+            Assert.IsNotNull(receiver4);
+            Assert.IsNotNull(receiver5);
+
+            List<int> data = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+            sender.Send(data);
+
+            var data1 = receiver1.Receive().ToArray();
+            Assert.AreEqual(1, data1[0]);
+            Assert.AreEqual(2, data1[1]);
+            Assert.AreEqual(3, data1[2]);
+            Assert.AreEqual(4, data1[3]);
+
+            var data2 = receiver2.Receive().ToArray();
+            Assert.AreEqual(5, data2[0]);
+            Assert.AreEqual(6, data2[1]);
+            Assert.AreEqual(7, data2[2]);
+            Assert.AreEqual(8, data2[3]);
+
+            var data3 = receiver3.Receive().ToArray();
+            Assert.AreEqual(1, data3[0]);
+            Assert.AreEqual(2, data3[1]);
+            
+            var data4= receiver4.Receive().ToArray();
+            Assert.AreEqual(3, data4[0]);
+            Assert.AreEqual(4, data4[1]);
+
+            var data5 = receiver5.Receive().ToArray();
+            Assert.AreEqual(5, data5[0]);
+            Assert.AreEqual(6, data5[1]);
+            Assert.AreEqual(7, data5[2]);
+            Assert.AreEqual(8, data5[3]);
+        }
+
+        [TestMethod]
+        public void TestScatterReduceOperators()
+        {
+            string groupName = "group1";
+            string scatterOperatorName = "scatter";
+            string reduceOperatorName = "reduce";
+            string masterTaskId = "task0";
+            string driverId = "Driver Id";
+            int numTasks = 5;
+            int fanOut = 2;
+
+            IMpiDriver mpiDriver = new MpiDriver(driverId, masterTaskId, fanOut, new AvroConfigurationSerializer());
+
+            ICommunicationGroupDriver commGroup = mpiDriver.NewCommunicationGroup(
+                groupName,
+                numTasks)
+                .AddScatter(
+                    scatterOperatorName,
+                    new ScatterOperatorSpec<int>(
+                        masterTaskId,
+                        new IntCodec()), TopologyTypes.Tree)
+                .AddReduce(
+                    reduceOperatorName,
+                    new ReduceOperatorSpec<int>(
+                        masterTaskId,
+                        new IntCodec(),
+                        new SumFunction()))
+                .Build();
+
+            List<IConfiguration> partialConfigs = new List<IConfiguration>();
+            for (int i = 0; i < numTasks; i++)
+            {
+                string taskId = "task" + i;
+                IConfiguration partialTaskConfig = TangFactory.GetTang().NewConfigurationBuilder(
+                    TaskConfiguration.ConfigurationModule
+                        .Set(TaskConfiguration.Identifier, taskId)
+                        .Set(TaskConfiguration.Task, GenericType<MyTask>.Class)
+                        .Build())
+                    .Build();
+                commGroup.AddTask(taskId);
+                partialConfigs.Add(partialTaskConfig);
+            }
+
+            IConfiguration serviceConfig = mpiDriver.GetServiceConfiguration();
+
+            List<ICommunicationGroupClient> commGroups = new List<ICommunicationGroupClient>();
+
+            for (int i = 0; i < numTasks; i++)
+            {
+                string taskId = "task" + i;
+                IConfiguration mpiTaskConfig = mpiDriver.GetMpiTaskConfiguration(taskId);
+                IConfiguration mergedConf = Configurations.Merge(mpiTaskConfig, partialConfigs[i], serviceConfig);
+                IInjector injector = TangFactory.GetTang().NewInjector(mergedConf);
+
+                IMpiClient mpiClient = injector.GetInstance<IMpiClient>();
+                commGroups.Add(mpiClient.GetCommunicationGroup(groupName));
+            }
+
+            IScatterSender<int> sender = commGroups[0].GetScatterSender<int>(scatterOperatorName);
+            IReduceReceiver<int> sumReducer = commGroups[0].GetReduceReceiver<int>(reduceOperatorName);
+
+            IScatterReceiver<int> receiver1 = commGroups[1].GetScatterReceiver<int>(scatterOperatorName);
+            IReduceSender<int> sumSender1 = commGroups[1].GetReduceSender<int>(reduceOperatorName);
+
+            IScatterReceiver<int> receiver2 = commGroups[2].GetScatterReceiver<int>(scatterOperatorName);
+            IReduceSender<int> sumSender2 = commGroups[2].GetReduceSender<int>(reduceOperatorName);
+
+            IScatterReceiver<int> receiver3 = commGroups[3].GetScatterReceiver<int>(scatterOperatorName);
+            IReduceSender<int> sumSender3 = commGroups[3].GetReduceSender<int>(reduceOperatorName);
+
+            IScatterReceiver<int> receiver4 = commGroups[4].GetScatterReceiver<int>(scatterOperatorName);
+            IReduceSender<int> sumSender4 = commGroups[4].GetReduceSender<int>(reduceOperatorName);
+
+            Assert.IsNotNull(sender);
+            Assert.IsNotNull(receiver1);
+            Assert.IsNotNull(receiver2);
+            Assert.IsNotNull(receiver3);
+            Assert.IsNotNull(receiver4);
+
+            List<int> data = Enumerable.Range(1, 100).ToList();
+            //List<string> order = new List<string> { "task4", "task3", "task2", "task1" };
+
+            sender.Send(data);
+
+            List<int> data1 = receiver1.Receive();
+            List<int> data2 = receiver2.Receive();
+
+            List<int> data3 = receiver3.Receive();
+            List<int> data4 = receiver4.Receive();
+
+            int sum3 = data3.Sum();
+            sumSender3.Send(sum3);
+
+            int sum4 = data4.Sum();
+            sumSender4.Send(sum4);
+
+            int sum2 = data2.Sum();
+            sumSender2.Send(sum2);
+
+            //middle nodes only passes through data
+            int sum1 = data1.Sum();
+            sumSender1.Send();
+
+            int sum = sumReducer.Reduce();
+
+            Assert.AreEqual(sum, data.Sum());
+        }
+
+        private static void ScatterReceiveReduce(IScatterReceiver<int> receiver, IReduceSender<int> sumSender)
+        {
+            List<int> data1 = receiver.Receive();
+            int sum1 = data1.Sum();
+            sumSender.Send(sum1);
+        }
+
+        private int TriangleNumber(int n)
+        {
+            return Enumerable.Range(1, n).Sum();
+        }
+
+        private class SumFunction : IReduceFunction<int>
+        {
+            [Inject]
+            public SumFunction()
+            {
+            }
+
+            public int Reduce(IEnumerable<int> elements)
+            {
+                return elements.Sum();
+            }
+        }
+
+        private class MyTask : ITask
+        {
+            public void Dispose()
+            {
+                throw new NotImplementedException();
+            }
+
+            public byte[] Call(byte[] memento)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Tests/Network/GroupCommunicationTreeTopologyTests.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Network/GroupCommunicationTreeTopologyTests.cs
@@ -695,7 +695,6 @@ namespace Org.Apache.REEF.Tests.Network
             Assert.AreEqual(8, data3[3]);
         }
 
-
         [TestMethod]
         public void TestScatterOperator5()
         {
@@ -812,7 +811,7 @@ namespace Org.Apache.REEF.Tests.Network
                     new ReduceOperatorSpec<int>(
                         masterTaskId,
                         new IntCodec(),
-                        new SumFunction()))
+                        new SumFunction()), TopologyTypes.Tree)
                 .Build();
 
             List<IConfiguration> partialConfigs = new List<IConfiguration>();
@@ -866,7 +865,6 @@ namespace Org.Apache.REEF.Tests.Network
             Assert.IsNotNull(receiver4);
 
             List<int> data = Enumerable.Range(1, 100).ToList();
-            //List<string> order = new List<string> { "task4", "task3", "task2", "task1" };
 
             sender.Send(data);
 
@@ -885,13 +883,11 @@ namespace Org.Apache.REEF.Tests.Network
             int sum2 = data2.Sum();
             sumSender2.Send(sum2);
 
-            //middle nodes only passes through data
             int sum1 = data1.Sum();
-            sumSender1.Send();
+            sumSender1.Send(sum1);
 
             int sum = sumReducer.Reduce();
-
-            Assert.AreEqual(sum, data.Sum());
+            Assert.AreEqual(sum, 6325);
         }
 
         private static void ScatterReceiveReduce(IScatterReceiver<int> receiver, IReduceSender<int> sumSender)

--- a/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
@@ -117,6 +117,14 @@ under the License.
       <Project>{cdfb3464-4041-42b1-9271-83af24cd5008}</Project>
       <Name>Org.Apache.REEF.Wake</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Org.Apache.REEF.Client\Org.Apache.REEF.Client.csproj">
+      <Project>{5094c35b-4fdb-4322-ac05-45d684501cbf}</Project>
+      <Name>Org.Apache.REEF.Client</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Org.Apache.REEF.Evaluator\Org.Apache.REEF.Evaluator.csproj">
+      <Project>{1b983182-9c30-464c-948d-f87eb93a8240}</Project>
+      <Name>Org.Apache.REEF.Evaluator</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="bin\reef-bridge-0.11.0-incubating-SNAPSHOT-shaded.jar">

--- a/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
@@ -117,11 +117,11 @@ under the License.
       <Project>{cdfb3464-4041-42b1-9271-83af24cd5008}</Project>
       <Name>Org.Apache.REEF.Wake</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Org.Apache.REEF.Client\Org.Apache.REEF.Client.csproj">
+    <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Client\Org.Apache.REEF.Client.csproj">
       <Project>{5094c35b-4fdb-4322-ac05-45d684501cbf}</Project>
       <Name>Org.Apache.REEF.Client</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Org.Apache.REEF.Evaluator\Org.Apache.REEF.Evaluator.csproj">
+    <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Evaluator\Org.Apache.REEF.Evaluator.csproj">
       <Project>{1b983182-9c30-464c-948d-f87eb93a8240}</Project>
       <Name>Org.Apache.REEF.Evaluator</Name>
     </ProjectReference>

--- a/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
@@ -73,6 +73,7 @@ under the License.
     <Compile Include="Functional\ReefFunctionalTest.cs" />
     <Compile Include="Network\BlockingCollectionExtensionTests.cs" />
     <Compile Include="Network\GroupCommunicationTests.cs" />
+    <Compile Include="Network\GroupCommunicationTreeTopologyTests.cs" />
     <Compile Include="Network\NameServerTests.cs" />
     <Compile Include="Network\NetworkServiceTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
This PR is to add tree topology for group communication
  * add tree Topology
  * Updated Group communication driver code to use it
  * Update broadcast operator for tree typology
  * Add test cases for broadcast using tree topology

JIRA: Reef-166. (https://issues.apache.org/jira/browse/REEF-166)

Author: Julia Wang  Email: jwang98052@yahoo.com