### PR TITLE
[REEF-95] Update the releases page

### DIFF
--- a/website/pom.xml
+++ b/website/pom.xml
@@ -86,22 +86,7 @@ under the License.
                     <ignorePathsToDelete>
                         <ignorePathToDelete>apidocs</ignorePathToDelete>
                     </ignorePathsToDelete>
-                    <providerImplementations>
-                        <svn>javasvn</svn>
-                    </providerImplementations>
                 </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.google.code.maven-scm-provider-svnjava</groupId>
-                        <artifactId>maven-scm-provider-svnjava</artifactId>
-                        <version>2.1.1</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.tmatesoft.svnkit</groupId>
-                        <artifactId>svnkit</artifactId>
-                        <version>1.8.7</version>
-                    </dependency>
-                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/website/src/site/markdown/downloads.md
+++ b/website/src/site/markdown/downloads.md
@@ -20,17 +20,20 @@ under the License.
 
 ##Releases
 
-- [0.10.0-incubating](#0.10.0-incubating)
+Choose a release version:
+<select id="selectRelease" onchange="setReleaseLink()">
+    <option value="0.10.0-incubating" selected="selected">0.10.0-incubating</option>
+</select>
 
-###<a name="0.10.0-incubating"></a>0.10.0-incubating
-
-#####Downloads
-
-- [apache-reef-0.10.0-incubating.tar.gz](http://www.apache.org/dist/incubator/reef/0.10.0-incubating/apache-reef-0.10.0-incubating.tar.gz)
-- [apache-reef-0.10.0-incubating.tar.gz.asc](http://www.apache.org/dist/incubator/reef/0.10.0-incubating/apache-reef-0.10.0-incubating.tar.gz.asc)
-- [apache-reef-0.10.0-incubating.tar.gz.md5](http://www.apache.org/dist/incubator/reef/0.10.0-incubating/apache-reef-0.10.0-incubating.tar.gz.md5)
-- [apache-reef-0.10.0-incubating.tar.gz.sha1](http://www.apache.org/dist/incubator/reef/0.10.0-incubating/apache-reef-0.10.0-incubating.tar.gz.sha1)
-- [apache-reef-0.10.0-incubating.tar.gz.sha512](http://www.apache.org/dist/incubator/reef/0.10.0-incubating/apache-reef-0.10.0-incubating.tar.gz.sha512)
+<ul id="listRelease">
+    <li>Download directly:
+        <a id="directLink" href="http://www.apache.org/dist/incubator/reef/0.10.0-incubating/apache-reef-0.10.0-incubating.tar.gz">
+        apache-reef-0.10.0-incubating.tar.gz
+        </a></li>
+    <li>Download with signatures:
+        <a id="mirrorLink" href="http://www.apache.org/dyn/closer.cgi/incubator/reef/0.10.0-incubating">
+        Closest Apache Mirror</a></li>
+</ul>
 
 ##Development and Maintenance Branches
 
@@ -73,3 +76,4 @@ REEF artifacts are hosted in [Maven Central](http://search.maven.org/#search|ga|
         <artifactId>reef-project</artifactId>
         <version>{$REEF_VERSION}</version>
     </dependency>
+    

--- a/website/src/site/resources/js/test2.js
+++ b/website/src/site/resources/js/test2.js
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+var releaseDirect = {
+    "0.10.0-incubating": "http://www.apache.org/dist/incubator/reef/0.10.0-incubating/apache-reef-0.10.0-incubating.tar.gz"
+};
+
+var releaseMirror = {
+    "0.10.0-incubating": "http://www.apache.org/dyn/closer.cgi/incubator/reef/0.10.0-incubating"
+};
+
+function setReleaseLink() {
+    var releaseVersion = this.document.getElementById("selectRelease").value;
+    if (releaseDirect[releaseVersion] == undefined) {
+        this.document.getElementById("listRelease").style.display= "none";
+        
+    } else {
+        this.document.getElementById("listRelease").style.display = "block";
+
+        var releaseDirectStr = releaseDirect[releaseVersion];
+        this.document.getElementById("directLink").setAttribute("href", releaseDirectStr);
+        this.document.getElementById("mirrorLink").setAttribute("href", releaseMirror[releaseVersion]);
+
+        var directReleaseStrSplit = releaseDirectStr.split("/");
+        this.document.getElementById("directLink").innerHTML =
+            directReleaseStrSplit[directReleaseStrSplit.length - 1];
+
+    }
+
+}

--- a/website/src/site/site.xml
+++ b/website/src/site/site.xml
@@ -57,6 +57,10 @@ under the License.
   <publishDate position="none"/>
   
     <body>   
+        <head>
+            <script src="js/test2.js" type="text/javascript"></script>
+        </head>
+        
 	    <breadcrumbs>
 	      <item name="Apache REEF" href="index.html"/>
 	    </breadcrumbs>


### PR DESCRIPTION
This updates the website releases page to reflect the current
REEF release status, as well as a small change in how the release
links are displayed.

This also removes `javasvn` and instead forces the website publish user
to use `svn` client to upload local contents. This is due to a bug
related to `javasvn` that was found during the use of `publish.sh` that
prevents content being uploaded to the server.

JIRA: [REEF-95](https://issues.apache.org/jira/browse/REEF-95)

Thanks to @johnyangk for Apache committer authentication. (not included in commit message)