### PR TITLE
[REEF-180] Automate pushing REEF.NET NuGet packages to Nuget.org

### DIFF
--- a/lang/cs/.gitignore
+++ b/lang/cs/.gitignore
@@ -6,5 +6,7 @@ TestResults
 **/*.suo
 **/*.csproj.user
 **/obj
+**/.nuget/nuspec
+**/.nuget/packages
 
 

--- a/lang/cs/.nuget/NuGet.targets
+++ b/lang/cs/.nuget/NuGet.targets
@@ -79,9 +79,15 @@ under the License.
         <PaddedSolutionDir Condition=" '$(OS)' == 'Windows_NT'">"$(SolutionDir) "</PaddedSolutionDir>
         <PaddedSolutionDir Condition=" '$(OS)' != 'Windows_NT' ">"$(SolutionDir)"</PaddedSolutionDir>
 
+        <!-- Nuspec file -->
+        <FinalizedNuspecFile>$(SolutionDir)\.nuget\nuspec\$(AssemblyName).nuspec</FinalizedNuspecFile>
+
+        <!-- Project path -->
+        <NugetProjectPath>$(SolutionDir)\$(RootNamespace)</NugetProjectPath>
+
         <!-- Commands -->
         <RestoreCommand>$(NuGetCommand) install "$(PackagesConfig)" -source "$(PackageSources)"  $(NonInteractiveSwitch) $(RequireConsentSwitch) -solutionDir $(PaddedSolutionDir)</RestoreCommand>
-        <BuildCommand>$(NuGetCommand) pack "$(ProjectPath)" -Properties "Configuration=$(Configuration);Platform=$(Platform)" $(NonInteractiveSwitch) -OutputDirectory "$(PackageOutputDir)" -symbols</BuildCommand>
+        <BuildCommand>$(NuGetCommand) pack "$(FinalizedNuspecFile)" -BasePath $(NugetProjectPath) -Properties "Configuration=$(Configuration);Platform=$(Platform)" $(NonInteractiveSwitch) -OutputDirectory "$(PackageOutputDir)" </BuildCommand>
 
         <!-- We need to ensure packages are restored prior to assembly resolve -->
         <BuildDependsOn Condition="$(RestorePackages) == 'true'">
@@ -94,6 +100,11 @@ under the License.
             $(BuildDependsOn);
             BuildPackage;
         </BuildDependsOn>
+    </PropertyGroup>
+
+    <!-- Make sure clean will clean up .nuget/packages and .nuget/nuspec directories -->
+    <PropertyGroup>
+        <CleanDependsOn>$(CleanDependsOn);CleanNugetPackages</CleanDependsOn>
     </PropertyGroup>
 
     <Target Name="CheckPrerequisites">
@@ -120,7 +131,10 @@ under the License.
               Condition="'$(OS)' == 'Windows_NT' And Exists('$(PackagesConfig)')" />
     </Target>
 
-    <Target Name="BuildPackage" DependsOnTargets="CheckPrerequisites; FinalizeNuspecFiles">
+    <Target Name="BuildPackage" DependsOnTargets="BuildNupkg; MoveNuGetPackage">
+    </Target>
+
+    <Target Name="BuildNupkg" DependsOnTargets="CheckPrerequisites; FinalizeNuspecFiles">
         <Exec Command="$(BuildCommand)"
               Condition=" '$(OS)' != 'Windows_NT' " />
 
@@ -131,11 +145,38 @@ under the License.
 
     <Target Name="FinalizeNuspecFiles">
         <PropertyGroup>
+            <IsSnapshot>$true</IsSnapshot>
+            <SnapshotNumber>0</SnapshotNumber>
             <FinalizeNuspecScript>$(SolutionDir)\.nuget\finalizeNuspec.ps1</FinalizeNuspecScript>
+            <ScriptCommand>$(FinalizeNuspecScript) $(SolutionDir) $(IsSnapshot) $(SnapshotNumber)</ScriptCommand>
         </PropertyGroup>
 
-        <Exec Command="powershell $(FinalizeNuspecScript)" />
+        <Exec Command="powershell -NonInteractive -NoProfile -Command $(ScriptCommand)" >
+        </Exec>
     </Target>
+
+    <Target Name="MoveNuGetPackage" DependsOnTargets="BuildNupkg">
+        <ItemGroup>
+            <NugetPackageFiles Include="$(SolutionDir)\bin\$(Platform)\$(Configuration)\$(RootNamespace)\*.nupkg" />
+        </ItemGroup>
+
+        <PropertyGroup>
+            <NugetPackageOutputDir>$(SolutionDir)\.nuget\packages</NugetPackageOutputDir>
+        </PropertyGroup>
+
+        <Copy SourceFiles="@(NugetPackageFiles)" DestinationFolder="$(NugetPackageOutputDir)" />
+    </Target>
+
+    <Target Name="CleanNugetPackages">
+        <PropertyGroup>
+            <NuspecFilesDir>$(SolutionDir)\.nuget\nuspec</NuspecFilesDir>
+            <PackagesDir>$(SolutionDir)\.nuget\packages</PackagesDir>
+        </PropertyGroup>
+
+        <RemoveDir Directories="$(NuspecFilesDir);$(PackagesDir)" />
+    </Target>
+
+
 
     <UsingTask TaskName="DownloadNuGet" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
         <ParameterGroup>

--- a/lang/cs/.nuget/NuGet.targets
+++ b/lang/cs/.nuget/NuGet.targets
@@ -145,11 +145,11 @@ under the License.
 
     <Target Name="FinalizeNuspecFiles">
         <PropertyGroup>
-            <IsSnapshot>$true</IsSnapshot>
-            <SnapshotNumber>0</SnapshotNumber>
             <FinalizeNuspecScript>$(SolutionDir)\.nuget\finalizeNuspec.ps1</FinalizeNuspecScript>
-            <ScriptCommand>$(FinalizeNuspecScript) $(SolutionDir) $(IsSnapshot) $(SnapshotNumber)</ScriptCommand>
+            <ScriptCommand Condition="'$(IsSnapshot)' == 'true'">$(FinalizeNuspecScript) -SolutionDir $(SolutionDir) -Snapshot -SnapshotNumber $(SnapshotNumber)</ScriptCommand>
+            <ScriptCommand Condition="'$(IsSnapshot)' == 'false'">$(FinalizeNuspecScript) -SolutionDir $(SolutionDir)</ScriptCommand>
         </PropertyGroup>
+        <Message Text="===SCRIPT: $(ScriptCommand)" />
 
         <Exec Command="powershell -NonInteractive -NoProfile -Command $(ScriptCommand)" >
         </Exec>

--- a/lang/cs/.nuget/NuGet.targets
+++ b/lang/cs/.nuget/NuGet.targets
@@ -81,7 +81,7 @@ under the License.
 
         <!-- Commands -->
         <RestoreCommand>$(NuGetCommand) install "$(PackagesConfig)" -source "$(PackageSources)"  $(NonInteractiveSwitch) $(RequireConsentSwitch) -solutionDir $(PaddedSolutionDir)</RestoreCommand>
-        <BuildCommand>$(NuGetCommand) pack "$(ProjectPath)" -Properties "Configuration=$(Configuration);Platform=$(Platform)" $(NonInteractiveSwitch) -OutputDirectory "$(PackageOutputDir)" -symbols</BuildCommand>
+        <BuildCommand>$(NuGetCommand) pack "$(ProjectPath)" -Properties "Configuration=$(Configuration);Platform=$(Platform)" $(NonInteractiveSwitch) -OutputDirectory "$(PackageOutputDir)" -Version $(ReefVersion) -symbols</BuildCommand>
 
         <!-- We need to ensure packages are restored prior to assembly resolve -->
         <BuildDependsOn Condition="$(RestorePackages) == 'true'">

--- a/lang/cs/.nuget/NuGet.targets
+++ b/lang/cs/.nuget/NuGet.targets
@@ -19,7 +19,7 @@ under the License.
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(MSBuildProjectDirectory)\..\</SolutionDir>
+        <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(MSBuildProjectDirectory)\..</SolutionDir>
 
         <!-- Enable the restore command to run before builds -->
         <RestorePackages Condition="  '$(RestorePackages)' == '' ">false</RestorePackages>
@@ -50,7 +50,7 @@ under the License.
 
     <PropertyGroup Condition=" '$(OS)' != 'Windows_NT'">
         <!-- We need to launch nuget.exe with the mono command if we're not on windows -->
-        <NuGetToolsPath>$(SolutionDir).nuget</NuGetToolsPath>
+        <NuGetToolsPath>$(SolutionDir)\.nuget</NuGetToolsPath>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -71,7 +71,7 @@ under the License.
         <NuGetCommand Condition=" '$(OS)' == 'Windows_NT'">"$(NuGetExePath)"</NuGetCommand>
         <NuGetCommand Condition=" '$(OS)' != 'Windows_NT' ">mono --runtime=v4.0.30319 "$(NuGetExePath)"</NuGetCommand>
 
-        <PackageOutputDir Condition="$(PackageOutputDir) == ''">$(TargetDir.Trim('\\'))</PackageOutputDir>
+        <PackageOutputDir Condition="$(PackageOutputDir) == ''">$(SolutionDir)\.nuget\packages</PackageOutputDir>
 
         <RequireConsentSwitch Condition=" $(RequireRestoreConsent) == 'true' ">-RequireConsent</RequireConsentSwitch>
         <NonInteractiveSwitch Condition=" '$(VisualStudioVersion)' != '' AND '$(OS)' == 'Windows_NT' ">-NonInteractive</NonInteractiveSwitch>
@@ -100,6 +100,11 @@ under the License.
             $(BuildDependsOn);
             BuildPackage;
         </BuildDependsOn>
+
+        <BuildDependsOn Condition="$(PushPackages) == 'true'">
+            $(BuildDependsOn);
+            PushPackages;
+        </BuildDependsOn>
     </PropertyGroup>
 
     <!-- Make sure clean will clean up .nuget/packages and .nuget/nuspec directories -->
@@ -116,6 +121,7 @@ under the License.
         parallel builds will have to wait for it to complete.
         -->
         <MsBuild Targets="_DownloadNuGet" Projects="$(MSBuildThisFileFullPath)" Properties="Configuration=NOT_IMPORTANT;DownloadNuGetExe=$(DownloadNuGetExe)" />
+        <MakeDir Directories="$(PackageOutputDir)" />
     </Target>
 
     <Target Name="_DownloadNuGet">
@@ -131,10 +137,7 @@ under the License.
               Condition="'$(OS)' == 'Windows_NT' And Exists('$(PackagesConfig)')" />
     </Target>
 
-    <Target Name="BuildPackage" DependsOnTargets="BuildNupkg; MoveNuGetPackage">
-    </Target>
-
-    <Target Name="BuildNupkg" DependsOnTargets="CheckPrerequisites; FinalizeNuspecFiles">
+    <Target Name="BuildPackage" DependsOnTargets="CheckPrerequisites; FinalizeNuspecFiles">
         <Exec Command="$(BuildCommand)"
               Condition=" '$(OS)' != 'Windows_NT' " />
 
@@ -149,22 +152,10 @@ under the License.
             <ScriptCommand Condition="'$(IsSnapshot)' == 'true'">$(FinalizeNuspecScript) -SolutionDir $(SolutionDir) -Snapshot -SnapshotNumber $(SnapshotNumber)</ScriptCommand>
             <ScriptCommand Condition="'$(IsSnapshot)' == 'false'">$(FinalizeNuspecScript) -SolutionDir $(SolutionDir)</ScriptCommand>
         </PropertyGroup>
-        <Message Text="===SCRIPT: $(ScriptCommand)" />
 
-        <Exec Command="powershell -NonInteractive -NoProfile -Command $(ScriptCommand)" >
+        <Exec Command="powershell -NonInteractive -NoProfile -Command $(ScriptCommand)"
+            LogStandardErrorAsError="true">
         </Exec>
-    </Target>
-
-    <Target Name="MoveNuGetPackage" DependsOnTargets="BuildNupkg">
-        <ItemGroup>
-            <NugetPackageFiles Include="$(SolutionDir)\bin\$(Platform)\$(Configuration)\$(RootNamespace)\*.nupkg" />
-        </ItemGroup>
-
-        <PropertyGroup>
-            <NugetPackageOutputDir>$(SolutionDir)\.nuget\packages</NugetPackageOutputDir>
-        </PropertyGroup>
-
-        <Copy SourceFiles="@(NugetPackageFiles)" DestinationFolder="$(NugetPackageOutputDir)" />
     </Target>
 
     <Target Name="CleanNugetPackages">
@@ -174,6 +165,23 @@ under the License.
         </PropertyGroup>
 
         <RemoveDir Directories="$(NuspecFilesDir);$(PackagesDir)" />
+    </Target>
+
+    <Target Name="PushPackages" >
+        <ItemGroup>
+            <PackageFile Include="$(SolutionDir).nuget\packages\$(RootNamespace)*.nupkg" />
+        </ItemGroup>
+
+        <PropertyGroup>
+            <PushCommand Condition="'$(NuGetApiKey)' == '' OR '$(NuGetApiKey)' == '*Undefined*'">$(NuGetCommand) push @(PackageFile) -Source $(NuGetRepository)</PushCommand>
+            <PushCommand Condition="'$(NuGetApiKey)' != '' AND '$(NuGetApiKey)' != '*Undefined*'">$(NuGetCommand) push @(PackageFile) $(NuGetApiKey) -Source $(NuGetRepository)</PushCommand>
+        </PropertyGroup>
+
+        <Exec 
+            Condition="'$(BuildPackage)' == 'true'"
+            Command="$(PushCommand)"
+            LogStandardErrorAsError="true">
+        </Exec>
     </Target>
 
 

--- a/lang/cs/.nuget/NuGet.targets
+++ b/lang/cs/.nuget/NuGet.targets
@@ -81,7 +81,7 @@ under the License.
 
         <!-- Commands -->
         <RestoreCommand>$(NuGetCommand) install "$(PackagesConfig)" -source "$(PackageSources)"  $(NonInteractiveSwitch) $(RequireConsentSwitch) -solutionDir $(PaddedSolutionDir)</RestoreCommand>
-        <BuildCommand>$(NuGetCommand) pack "$(ProjectPath)" -Properties "Configuration=$(Configuration);Platform=$(Platform)" $(NonInteractiveSwitch) -OutputDirectory "$(PackageOutputDir)" -Version $(ReefVersion) -symbols</BuildCommand>
+        <BuildCommand>$(NuGetCommand) pack "$(ProjectPath)" -Properties "Configuration=$(Configuration);Platform=$(Platform)" $(NonInteractiveSwitch) -OutputDirectory "$(PackageOutputDir)" -symbols</BuildCommand>
 
         <!-- We need to ensure packages are restored prior to assembly resolve -->
         <BuildDependsOn Condition="$(RestorePackages) == 'true'">
@@ -120,13 +120,21 @@ under the License.
               Condition="'$(OS)' == 'Windows_NT' And Exists('$(PackagesConfig)')" />
     </Target>
 
-    <Target Name="BuildPackage" DependsOnTargets="CheckPrerequisites">
+    <Target Name="BuildPackage" DependsOnTargets="CheckPrerequisites; FinalizeNuspecFiles">
         <Exec Command="$(BuildCommand)"
               Condition=" '$(OS)' != 'Windows_NT' " />
 
         <Exec Command="$(BuildCommand)"
               LogStandardErrorAsError="true"
               Condition=" '$(OS)' == 'Windows_NT' " />
+    </Target>
+
+    <Target Name="FinalizeNuspecFiles">
+        <PropertyGroup>
+            <FinalizeNuspecScript>$(SolutionDir)\.nuget\finalizeNuspec.ps1</FinalizeNuspecScript>
+        </PropertyGroup>
+
+        <Exec Command="powershell $(FinalizeNuspecScript)" />
     </Target>
 
     <UsingTask TaskName="DownloadNuGet" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">

--- a/lang/cs/.nuget/finalizeNuspec.ps1
+++ b/lang/cs/.nuget/finalizeNuspec.ps1
@@ -1,0 +1,13 @@
+$nuspecdir = "nuspec"
+
+# Delete the directory if it already exists
+rmdir -Force -Recurse $nuspecdir
+
+# Create directory for finalized nuspec files to live
+mkdir -Force $nuspecdir
+
+# copy over temporary nuspec files into new nuspec directory
+$nuspecfiles = Get-Childitem -Recurse .. *.nuspec
+$nuspecfiles | foreach { cp $_.FullName $nuspecDir }
+
+# Replace package version token with actual version

--- a/lang/cs/.nuget/finalizeNuspec.ps1
+++ b/lang/cs/.nuget/finalizeNuspec.ps1
@@ -17,12 +17,11 @@ under the License.
 
 Param(
     [Parameter(Mandatory=$true)]
-    [string]$solutionDir,
+    [string]$SolutionDir,
 
-    [Parameter(Mandatory=$true)]
-    [bool]$isSnapshot,
+    [switch]$Snapshot,
 
-    [int]$snapshotNumber
+    [int]$SnapshotNumber
 )
 
 Function Get-Nuspec-Version {
@@ -31,7 +30,7 @@ Function Get-Nuspec-Version {
     Extracts the NuGet version number from the pom.xml file in the source directory.
     #>
 
-    $pomPath = "$solutionDir\pom.xml"
+    $pomPath = "$SolutionDir\pom.xml"
     $pom = [xml] (Get-Content $pomPath)
     $version = $pom.project.parent.version -replace '-incubating-SNAPSHOT',''
     return $version
@@ -45,7 +44,7 @@ Function Prep-Nuspec-Files {
     to the new nuspec directory.
     #>
 
-    $nuspecDir = "$solutionDir\.nuget\nuspec"
+    $nuspecDir = "$SolutionDir\.nuget\nuspec"
 
     # Delete the directory if it already exists
     if (Test-Path $nuspecDir) {
@@ -56,7 +55,7 @@ Function Prep-Nuspec-Files {
     mkdir -Force $nuspecDir
 
     # Copy over temporary nuspec files into new nuspec directory
-    $tempNuspecFiles = Get-ChildItem $solutionDir\**\*.nuspec
+    $tempNuspecFiles = Get-ChildItem $SolutionDir\**\*.nuspec
     foreach ($tempNuspecFile in $tempNuspecFiles) {
         Copy-Item $tempNuspecFile.FullName $nuspecDir
     }
@@ -70,14 +69,14 @@ Function Finalize-Nuspec-Version {
 
     param([string]$version)
 
-    if ($isSnapshot) {
-        $fullVersion = "$version-SNAPSHOT-$snapshotNumber"
+    if ($Snapshot) {
+        $fullVersion = "$version-SNAPSHOT-$SnapshotNumber"
     } 
     else {
         $fullVersion = $version
     }
 
-    $nuspecDir = "$solutionDir\.nuget\nuspec"
+    $nuspecDir = "$SolutionDir\.nuget\nuspec"
     $nuspecFiles = Get-ChildItem $nuspecDir
     
     # Replace the $version$ token with the specified version in each nuspec file
@@ -87,18 +86,7 @@ Function Finalize-Nuspec-Version {
     }
 }
 
-function ExitWithCode 
-{ 
-    param ( 
-        $exitcode 
-    )
-
-    $host.SetShouldExit($exitcode) 
-    exit 
-}
-
-
 Prep-Nuspec-Files
 $version = Get-Nuspec-Version
 Finalize-Nuspec-Version($version)
-ExitWithCode -exitcode $LASTEXITCODE 
+Exit $LASTEXITCODE 

--- a/lang/cs/.nuget/finalizeNuspec.ps1
+++ b/lang/cs/.nuget/finalizeNuspec.ps1
@@ -1,13 +1,87 @@
-$nuspecdir = "nuspec"
+Param(
+    [Parameter(Mandatory=$true)]
+    [string]$solutionDir,
 
-# Delete the directory if it already exists
-rmdir -Force -Recurse $nuspecdir
+    [Parameter(Mandatory=$true)]
+    [bool]$isSnapshot,
 
-# Create directory for finalized nuspec files to live
-mkdir -Force $nuspecdir
+    [int]$snapshotNumber
+)
 
-# copy over temporary nuspec files into new nuspec directory
-$nuspecfiles = Get-Childitem -Recurse .. *.nuspec
-$nuspecfiles | foreach { cp $_.FullName $nuspecDir }
+Function Get-Nuspec-Version {
+    <#
+    .DESCRIPTION
+    Extracts the NuGet version number from the pom.xml file in the source directory.
+    #>
 
-# Replace package version token with actual version
+    $pomPath = "$solutionDir\pom.xml"
+    $pom = [xml] (Get-Content $pomPath)
+    $version = $pom.project.parent.version -replace '-incubating-SNAPSHOT',''
+    return $version
+}
+
+Function Prep-Nuspec-Files {
+    <#
+    .DESCRIPTION
+    Creates a directory for the finalized nuspec files to live.  Next,
+    the temporary nuspec files in each source directory will get copied
+    to the new nuspec directory.
+    #>
+
+    $nuspecDir = "$solutionDir\.nuget\nuspec"
+
+    # Delete the directory if it already exists
+    if (Test-Path $nuspecDir) {
+        rmdir -Force -Recurse $nuspecDir
+    }
+
+    # Create directory for finalized nuspec files to live
+    mkdir -Force $nuspecDir
+
+    # Copy over temporary nuspec files into new nuspec directory
+    $tempNuspecFiles = Get-ChildItem $solutionDir\**\*.nuspec
+    foreach ($tempNuspecFile in $tempNuspecFiles) {
+        Copy-Item $tempNuspecFile.FullName $nuspecDir
+    }
+}
+
+Function Finalize-Nuspec-Version {
+    <#
+    .DESCRIPTION
+    Replaces the $version$ token in each nuspec file with the actual version string.
+    #>
+
+    param([string]$version)
+
+    if ($isSnapshot) {
+        $fullVersion = "$version-SNAPSHOT-$snapshotNumber"
+    } 
+    else {
+        $fullVersion = $version
+    }
+
+    $nuspecDir = "$solutionDir\.nuget\nuspec"
+    $nuspecFiles = Get-ChildItem $nuspecDir
+    
+    # Replace the $version$ token with the specified version in each nuspec file
+    foreach ($nuspec in $nuspecFiles) {
+        $finalizedNuspec = Get-Content $nuspec.FullName | foreach { $_ -replace '\$version\$',"$fullVersion" }
+        Set-Content -Path $nuspec.FullName -Value $finalizedNuspec
+    }
+}
+
+function ExitWithCode 
+{ 
+    param ( 
+        $exitcode 
+    )
+
+    $host.SetShouldExit($exitcode) 
+    exit 
+}
+
+
+Prep-Nuspec-Files
+$version = Get-Nuspec-Version
+Finalize-Nuspec-Version($version)
+ExitWithCode -exitcode $LASTEXITCODE 

--- a/lang/cs/.nuget/finalizeNuspec.ps1
+++ b/lang/cs/.nuget/finalizeNuspec.ps1
@@ -1,3 +1,20 @@
+<#
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+#>
+
 Param(
     [Parameter(Mandatory=$true)]
     [string]$solutionDir,

--- a/lang/cs/build.props
+++ b/lang/cs/build.props
@@ -70,6 +70,8 @@ under the License.
   <PropertyGroup>
     <IsSnapshot>true</IsSnapshot>
     <SnapshotNumber>0</SnapshotNumber>
+    <PushPackages>false</PushPackages>
+    <NuGetRepository>https://www.nuget.org</NuGetRepository>
   </PropertyGroup>
 
   <!-- Package versions -->

--- a/lang/cs/build.props
+++ b/lang/cs/build.props
@@ -66,6 +66,13 @@ under the License.
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
 
+  <!-- REEF version -->
+  <PropertyGroup>
+    <PomFileVersion>__POM_VERSION__</PomFileVersion>
+    <SnapshotVersion>0</SnapshotVersion>
+    <ReefVersion>$(PomFileVersion)-SNAPSHOT-$(SnapshotVersion)</ReefVersion>
+  </PropertyGroup>
+
   <!-- Package versions -->
   <PropertyGroup>
     <AvroVersion>1.4.0.0</AvroVersion> 
@@ -73,5 +80,6 @@ under the License.
     <ProtobufVersion>2.0.0.668</ProtobufVersion> 
     <RxVersion>2.2.5</RxVersion> 
   </PropertyGroup>
+
 </Project>
 

--- a/lang/cs/build.props
+++ b/lang/cs/build.props
@@ -66,6 +66,12 @@ under the License.
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
 
+  <!-- REEF NuGet properties -->
+  <PropertyGroup>
+    <IsSnapshot>true</IsSnapshot>
+    <SnapshotNumber>0</SnapshotNumber>
+  </PropertyGroup>
+
   <!-- Package versions -->
   <PropertyGroup>
     <AvroVersion>1.4.0.0</AvroVersion> 

--- a/lang/cs/build.props
+++ b/lang/cs/build.props
@@ -66,13 +66,6 @@ under the License.
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
 
-  <!-- REEF version -->
-  <PropertyGroup>
-    <PomFileVersion>__POM_VERSION__</PomFileVersion>
-    <SnapshotVersion>0</SnapshotVersion>
-    <ReefVersion>$(PomFileVersion)-SNAPSHOT-$(SnapshotVersion)</ReefVersion>
-  </PropertyGroup>
-
   <!-- Package versions -->
   <PropertyGroup>
     <AvroVersion>1.4.0.0</AvroVersion> 


### PR DESCRIPTION
[JIRA: [REEF-180]](https://issues.apache.org/jira/browse/REEF-180)

Added PushPackages and NuGetRepository properties to build.props. When PushPackages is set to true and Configuration is set to Release, the NuGet packages that are generated will be pushed to NuGet.Org. You can also change the repository that the packages are pushed to using the NuGetRepository property.

If pushing to NuGet.org, you must set the NuGetApiKey environment variable to be a valid API key.  You must also be an owner of the REEF.NET packages on NuGet.org.