### PR TITLE
[REEF-182] Clean up Link and LinkListener for better message and error handling

### DIFF
--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NSConnection.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NSConnection.java
@@ -125,10 +125,10 @@ final class NSMessageLinkListener<T> implements LinkListener<NSMessage<T>> {
   }
 
   @Override
-  public void onSuccess(NSMessage<T> message) {
+  public void onSuccess(final NSMessage<T> message) {
   }
 
   @Override
-  public void onException(Throwable cause, SocketAddress remoteAddress, NSMessage<T> message) {
+  public void onException(final Throwable cause, final SocketAddress remoteAddress, final NSMessage<T> message) {
   }
 }

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NSConnection.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NSConnection.java
@@ -28,6 +28,7 @@ import org.apache.reef.wake.remote.transport.LinkListener;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -101,12 +102,7 @@ class NSConnection<T> implements Connection<T> {
    */
   @Override
   public void write(final T obj) throws NetworkException {
-    try {
-      this.link.write(new NSMessage<T>(this.srcId, this.destId, obj));
-    } catch (final IOException ex) {
-      LOG.log(Level.WARNING, "Could not write to " + this.destId, ex);
-      throw new NetworkException(ex);
-    }
+    this.link.write(new NSMessage<T>(this.srcId, this.destId, obj));
   }
 
   /**
@@ -129,6 +125,10 @@ final class NSMessageLinkListener<T> implements LinkListener<NSMessage<T>> {
   }
 
   @Override
-  public void messageReceived(final NSMessage<T> message) {
+  public void onSuccess(NSMessage<T> message) {
+  }
+
+  @Override
+  public void onException(Throwable cause, SocketAddress remoteAddress, NSMessage<T> message) {
   }
 }

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkService.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkService.java
@@ -42,6 +42,7 @@ import org.apache.reef.wake.remote.transport.Transport;
 
 import javax.inject.Inject;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
@@ -206,7 +207,13 @@ public final class NetworkService<T> implements Stage, ConnectionFactory<T> {
     final Connection<T> newConnection = new NSConnection<T>(
         this.myId, destId, new LinkListener<T>() {
       @Override
-      public void messageReceived(final Object message) {
+      public void onSuccess(T message) {
+
+      }
+
+      @Override
+      public void onException(Throwable cause, SocketAddress remoteAddress, T message) {
+
       }
     }, this);
 

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkService.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkService.java
@@ -39,6 +39,7 @@ import org.apache.reef.wake.remote.Codec;
 import org.apache.reef.wake.remote.impl.TransportEvent;
 import org.apache.reef.wake.remote.transport.LinkListener;
 import org.apache.reef.wake.remote.transport.Transport;
+import org.apache.reef.wake.remote.transport.netty.LoggingLinkListener;
 
 import javax.inject.Inject;
 import java.net.InetSocketAddress;
@@ -205,17 +206,7 @@ public final class NetworkService<T> implements Stage, ConnectionFactory<T> {
     }
 
     final Connection<T> newConnection = new NSConnection<T>(
-        this.myId, destId, new LinkListener<T>() {
-      @Override
-      public void onSuccess(T message) {
-
-      }
-
-      @Override
-      public void onException(Throwable cause, SocketAddress remoteAddress, T message) {
-
-      }
-    }, this);
+        this.myId, destId, new LoggingLinkListener<T>(), this);
 
     final Connection<T> existing = this.idToConnMap.putIfAbsent(destId, newConnection);
     return existing == null ? newConnection : existing;

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameRegistryClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameRegistryClient.java
@@ -145,7 +145,11 @@ public class NameRegistryClient implements Stage, NamingRegistry {
     Link<NamingMessage> link = transport.open(serverSocketAddr, codec,
         new LinkListener<NamingMessage>() {
           @Override
-          public void messageReceived(NamingMessage message) {
+          public void onSuccess(NamingMessage message) {
+          }
+
+          @Override
+          public void onException(Throwable cause, SocketAddress remoteAddress, NamingMessage message) {
           }
         });
     link.write(new NamingUnregisterRequest(id));

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameRegistryClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameRegistryClient.java
@@ -143,15 +143,7 @@ public class NameRegistryClient implements Stage, NamingRegistry {
   @Override
   public void unregister(Identifier id) throws IOException {
     Link<NamingMessage> link = transport.open(serverSocketAddr, codec,
-        new LinkListener<NamingMessage>() {
-          @Override
-          public void onSuccess(NamingMessage message) {
-          }
-
-          @Override
-          public void onException(Throwable cause, SocketAddress remoteAddress, NamingMessage message) {
-          }
-        });
+        new LoggingLinkListener<NamingMessage>());
     link.write(new NamingUnregisterRequest(id));
   }
 

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameServerImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameServerImpl.java
@@ -242,13 +242,7 @@ class NamingLookupRequestHandler implements EventHandler<NamingLookupRequest> {
   public void onNext(final NamingLookupRequest value) {
     final List<NameAssignment> nas = server.lookup(value.getIdentifiers());
     final byte[] resp = codec.encode(new NamingLookupResponse(nas));
-    try {
-      value.getLink().write(resp);
-    } catch (final IOException e) {
-      //Actually, there is no way Link.write can throw and IOException
-      //after netty4 merge. This needs to cleaned up
-      LOG.throwing("NamingLookupRequestHandler", "onNext", e);
-    }
+    value.getLink().write(resp);
   }
 }
 
@@ -272,13 +266,7 @@ class NamingRegisterRequestHandler implements EventHandler<NamingRegisterRequest
   public void onNext(final NamingRegisterRequest value) {
     server.register(value.getNameAssignment().getIdentifier(), value.getNameAssignment().getAddress());
     final byte[] resp = codec.encode(new NamingRegisterResponse(value));
-    try {
-      value.getLink().write(resp);
-    } catch (final IOException e) {
-      //Actually, there is no way Link.write can throw and IOException
-      //after netty4 merge. This needs to cleaned up
-      LOG.throwing("NamingRegisterRequestHandler", "onNext", e);
-    }
+    value.getLink().write(resp);
   }
 }
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteSenderEventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteSenderEventHandler.java
@@ -75,7 +75,7 @@ class RemoteSenderEventHandler<T> implements EventHandler<RemoteEvent<T>> {
         LOG.log(Level.FINEST, "{0}", event);
         linkRef.get().write(encoder.encode(event));
       }
-    } catch (InterruptedException | IOException e) {
+    } catch (InterruptedException e) {
       e.printStackTrace();
       throw new RemoteRuntimeException(e);
     }
@@ -112,9 +112,6 @@ class RemoteSenderEventHandler<T> implements EventHandler<RemoteEvent<T>> {
           LOG.log(Level.FINEST, "Send an event from " + linkRef.get().getLocalAddress() + " to " + linkRef.get().getRemoteAddress() + " value " + value);
         linkRef.get().write(encoder.encode(value));
       }
-    } catch (IOException ex) {
-      ex.printStackTrace();
-      throw new RemoteRuntimeException(ex);
     } catch (RemoteRuntimeException ex2) {
       ex2.printStackTrace();
       throw ex2;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/Link.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/Link.java
@@ -18,7 +18,6 @@
  */
 package org.apache.reef.wake.remote.transport;
 
-import java.io.IOException;
 import java.net.SocketAddress;
 
 /**
@@ -26,7 +25,7 @@ import java.net.SocketAddress;
  *
  * @param <T> type of the message.
  */
-public interface Link<T> extends LinkListener<T> {
+public interface Link<T> {
 
   /**
    * Gets its local address.
@@ -43,10 +42,9 @@ public interface Link<T> extends LinkListener<T> {
   SocketAddress getRemoteAddress();
 
   /**
-   * Writes the value to this link.
+   * Asynchronously writes the value to this link.
    *
    * @param value the data value.
-   * @throws IOException
    */
-  void write(T value) throws IOException;
+  void write(T value);
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/LinkListener.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/LinkListener.java
@@ -18,6 +18,8 @@
  */
 package org.apache.reef.wake.remote.transport;
 
+import java.net.SocketAddress;
+
 /**
  * Link listener
  *
@@ -26,9 +28,18 @@ package org.apache.reef.wake.remote.transport;
 public interface LinkListener<T> {
 
   /**
-   * Handles the received message
+   * Called when the sent message is successfully transferred
    *
-   * @param message the message
+   * @param message the sent message
    */
-  public void messageReceived(T message);
+  public void onSuccess(T message);
+
+  /**
+   * Called when the sent message to remoteAddress is failed to be transferred.
+   *
+   * @param cause the cause of exception
+   * @param remoteAddress the exception occurred remote address
+   * @param message the send message
+   */
+  public void onException(Throwable cause, SocketAddress remoteAddress, T message);
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/LoggingLinkListener.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/LoggingLinkListener.java
@@ -39,7 +39,7 @@ public class LoggingLinkListener<T> implements LinkListener<T> {
   @Override
   public void onSuccess(T message) {
     if (LOG.isLoggable(Level.FINEST)) {
-      LOG.log(Level.FINEST, "The message is successfully sent : " + message);
+      LOG.log(Level.FINEST, "The message is successfully sent : {0}", new Object[]{message});
     }
   }
 
@@ -49,7 +49,8 @@ public class LoggingLinkListener<T> implements LinkListener<T> {
   @Override
   public void onException(Throwable cause, SocketAddress remoteAddress, T message) {
     if (LOG.isLoggable(Level.FINEST)) {
-      LOG.log(Level.FINEST, "The message to " + remoteAddress + " is failed to be sent : " + message + ", cause : " + cause);
+      LOG.log(Level.FINEST, "The message to {0} is failed to be sent. message : {1}, cause : {2}"
+          , new Object[]{remoteAddress, message, cause});
     }
   }
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/LoggingLinkListener.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/LoggingLinkListener.java
@@ -20,11 +20,12 @@ package org.apache.reef.wake.remote.transport.netty;
 
 import org.apache.reef.wake.remote.transport.LinkListener;
 
+import java.net.SocketAddress;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Link listener that logs a message received
+ * Link listener that logs whether the message is sent successfully
  *
  * @param <T> type
  */
@@ -33,14 +34,22 @@ public class LoggingLinkListener<T> implements LinkListener<T> {
   private static final Logger LOG = Logger.getLogger(LoggingLinkListener.class.getName());
 
   /**
-   * Handles the message received
-   *
-   * @param message the message
+   * Called when the sent message is transferred successfully
    */
   @Override
-  public void messageReceived(T message) {
-    if (LOG.isLoggable(Level.FINEST))
-      LOG.log(Level.FINEST, "The linklistener " + this.getClass().toString() + "has received " + message);
+  public void onSuccess(T message) {
+    if (LOG.isLoggable(Level.FINEST)) {
+      LOG.log(Level.FINEST, "The message is successfully sent : " + message);
+    }
   }
 
+  /**
+   * Called when the sent message to remoteAddress is failed to be transferred.
+   */
+  @Override
+  public void onException(Throwable cause, SocketAddress remoteAddress, T message) {
+    if (LOG.isLoggable(Level.FINEST)) {
+      LOG.log(Level.FINEST, "The message to " + remoteAddress + " is failed to be sent : " + message + ", cause : " + cause);
+    }
+  }
 }

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/LargeMsgTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/LargeMsgTest.java
@@ -86,11 +86,7 @@ public class LargeMsgTest {
 
       @Override
       public void onNext(byte[] value) {
-        try {
-          link.write(value);
-        } catch (IOException e) {
-          e.printStackTrace();
-        }
+        link.write(value);
       }
     }, 3, new LoggingEventHandler<Throwable>());
     writeSubmitter.onNext(values[0]);


### PR DESCRIPTION
  This addressed issue by

    * Removing throw clause of write method in Link interface
    * Modifying LinkListener interface and implemented classes to work properly in asynchronous communication
    * Removing redundant try-catches where Link instances were used before

JIRA : https://issues.apache.org/jira/browse/REEF-182

Author : Geon Woo Kim <gwsshs22@gmail.com>