### PR TITLE
[REEF-37] Use MaxNumberOfEvaluators in place of the previous confusing names for the class NumberOfProcesses

### DIFF
--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/Launch.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/Launch.java
@@ -32,7 +32,6 @@ import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.tang.formats.CommandLine;
 import org.apache.reef.util.logging.LoggingScope;
 import org.apache.reef.util.logging.LoggingScopeFactory;
-import org.apache.reef.util.logging.LoggingScopeImpl;
 
 import java.io.File;
 import java.io.IOException;
@@ -47,9 +46,9 @@ import java.util.logging.Logger;
 public final class Launch {
 
   /**
-   * Number of REEF worker threads in local mode. We assume maximum 10 evaluators can be requested on local runtime
+   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently
    */
-  private static final int NUM_LOCAL_THREADS = 10;
+  private static final int MAX_NUMBER_OF_EVALUATORS = 10;
   /**
    * Standard Java logger
    */
@@ -122,7 +121,7 @@ public final class Launch {
       if (isLocal) {
         LOG.log(Level.INFO, "Running on the local runtime");
         runtimeConfiguration = LocalRuntimeConfiguration.CONF
-            .set(LocalRuntimeConfiguration.NUMBER_OF_THREADS, NUM_LOCAL_THREADS)
+            .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, MAX_NUMBER_OF_EVALUATORS)
             .build();
       } else {
         LOG.log(Level.INFO, "Running on YARN");

--- a/lang/java/reef-examples-clr/src/main/java/org/apache/reef/examples/helloCLR/HelloCLR.java
+++ b/lang/java/reef-examples-clr/src/main/java/org/apache/reef/examples/helloCLR/HelloCLR.java
@@ -83,7 +83,7 @@ public final class HelloCLR {
    */
   public static void main(final String[] args) throws BindException, InjectionException {
     final Configuration runtimeConfiguration = LocalRuntimeConfiguration.CONF
-        .set(LocalRuntimeConfiguration.NUMBER_OF_THREADS, 2)
+        .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, 2)
         .build();
 
     final File dotNetFolder = new File(args[0]).getAbsoluteFile();

--- a/lang/java/reef-examples-clr/src/main/java/org/apache/reef/examples/retained_evalCLR/Launch.java
+++ b/lang/java/reef-examples-clr/src/main/java/org/apache/reef/examples/retained_evalCLR/Launch.java
@@ -46,9 +46,9 @@ import java.util.logging.Logger;
 public final class Launch {
 
   /**
-   * Number of REEF worker threads in local mode.
+   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently
    */
-  private static final int NUM_LOCAL_THREADS = JobDriver.totalEvaluators;
+  private static final int MAX_NUMBER_OF_EVALUATORS = JobDriver.totalEvaluators;
   /**
    * Standard Java logger
    */
@@ -118,7 +118,7 @@ public final class Launch {
     if (isLocal) {
       LOG.log(Level.INFO, "Running on the local runtime");
       runtimeConfiguration = LocalRuntimeConfiguration.CONF
-          .set(LocalRuntimeConfiguration.NUMBER_OF_THREADS, NUM_LOCAL_THREADS)
+          .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, MAX_NUMBER_OF_EVALUATORS)
           .build();
     } else {
       LOG.log(Level.INFO, "Running on YARN");

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/data/loading/DataLoadingREEF.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/data/loading/DataLoadingREEF.java
@@ -50,7 +50,11 @@ public class DataLoadingREEF {
 
   private static final Logger LOG = Logger.getLogger(DataLoadingREEF.class.getName());
 
-  private static final int NUM_LOCAL_THREADS = 16;
+  /**
+   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently
+   */
+  private static final int MAX_NUMBER_OF_EVALUATORS = 16;
+
   private static final int NUM_SPLITS = 6;
   private static final int NUM_COMPUTE_EVALUATORS = 2;
 
@@ -77,7 +81,7 @@ public class DataLoadingREEF {
     if (isLocal) {
       LOG.log(Level.INFO, "Running Data Loading demo on the local runtime");
       runtimeConfiguration = LocalRuntimeConfiguration.CONF
-          .set(LocalRuntimeConfiguration.NUMBER_OF_THREADS, NUM_LOCAL_THREADS)
+          .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, MAX_NUMBER_OF_EVALUATORS)
           .build();
     } else {
       LOG.log(Level.INFO, "Running Data Loading demo on YARN");

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/BGDLocal.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/BGDLocal.java
@@ -33,7 +33,7 @@ public class BGDLocal {
 
   private static final Logger LOG = Logger.getLogger(BGDLocal.class.getName());
 
-  private static final int NUM_LOCAL_THREADS = 20;
+  private static final int MAX_NUMBER_OF_EVALUATORS = 20;
   private static final int TIMEOUT = 10 * Timer.MINUTES;
 
   public static void main(final String[] args) throws Exception {
@@ -41,7 +41,7 @@ public class BGDLocal {
     final BGDClient bgdClient = BGDClient.fromCommandLine(args);
 
     final Configuration runtimeConfiguration = LocalRuntimeConfiguration.CONF
-        .set(LocalRuntimeConfiguration.NUMBER_OF_THREADS, "" + NUM_LOCAL_THREADS)
+        .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, "" + MAX_NUMBER_OF_EVALUATORS)
         .build();
 
     final String jobName = System.getProperty("user.name") + "-" + "ResourceAwareBGDLocal";

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/BroadcastREEF.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/BroadcastREEF.java
@@ -46,7 +46,7 @@ import java.util.logging.Logger;
 public class BroadcastREEF {
   private static final Logger LOG = Logger.getLogger(BroadcastREEF.class.getName());
 
-  private static final String NUM_LOCAL_THREADS = "20";
+  private static final String MAX_NUMBER_OF_EVALUATORS = "20";
 
   /**
    * Number of milliseconds to wait for the job to complete.
@@ -103,7 +103,7 @@ public class BroadcastREEF {
     if (local) {
       LOG.log(Level.INFO, "Running Broadcast example using group API on the local runtime");
       runtimeConfiguration = LocalRuntimeConfiguration.CONF
-          .set(LocalRuntimeConfiguration.NUMBER_OF_THREADS, NUM_LOCAL_THREADS)
+          .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, MAX_NUMBER_OF_EVALUATORS)
           .build();
     } else {
       LOG.log(Level.INFO, "Running Broadcast example using group API on YARN");

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEF.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEF.java
@@ -34,8 +34,12 @@ import java.util.logging.Logger;
  * The Client for Hello REEF example.
  */
 public final class HelloREEF {
-
   private static final Logger LOG = Logger.getLogger(HelloREEF.class.getName());
+
+  /**
+   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently
+   */
+  private static final int MAX_NUMBER_OF_EVALUATORS = 2;
 
   /**
    * Number of milliseconds to wait for the job to complete.
@@ -69,7 +73,7 @@ public final class HelloREEF {
    */
   public static void main(final String[] args) throws BindException, InjectionException {
     final Configuration runtimeConfiguration = LocalRuntimeConfiguration.CONF
-        .set(LocalRuntimeConfiguration.NUMBER_OF_THREADS, 2)
+        .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, MAX_NUMBER_OF_EVALUATORS)
         .build();
     final LauncherStatus status = runHelloReef(runtimeConfiguration, JOB_TIMEOUT);
     LOG.log(Level.INFO, "REEF job completed: {0}", status);

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEFNoClient.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEFNoClient.java
@@ -55,7 +55,7 @@ public final class HelloREEFNoClient {
   public static void main(final String[] args) throws BindException, InjectionException {
 
     final Configuration runtimeConfiguration = LocalRuntimeConfiguration.CONF
-        .set(LocalRuntimeConfiguration.NUMBER_OF_THREADS, 2)
+        .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, 2)
         .build();
 
     runHelloReefWithoutClient(runtimeConfiguration);

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hellohttp/HelloREEFHttp.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hellohttp/HelloREEFHttp.java
@@ -39,6 +39,11 @@ import java.util.logging.Logger;
  */
 public final class HelloREEFHttp {
   /**
+   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently
+   */
+  private static final int MAX_NUMBER_OF_EVALUATORS = 3;
+
+  /**
    * Number of milliseconds to wait for the job to complete.
    */
   public static final int JOB_TIMEOUT = 60 * 1000; // 60 sec.
@@ -105,7 +110,7 @@ public final class HelloREEFHttp {
    */
   public static void main(final String[] args) throws InjectionException {
     final Configuration runtimeConfiguration = LocalRuntimeConfiguration.CONF
-        .set(LocalRuntimeConfiguration.NUMBER_OF_THREADS, 3)
+        .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, MAX_NUMBER_OF_EVALUATORS)
         .build();
     final LauncherStatus status = runHelloReef(runtimeConfiguration, HelloREEFHttp.JOB_TIMEOUT);
   }

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/pool/Launch.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/pool/Launch.java
@@ -44,9 +44,9 @@ import java.util.logging.Logger;
 public final class Launch {
 
   /**
-   * Number of REEF worker threads in local mode.
+   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently
    */
-  private static final int NUM_LOCAL_THREADS = 4;
+  private static final int MAX_NUMBER_OF_EVALUATORS = 4;
   /**
    * Standard Java logger
    */
@@ -107,7 +107,7 @@ public final class Launch {
     if (isLocal) {
       LOG.log(Level.FINE, "Running on the local runtime");
       runtimeConfiguration = LocalRuntimeConfiguration.CONF
-          .set(LocalRuntimeConfiguration.NUMBER_OF_THREADS, NUM_LOCAL_THREADS)
+          .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, MAX_NUMBER_OF_EVALUATORS)
           .build();
     } else {
       LOG.log(Level.FINE, "Running on YARN");

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/retained_eval/Launch.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/retained_eval/Launch.java
@@ -43,9 +43,9 @@ import java.util.logging.Logger;
 public final class Launch {
 
   /**
-   * Number of REEF worker threads in local mode.
+   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently
    */
-  private static final int NUM_LOCAL_THREADS = 4;
+  private static final int MAX_NUMBER_OF_EVALUATORS = 4;
   /**
    * Standard Java logger
    */
@@ -117,7 +117,7 @@ public final class Launch {
     if (isLocal) {
       LOG.log(Level.INFO, "Running on the local runtime");
       runtimeConfiguration = LocalRuntimeConfiguration.CONF
-          .set(LocalRuntimeConfiguration.NUMBER_OF_THREADS, NUM_LOCAL_THREADS)
+          .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, MAX_NUMBER_OF_EVALUATORS)
           .build();
     } else {
       LOG.log(Level.INFO, "Running on YARN");

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerREEF.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerREEF.java
@@ -38,6 +38,10 @@ import java.io.IOException;
  * REEF TaskScheduler.
  */
 public final class SchedulerREEF {
+  /**
+   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently
+   */
+  private static final int MAX_NUMBER_OF_EVALUATORS = 3;
 
   /**
    * Command line parameter = true to reuse evaluators,
@@ -102,7 +106,7 @@ public final class SchedulerREEF {
    */
   public final static void main(String[] args) throws InjectionException, IOException, ParseException {
     final Configuration runtimeConfiguration = LocalRuntimeConfiguration.CONF
-      .set(LocalRuntimeConfiguration.NUMBER_OF_THREADS, 3)
+      .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, MAX_NUMBER_OF_EVALUATORS)
       .build();
     runTaskScheduler(runtimeConfiguration, args);
   }

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/Launch.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/Launch.java
@@ -46,9 +46,9 @@ public final class Launch {
    */
   private static final Logger LOG = Logger.getLogger(Launch.class.getName());
   /**
-   * Number of REEF worker threads in local mode.
+   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently
    */
-  private static final int NUM_LOCAL_THREADS = 4;
+  private static final int MAX_NUMBER_OF_EVALUATORS = 4;
 
   /**
    * This class should not be instantiated.
@@ -111,7 +111,7 @@ public final class Launch {
     if (isLocal) {
       LOG.log(Level.INFO, "Running on the local runtime");
       runtimeConfiguration = LocalRuntimeConfiguration.CONF
-          .set(LocalRuntimeConfiguration.NUMBER_OF_THREADS, NUM_LOCAL_THREADS)
+          .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, MAX_NUMBER_OF_EVALUATORS)
           .build();
     } else {
       LOG.log(Level.INFO, "Running on YARN");

--- a/lang/java/reef-examples/src/test/java/org/apache/reef/examples/hello/HelloHttpTest.java
+++ b/lang/java/reef-examples/src/test/java/org/apache/reef/examples/hello/HelloHttpTest.java
@@ -32,7 +32,7 @@ public class HelloHttpTest {
   public void testHttpServer() throws BindException, InjectionException {
 
     final Configuration runtimeConfiguration = LocalRuntimeConfiguration.CONF
-        .set(LocalRuntimeConfiguration.NUMBER_OF_THREADS, 2)
+        .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, 2)
         .build();
 
     final LauncherStatus status = HelloREEFHttp.runHelloReef(runtimeConfiguration, 10 * 1000);

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/DriverConfigurationProvider.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/DriverConfigurationProvider.java
@@ -19,7 +19,7 @@
 package org.apache.reef.runtime.local.client;
 
 import org.apache.reef.runtime.common.parameters.JVMHeapSlack;
-import org.apache.reef.runtime.local.client.parameters.NumberOfProcesses;
+import org.apache.reef.runtime.local.client.parameters.MaxNumberOfEvaluators;
 import org.apache.reef.runtime.local.driver.LocalDriverConfiguration;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Configurations;
@@ -33,13 +33,13 @@ import java.io.File;
  */
 public final class DriverConfigurationProvider {
 
-  private final int nThreads;
+  private final int maxEvaluators;
   private final double jvmHeapSlack;
 
   @Inject
-  DriverConfigurationProvider(final @Parameter(NumberOfProcesses.class) int nThreads,
+  DriverConfigurationProvider(final @Parameter(MaxNumberOfEvaluators.class) int maxEvaluators,
                               final @Parameter(JVMHeapSlack.class) double jvmHeapSlack) {
-    this.nThreads = nThreads;
+    this.maxEvaluators = maxEvaluators;
     this.jvmHeapSlack = jvmHeapSlack;
   }
 
@@ -47,7 +47,7 @@ public final class DriverConfigurationProvider {
                                                final String clientRemoteId,
                                                final String jobId) {
     return LocalDriverConfiguration.CONF
-        .set(LocalDriverConfiguration.NUMBER_OF_PROCESSES, this.nThreads)
+        .set(LocalDriverConfiguration.MAX_NUMBER_OF_EVALUATORS, this.maxEvaluators)
         .set(LocalDriverConfiguration.ROOT_FOLDER, jobFolder.getAbsolutePath())
         .set(LocalDriverConfiguration.JVM_HEAP_SLACK, this.jvmHeapSlack)
         .set(LocalDriverConfiguration.CLIENT_REMOTE_IDENTIFIER, clientRemoteId)

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/LocalJobSubmissionHandler.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/LocalJobSubmissionHandler.java
@@ -27,7 +27,6 @@ import org.apache.reef.runtime.common.files.ClasspathProvider;
 import org.apache.reef.runtime.common.files.REEFFileNames;
 import org.apache.reef.runtime.common.launch.JavaLaunchCommandBuilder;
 import org.apache.reef.runtime.local.client.parameters.RootFolder;
-import org.apache.reef.runtime.local.driver.LocalDriverConfiguration;
 import org.apache.reef.runtime.local.process.LoggingRunnableProcessObserver;
 import org.apache.reef.runtime.local.process.RunnableProcess;
 import org.apache.reef.tang.Configuration;

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/LocalRuntimeConfiguration.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/LocalRuntimeConfiguration.java
@@ -27,7 +27,7 @@ import org.apache.reef.runtime.common.files.RuntimeClasspathProvider;
 import org.apache.reef.runtime.common.launch.REEFMessageCodec;
 import org.apache.reef.runtime.common.parameters.JVMHeapSlack;
 import org.apache.reef.runtime.local.LocalClasspathProvider;
-import org.apache.reef.runtime.local.client.parameters.NumberOfProcesses;
+import org.apache.reef.runtime.local.client.parameters.MaxNumberOfEvaluators;
 import org.apache.reef.runtime.local.client.parameters.RootFolder;
 import org.apache.reef.tang.formats.ConfigurationModule;
 import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
@@ -47,7 +47,7 @@ public class LocalRuntimeConfiguration extends ConfigurationModuleBuilder {
    * terms of the number of slots available on it with one important caveat: The Driver is not counted against this
    * number.
    */
-  public static final OptionalParameter<Integer> NUMBER_OF_THREADS = new OptionalParameter<>();
+  public static final OptionalParameter<Integer> MAX_NUMBER_OF_EVALUATORS = new OptionalParameter<>();
   /**
    * The folder in which the sub-folders, one per Node, will be created. Those will contain one folder per
    * Evaluator instantiated on the virtual node. Those inner folders will be named by the time when the Evaluator was
@@ -72,7 +72,7 @@ public class LocalRuntimeConfiguration extends ConfigurationModuleBuilder {
       .bindConstructor(ExecutorService.class, ExecutorServiceConstructor.class)
           // Bind the message codec for REEF.
       .bindNamedParameter(RemoteConfiguration.MessageCodec.class, REEFMessageCodec.class)
-      .bindNamedParameter(NumberOfProcesses.class, NUMBER_OF_THREADS)
+      .bindNamedParameter(MaxNumberOfEvaluators.class, MAX_NUMBER_OF_EVALUATORS)
       .bindNamedParameter(RootFolder.class, RUNTIME_ROOT_FOLDER)
       .bindNamedParameter(JVMHeapSlack.class, JVM_HEAP_SLACK)
       .bindImplementation(RuntimeClasspathProvider.class, LocalClasspathProvider.class)

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/parameters/MaxNumberOfEvaluators.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/parameters/MaxNumberOfEvaluators.java
@@ -22,8 +22,8 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
- * The maximum number of processes to use at once
+ * The maximum number of evaluators to allow to run at once
  */
-@NamedParameter(default_value = "4", doc = "The maximum number of processes to use at once", short_name = "nThreads")
-public final class NumberOfProcesses implements Name<Integer> {
+@NamedParameter(default_value = "4", doc = "The maximum number of evaluators to allow to run at once", short_name = "maxEvaluators")
+public final class MaxNumberOfEvaluators implements Name<Integer> {
 }

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
@@ -26,7 +26,7 @@ import org.apache.reef.proto.ReefServiceProtos;
 import org.apache.reef.runtime.common.driver.api.RuntimeParameters;
 import org.apache.reef.runtime.common.files.REEFFileNames;
 import org.apache.reef.runtime.common.utils.RemoteManager;
-import org.apache.reef.runtime.local.client.parameters.NumberOfProcesses;
+import org.apache.reef.runtime.local.client.parameters.MaxNumberOfEvaluators;
 import org.apache.reef.runtime.local.client.parameters.RootFolder;
 import org.apache.reef.runtime.local.process.ReefRunnableProcessObserver;
 import org.apache.reef.tang.annotations.Parameter;
@@ -78,7 +78,7 @@ final class ContainerManager implements AutoCloseable {
       final RemoteManager remoteManager,
       final RuntimeClock clock,
       final REEFFileNames fileNames,
-      final @Parameter(NumberOfProcesses.class) int capacity,
+      final @Parameter(MaxNumberOfEvaluators.class) int capacity,
       final @Parameter(RootFolder.class) String rootFolderName,
       final @Parameter(RuntimeParameters.NodeDescriptorHandler.class)
       EventHandler<DriverRuntimeProtocol.NodeDescriptorProto> nodeDescriptorHandler,

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalDriverConfiguration.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalDriverConfiguration.java
@@ -25,7 +25,7 @@ import org.apache.reef.runtime.common.driver.api.ResourceRequestHandler;
 import org.apache.reef.runtime.common.files.RuntimeClasspathProvider;
 import org.apache.reef.runtime.common.parameters.JVMHeapSlack;
 import org.apache.reef.runtime.local.LocalClasspathProvider;
-import org.apache.reef.runtime.local.client.parameters.NumberOfProcesses;
+import org.apache.reef.runtime.local.client.parameters.MaxNumberOfEvaluators;
 import org.apache.reef.runtime.local.client.parameters.RootFolder;
 import org.apache.reef.tang.formats.ConfigurationModule;
 import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
@@ -38,9 +38,9 @@ import org.apache.reef.tang.formats.RequiredParameter;
  */
 public class LocalDriverConfiguration extends ConfigurationModuleBuilder {
   /**
-   * The maximum number or processes to spawn.
+   * The maximum number of evaluators.
    */
-  public static final RequiredParameter<Integer> NUMBER_OF_PROCESSES = new RequiredParameter<>();
+  public static final RequiredParameter<Integer> MAX_NUMBER_OF_EVALUATORS = new RequiredParameter<>();
   /**
    * The root folder of the job. Assumed to be an absolute path.
    */
@@ -66,7 +66,7 @@ public class LocalDriverConfiguration extends ConfigurationModuleBuilder {
       .bindImplementation(ResourceReleaseHandler.class, LocalResourceReleaseHandler.class)
       .bindNamedParameter(AbstractDriverRuntimeConfiguration.ClientRemoteIdentifier.class, CLIENT_REMOTE_IDENTIFIER)
       .bindNamedParameter(AbstractDriverRuntimeConfiguration.JobIdentifier.class, JOB_IDENTIFIER)
-      .bindNamedParameter(NumberOfProcesses.class, NUMBER_OF_PROCESSES)
+      .bindNamedParameter(MaxNumberOfEvaluators.class, MAX_NUMBER_OF_EVALUATORS)
       .bindNamedParameter(RootFolder.class, ROOT_FOLDER)
       .bindNamedParameter(JVMHeapSlack.class, JVM_HEAP_SLACK)
       .bindImplementation(RuntimeClasspathProvider.class, LocalClasspathProvider.class)

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/yarn/failure/FailureREEF.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/yarn/failure/FailureREEF.java
@@ -39,8 +39,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public final class FailureREEF {
-
-  public static final int NUM_LOCAL_THREADS = 16;
+  /**
+   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently
+   */
+  public static final int MAX_NUMBER_OF_EVALUATORS = 16;
 
   private static final Logger LOG = Logger.getLogger(FailureREEF.class.getName());
 
@@ -71,7 +73,7 @@ public final class FailureREEF {
     if (isLocal) {
       LOG.log(Level.INFO, "Running Failure demo on the local runtime");
       runtimeConfiguration = LocalRuntimeConfiguration.CONF
-          .set(LocalRuntimeConfiguration.NUMBER_OF_THREADS, NUM_LOCAL_THREADS)
+          .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, MAX_NUMBER_OF_EVALUATORS)
           .build();
     } else {
       LOG.log(Level.INFO, "Running Failure demo on YARN");

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/LocalTestEnvironment.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/LocalTestEnvironment.java
@@ -27,9 +27,9 @@ import org.apache.reef.tang.Configuration;
 public final class LocalTestEnvironment extends TestEnvironmentBase implements TestEnvironment {
 
   /**
-   * The number of threads allocated to the local runtime.
+   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently
    */
-  public static final int NUMBER_OF_THREADS = 4;
+  public static final int MAX_NUMBER_OF_EVALUATORS = 4;
   // Used to make sure the tests call the methods in the right order.
   private boolean ready = false;
 
@@ -44,11 +44,11 @@ public final class LocalTestEnvironment extends TestEnvironmentBase implements T
     final String rootFolder = System.getProperty("org.apache.reef.runtime.local.folder");
     if (null == rootFolder) {
       return LocalRuntimeConfiguration.CONF
-          .set(LocalRuntimeConfiguration.NUMBER_OF_THREADS, NUMBER_OF_THREADS)
+          .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, MAX_NUMBER_OF_EVALUATORS)
           .build();
     } else {
       return LocalRuntimeConfiguration.CONF
-          .set(LocalRuntimeConfiguration.NUMBER_OF_THREADS, NUMBER_OF_THREADS)
+          .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, MAX_NUMBER_OF_EVALUATORS)
           .set(LocalRuntimeConfiguration.RUNTIME_ROOT_FOLDER, rootFolder)
           .build();
 

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/examples/TestRetainedEvaluators.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/examples/TestRetainedEvaluators.java
@@ -50,7 +50,7 @@ public final class TestRetainedEvaluators {
    */
   private static Configuration getLaunchConfiguration() {
     return Tang.Factory.getTang().newConfigurationBuilder()
-        .bindNamedParameter(Launch.NumEval.class, "" + (LocalTestEnvironment.NUMBER_OF_THREADS - 1))
+        .bindNamedParameter(Launch.NumEval.class, "" + (LocalTestEnvironment.MAX_NUMBER_OF_EVALUATORS - 1))
         .bindNamedParameter(Launch.NumRuns.class, "2")
         .bindNamedParameter(Command.class, "echo " + MESSAGE)
         .build();

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/multipleEventHandlerInstances/Client.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/multipleEventHandlerInstances/Client.java
@@ -68,7 +68,7 @@ public class Client {
   @Test
   public void testMultipleInstances() throws BindException, InjectionException {
     final Configuration runtimeConfiguration = LocalRuntimeConfiguration.CONF
-        .set(LocalRuntimeConfiguration.NUMBER_OF_THREADS, 2)
+        .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, 2)
         .build();
     final LauncherStatus status = runReefJob(runtimeConfiguration, JOB_TIMEOUT);
     Assert.assertTrue("Reef Job MultipleHandlerInstances failed: " + status, status.isSuccess());


### PR DESCRIPTION
Change the class name from NumberOfProcesses to MaxNumberOfEvaluators
Change related static global variables' names to MaxNumberOfEvaluators as well

JIRA:
  [REEF-37] https://issues.apache.org/jira/browse/REEF-37