### PR TITLE
[REEF-197] Renamed the Bridge DLLs into the Org.Apache.REEF.* scheme

### DIFF
--- a/lang/cpp/reef-bridge-clr/src/main/CSharp/CSharp/ClrHandler/Org.Apache.REEF.Bridge.Clr.csproj
+++ b/lang/cpp/reef-bridge-clr/src/main/CSharp/CSharp/ClrHandler/Org.Apache.REEF.Bridge.Clr.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{443A7B61-5C91-4F67-9FCD-81BC6FABFDBD}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>ClrHandler</RootNamespace>
-    <AssemblyName>ClrHandler</AssemblyName>
+    <RootNamespace>Org.Apache.REEF.Bridge.Clr</RootNamespace>
+    <AssemblyName>Org.Apache.REEF.Bridge.Clr</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>

--- a/lang/cpp/reef-bridge-clr/src/main/CSharp/CSharp/ClrHandler/Properties/AssemblyInfo.cs
+++ b/lang/cpp/reef-bridge-clr/src/main/CSharp/CSharp/ClrHandler/Properties/AssemblyInfo.cs
@@ -22,9 +22,9 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("ClrHandler")]
+[assembly: AssemblyTitle("Org.Apache.REEF.Bridge.Clr")]
 [assembly: AssemblyDescription("The interface dll between CPP and CLR code")]
-[assembly: AssemblyProduct("ClrHandler")]
+[assembly: AssemblyProduct("Org.Apache.REEF.Bridge.Clr")]
 [assembly: AssemblyCopyright("Copyright ©  2014")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/lang/cpp/reef-bridge-clr/src/main/Cpp/CppBridge/JavaClrBridge/Clr2JavaImpl.h
+++ b/lang/cpp/reef-bridge-clr/src/main/Cpp/CppBridge/JavaClrBridge/Clr2JavaImpl.h
@@ -20,7 +20,7 @@
 #include "org_apache_reef_javabridge_NativeInterop.h"
 #include "JavaClrBridge.h"
 #include "InteropAssemblies.h"
-#using "clrhandler.dll"
+#using "Org.Apache.REEF.Bridge.Clr.dll"
 #using "Org.Apache.REEF.Driver.dll"
 
 using namespace System;

--- a/lang/cpp/reef-bridge-clr/src/main/Cpp/CppBridge/JavaClrBridge/InteropLogger.h
+++ b/lang/cpp/reef-bridge-clr/src/main/Cpp/CppBridge/JavaClrBridge/InteropLogger.h
@@ -20,7 +20,7 @@
 #include "org_apache_reef_javabridge_NativeInterop.h"
 #include "JavaClrBridge.h"
 #include "InteropAssemblies.h"
-#using "clrhandler.dll"
+#using "Org.Apache.REEF.Bridge.Clr.dll"
 
 using namespace System;
 using namespace System::IO;

--- a/lang/cpp/reef-bridge-clr/src/main/Cpp/CppBridge/JavaClrBridge/InteropReturnInfo.h
+++ b/lang/cpp/reef-bridge-clr/src/main/Cpp/CppBridge/JavaClrBridge/InteropReturnInfo.h
@@ -20,7 +20,7 @@
 #include "org_apache_reef_javabridge_NativeInterop.h"
 #include "JavaClrBridge.h"
 #include "InteropAssemblies.h"
-#using "clrhandler.dll"
+#using "Org.Apache.REEF.Bridge.Clr.dll"
 
 using namespace System;
 using namespace System::IO;

--- a/lang/cpp/reef-bridge-clr/src/main/Cpp/CppBridge/JavaClrBridge/JavaClrBridge.sln
+++ b/lang/cpp/reef-bridge-clr/src/main/Cpp/CppBridge/JavaClrBridge/JavaClrBridge.sln
@@ -1,14 +1,14 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "JavaClrBridge", "JavaClrBridge.vcxproj", "{2825FD53-350B-4294-8CFC-8DD2F4F4F285}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Org.Apache.REEF.Bridge.JavaClrBridge", "JavaClrBridge.vcxproj", "{2825FD53-350B-4294-8CFC-8DD2F4F4F285}"
 	ProjectSection(ProjectDependencies) = postProject
 		{443A7B61-5C91-4F67-9FCD-81BC6FABFDBD} = {443A7B61-5C91-4F67-9FCD-81BC6FABFDBD}
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClrHandler", "..\..\..\CSharp\CSharp\ClrHandler\ClrHandler.csproj", "{443A7B61-5C91-4F67-9FCD-81BC6FABFDBD}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Org.Apache.REEF.Bridge.Clr", "..\..\..\CSharp\CSharp\ClrHandler\Org.Apache.REEF.Bridge.Clr.csproj", "{443A7B61-5C91-4F67-9FCD-81BC6FABFDBD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/lang/cpp/reef-bridge-clr/src/main/Cpp/CppBridge/JavaClrBridge/JavaClrBridge.vcxproj
+++ b/lang/cpp/reef-bridge-clr/src/main/Cpp/CppBridge/JavaClrBridge/JavaClrBridge.vcxproj
@@ -29,6 +29,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <Keyword>ManagedCProj</Keyword>
     <RootNamespace>Microsoft.Reef.Interop</RootNamespace>
+    <ProjectName>Org.Apache.REEF.Bridge.JavaClrBridge</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/LibLoader.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/LibLoader.java
@@ -40,9 +40,6 @@ public class LibLoader {
   private static final String LIB_BIN = "/";
   private static final String DLL_EXTENSION = ".dll";
   private static final String USER_DIR = "user.dir";
-  private static final String[] MANAGED_DLLS = {
-      "ClrHandler"
-  };
 
   private final LoggingScopeFactory loggingScopeFactory;
 
@@ -60,47 +57,92 @@ public class LibLoader {
   public void loadLib() throws IOException {
     LOG.log(Level.INFO, "Loading DLLs for driver at time {0}." + new Date().toString());
     try (final LoggingScope lb = loggingScopeFactory.loadLib()) {
-      final String tempLoadDir = System.getProperty(USER_DIR) + this.reefFileNames.getLoadDir();
-      LOG.log(Level.INFO, "load Folder: " + tempLoadDir);
-      new File(tempLoadDir).mkdir();
 
-      loadFromReefJar(this.reefFileNames.getCppBridge(), false);
+      // Load the native library connecting C# and Java
+      this.loadMixedDLL();
 
-      loadLibFromGlobal();
+      // Load the CLR side
+      this.loadCLRBridgeDLL();
 
-      for (int i = 0; i < MANAGED_DLLS.length; i++) {
-        loadFromReefJar(MANAGED_DLLS[i], true);
-      }
+      // Load all DLLs in local
+      this.loadAllManagedDLLs(this.reefFileNames.getLocalFolder());
+
+      // Load all DLLs in global
+      this.loadAllManagedDLLs(this.reefFileNames.getGlobalFolder());
     }
     LOG.log(Level.INFO, "Done loading DLLs for Driver at time {0}." + new Date().toString());
   }
 
+  private void loadMixedDLL() throws IOException {
+    final String tempLoadDir = System.getProperty(USER_DIR) + this.reefFileNames.getLoadDir();
+    try {
+      System.load(this.reefFileNames.getMixedDLLFile().getAbsolutePath());
+    } catch (final Throwable e) {
+      LOG.log(Level.WARNING, "Unable to load {0}, trying the JAR", this.reefFileNames.getMixedDLLFile().getAbsolutePath());
+      new File(tempLoadDir).mkdir();
+      LOG.log(Level.INFO, "load Folder: " + tempLoadDir);
+      loadFromReefJar(this.reefFileNames.getBridgeMixedDLLName(), false);
+    }
+  }
+
+  private void loadCLRBridgeDLL() throws IOException {
+    final String tempLoadDir = System.getProperty(USER_DIR) + this.reefFileNames.getLoadDir();
+    try {
+      loadManagedDLL(this.reefFileNames.getBridgeClrDLLFile());
+    } catch (final Throwable t) {
+      LOG.log(Level.WARNING, "Unable to load {0}, trying the JAR", this.reefFileNames.getMixedDLLFile().getAbsolutePath());
+      new File(tempLoadDir).mkdir();
+      LOG.log(Level.INFO, "load Folder: " + tempLoadDir);
+      loadFromReefJar(this.reefFileNames.getBridgeClrDllName(), true);
+    }
+  }
+
+
   /**
    * Load assemblies at global folder
    */
-  private void loadLibFromGlobal() {
-    final String globalFilePath = System.getProperty(USER_DIR) + this.reefFileNames.getReefGlobal();
-    final File[] files = new File(globalFilePath).listFiles(new FilenameFilter() {
+  private void loadDLLsInGlobal() {
+    loadAllManagedDLLs(this.reefFileNames.getGlobalFolder());
+  }
+
+  /**
+   * Loads all managed DLLs found in the given folder.
+   *
+   * @param folder
+   */
+  private void loadAllManagedDLLs(final File folder) {
+    LOG.log(Level.FINE, "Loading all managed DLLs from {0}", folder.getAbsolutePath());
+    final File[] files = folder.listFiles(new FilenameFilter() {
       public boolean accept(File dir, String name) {
         return name.toLowerCase().endsWith(DLL_EXTENSION);
       }
     });
 
-    LOG.log(Level.INFO, "Total dll files to load from {0} is {1}.", new Object[] {globalFilePath, files.length} );
-    for (int i = 0; i < files.length; i++) {
-      try {
-        LOG.log(Level.INFO, "file to load : " + files[i].toString());
-        NativeInterop.loadClrAssembly(files[i].toString());
-      } catch (final Exception e) {
-        LOG.log(Level.SEVERE, "exception in loading dll library: ", files[i].toString());
-        throw e;
-      }
+    for (final File f : files) {
+      loadManagedDLL(f);
     }
   }
 
   /**
+   * Loads the given DLL.
+   *
+   * @param dllFile
+   */
+  private void loadManagedDLL(final File dllFile) {
+    final String absolutePath = dllFile.getAbsolutePath();
+    try {
+      LOG.log(Level.FINE, "Loading Managed DLL {0} ", absolutePath);
+      NativeInterop.loadClrAssembly(absolutePath);
+    } catch (final Exception e) {
+      LOG.log(Level.SEVERE, "Unable to load managed DLL {0}", absolutePath);
+      throw e;
+    }
+  }
+
+
+  /**
    * Get file from jar file and copy it to temp dir and loads the library to memory
-  **/
+   */
   private void loadFromReefJar(String name, final boolean managed) throws IOException {
 
     name = name + DLL_EXTENSION;
@@ -122,7 +164,7 @@ public class LibLoader {
           LOG.log(Level.WARNING, "Cannot find " + path);
           return;
         }
-        try (final OutputStream out = new FileOutputStream(fileOut) ) {
+        try (final OutputStream out = new FileOutputStream(fileOut)) {
           IOUtils.copy(in, out);
         }
       }
@@ -138,6 +180,7 @@ public class LibLoader {
 
   /**
    * load assembly
+   *
    * @param fileOut
    * @param managed
    */

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/REEFFileNames.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/REEFFileNames.java
@@ -47,14 +47,49 @@ public final class REEFFileNames {
   private static final String DRIVER_STDOUT = "driver.stdout";
   private static final String EVALUATOR_STDERR = "evaluator.stderr";
   private static final String EVALUATOR_STDOUT = "evaluator.stdout";
-  private static final String CPP_BRIDGE = "JavaClrBridge";
-  private static final String REEF_GLOBAL = "/reef/global";
   private static final String REEF_DRIVER_APPDLL_DIR = "/ReefDriverAppDlls/";
   private static final String TMP_LOAD_DIR = "/reef/CLRLoadingDirectory";
+  private static final String BRIDGE_CLR_DLL_NAME = "Org.Apache.REEF.Bridge.Clr.dll";
+  private static final String BRIDGE_MIXED_DLL_NAME = "Org.Apache.REEF.Bridge.JavaClrBridge.dll";
+
 
   @Inject
   public REEFFileNames() {
   }
+
+
+  /**
+   * @return the filename of the DLL containing the CLR side of the bridge.
+   */
+  public String getBridgeClrDllName() {
+    return BRIDGE_CLR_DLL_NAME;
+  }
+
+  /**
+   * reef/local/BRIDGE_CLR_DLL_NAME
+   *
+   * @return the File pointing to the DLL containing the CLR side of the bridge.
+   */
+  public File getBridgeClrDLLFile() {
+    return new File(getLocalFolder(), getBridgeClrDllName());
+  }
+
+  /**
+   * @return the filename of the CPP DLL for the bridge.
+   */
+  public String getBridgeMixedDLLName() {
+    return BRIDGE_MIXED_DLL_NAME;
+  }
+
+  /**
+   * reef/local/BRIDGE_MIXED_DLL_NAME
+   *
+   * @return the File pointing to the DLL containing the CPP DLL for the bridge.
+   */
+  public File getMixedDLLFile() {
+    return new File(getLocalFolder(), getBridgeMixedDLLName());
+  }
+
 
   /**
    * The name of the REEF folder inside of the working directory of an Evaluator or Driver
@@ -194,23 +229,18 @@ public final class REEFFileNames {
     return EVALUATOR_STDOUT;
   }
 
-  /**
-   * @return the name of cpp bridge file
-   */
-  public String getCppBridge() { return CPP_BRIDGE; }
-
-  /**
-   * @return reeg global file folder
-   */
-  public String getReefGlobal() { return REEF_GLOBAL; }
 
   /**
    * @return reef driver app dll directory
    */
-  public String getReefDriverAppDllDir() { return REEF_DRIVER_APPDLL_DIR; }
+  public String getReefDriverAppDllDir() {
+    return REEF_DRIVER_APPDLL_DIR;
+  }
 
   /**
    * @return temp load directory
    */
-  public String getLoadDir() { return TMP_LOAD_DIR; }
+  public String getLoadDir() {
+    return TMP_LOAD_DIR;
+  }
 }


### PR DESCRIPTION
  * The Bridge DLLs now follow the Org.Apache.REEF scheme
  * Their names are now covered in REEFFileNames
  * LobLoader now tries to load the DLLs from the filesystem first, JAR second

JIRA:
  [REEF-197](https://issues.apache.org/jira/browse/REEF-197)