### PR TITLE
[REEF-199] Update NuGet spec to resolve dependency issue

### DIFF
--- a/lang/cs/Org.Apache.REEF.All/Org.Apache.REEF.All.nuspec
+++ b/lang/cs/Org.Apache.REEF.All/Org.Apache.REEF.All.nuspec
@@ -13,13 +13,13 @@
     <copyright>The Apache Software Foundation</copyright>
     <tags>Single entry point to reference all Reef/Wake/Tang projects </tags>
      <dependencies>
-      <dependency id="Org.Apache.REEF.Evaluator" version="$version$" />
-      <dependency id="Org.Apache.REEF.Driver" version="$version$" />
       <dependency id="Org.Apache.REEF.Utilities" version="$version$" />
-      <dependency id="Org.Apache.REEF.Network" version="$version$" />
+      <dependency id="Org.Apache.REEF.Tang" version="$version$" />
+      <dependency id="Org.Apache.REEF.Wake" version="$version$" />
       <dependency id="Org.Apache.REEF.Common" version="$version$" />
-      <dependency id="Org.Apache.Tang" version="$version$" />
-      <dependency id="Org.Apache.Wake" version="$version$" />
+      <dependency id="Org.Apache.REEF.Driver" version="$version$" />
+      <dependency id="Org.Apache.REEF.Network" version="$version$" />
+      <dependency id="Org.Apache.REEF.Evaluator" version="$version$" />
     </dependencies>
   </metadata>
 </package>

--- a/lang/cs/Org.Apache.REEF.Evaluator/Org.Apache.REEF.Evaluator.nuspec
+++ b/lang/cs/Org.Apache.REEF.Evaluator/Org.Apache.REEF.Evaluator.nuspec
@@ -12,16 +12,15 @@
     <description>Evaluator for REEF.NET</description>
     <copyright>The Apache Software Foundation</copyright>
     <dependencies>
+      <dependency id="Org.Apache.REEF.Utilities" version="$version$" />
+      <dependency id="Org.Apache.REEF.Tang" version="$version$" />
+      <dependency id="Org.Apache.REEF.Wake" version="$version$" />
       <dependency id="Org.Apache.REEF.Common" version="$version$" />
       <dependency id="Org.Apache.REEF.Driver" version="$version$" />
-      <dependency id="Org.Apache.Tang" version="$version$" />
-      <dependency id="Org.Apache.Wake" version="$version$" />
-      <dependency id="Org.Apache.REEF.Utilities" version="$version$" />
       <dependency id="Rx-Core" version="2.2.5" />
       <dependency id="protobuf-net" version="2.0.0.668" />
     </dependencies>
   </metadata>
-
   <files>
     <file src="..\bin\$Platform$\$Configuration$\Org.Apache.REEF.Evaluator\Org.Apache.REEF.Evaluator.exe" target="tools" />
     <file src="..\bin\$Platform$\$Configuration$\Org.Apache.REEF.Evaluator\NugetExeFix.txt" target="lib\net45" />

--- a/lang/cs/build.props
+++ b/lang/cs/build.props
@@ -73,7 +73,7 @@ under the License.
   <!-- REEF NuGet properties -->
   <PropertyGroup>
     <IsSnapshot>true</IsSnapshot>
-    <SnapshotNumber>6</SnapshotNumber>
+    <SnapshotNumber>7</SnapshotNumber>
     <PushPackages>false</PushPackages>
     <NuGetRepository>https://www.nuget.org</NuGetRepository>
   </PropertyGroup>


### PR DESCRIPTION
This PR is to fix dependent package names so that to resolve dependency issue.
As the new package -6 has been pushed to NuGet.org, updated teh version to next number -7.

JIRA: Reef-199. (https://issues.apache.org/jira/browse/REEF-199)

Author: Julia Wang  Email: jwang98052@yahoo.com