### PR TITLE
[REEF-202] Fix NameClient injection issue in Group Communication

### DIFF
--- a/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/MpiDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/MpiDriver.cs
@@ -201,6 +201,8 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
                 .BindNamedParameter<NamingConfigurationOptions.NameServerPort, int>(
                     GenericType<NamingConfigurationOptions.NameServerPort>.Class, 
                     _nameServerPort.ToString(CultureInfo.InvariantCulture))
+                .BindImplementation(GenericType<INameClient>.Class,
+                    GenericType<NameClient>.Class)
                 .Build();
         }
 

--- a/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/OperatorTopology.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/OperatorTopology.cs
@@ -64,7 +64,7 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
         private readonly INameClient _nameClient;
         private readonly Sender _sender;
         private readonly BlockingCollection<NodeStruct> _nodesWithData;
-            
+
         /// <summary>
         /// Creates a new OperatorTopology object.
         /// </summary>

--- a/lang/cs/Org.Apache.REEF.Network/NetworkService/NetworkService.cs
+++ b/lang/cs/Org.Apache.REEF.Network/NetworkService/NetworkService.cs
@@ -60,11 +60,10 @@ namespace Org.Apache.REEF.Network.NetworkService
         [Inject]
         public NetworkService(
             [Parameter(typeof(NetworkServiceOptions.NetworkServicePort))] int nsPort,
-            [Parameter(typeof(NamingConfigurationOptions.NameServerAddress))] string nameServerAddr,
-            [Parameter(typeof(NamingConfigurationOptions.NameServerPort))] int nameServerPort,
             IObserver<NsMessage<T>> messageHandler,
             IIdentifierFactory idFactory,
-            ICodec<T> codec)
+            ICodec<T> codec,
+            INameClient nameClient)
         {
             _codec = new NsMessageCodec<T>(codec, idFactory);
 
@@ -72,7 +71,7 @@ namespace Org.Apache.REEF.Network.NetworkService
             _remoteManager = new DefaultRemoteManager<NsMessage<T>>(localAddress, nsPort, _codec);
             _messageHandler = messageHandler;
 
-            NamingClient = new NameClient(nameServerAddr, nameServerPort);
+            NamingClient = nameClient;//new NameClient(nameServerAddr, nameServerPort);
             _connectionMap = new Dictionary<IIdentifier, IConnection<T>>();
 
             LOGGER.Log(Level.Info, "Started network service");
@@ -123,6 +122,8 @@ namespace Org.Apache.REEF.Network.NetworkService
             // Create and register incoming message handler
             var anyEndpoint = new IPEndPoint(IPAddress.Any, 0);
             _messageHandlerDisposable = _remoteManager.RegisterObserver(anyEndpoint, _messageHandler);
+
+            LOGGER.Log(Level.Info, "End of Registering id {0} with network service.", id);
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Tests/Network/GroupCommunicationTests.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Network/GroupCommunicationTests.cs
@@ -696,8 +696,7 @@ namespace Org.Apache.REEF.Tests.Network
             IPEndPoint nameServerEndpoint, IObserver<NsMessage<GroupCommunicationMessage>> handler)
         {
             return new NetworkService<GroupCommunicationMessage>(
-                0, nameServerEndpoint.Address.ToString(), nameServerEndpoint.Port, 
-                handler, new StringIdentifierFactory(), new GroupCommunicationMessageCodec());
+                0, handler, new StringIdentifierFactory(), new GroupCommunicationMessageCodec(), new NameClient(nameServerEndpoint.Address.ToString(), nameServerEndpoint.Port));
         }
 
         private GroupCommunicationMessage CreateGcm(string message, string from, string to)


### PR DESCRIPTION
This PR is to fix NameClient injection issue in Group Communication
It also added SleepTime in OperatorTopology as a named parameter so that client can set their own value

JIRA: Reef-202. (https://issues.apache.org/jira/browse/REEF-202)

Author: Julia Wang  Email: jwang98052@yahoo.com