### PR TITLE
[REEF-203] Adding sleep time for Group Communication

### DIFF
--- a/lang/cs/Org.Apache.REEF.Network/Group/Config/MpiConfigurationOptions.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Config/MpiConfigurationOptions.cs
@@ -44,6 +44,11 @@ namespace Org.Apache.REEF.Network.Group.Config
         {
         }
 
+        [NamedParameter("sleep time in OperatorTypology initialization", defaultValue: "500")]
+        public class SleepTime : Name<int>
+        {
+        }
+
         [NamedParameter("Retry times", defaultValue: "5")]
         public class RetryCount : Name<int>
         {

--- a/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/MpiClient.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/MpiClient.cs
@@ -28,6 +28,7 @@ using Org.Apache.REEF.Tang.Formats;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
+using Org.Apache.REEF.Utilities.Logging;
 using Org.Apache.REEF.Wake.Remote.Impl;
 
 namespace Org.Apache.REEF.Network.Group.Task.Impl
@@ -37,6 +38,8 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
     /// </summary>
     public class MpiClient : IMpiClient
     {
+        private static readonly Logger LOGGER = Logger.GetLogger(typeof(MpiClient));
+
         private readonly Dictionary<string, ICommunicationGroupClient> _commGroups;
 
         private readonly INetworkService<GroupCommunicationMessage> _networkService;
@@ -58,6 +61,7 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
             NetworkService<GroupCommunicationMessage> networkService,
             AvroConfigurationSerializer configSerializer)
         {
+            LOGGER.LogFunction("MpiClient constructor for task {0}", taskId);
             _commGroups = new Dictionary<string, ICommunicationGroupClient>();
             _networkService = networkService;
             networkService.Register(new StringIdentifier(taskId));

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/BroadcastReduceTest/BroadcastReduceDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/BroadcastReduceTest/BroadcastReduceDriver.cs
@@ -32,6 +32,7 @@ using Org.Apache.REEF.Network.Group.Driver;
 using Org.Apache.REEF.Network.Group.Driver.Impl;
 using Org.Apache.REEF.Network.Group.Operators;
 using Org.Apache.REEF.Network.Group.Operators.Impl;
+using Org.Apache.REEF.Network.Group.Topology;
 using Org.Apache.REEF.Network.NetworkService;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Formats;
@@ -68,12 +69,14 @@ namespace Org.Apache.REEF.Tests.Functional.MPI.BroadcastReduceTest
                     .AddBroadcast(
                         MpiTestConstants.BroadcastOperatorName,
                        MpiTestConstants.MasterTaskId,
-                            new IntCodec())
+                            new IntCodec(),
+                            TopologyTypes.Tree)
                     .AddReduce(
                         MpiTestConstants.ReduceOperatorName,
                             MpiTestConstants.MasterTaskId,
                             new IntCodec(), 
-                            new SumFunction())
+                            new SumFunction(),
+                            TopologyTypes.Tree)
                     .Build();
 
             _mpiTaskStarter = new TaskStarter(_mpiDriver, numEvaluators);
@@ -100,6 +103,7 @@ namespace Org.Apache.REEF.Tests.Functional.MPI.BroadcastReduceTest
         {
             if (_mpiDriver.IsMasterTaskContext(activeContext))
             {
+                LOGGER.Log(Level.Info, "Creating master task context, master task id = " + MpiTestConstants.MasterTaskId);
                 // Configure Master Task
                 IConfiguration partialTaskConf = TangFactory.GetTang().NewConfigurationBuilder(
                     TaskConfiguration.ConfigurationModule
@@ -121,6 +125,7 @@ namespace Org.Apache.REEF.Tests.Functional.MPI.BroadcastReduceTest
             {
                 // Configure Slave Task
                 string slaveTaskId = "SlaveTask-" + activeContext.Id;
+                LOGGER.Log(Level.Info, "Creating slave task context, task id = " + slaveTaskId);
                 IConfiguration partialTaskConf = TangFactory.GetTang().NewConfigurationBuilder(
                     TaskConfiguration.ConfigurationModule
                         .Set(TaskConfiguration.Identifier, slaveTaskId)

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/BroadcastReduceTest/BroadcastReduceTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/BroadcastReduceTest/BroadcastReduceTest.cs
@@ -53,7 +53,7 @@ namespace Org.Apache.REEF.Tests.Functional.MPI.BroadcastReduceTest
         [TestMethod]
         public void TestBroadcastAndReduce()
         {
-            int numTasks = 4;
+            int numTasks = 7;
 
             IConfiguration driverConfig = TangFactory.GetTang().NewConfigurationBuilder(
                 DriverBridgeConfiguration.ConfigurationModule
@@ -78,6 +78,9 @@ namespace Org.Apache.REEF.Tests.Functional.MPI.BroadcastReduceTest
                 .BindStringNamedParam<MpiConfigurationOptions.GroupName>(MpiTestConstants.GroupName)
                 .BindIntNamedParam<MpiConfigurationOptions.FanOut>(MpiTestConstants.FanOut.ToString(CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture))
                 .BindIntNamedParam<MpiConfigurationOptions.NumberOfTasks>(numTasks.ToString(CultureInfo.InvariantCulture))
+                .BindIntNamedParam<MpiConfigurationOptions.Timeout>(MpiTestConstants.Timeout.ToString(CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture))
+                .BindIntNamedParam<MpiConfigurationOptions.RetryCount>(MpiTestConstants.RetryCount.ToString(CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture))
+                .BindIntNamedParam<MpiConfigurationOptions.SleepTime>(MpiTestConstants.SleepTime.ToString(CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture))
                 .Build();
 
             IConfiguration merged = Configurations.Merge(driverConfig, mpiDriverConfig);

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/MpiTestConstants.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/MpiTestConstants.cs
@@ -30,5 +30,8 @@ namespace Org.Apache.REEF.Tests.Functional.MPI
         public const string SlaveTaskId = "SlaveTask-";
         public const int NumIterations = 10;
         public const int FanOut = 2;
+        public const int Timeout = 80000;
+        public const int RetryCount = 10;
+        public const int SleepTime = 8000;
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/ScatterReduceTest/ScatterReduceTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/ScatterReduceTest/ScatterReduceTest.cs
@@ -74,6 +74,10 @@ namespace Org.Apache.REEF.Tests.Functional.MPI.ScatterReduceTest
                .BindStringNamedParam<MpiConfigurationOptions.GroupName>(MpiTestConstants.GroupName)
                .BindIntNamedParam<MpiConfigurationOptions.FanOut>(MpiTestConstants.FanOut.ToString(CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture))
                .BindIntNamedParam<MpiConfigurationOptions.NumberOfTasks>(numTasks.ToString())
+               .BindIntNamedParam<MpiConfigurationOptions.Timeout>(MpiTestConstants.Timeout.ToString(CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture))
+               .BindIntNamedParam<MpiConfigurationOptions.RetryCount>(MpiTestConstants.RetryCount.ToString(CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture))
+               .BindIntNamedParam<MpiConfigurationOptions.SleepTime>(MpiTestConstants.SleepTime.ToString(CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture))
+
                .Build();
 
             IConfiguration merged = Configurations.Merge(driverConfig, mpiDriverConfig);


### PR DESCRIPTION
This PR is to add SleepTime in OperatorTopology as a named parameter so that client can set their own value. Addigng sleep time would eliminate the Node Registration dependency waiting issue.

JIRA: REEF-203. (https://issues.apache.org/jira/browse/REEF-203)

Author: Julia Wang  Email: jwang98052@yahoo.com