### PR TITLE
[REEF-126] Merge Enhanced Features into Shimoga

### DIFF
--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/CommunicationGroupDriver.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/CommunicationGroupDriver.java
@@ -21,13 +21,15 @@ package org.apache.reef.io.network.group.api.driver;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.io.network.group.api.task.GroupCommClient;
 import org.apache.reef.io.network.group.impl.config.BroadcastOperatorSpec;
+import org.apache.reef.io.network.group.impl.config.GatherOperatorSpec;
 import org.apache.reef.io.network.group.impl.config.ReduceOperatorSpec;
+import org.apache.reef.io.network.group.impl.config.ScatterOperatorSpec;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.annotations.Name;
 
 /**
  * The driver side interface of a Communication Group
- * Lets one add opertaors and tasks.
+ * Lets one add operators and tasks.
  * Main function is to extract the configuration related
  * to the Group Communication for a task in the comm group
  */
@@ -56,6 +58,28 @@ public interface CommunicationGroupDriver {
    */
   public CommunicationGroupDriver addReduce(Class<? extends Name<String>> operatorName, ReduceOperatorSpec spec);
 
+  /**
+   * Add the scatter operator specified by the
+   * 'spec' with name 'operatorName' into this
+   * Communication Group
+   *
+   * @param operatorName
+   * @param spec
+   * @return
+   */
+  public CommunicationGroupDriver addScatter(Class<? extends Name<String>> operatorName, ScatterOperatorSpec spec);
+
+  /**
+   * Add the gather operator specified by the
+   * 'spec' with name 'operatorName' into this
+   * Communication Group
+   *
+   * @param operatorName
+   * @param spec
+   * @return
+   */
+  public CommunicationGroupDriver addGather(Class<? extends Name<String>> operatorName, GatherOperatorSpec spec);
+  
   /**
    * This signals to the service that no more
    * operator specs will be added to this communication

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Gather.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Gather.java
@@ -19,6 +19,9 @@
 package org.apache.reef.io.network.group.api.operators;
 
 import org.apache.reef.exception.evaluator.NetworkException;
+import org.apache.reef.io.network.group.impl.operators.GatherReceiver;
+import org.apache.reef.io.network.group.impl.operators.GatherSender;
+import org.apache.reef.tang.annotations.DefaultImplementation;
 import org.apache.reef.wake.Identifier;
 
 import java.util.List;
@@ -34,6 +37,7 @@ public interface Gather {
   /**
    * Senders or non-roots.
    */
+  @DefaultImplementation(GatherSender.class)
   static interface Sender<T> extends GroupCommOperator {
 
     /**
@@ -45,6 +49,7 @@ public interface Gather {
   /**
    * Receiver or Root
    */
+  @DefaultImplementation(GatherReceiver.class)
   static interface Receiver<T> extends GroupCommOperator {
 
     /**

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Scatter.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Scatter.java
@@ -19,6 +19,9 @@
 package org.apache.reef.io.network.group.api.operators;
 
 import org.apache.reef.exception.evaluator.NetworkException;
+import org.apache.reef.io.network.group.impl.operators.ScatterReceiver;
+import org.apache.reef.io.network.group.impl.operators.ScatterSender;
+import org.apache.reef.tang.annotations.DefaultImplementation;
 import org.apache.reef.wake.Identifier;
 
 import java.util.List;
@@ -35,6 +38,7 @@ public interface Scatter {
   /**
    * Sender or Root.
    */
+  @DefaultImplementation(ScatterSender.class)
   static interface Sender<T> extends GroupCommOperator {
 
     /**
@@ -63,6 +67,7 @@ public interface Scatter {
   /**
    * Receiver or non-roots.
    */
+  @DefaultImplementation(ScatterReceiver.class)
   static interface Receiver<T> extends GroupCommOperator {
     /**
      * Receive the sub-list of elements targeted for the current receiver.

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/CommunicationGroupClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/CommunicationGroupClient.java
@@ -19,9 +19,11 @@
 package org.apache.reef.io.network.group.api.task;
 
 import org.apache.reef.annotations.audience.TaskSide;
-import org.apache.reef.io.network.group.api.operators.Broadcast;
-import org.apache.reef.io.network.group.api.operators.Reduce;
 import org.apache.reef.io.network.group.api.GroupChanges;
+import org.apache.reef.io.network.group.api.operators.Broadcast;
+import org.apache.reef.io.network.group.api.operators.Gather;
+import org.apache.reef.io.network.group.api.operators.Reduce;
+import org.apache.reef.io.network.group.api.operators.Scatter;
 import org.apache.reef.io.network.group.impl.task.CommunicationGroupClientImpl;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 import org.apache.reef.tang.annotations.Name;
@@ -43,7 +45,7 @@ public interface CommunicationGroupClient {
 
   /**
    * The broadcast sender configured on this communication group
-   * with the given oepratorName
+   * with the given operatorName
    *
    * @param operatorName
    * @return
@@ -52,7 +54,7 @@ public interface CommunicationGroupClient {
 
   /**
    * The broadcast receiver configured on this communication group
-   * with the given oepratorName
+   * with the given operatorName
    *
    * @param operatorName
    * @return
@@ -61,7 +63,7 @@ public interface CommunicationGroupClient {
 
   /**
    * The reduce receiver configured on this communication group
-   * with the given oepratorName
+   * with the given operatorName
    *
    * @param operatorName
    * @return
@@ -70,13 +72,48 @@ public interface CommunicationGroupClient {
 
   /**
    * The reduce sender configured on this communication group
-   * with the given oepratorName
+   * with the given operatorName
    *
    * @param operatorName
    * @return
    */
   Reduce.Sender getReduceSender(Class<? extends Name<String>> operatorName);
 
+  /**
+   * The scatter sender configured on this communication group
+   * with the given operatorName
+   *
+   * @param operatorName
+   * @return
+   */
+  Scatter.Sender getScatterSender(Class<? extends Name<String>> operatorName);
+
+  /**
+   * The scatter receiver configured on this communication group
+   * with the given operatorName
+   *
+   * @param operatorName
+   * @return
+   */
+  Scatter.Receiver getScatterReceiver(Class<? extends Name<String>> operatorName);
+
+  /**
+   * The gather receiver configured on this communication group
+   * with the given operatorName
+   *
+   * @param operatorName
+   * @return
+   */
+  Gather.Receiver getGatherReceiver(Class<? extends Name<String>> operatorName);
+  
+  /**
+   * The gather sender configured on this communication group
+   * with the given operatorName
+   *
+   * @param operatorName
+   * @return
+   */
+  Gather.Sender getGatherSender(Class<? extends Name<String>> operatorName);
   /**
    * @return Changes in topology of this communication group since the last time
    * this method was called

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/NodeStruct.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/NodeStruct.java
@@ -37,6 +37,8 @@ public interface NodeStruct {
   void setVersion(int version);
 
   byte[] getData();
+  
+  byte[][] getDataArray();
 
   void addData(GroupCommunicationMessage msg);
 }

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/OperatorTopology.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/OperatorTopology.java
@@ -48,11 +48,19 @@ public interface OperatorTopology {
 
   void sendToParent(byte[] encode, ReefNetworkGroupCommProtos.GroupCommMessage.Type reduce) throws ParentDeadException;
 
+  void sendArrayToParent(byte[][] encode, ReefNetworkGroupCommProtos.GroupCommMessage.Type msgType) throws ParentDeadException;
+  
   byte[] recvFromParent() throws ParentDeadException;
+  
+  byte[][] recvArrayFromParent() throws ParentDeadException;
 
   void sendToChildren(byte[] data, ReefNetworkGroupCommProtos.GroupCommMessage.Type msgType) throws ParentDeadException;
+  
+  void sendArrayToChildren(byte[][] data, ReefNetworkGroupCommProtos.GroupCommMessage.Type msgType) throws ParentDeadException;
 
   <T> T recvFromChildren(ReduceFunction<T> redFunc, Codec<T> dataCodec) throws ParentDeadException;
+  
+  byte[][] recvArrayFromChildren() throws ParentDeadException;
 
   void initialize() throws ParentDeadException;
 }

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/OperatorTopologyStruct.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/OperatorTopologyStruct.java
@@ -65,9 +65,17 @@ public interface OperatorTopologyStruct {
 
   void sendToParent(byte[] data, ReefNetworkGroupCommProtos.GroupCommMessage.Type msgType);
 
+  void sendArrayToParent(byte[][] data, ReefNetworkGroupCommProtos.GroupCommMessage.Type msgType);
+  
   byte[] recvFromParent();
+  
+  byte[][] recvArrayFromParent();
 
   void sendToChildren(byte[] data, ReefNetworkGroupCommProtos.GroupCommMessage.Type msgType);
+  
+  void sendArrayToChildren(byte[][] data, ReefNetworkGroupCommProtos.GroupCommMessage.Type msgType);
 
   <T> T recvFromChildren(ReduceFunction<T> redFunc, Codec<T> dataCodec);
+  
+  byte[][] recvArrayFromChildren();
 }

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/GatherOperatorSpec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/GatherOperatorSpec.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.io.network.group.impl.config;
+
+import org.apache.reef.io.network.group.api.config.OperatorSpec;
+import org.apache.reef.io.network.group.impl.utils.Utils;
+import org.apache.reef.io.serialization.Codec;
+
+/**
+ * The specification for the gather operator
+ */
+public class GatherOperatorSpec implements OperatorSpec {
+
+  private final String receiverId;
+
+  /**
+   * Codec to be used to serialize data
+   */
+  private final Class<? extends Codec> dataCodecClass;
+
+  public GatherOperatorSpec(final String receiverId,
+                            final Class<? extends Codec> dataCodecClass) {
+    super();
+    this.receiverId = receiverId;
+    this.dataCodecClass = dataCodecClass;
+  }
+
+  public String getReceiverId() {
+    return receiverId;
+  }
+
+  @Override
+  public Class<? extends Codec> getDataCodecClass() {
+    return dataCodecClass;
+  }
+
+  @Override
+  public String toString() {
+    return "Gather Operator Spec: [receiver=" + receiverId + "] [dataCodecClass= " + Utils.simpleName(dataCodecClass)
+        + "]";
+  }
+
+  public static Builder newBuilder() {
+    return new GatherOperatorSpec.Builder();
+  }
+
+  public static class Builder implements org.apache.reef.util.Builder<GatherOperatorSpec> {
+    private String receiverId;
+
+    private Class<? extends Codec> dataCodecClass;
+
+    public Builder setReceiverId(final String receiverId) {
+      this.receiverId = receiverId;
+      return this;
+    }
+
+    public Builder setDataCodecClass(final Class<? extends Codec> codecClazz) {
+      this.dataCodecClass = codecClazz;
+      return this;
+    }
+
+    @Override
+    public GatherOperatorSpec build() {
+      return new GatherOperatorSpec(receiverId, dataCodecClass);
+    }
+  }
+}

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/ScatterOperatorSpec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/ScatterOperatorSpec.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.io.network.group.impl.config;
+
+import org.apache.reef.io.network.group.api.config.OperatorSpec;
+import org.apache.reef.io.network.group.impl.utils.Utils;
+import org.apache.reef.io.serialization.Codec;
+
+/**
+ * The specification for the scatter operator 
+ */
+public class ScatterOperatorSpec implements OperatorSpec {
+  
+  private final String senderId;
+  
+  /**
+   * Codec to be used to serialize data
+   */
+  private final Class<? extends Codec> dataCodecClass;
+
+  public ScatterOperatorSpec(final String senderId,
+                             final Class<? extends Codec> dataCodecClass) {
+    super();
+    this.senderId = senderId;
+    this.dataCodecClass = dataCodecClass;
+  }
+  
+  public String getSenderId() {
+    return senderId;
+  }
+  
+  @Override
+  public Class<? extends Codec> getDataCodecClass() {
+    return dataCodecClass;
+  }
+  
+  @Override
+  public String toString() {
+    return "Scatter Operator Spec: [sender=" + senderId + "] [dataCodecClass= " + Utils.simpleName(dataCodecClass)
+        + "]";
+  }
+  
+  public static Builder newBuilder() {
+    return new ScatterOperatorSpec.Builder();
+  }
+  
+  public static class Builder implements org.apache.reef.util.Builder<ScatterOperatorSpec> {
+    private String senderId;
+    
+    private Class<? extends Codec> dataCodecClass;
+    
+    public Builder setSenderId(final String senderId) {
+      this.senderId = senderId;
+      return this;
+    }
+    
+    public Builder setDataCodecClass(final Class<? extends Codec> codecClazz) {
+      this.dataCodecClass = codecClazz;
+      return this;
+    }
+    
+    @Override
+    public ScatterOperatorSpec build() {
+      return new ScatterOperatorSpec(senderId, dataCodecClass);
+    }
+  }
+}

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CommunicationGroupDriverImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CommunicationGroupDriverImpl.java
@@ -30,7 +30,9 @@ import org.apache.reef.io.network.group.api.driver.CommunicationGroupDriver;
 import org.apache.reef.io.network.group.api.driver.Topology;
 import org.apache.reef.io.network.group.impl.GroupCommunicationMessage;
 import org.apache.reef.io.network.group.impl.config.BroadcastOperatorSpec;
+import org.apache.reef.io.network.group.impl.config.GatherOperatorSpec;
 import org.apache.reef.io.network.group.impl.config.ReduceOperatorSpec;
+import org.apache.reef.io.network.group.impl.config.ScatterOperatorSpec;
 import org.apache.reef.io.network.group.impl.config.parameters.CommunicationGroupName;
 import org.apache.reef.io.network.group.impl.config.parameters.OperatorName;
 import org.apache.reef.io.network.group.impl.config.parameters.SerializedOperConfigs;
@@ -133,16 +135,50 @@ public class CommunicationGroupDriverImpl implements CommunicationGroupDriver {
     if (finalised) {
       throw new IllegalStateException("Can't add more operators to a finalised spec");
     }
-    LOG.finer(getQualifiedName() + "Adding reduce operator to tree topology: " + spec);
+    LOG.finer(getQualifiedName() + "Adding reduce operator to topology: " + spec);
     operatorSpecs.put(operatorName, spec);
-    final Topology topology = new TreeTopology(senderStage, groupName, operatorName, driverId, numberOfTasks, fanOut);
+    final Topology topology = new FlatTopology(senderStage, groupName, operatorName, driverId, numberOfTasks);
     topology.setRootTask(spec.getReceiverId());
     topology.setOperatorSpecification(spec);
     topologies.put(operatorName, topology);
     LOG.exiting("CommunicationGroupDriverImpl", "addReduce", Arrays.toString(new Object[]{getQualifiedName(), Utils.simpleName(operatorName), " added"}));
     return this;
   }
+  
+  @Override
+  public CommunicationGroupDriver addScatter(final Class<? extends Name<String>> operatorName,
+                                             final ScatterOperatorSpec spec) {
+    LOG.entering("CommunicationGroupDriverImpl", "addScatter", new Object[]{getQualifiedName(), Utils.simpleName(operatorName), spec});
+    if (finalised) {
+      throw new IllegalStateException("Can't add more operators to a finalised spec");
+    }
+    LOG.finer(getQualifiedName() + "Adding scatter operator to topology: " + spec);
+    operatorSpecs.put(operatorName, spec);
+    final Topology topology = new FlatTopology(senderStage, groupName, operatorName, driverId, numberOfTasks);
+    topology.setRootTask(spec.getSenderId());
+    topology.setOperatorSpecification(spec);
+    topologies.put(operatorName, topology);
+    LOG.exiting("CommunicationGroupDriverImpl", "addScatter", Arrays.toString(new Object[]{getQualifiedName(), Utils.simpleName(operatorName), " added"}));
+    return this;
+  }
 
+  @Override
+  public CommunicationGroupDriver addGather(final Class<? extends Name<String>> operatorName,
+                                            final GatherOperatorSpec spec) {
+    LOG.entering("CommunicationGroupDriverImpl", "addGather", new Object[]{getQualifiedName(), Utils.simpleName(operatorName), spec});
+    if (finalised) {
+      throw new IllegalStateException("Can't add more operators to a finalised spec");
+    }
+    LOG.finer(getQualifiedName() + "Adding gather operator to topology: " + spec);
+    operatorSpecs.put(operatorName, spec);
+    final Topology topology = new FlatTopology(senderStage, groupName, operatorName, driverId, numberOfTasks);
+    topology.setRootTask(spec.getReceiverId());
+    topology.setOperatorSpecification(spec);
+    topologies.put(operatorName, topology);
+    LOG.exiting("CommunicationGroupDriverImpl", "addGather", Arrays.toString(new Object[]{getQualifiedName(), Utils.simpleName(operatorName), " added"}));
+    return this;
+  }
+  
   @Override
   public Configuration getTaskConfiguration(final Configuration taskConf) {
     LOG.entering("CommunicationGroupDriverImpl", "getTaskConfiguration", new Object[]{getQualifiedName(), confSerializer.toString(taskConf)});

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/FlatTopology.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/FlatTopology.java
@@ -27,14 +27,13 @@ import org.apache.reef.io.network.group.impl.GroupChangesCodec;
 import org.apache.reef.io.network.group.impl.GroupChangesImpl;
 import org.apache.reef.io.network.group.impl.GroupCommunicationMessage;
 import org.apache.reef.io.network.group.impl.config.BroadcastOperatorSpec;
+import org.apache.reef.io.network.group.impl.config.GatherOperatorSpec;
 import org.apache.reef.io.network.group.impl.config.ReduceOperatorSpec;
+import org.apache.reef.io.network.group.impl.config.ScatterOperatorSpec;
 import org.apache.reef.io.network.group.impl.config.parameters.DataCodec;
 import org.apache.reef.io.network.group.impl.config.parameters.ReduceFunctionParam;
 import org.apache.reef.io.network.group.impl.config.parameters.TaskVersion;
-import org.apache.reef.io.network.group.impl.operators.BroadcastReceiver;
-import org.apache.reef.io.network.group.impl.operators.BroadcastSender;
-import org.apache.reef.io.network.group.impl.operators.ReduceReceiver;
-import org.apache.reef.io.network.group.impl.operators.ReduceSender;
+import org.apache.reef.io.network.group.impl.operators.*;
 import org.apache.reef.io.network.group.impl.utils.Utils;
 import org.apache.reef.io.network.proto.ReefNetworkGroupCommProtos;
 import org.apache.reef.io.serialization.Codec;
@@ -117,14 +116,27 @@ public class FlatTopology implements Topology {
       } else {
         jcb.bindImplementation(GroupCommOperator.class, BroadcastReceiver.class);
       }
-    }
-    if (operatorSpec instanceof ReduceOperatorSpec) {
+    } else if (operatorSpec instanceof ReduceOperatorSpec) {
       final ReduceOperatorSpec reduceOperatorSpec = (ReduceOperatorSpec) operatorSpec;
       jcb.bindNamedParameter(ReduceFunctionParam.class, reduceOperatorSpec.getRedFuncClass());
       if (taskId.equals(reduceOperatorSpec.getReceiverId())) {
         jcb.bindImplementation(GroupCommOperator.class, ReduceReceiver.class);
       } else {
         jcb.bindImplementation(GroupCommOperator.class, ReduceSender.class);
+      }
+    } else if (operatorSpec instanceof ScatterOperatorSpec) {
+      final ScatterOperatorSpec scatterOperatorSpec = (ScatterOperatorSpec) operatorSpec;
+      if (taskId.equals(scatterOperatorSpec.getSenderId())) {
+        jcb.bindImplementation(GroupCommOperator.class, ScatterSender.class);
+      } else {
+        jcb.bindImplementation(GroupCommOperator.class, ScatterReceiver.class);
+      }
+    } else if (operatorSpec instanceof GatherOperatorSpec) {
+      final GatherOperatorSpec gatherOperatorSpec = (GatherOperatorSpec) operatorSpec;
+      if (taskId.equals(gatherOperatorSpec.getReceiverId())) {
+        jcb.bindImplementation(GroupCommOperator.class, GatherReceiver.class);
+      } else {
+        jcb.bindImplementation(GroupCommOperator.class, GatherSender.class);
       }
     }
     return jcb.build();

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TreeTopology.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TreeTopology.java
@@ -27,14 +27,13 @@ import org.apache.reef.io.network.group.impl.GroupChangesCodec;
 import org.apache.reef.io.network.group.impl.GroupChangesImpl;
 import org.apache.reef.io.network.group.impl.GroupCommunicationMessage;
 import org.apache.reef.io.network.group.impl.config.BroadcastOperatorSpec;
+import org.apache.reef.io.network.group.impl.config.GatherOperatorSpec;
 import org.apache.reef.io.network.group.impl.config.ReduceOperatorSpec;
+import org.apache.reef.io.network.group.impl.config.ScatterOperatorSpec;
 import org.apache.reef.io.network.group.impl.config.parameters.DataCodec;
 import org.apache.reef.io.network.group.impl.config.parameters.ReduceFunctionParam;
 import org.apache.reef.io.network.group.impl.config.parameters.TaskVersion;
-import org.apache.reef.io.network.group.impl.operators.BroadcastReceiver;
-import org.apache.reef.io.network.group.impl.operators.BroadcastSender;
-import org.apache.reef.io.network.group.impl.operators.ReduceReceiver;
-import org.apache.reef.io.network.group.impl.operators.ReduceSender;
+import org.apache.reef.io.network.group.impl.operators.*;
 import org.apache.reef.io.network.group.impl.utils.Utils;
 import org.apache.reef.io.network.proto.ReefNetworkGroupCommProtos;
 import org.apache.reef.io.serialization.Codec;
@@ -136,6 +135,20 @@ public class TreeTopology implements Topology {
         jcb.bindImplementation(GroupCommOperator.class, ReduceReceiver.class);
       } else {
         jcb.bindImplementation(GroupCommOperator.class, ReduceSender.class);
+      }
+    } else if (operatorSpec instanceof ScatterOperatorSpec) {
+      final ScatterOperatorSpec scatterOperatorSpec = (ScatterOperatorSpec) operatorSpec;
+      if (taskId.equals(scatterOperatorSpec.getSenderId())) {
+        jcb.bindImplementation(GroupCommOperator.class, ScatterSender.class);
+      } else {
+        jcb.bindImplementation(GroupCommOperator.class, ScatterReceiver.class);
+      }
+    } else if (operatorSpec instanceof GatherOperatorSpec) {
+      final GatherOperatorSpec gatherOperatorSpec = (GatherOperatorSpec) operatorSpec;
+      if (taskId.equals(gatherOperatorSpec.getReceiverId())) {
+        jcb.bindImplementation(GroupCommOperator.class, GatherReceiver.class);
+      } else {
+        jcb.bindImplementation(GroupCommOperator.class, GatherSender.class);
       }
     }
     final Configuration retConf = jcb.build();

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/operators/GatherReceiver.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/operators/GatherReceiver.java
@@ -1,0 +1,152 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.io.network.group.impl.operators;
+
+import org.apache.reef.driver.parameters.DriverIdentifier;
+import org.apache.reef.driver.task.TaskConfigurationOptions;
+import org.apache.reef.exception.evaluator.NetworkException;
+import org.apache.reef.io.network.exception.ParentDeadException;
+import org.apache.reef.io.network.group.api.operators.Gather;
+import org.apache.reef.io.network.group.api.task.CommGroupNetworkHandler;
+import org.apache.reef.io.network.group.api.task.CommunicationGroupServiceClient;
+import org.apache.reef.io.network.group.api.task.OperatorTopology;
+import org.apache.reef.io.network.group.impl.GroupCommunicationMessage;
+import org.apache.reef.io.network.group.impl.config.parameters.CommunicationGroupName;
+import org.apache.reef.io.network.group.impl.config.parameters.DataCodec;
+import org.apache.reef.io.network.group.impl.config.parameters.OperatorName;
+import org.apache.reef.io.network.group.impl.config.parameters.TaskVersion;
+import org.apache.reef.io.network.group.impl.task.OperatorTopologyImpl;
+import org.apache.reef.io.network.group.impl.utils.Utils;
+import org.apache.reef.io.network.impl.NetworkService;
+import org.apache.reef.io.serialization.Codec;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.Parameter;
+import org.apache.reef.wake.EventHandler;
+
+import javax.inject.Inject;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Logger;
+
+public class GatherReceiver<T> implements Gather.Receiver, EventHandler<GroupCommunicationMessage> {
+  
+  private static final Logger LOG = Logger.getLogger(GatherReceiver.class.getName());
+
+  private final Class<? extends Name<String>> groupName;
+  private final Class<? extends Name<String>> operName;
+  private final CommGroupNetworkHandler commGroupNetworkHandler;
+  private final Codec<T> dataCodec;
+  private final NetworkService<GroupCommunicationMessage> netService;
+  private final Sender sender;
+
+  private final OperatorTopology topology;
+
+  private final CommunicationGroupServiceClient commGroupClient;
+
+  private final AtomicBoolean init = new AtomicBoolean(false);
+
+  private final int version;
+
+  @Inject
+  public GatherReceiver(@Parameter(CommunicationGroupName.class) final String groupName,
+                        @Parameter(OperatorName.class) final String operName,
+                        @Parameter(TaskConfigurationOptions.Identifier.class) final String selfId,
+                        @Parameter(DataCodec.class) final Codec<T> dataCodec,
+                        @Parameter(DriverIdentifier.class) final String driverId,
+                        @Parameter(TaskVersion.class) final int version,
+                        final CommGroupNetworkHandler commGroupNetworkHandler,
+                        final NetworkService<GroupCommunicationMessage> netService,
+                        final CommunicationGroupServiceClient commGroupClient) {
+    super();
+    this.version = version;
+    this.groupName = Utils.getClass(groupName);
+    this.operName = Utils.getClass(operName);
+    this.dataCodec = dataCodec;
+    this.commGroupNetworkHandler = commGroupNetworkHandler;
+    this.netService = netService;
+    this.sender = new Sender(this.netService);
+    this.topology = new OperatorTopologyImpl(this.groupName, this.operName, selfId, driverId, sender, version);
+    this.commGroupNetworkHandler.register(this.operName, this);
+    this.commGroupClient = commGroupClient;
+  }
+
+  @Override
+  public int getVersion() {
+    return version;
+  }
+
+  @Override
+  public void initialize() throws ParentDeadException {
+    topology.initialize();
+  }
+
+  @Override
+  public Class<? extends Name<String>> getOperName() {
+    return operName;
+  }
+
+  @Override
+  public Class<? extends Name<String>> getGroupName() {
+    return groupName;
+  }
+
+  @Override
+  public String toString() {
+    return Utils.simpleName(groupName) + ":" + Utils.simpleName(operName) + ":" + version;
+  }
+
+  @Override
+  public void onNext(GroupCommunicationMessage msg) {
+    topology.handle(msg);
+  }
+
+  @Override
+  public List<T> receive() throws InterruptedException, NetworkException {
+    LOG.entering("GatherReceiver", "receive", this);
+    LOG.fine("I am " + this);
+
+    if (init.compareAndSet(false, true)) {
+      commGroupClient.initialize();
+    }
+    // I am root
+    LOG.fine(this + " Waiting to receive values");
+    // Wait for children to send
+    final List<T> valLst = new LinkedList<>();
+    try {
+      final byte[][] retLst = topology.recvArrayFromChildren();
+
+      for (byte[] val : retLst) {
+        valLst.add(dataCodec.decode(val));
+      }
+
+    } catch (ParentDeadException e) {
+      throw new RuntimeException("ParentDeadException", e);
+    }
+    LOG.fine(this + " Received number of values: " + valLst.size());
+    LOG.exiting("GatherReceiver", "receive", this);
+    return valLst;
+  }
+
+  @Override
+  @Deprecated
+  public List receive(List order) throws InterruptedException, NetworkException {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/operators/GatherSender.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/operators/GatherSender.java
@@ -1,0 +1,150 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.io.network.group.impl.operators;
+
+
+import org.apache.reef.driver.parameters.DriverIdentifier;
+import org.apache.reef.driver.task.TaskConfigurationOptions;
+import org.apache.reef.exception.evaluator.NetworkException;
+import org.apache.reef.io.network.exception.ParentDeadException;
+import org.apache.reef.io.network.group.api.operators.Gather;
+import org.apache.reef.io.network.group.api.task.CommGroupNetworkHandler;
+import org.apache.reef.io.network.group.api.task.CommunicationGroupServiceClient;
+import org.apache.reef.io.network.group.api.task.OperatorTopology;
+import org.apache.reef.io.network.group.impl.GroupCommunicationMessage;
+import org.apache.reef.io.network.group.impl.config.parameters.CommunicationGroupName;
+import org.apache.reef.io.network.group.impl.config.parameters.DataCodec;
+import org.apache.reef.io.network.group.impl.config.parameters.OperatorName;
+import org.apache.reef.io.network.group.impl.config.parameters.TaskVersion;
+import org.apache.reef.io.network.group.impl.task.OperatorTopologyImpl;
+import org.apache.reef.io.network.group.impl.utils.Utils;
+import org.apache.reef.io.network.proto.ReefNetworkGroupCommProtos;
+import org.apache.reef.io.network.impl.NetworkService;
+import org.apache.reef.io.serialization.Codec;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.Parameter;
+import org.apache.reef.wake.EventHandler;
+
+import javax.inject.Inject;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Logger;
+
+public class GatherSender<T> implements Gather.Sender<T>, EventHandler<GroupCommunicationMessage> {
+  
+  private final Logger LOG = Logger.getLogger(ReduceSender.class.getName());
+
+  private final Class<? extends Name<String>> groupName;
+  private final Class<? extends Name<String>> operName;
+  private final CommGroupNetworkHandler commGroupNetworkHandler;
+  private final Codec<T> dataCodec;
+  private final NetworkService<GroupCommunicationMessage> netService;
+  private final Sender sender;
+
+  private final OperatorTopology topology;
+
+  private final CommunicationGroupServiceClient commGroupClient;
+
+  private final AtomicBoolean init = new AtomicBoolean(false);
+
+  private final int version;
+
+  @Inject
+  public GatherSender(@Parameter(CommunicationGroupName.class) final String groupName,
+                      @Parameter(OperatorName.class) final String operName,
+                      @Parameter(TaskConfigurationOptions.Identifier.class) final String selfId,
+                      @Parameter(DataCodec.class) final Codec<T> dataCodec,
+                      @Parameter(DriverIdentifier.class) final String driverId,
+                      @Parameter(TaskVersion.class) final int version,
+                      final CommGroupNetworkHandler commGroupNetworkHandler,
+                      final NetworkService<GroupCommunicationMessage> netService,
+                      final CommunicationGroupServiceClient commGroupClient) {
+    super();
+    this.version = version;
+    this.groupName = Utils.getClass(groupName);
+    this.operName = Utils.getClass(operName);
+    this.dataCodec = dataCodec;
+    this.commGroupNetworkHandler = commGroupNetworkHandler;
+    this.netService = netService;
+    this.sender = new Sender(this.netService);
+    this.topology = new OperatorTopologyImpl(this.groupName, this.operName, selfId, driverId, sender, version);
+    this.commGroupNetworkHandler.register(this.operName, this);
+    this.commGroupClient = commGroupClient;
+  }
+
+  @Override
+  public int getVersion() {
+    return version;
+  }
+
+  @Override
+  public void initialize() throws ParentDeadException {
+    topology.initialize();
+  }
+
+  @Override
+  public Class<? extends Name<String>> getOperName() {
+    return operName;
+  }
+
+  @Override
+  public Class<? extends Name<String>> getGroupName() {
+    return groupName;
+  }
+
+  @Override
+  public String toString() {
+    return Utils.simpleName(groupName) + ":" + Utils.simpleName(operName) + ":" + version;
+  }
+
+  @Override
+  public void onNext(GroupCommunicationMessage msg) {
+    topology.handle(msg);
+
+  }
+
+  @Override
+  public void send(T myData) throws InterruptedException, NetworkException {
+    LOG.entering("GatherSender", "send", Arrays.toString(new Object[]{this, myData}));
+    if (init.compareAndSet(false, true)) {
+      commGroupClient.initialize();
+    }
+    // I am an intermediate node or leaf.
+    LOG.finest("Waiting for children");
+    // Wait for children to send
+    try {
+      final byte[][] receivedValuesOfChildren = topology.recvArrayFromChildren();
+
+      byte[][] valList = new byte[receivedValuesOfChildren.length+1][];
+
+      int i = 0;
+      valList[i++] = dataCodec.encode(myData);
+      for (final byte[] elem : receivedValuesOfChildren) {
+        valList[i++] = elem;
+      }
+
+      LOG.fine(this + " Sending local " + valList + " to parent");
+
+      topology.sendArrayToParent(valList, ReefNetworkGroupCommProtos.GroupCommMessage.Type.Gather);
+    } catch (final ParentDeadException e) {
+      throw new RuntimeException("ParentDeadException", e);
+    }
+    LOG.exiting("GatherSender", "send", Arrays.toString(new Object[]{this, myData}));
+  }
+}

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/operators/ScatterReceiver.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/operators/ScatterReceiver.java
@@ -1,0 +1,169 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.io.network.group.impl.operators;
+
+import org.apache.reef.driver.parameters.DriverIdentifier;
+import org.apache.reef.driver.task.TaskConfigurationOptions;
+import org.apache.reef.exception.evaluator.NetworkException;
+import org.apache.reef.io.network.exception.ParentDeadException;
+import org.apache.reef.io.network.group.api.operators.Scatter;
+import org.apache.reef.io.network.group.api.task.CommGroupNetworkHandler;
+import org.apache.reef.io.network.group.api.task.CommunicationGroupServiceClient;
+import org.apache.reef.io.network.group.api.task.OperatorTopology;
+import org.apache.reef.io.network.group.impl.GroupCommunicationMessage;
+import org.apache.reef.io.network.group.impl.config.parameters.CommunicationGroupName;
+import org.apache.reef.io.network.group.impl.config.parameters.DataCodec;
+import org.apache.reef.io.network.group.impl.config.parameters.OperatorName;
+import org.apache.reef.io.network.group.impl.config.parameters.TaskVersion;
+import org.apache.reef.io.network.group.impl.task.OperatorTopologyImpl;
+import org.apache.reef.io.network.group.impl.utils.Utils;
+import org.apache.reef.io.network.impl.NetworkService;
+import org.apache.reef.io.serialization.Codec;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.Parameter;
+import org.apache.reef.wake.EventHandler;
+
+import javax.inject.Inject;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Logger;
+
+/**
+ * The group communication operator for receiving Scatter messages.
+ *
+ * This class is only designed for @FlatTopology. In other words, we assume this node has no child in the topology
+ * and do not send received messages further down the topology.
+ */
+public class ScatterReceiver<T> implements Scatter.Receiver<T>, EventHandler<GroupCommunicationMessage> {
+  
+  private static final Logger LOG = Logger.getLogger(ScatterReceiver.class.getName());
+
+  private final Class<? extends Name<String>> groupName;
+  private final Class<? extends Name<String>> operName;
+  private final CommGroupNetworkHandler commGroupNetworkHandler;
+  private final Codec<T> dataCodec;
+  private final NetworkService<GroupCommunicationMessage> netService;
+  private final Sender sender;
+
+  private final OperatorTopology topology;
+
+  private final AtomicBoolean init = new AtomicBoolean(false);
+
+  private final CommunicationGroupServiceClient commGroupClient;
+
+  private final int version;
+
+  @Inject
+  public ScatterReceiver(@Parameter(CommunicationGroupName.class) final String groupName,
+                         @Parameter(OperatorName.class) final String operName,
+                         @Parameter(TaskConfigurationOptions.Identifier.class) final String selfId,
+                         @Parameter(DataCodec.class) final Codec<T> dataCodec,
+                         @Parameter(DriverIdentifier.class) final String driverId,
+                         @Parameter(TaskVersion.class) final int version,
+                         final CommGroupNetworkHandler commGroupNetworkHandler,
+                         final NetworkService<GroupCommunicationMessage> netService,
+                         final CommunicationGroupServiceClient commGroupClient) {
+    super();
+    this.version = version;
+    LOG.finest(operName + "has CommGroupHandler-" + commGroupNetworkHandler.toString());
+    this.groupName = Utils.getClass(groupName);
+    this.operName = Utils.getClass(operName);
+    this.dataCodec = dataCodec;
+    this.commGroupNetworkHandler = commGroupNetworkHandler;
+    this.netService = netService;
+    this.sender = new Sender(this.netService);
+    this.topology = new OperatorTopologyImpl(this.groupName, this.operName, selfId, driverId, sender, version);
+    this.commGroupNetworkHandler.register(this.operName, this);
+    this.commGroupClient = commGroupClient;
+  }
+
+  @Override
+  public int getVersion() {
+    return version;
+  }
+
+  @Override
+  public void initialize() throws ParentDeadException {
+    topology.initialize();
+  }
+
+  @Override
+  public Class<? extends Name<String>> getOperName() {
+    return operName;
+  }
+
+  @Override
+  public Class<? extends Name<String>> getGroupName() {
+    return groupName;
+  }
+
+  @Override
+  public String toString() {
+    return "ScatterReceiver:" + Utils.simpleName(groupName) + ":" + Utils.simpleName(operName) + ":" + version;
+  }
+
+  @Override
+  public void onNext(final GroupCommunicationMessage msg) {
+    topology.handle(msg);
+  }
+
+
+  @Override
+  public List<T> receive() throws NetworkException, InterruptedException {
+    LOG.entering("ScatterReceiver", "receive", this);
+    LOG.fine("I am " + this);
+    // I am an intermediate node or leaf.
+
+    if (init.compareAndSet(false, true)) {
+      LOG.fine(this + " Communication group initializing");
+      commGroupClient.initialize();
+      LOG.fine(this + " Communication group initialized");
+    }
+
+    final List<T> retVal;
+    try {
+      LOG.fine(this + " Waiting to receive scatter");
+      byte[][] data = topology.recvArrayFromParent();
+
+      if (data == null) {
+        LOG.fine(this + " Received null. Perhaps one of my ancestors is dead.");
+        retVal = null;
+
+      } else {
+        LOG.finest("Using " + dataCodec.getClass().getSimpleName() + " as codec");
+        retVal = new LinkedList<>();
+        for (final byte[] innerData : data) {
+          retVal.add(dataCodec.decode(innerData));
+        }
+        LOG.finest("Decoded msg successfully");
+        LOG.fine(this + " Received: " + retVal);
+      }
+
+      // TODO: topology.sendToChildren(data, Type.Scatter);
+      // Propagating the message to children will be needed for non-flat topologies
+
+    } catch (final ParentDeadException e) {
+      throw new RuntimeException("ParentDeadException", e);
+    }
+
+    LOG.exiting("ScatterReceiver", "receive", this);
+    return retVal;
+  }
+}

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/operators/ScatterSender.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/operators/ScatterSender.java
@@ -1,0 +1,202 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.io.network.group.impl.operators;
+
+import org.apache.reef.driver.parameters.DriverIdentifier;
+import org.apache.reef.driver.task.TaskConfigurationOptions;
+import org.apache.reef.exception.evaluator.NetworkException;
+import org.apache.reef.io.network.exception.ParentDeadException;
+import org.apache.reef.io.network.group.api.operators.Scatter;
+import org.apache.reef.io.network.group.api.task.CommGroupNetworkHandler;
+import org.apache.reef.io.network.group.api.task.CommunicationGroupServiceClient;
+import org.apache.reef.io.network.group.api.task.OperatorTopology;
+import org.apache.reef.io.network.group.impl.GroupCommunicationMessage;
+import org.apache.reef.io.network.group.impl.config.parameters.CommunicationGroupName;
+import org.apache.reef.io.network.group.impl.config.parameters.DataCodec;
+import org.apache.reef.io.network.group.impl.config.parameters.OperatorName;
+import org.apache.reef.io.network.group.impl.config.parameters.TaskVersion;
+import org.apache.reef.io.network.group.impl.task.OperatorTopologyImpl;
+import org.apache.reef.io.network.group.impl.utils.Utils;
+import org.apache.reef.io.network.proto.ReefNetworkGroupCommProtos;
+import org.apache.reef.io.network.impl.NetworkService;
+import org.apache.reef.io.serialization.Codec;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.Parameter;
+import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.Identifier;
+
+import javax.inject.Inject;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Logger;
+
+/**
+ * The group communication operator for sending Scatter messages.
+ *
+ * The Scatter.Sender interface this class implements is from the original inelastic group communication (as the
+ * other operators are), thus a few abstract methods are rather awkward and are marked @Deprecated.
+ */
+public class ScatterSender<T> implements Scatter.Sender<T>, EventHandler<GroupCommunicationMessage> {
+  
+  private static final Logger LOG = Logger.getLogger(ScatterSender.class.getName());
+  
+  private final Class<? extends Name<String>> groupName;
+  private final Class<? extends Name<String>> operName;
+  private final CommGroupNetworkHandler commGroupNetworkHandler;
+  private final Codec<T> dataCodec;
+  private final NetworkService<GroupCommunicationMessage> netService;
+  private final Sender sender;
+  
+  private final OperatorTopology topology;
+  
+  private final AtomicBoolean init = new AtomicBoolean(false);
+  
+  private final CommunicationGroupServiceClient commGroupClient;
+  
+  private final int version;
+  
+  @Inject
+  public ScatterSender(@Parameter(CommunicationGroupName.class) final String groupName,
+                       @Parameter(OperatorName.class) final String operName,
+                       @Parameter(TaskConfigurationOptions.Identifier.class) final String selfId,
+                       @Parameter(DataCodec.class) final Codec<T> dataCodec,
+                       @Parameter(DriverIdentifier.class) final String driverId,
+                       @Parameter(TaskVersion.class) final int version,
+                       final CommGroupNetworkHandler commGroupNetworkHandler,
+                       final NetworkService<GroupCommunicationMessage> netService,
+                       final CommunicationGroupServiceClient commGroupClient) {
+    super();
+    this.version = version;
+    LOG.finest(operName + "has commGroupHandler-" + commGroupNetworkHandler.toString());
+    this.groupName = Utils.getClass(groupName);
+    this.operName = Utils.getClass(operName);
+    this.dataCodec = dataCodec;
+    this.commGroupNetworkHandler = commGroupNetworkHandler;
+    this.netService = netService;
+    this.sender = new Sender(this.netService);
+    this.topology = new OperatorTopologyImpl(this.groupName, this.operName, selfId, driverId, sender, version);
+    this.commGroupNetworkHandler.register(this.operName, this);
+    this.commGroupClient = commGroupClient;
+  }
+  
+  @Override
+  public int getVersion() {
+    return version;
+  }
+
+  @Override
+  public void initialize() throws ParentDeadException {
+    topology.initialize();
+  }
+
+  @Override
+  public Class<? extends Name<String>> getOperName() {
+    return operName;
+  }
+
+  @Override
+  public Class<? extends Name<String>> getGroupName() {
+    return groupName;
+  }
+
+  @Override
+  public String toString() {
+    return "ScatterSender:" + Utils.simpleName(groupName) + ":" + Utils.simpleName(operName) + ":" + version;
+  }
+
+  @Override
+  public void onNext(final GroupCommunicationMessage msg) {
+    topology.handle(msg);
+  }
+
+  /**
+   * The main send() function to use to scatter messages to Child Tasks.
+   */
+  @Override
+  public void send(List<T> elements) throws NetworkException, InterruptedException {
+    LOG.entering("ScatterSender", "send", new Object[]{this, elements});
+    LOG.fine("I am " + this);
+    // I am root.
+
+    if (init.compareAndSet(false, true)) {
+      LOG.fine(this + " Communication group initializing");
+      commGroupClient.initialize();
+      LOG.fine(this + " Communication group initialized");
+    }
+
+    try {
+      final byte[][] data = new byte[elements.size()][];
+      for (final T element : elements) {
+        data[elements.indexOf(element)] = dataCodec.encode(element);
+      }
+      LOG.fine(this + " Scattering data");
+      topology.sendArrayToChildren(data, ReefNetworkGroupCommProtos.GroupCommMessage.Type.Scatter);
+
+    } catch (final ParentDeadException e) {
+      throw new RuntimeException("ParentDeadException", e);
+    }
+
+    LOG.exiting("ScatterSender", "send", Arrays.toString(new Object[]{this, elements}));
+  }
+
+  /**
+   * The send() function intended to specify how the data should be distributed to Compute (slave, Child) Tasks.
+   *
+   * However, in an elastic group, the number of Tasks participating may change through out the job
+   * and thus it may be safer to just let the Group Communication service do the dividing.
+   */
+  @Override
+  @Deprecated
+  public void send(List<T> elements, Integer... counts) throws NetworkException, InterruptedException {
+    LOG.entering("ScatterSender", "send", new Object[]{this, elements, counts});
+    send(elements);
+    LOG.exiting("ScatterSender", "send", Arrays.toString(new Object[]{this, elements, counts}));
+  }
+
+  /**
+   * The send() function intended to specify the order of Child Tasks to send data to.
+   *
+   * However, in an elastic group, the Tasks participating may change through out the job
+   * and thus it may be safer to just let the Group Communication service do the ordering.
+   */
+  @Override
+  @Deprecated
+  public void send(List<T> elements, List<? extends Identifier> order) throws NetworkException, InterruptedException {
+    LOG.entering("ScatterSender", "send", new Object[]{this, elements, order});
+    send(elements);
+    LOG.exiting("ScatterSender", "send", Arrays.toString(new Object[]{this, elements, order}));
+  }
+
+
+  /**
+   * The send() function intended to specify how much data to send to which Child Task.
+   *
+   * However, in an elastic group, the Tasks participating may change through out the job
+   * and thus it may be safer to just let the Group Communication service do the data distribution.
+   */
+  @Override
+  @Deprecated
+  public void send(List<T> elements, List<Integer> counts, List<? extends Identifier> order)
+      throws NetworkException, InterruptedException {
+    LOG.entering("ScatterSender", "send", new Object[]{this, elements, counts, order});
+    send(elements);
+    LOG.exiting("ScatterSender", "send", Arrays.toString(new Object[]{this, elements, counts, order}));
+  }
+}

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/operators/ScatterSender.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/operators/ScatterSender.java
@@ -143,8 +143,8 @@ public class ScatterSender<T> implements Scatter.Sender<T>, EventHandler<GroupCo
 
     try {
       final byte[][] data = new byte[elements.size()][];
-      for (final T element : elements) {
-        data[elements.indexOf(element)] = dataCodec.encode(element);
+      for (int index = 0; index < elements.size(); index++) {
+        data[index] = dataCodec.encode(elements.get(index));
       }
       LOG.fine(this + " Scattering data");
       topology.sendArrayToChildren(data, ReefNetworkGroupCommProtos.GroupCommMessage.Type.Scatter);

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/CommunicationGroupClientImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/CommunicationGroupClientImpl.java
@@ -21,9 +21,7 @@ package org.apache.reef.io.network.group.impl.task;
 import org.apache.reef.driver.parameters.DriverIdentifier;
 import org.apache.reef.driver.task.TaskConfigurationOptions;
 import org.apache.reef.exception.evaluator.NetworkException;
-import org.apache.reef.io.network.group.api.operators.Broadcast;
-import org.apache.reef.io.network.group.api.operators.GroupCommOperator;
-import org.apache.reef.io.network.group.api.operators.Reduce;
+import org.apache.reef.io.network.group.api.operators.*;
 import org.apache.reef.io.network.impl.NetworkService;
 import org.apache.reef.io.network.group.api.GroupChanges;
 import org.apache.reef.io.network.group.api.task.CommGroupNetworkHandler;
@@ -147,6 +145,32 @@ public class CommunicationGroupClientImpl implements CommunicationGroupServiceCl
   }
 
   @Override
+  public Scatter.Sender getScatterSender(final Class<? extends Name<String>> operatorName) {
+    LOG.entering("CommunicationGroupClientImpl", "getScatterSender", new Object[]{getQualifiedName(),
+        Utils.simpleName(operatorName)});
+    final GroupCommOperator op = operators.get(operatorName);
+    if (!(op instanceof Scatter.Sender)) {
+      throw new RuntimeException("Configured operator is not a scatter sender");
+    }
+    commGroupNetworkHandler.addTopologyElement(operatorName);
+    LOG.exiting("CommunicationGroupClientImpl", "getScatterSender", getQualifiedName() + op);
+    return (Scatter.Sender) op;
+  }
+  
+  @Override
+  public Gather.Receiver getGatherReceiver(final Class<? extends Name<String>> operatorName) {
+    LOG.entering("CommunicationGroupClientImpl", "getGatherReceiver", new Object[]{getQualifiedName(),
+        Utils.simpleName(operatorName)});
+    final GroupCommOperator op = operators.get(operatorName);
+    if (!(op instanceof Gather.Receiver)) {
+      throw new RuntimeException("Configured operator is not a gather receiver");
+    }
+    commGroupNetworkHandler.addTopologyElement(operatorName);
+    LOG.exiting("CommunicationGroupClientImpl", "getGatherReceiver", getQualifiedName() + op);
+    return (Gather.Receiver) op;
+  }
+  
+  @Override
   public Broadcast.Receiver getBroadcastReceiver(final Class<? extends Name<String>> operatorName) {
     LOG.entering("CommunicationGroupClientImpl", "getBroadcastReceiver", new Object[]{getQualifiedName(),
         Utils.simpleName(operatorName)});
@@ -171,7 +195,34 @@ public class CommunicationGroupClientImpl implements CommunicationGroupServiceCl
     LOG.exiting("CommunicationGroupClientImpl", "getReduceSender", getQualifiedName() + op);
     return (Reduce.Sender) op;
   }
-
+  
+  @Override
+  public Scatter.Receiver getScatterReceiver(final Class<? extends Name<String>> operatorName) {
+    LOG.entering("CommunicationGroupClientImpl", "getScatterReceiver", new Object[]{getQualifiedName(),
+        Utils.simpleName(operatorName)});
+    final GroupCommOperator op = operators.get(operatorName);
+    if (!(op instanceof Scatter.Receiver)) {
+      throw new RuntimeException("Configured operator is not a scatter receiver");
+    }
+    commGroupNetworkHandler.addTopologyElement(operatorName);
+    LOG.exiting("CommunicationGroupClientImpl", "getScatterReceiver", getQualifiedName() + op);
+    return (Scatter.Receiver) op;
+  }
+  
+  
+  @Override
+  public Gather.Sender getGatherSender(final Class<? extends Name<String>> operatorName) {
+    LOG.entering("CommunicationGroupClientImpl", "getGatherSender", new Object[]{getQualifiedName(),
+        Utils.simpleName(operatorName)});
+    final GroupCommOperator op = operators.get(operatorName);
+    if (!(op instanceof Gather.Sender)) {
+      throw new RuntimeException("Configured operator is not a gather sender");
+    }
+    commGroupNetworkHandler.addTopologyElement(operatorName);
+    LOG.exiting("CommunicationGroupClientImpl", "getGatherSender", getQualifiedName() + op);
+    return (Gather.Sender) op;
+  }
+  
   @Override
   public void initialize() {
     LOG.entering("CommunicationGroupClientImpl", "initialize", getQualifiedName());

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/NodeStructImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/NodeStructImpl.java
@@ -77,6 +77,21 @@ public abstract class NodeStructImpl implements NodeStruct {
     LOG.exiting("NodeStructImpl", "getData", retVal);
     return retVal;
   }
+  
+  @Override
+  public byte[][] getDataArray() {
+    LOG.entering("NodeStructImpl", "getDataArray");
+    GroupCommunicationMessage gcm;
+    try {
+      gcm = dataQue.take();
+    } catch (final InterruptedException e) {
+      throw new RuntimeException("InterruptedException while waiting for data from " + id, e);
+    }
+    
+    final byte[][] retVal = checkDead(gcm) ? null : Utils.getDataArray(gcm);
+    LOG.exiting("NodeStructImpl", "getDataArray", retVal);
+    return retVal;
+  }
 
   @Override
   public String toString() {

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/OperatorTopologyImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/OperatorTopologyImpl.java
@@ -202,6 +202,15 @@ public class OperatorTopologyImpl implements OperatorTopology {
     effectiveTopology.sendToParent(data, msgType);
     LOG.exiting("OperatorTopologyImpl", "sendToParent", Arrays.toString(new Object[]{getQualifiedName(), data, msgType}));
   }
+  
+  @Override
+  public void sendArrayToParent(final byte[][] data, final ReefNetworkGroupCommProtos.GroupCommMessage.Type msgType) throws ParentDeadException {
+    LOG.entering("OperatorTopologyImpl", "sendArrayToParent", new Object[]{getQualifiedName(), data, msgType});
+    refreshEffectiveTopology();
+    assert (effectiveTopology != null);
+    effectiveTopology.sendArrayToParent(data, msgType);
+    LOG.exiting("OperatorTopologyImpl", "sendArrayToParent", Arrays.toString(new Object[]{getQualifiedName(), data, msgType}));
+  }
 
   @Override
   public void sendToChildren(final byte[] data, final ReefNetworkGroupCommProtos.GroupCommMessage.Type msgType) throws ParentDeadException {
@@ -210,6 +219,15 @@ public class OperatorTopologyImpl implements OperatorTopology {
     assert (effectiveTopology != null);
     effectiveTopology.sendToChildren(data, msgType);
     LOG.exiting("OperatorTopologyImpl", "sendToChildren", Arrays.toString(new Object[]{getQualifiedName(), data, msgType}));
+  }
+  
+  @Override
+  public void sendArrayToChildren(final byte[][] data, ReefNetworkGroupCommProtos.GroupCommMessage.Type msgType) throws ParentDeadException {
+    LOG.entering("OperatorTopologyImpl", "sendArrayToChildren", new Object[]{getQualifiedName(), data, msgType});
+    refreshEffectiveTopology();
+    assert (effectiveTopology != null);
+    effectiveTopology.sendArrayToChildren(data, msgType);
+    LOG.exiting("OperatorTopologyImpl", "sendArrayToChildren", new Object[]{getQualifiedName(), data, msgType});
   }
 
   @Override
@@ -221,6 +239,16 @@ public class OperatorTopologyImpl implements OperatorTopology {
     LOG.exiting("OperatorTopologyImpl", "recvFromParent", Arrays.toString(new Object[]{getQualifiedName(), retVal}));
     return retVal;
   }
+  
+  @Override
+  public byte[][] recvArrayFromParent() throws ParentDeadException {
+    LOG.entering("OperatorTopologyImpl", "recvArrayFromParent", getQualifiedName());
+    refreshEffectiveTopology();
+    assert (effectiveTopology != null);
+    final byte[][] retVal = effectiveTopology.recvArrayFromParent();
+    LOG.exiting("OperatorTopologyImpl", "recvArrayFromParent", Arrays.toString(new Object[]{getQualifiedName(), retVal}));
+    return retVal;
+  }
 
   @Override
   public <T> T recvFromChildren(final Reduce.ReduceFunction<T> redFunc, final Codec<T> dataCodec) throws ParentDeadException {
@@ -229,6 +257,16 @@ public class OperatorTopologyImpl implements OperatorTopology {
     assert (effectiveTopology != null);
     final T retVal = effectiveTopology.recvFromChildren(redFunc, dataCodec);
     LOG.exiting("OperatorTopologyImpl", "recvFromChildren", Arrays.toString(new Object[]{getQualifiedName(), retVal}));
+    return retVal;
+  }
+  
+  @Override
+  public byte[][] recvArrayFromChildren() throws ParentDeadException {
+    LOG.entering("OperatorTopologyImpl", "recvArrayFromChildren", getQualifiedName());
+    refreshEffectiveTopology();
+    assert (effectiveTopology != null);
+    final byte[][] retVal = effectiveTopology.recvArrayFromChildren();
+    LOG.exiting("OperatorTopologyImpl", "recvArrayFromChildren", Arrays.toString(new Object[]{getQualifiedName(), retVal}));
     return retVal;
   }
 

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/Utils.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/Utils.java
@@ -61,6 +61,10 @@ public class Utils {
     return (gcm.getMsgsCount() == 1) ? gcm.getData()[0] : null;
   }
 
+  public static byte[][] getDataArray(final GroupCommunicationMessage gcm) {
+    return (gcm.getMsgsCount() > 0) ? gcm.getData() : null;
+  }
+  
   /**
    * @param msg
    * @return
@@ -76,5 +80,13 @@ public class Utils {
     } else {
       throw new RuntimeException("Expecting exactly one GCM object inside Message but found none");
     }
+  }
+  
+  public static int getSizeOf2dByteArray(final byte[][] twoDArray) {
+    int size = 0;
+    for (final byte[] array: twoDArray) {
+      size += array.length;
+    }
+    return size;
   }
 }


### PR DESCRIPTION
* Gather and Scatter operators have been added
* Few methods from old API have been marked deprecated
* Current type of Scatter only supports `FlatTopology`

JIRA: [REEF-126](https://issues.apache.org/jira/browse/REEF-126)

A few issues:
* As mentioned in the commit message, the current form of Scatter is designed for flat topologies only. I'll add a JIRA issue that covers this problem.
* `FlatTopology` and `TreeTopology` cannot be used at the same time, e.g. a job that uses Broadcast with a flat topology and Reduce with a tree topology doesn't work (driver seems to hang at some point). If this actually is the intended behavior, then `CommunicationGroupDriverImpl` should be modified to use only one ~~time~~type of topology.
* `OperatorTopologyStructImpl` checks if a message to be sent is too big, but doesn't do anything afterwards.