### PR TITLE
[REEF-194]  Remove 3rd party libraries from REEF Client Nuget

### DIFF
--- a/lang/cpp/reef-bridge-clr/pom.xml
+++ b/lang/cpp/reef-bridge-clr/pom.xml
@@ -120,6 +120,22 @@ under the License.
                                     <goal>exec</goal>
                                 </goals>
                             </execution>
+			   <execution>
+                                <id>build1</id>
+                                <phase>pre-integration-test</phase>
+                                <configuration>
+                                    <arguments>
+                                        <argument>
+                                            ${project.basedir}/../../cs/Org.Apache.REEF.Bridge/Org.Apache.REEF.Bridge.csproj
+                                        </argument>
+                                        <argument>/p:Configuration="Release"</argument>
+                                        <argument>/p:Platform="x64"</argument>
+                                    </arguments>
+                                </configuration>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
                         </executions>
                     </plugin>
                     <plugin>

--- a/lang/cs/Org.Apache.REEF.Bridge/Org.Apache.REEF.Bridge.csproj
+++ b/lang/cs/Org.Apache.REEF.Bridge/Org.Apache.REEF.Bridge.csproj
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{3C851833-11F4-43D8-BF78-1150BD1A844B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Org.Apache.REEF.Bridge</RootNamespace>
+    <AssemblyName>Org.Apache.REEF.Bridge</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <RestorePackages>true</RestorePackages>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..</SolutionDir>
+    <BridgeClrDll Condition="$(BridgeClrDll) == ''">$(SolutionDir)\..\cpp\reef-bridge-clr\target\classes\Org.Apache.REEF.Bridge.Clr.dll</BridgeClrDll>    
+    <JavaClrBridgeDll Condition="$(JavaClrBridgeDll) == ''">$(SolutionDir)\..\cpp\reef-bridge-clr\target\classes\Org.Apache.REEF.Bridge.JavaClrBridge.dll</JavaClrBridgeDll>    
+  </PropertyGroup>
+  <Import Project="$(SolutionDir)\build.props" />
+  <Choose>
+    <When Condition="Exists('$(BridgeClrDll)')">
+      <ItemGroup>
+        <Reference Include="Org.Apache.REEF.Bridge.Clr">
+          <HintPath>$(SolutionDir)\..\cpp\reef-bridge-clr\target\classes\Org.Apache.REEF.Bridge.Clr.dll</HintPath>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="Exists('$(JavaClrBridgeDll)')">
+      <ItemGroup>
+        <Reference Include="Org.Apache.REEF.Bridge.JavaClrBridge">
+          <HintPath>$(SolutionDir)\..\cpp\reef-bridge-clr\target\classes\Org.Apache.REEF.Bridge.JavaClrBridge.dll</HintPath>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/lang/cs/Org.Apache.REEF.Bridge/Org.Apache.REEF.Bridge.nuspec
+++ b/lang/cs/Org.Apache.REEF.Bridge/Org.Apache.REEF.Bridge.nuspec
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Org.Apache.REEF.Bridge</id>
+    <version>$version$</version>
+    <title>Org.Apache.REEF.Bridge</title>
+    <authors>The Apache REEF project</authors>
+    <owners>The Apache REEF project</owners>
+    <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+    <projectUrl>http://reef.incubator.apache.org/</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>REEF is a platform to run applications on distributed environment</description>
+    <copyright>The Apache Software Foundation</copyright>
+    <tags>Reef Bridge framework</tags>
+    <dependencies>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="..\bin\$Platform$\$Configuration$\Org.Apache.REEF.Bridge\Org.Apache.REEF.Bridge.dll" target="lib\net45" />
+    <file src="..\bin\$Platform$\$Configuration$\Org.Apache.REEF.Bridge\Org.Apache.REEF.Bridge.pdb" target="lib\net45" />
+  </files>
+</package>

--- a/lang/cs/Org.Apache.REEF.Bridge/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Bridge/Properties/AssemblyInfo.cs
@@ -1,0 +1,55 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Org.Apache.REEF.Bridge")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Org.Apache.REEF.Bridge")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("7d1fda34-deb4-4120-a5ec-63a60d358423")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/lang/cs/Org.Apache.REEF.Jar/Org.Apache.REEF.Jar.csproj
+++ b/lang/cs/Org.Apache.REEF.Jar/Org.Apache.REEF.Jar.csproj
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{96BAB6AB-BD8C-45AE-B794-5BB83DBB4E21}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Org.Apache.REEF.Jar</RootNamespace>
+    <AssemblyName>Org.Apache.REEF.Jar</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <RestorePackages>true</RestorePackages>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..</SolutionDir>
+    <ReefJarFile Condition="$(ReefJarFile) == ''">$(SolutionDir)\cs\Org.Apache.REEF.Jar\reef-bridge-0.11.0-incubating-SNAPSHOT-shaded.jar</ReefJarFile> 
+  </PropertyGroup>
+  <Import Project="$(SolutionDir)\build.props" />
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="Exists('$(ReefJarFile)')">
+      <ItemGroup>
+        <Content Include="$(ReefJarFile)">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/lang/cs/Org.Apache.REEF.Jar/Org.Apache.REEF.Jar.nuspec
+++ b/lang/cs/Org.Apache.REEF.Jar/Org.Apache.REEF.Jar.nuspec
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Org.Apache.REEF.Jar</id>
+    <version>$version$</version>
+    <title>Org.Apache.REEF.Jar</title>
+    <authors>The Apache REEF project</authors>
+    <owners>The Apache REEF project</owners>
+    <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+    <projectUrl>http://reef.incubator.apache.org/</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>REEF is a platform to run applications on distributed environment</description>
+    <copyright>The Apache Software Foundation</copyright>
+    <tags>Reef</tags>
+    <dependencies>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="..\bin\$Platform$\$Configuration$\Org.Apache.REEF.Jar\Org.Apache.REEF.Jar.dll" target="lib\net45" />
+    <file src="..\bin\$Platform$\$Configuration$\Org.Apache.REEF.Jar\Org.Apache.REEF.jar.pdb" target="lib\net45" />
+  </files>
+</package>

--- a/lang/cs/Org.Apache.REEF.Jar/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Jar/Properties/AssemblyInfo.cs
@@ -1,0 +1,55 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Org.Apache.REEF.Jar")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Org.Apache.REEF.Jar")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("129603e3-7254-4bf2-8ce6-e54e659b7102")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/lang/cs/Org.Apache.REEF.sln
+++ b/lang/cs/Org.Apache.REEF.sln
@@ -42,6 +42,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Org.Apache.REEF.Examples", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Org.Apache.REEF.Common.Tests", "Org.Apache.REEF.Common.Tests\Org.Apache.REEF.Common.Tests.csproj", "{F1A3495C-2CBD-4F3B-AEDC-9C1A43D9F238}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Org.Apache.REEF.Jar", "Org.Apache.REEF.Jar\Org.Apache.REEF.Jar.csproj", "{96BAB6AB-BD8C-45AE-B794-5BB83DBB4E21}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Org.Apache.REEF.Bridge", "Org.Apache.REEF.Bridge\Org.Apache.REEF.Bridge.csproj", "{3C851833-11F4-43D8-BF78-1150BD1A844B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -176,6 +180,22 @@ Global
 		{F1A3495C-2CBD-4F3B-AEDC-9C1A43D9F238}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F1A3495C-2CBD-4F3B-AEDC-9C1A43D9F238}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F1A3495C-2CBD-4F3B-AEDC-9C1A43D9F238}.Release|x64.ActiveCfg = Release|Any CPU
+		{96BAB6AB-BD8C-45AE-B794-5BB83DBB4E21}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{96BAB6AB-BD8C-45AE-B794-5BB83DBB4E21}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{96BAB6AB-BD8C-45AE-B794-5BB83DBB4E21}.Debug|x64.ActiveCfg = Debug|x64
+		{96BAB6AB-BD8C-45AE-B794-5BB83DBB4E21}.Debug|x64.Build.0 = Debug|x64
+		{96BAB6AB-BD8C-45AE-B794-5BB83DBB4E21}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{96BAB6AB-BD8C-45AE-B794-5BB83DBB4E21}.Release|Any CPU.Build.0 = Release|Any CPU
+		{96BAB6AB-BD8C-45AE-B794-5BB83DBB4E21}.Release|x64.ActiveCfg = Release|x64
+		{96BAB6AB-BD8C-45AE-B794-5BB83DBB4E21}.Release|x64.Build.0 = Release|x64
+		{3C851833-11F4-43D8-BF78-1150BD1A844B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C851833-11F4-43D8-BF78-1150BD1A844B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3C851833-11F4-43D8-BF78-1150BD1A844B}.Debug|x64.ActiveCfg = Debug|x64
+		{3C851833-11F4-43D8-BF78-1150BD1A844B}.Debug|x64.Build.0 = Debug|x64
+		{3C851833-11F4-43D8-BF78-1150BD1A844B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3C851833-11F4-43D8-BF78-1150BD1A844B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3C851833-11F4-43D8-BF78-1150BD1A844B}.Release|x64.ActiveCfg = Release|x64
+		{3C851833-11F4-43D8-BF78-1150BD1A844B}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/lang/reef-bridge/pom.xml
+++ b/lang/reef-bridge/pom.xml
@@ -134,6 +134,53 @@ under the License.
                     </filters>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-jar</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <overwrite>true</overwrite>
+                            <outputDirectory>${basedir}/../cs/Org.Apache.REEF.Jar</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.build.directory}</directory>
+                                    <include>*-shaded.jar</include>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <configuration>
+                    <executable>msbuild.exe</executable>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>build</id>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <arguments>
+                                <argument>
+                                    ${project.basedir}/../cs/Org.Apache.REEF.Jar/Org.Apache.REEF.Jar.csproj
+                                </argument>
+                                <argument>/p:Configuration="Release"</argument>
+                                <argument>/p:Platform="x64"</argument>
+                            </arguments>
+                        </configuration>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
This PR added

 * Org.Apache.REEF.Bridge project, that wraps clr dlls including Org.Apache.REEF.Bridge.Clr.dll and Org.Apache.REEF.Bridge.JavaClrBridge.dll. NuGet will be generated for Org.Apache.REEF.Bridge.dll with the spec and script during the build. The clr dlls are generated on the fly through mvn build
 * Org.Apache.REEF.Jar project, that wraps shaded jar file only. The NuGet for Org.Apache.REEF.Jar.dll. will be generated during the build process. The jar file is grabbed on the fly.

JIRA: REEF-194. (https://issues.apache.org/jira/browse/REEF-194)

Author: Julia Wang  Email: jwang98052@yahoo.com