### PR TITLE
[REEF-204] Fixed failure to react to misconfigured Hadoop 2.6 clusters.

### DIFF
--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/UnsafeHDInsightRuntimeConfigurationStatic.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/UnsafeHDInsightRuntimeConfigurationStatic.java
@@ -24,8 +24,10 @@ import org.apache.reef.client.RunningJob;
 import org.apache.reef.runtime.common.client.REEFImplementation;
 import org.apache.reef.runtime.common.client.RunningJobImpl;
 import org.apache.reef.runtime.common.client.api.JobSubmissionHandler;
+import org.apache.reef.runtime.common.files.RuntimeClasspathProvider;
 import org.apache.reef.runtime.common.launch.REEFMessageCodec;
 import org.apache.reef.runtime.hdinsight.client.sslhacks.UnsafeClientConstructor;
+import org.apache.reef.runtime.yarn.YarnClasspathProvider;
 import org.apache.reef.tang.formats.ConfigurationModule;
 import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
 import org.apache.reef.util.logging.LoggingSetup;
@@ -41,6 +43,7 @@ public final class UnsafeHDInsightRuntimeConfigurationStatic extends Configurati
 
   public static final ConfigurationModule CONF = new UnsafeHDInsightRuntimeConfigurationStatic()
       .bindImplementation(REEF.class, REEFImplementation.class)
+          .bindImplementation(RuntimeClasspathProvider.class, YarnClasspathProvider.class)
       .bindImplementation(RunningJob.class, RunningJobImpl.class)
       .bindNamedParameter(RemoteConfiguration.MessageCodec.class, REEFMessageCodec.class)
       .bindImplementation(JobSubmissionHandler.class, HDInsightJobSubmissionHandler.class)

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/ClassPathBuilder.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/ClassPathBuilder.java
@@ -45,8 +45,8 @@ final class ClassPathBuilder {
    */
   private static boolean couldBeYarnConfigurationPath(final String path) {
     return path.contains("conf") ||
-        path.contains("etc") ||
-        path.contains(HadoopEnvironment.HADOOP_CONF_DIR);
+            path.contains("etc") ||
+            path.contains(HadoopEnvironment.HADOOP_CONF_DIR);
   }
 
   /**
@@ -92,6 +92,18 @@ final class ClassPathBuilder {
       this.add(classPathEntry);
     }
   }
+
+  /**
+   * Adds all the given entries to the classpath suffix.
+   *
+   * @param entries
+   */
+  void addAllToSuffix(final String... entries) {
+    for (final String classPathEntry : entries) {
+      this.addToPrefix(classPathEntry);
+    }
+  }
+
 
   /**
    * @return the suffix in an immutable list.


### PR DESCRIPTION
  This addressed the issue by making sure that both `YarnConfiguration.YARN_APPLICATION_CLASSPATH`  and `DEFAULT_YARN_CROSS_PLATFORM_APPLICATION_CLASSPATH` are configured,   otherwise we use legacy CLASSPATH. We also make sure that HADOOP_CONF_DIR is in the prefix.
JIRA: [REEF-204](https://issues.apache.org/jira/browse/REEF-204)