### PR TITLE
[REEF-205] Add Org.Apache.REEF.Bridge.JAR

### DIFF
--- a/lang/cs/Org.Apache.REEF.Bridge.JAR/Org.Apache.REEF.Bridge.JAR.csproj
+++ b/lang/cs/Org.Apache.REEF.Bridge.JAR/Org.Apache.REEF.Bridge.JAR.csproj
@@ -16,13 +16,23 @@ specific language governing permissions and limitations
 under the License.
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
+  <PropertyGroup>
+    <!--Set configuration parameters usually set in the Solution. This is needed for build.props to work.-->
+    <SolutionDir Condition="'$(SolutionDir)' == ''">$([System.IO.Path]::GetFullPath($(MSBuildProjectDirectory)\..))</SolutionDir>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <Platform Condition="'$(Platform)' == ''">x64</Platform>
+    <RootNameSpace>$(MSBuildProjectName)</RootNameSpace>
+  </PropertyGroup>
   <Import Project="..\build.props" />
   <PropertyGroup>
     <!--The folder where the REEF sources have been checked out to.-->
     <REEF_Source_Folder>$([System.IO.Path]::GetFullPath($(MSBuildProjectDirectory)\..\..\..))</REEF_Source_Folder>
     <!--The shaded jar of the bridge -->
-    <Bridge_JAR>$(REEF_Source_Folder)\lang\java\reef-bridge-java\target\reef-bridge-java-$(REEF_Version)-shaded.jar</Bridge_JAR>
+    <Bridge_JAR_Name>reef-bridge-java-$(REEF_Version)-shaded.jar</Bridge_JAR_Name>
+    <Bridge_JAR>$(REEF_Source_Folder)\lang\java\reef-bridge-java\target\$(Bridge_JAR_Name)</Bridge_JAR>
+    <!--The destination folder where to put the JAR file -->
   </PropertyGroup>
+  
   <Target Name="CheckMavenInstall">
     <!--Check that maven is installed-->
     <Error Condition=" '$(M2_HOME)' == '' " Text="$M2_HOME is not set. Please make sure that Maven is installed and configured. See https://cwiki.apache.org/confluence/display/REEF/Compiling+REEF for details." />
@@ -33,11 +43,13 @@ under the License.
   -->
   <Target Name="Build" DependsOnTargets="CheckMavenInstall">
     <Exec Command="$(M2_HOME)\bin\mvn -TC1 -DskipTests install" Condition="!Exists('$(Bridge_JAR)')" WorkingDirectory="$(REEF_Source_Folder)" />
+    <Copy DestinationFolder="$(OutputPath)" SourceFiles="$(Bridge_JAR)"/>
   </Target>
   <!--
     Executes 'mvn clean', if the JAR exists.
   -->
   <Target Name="Clean" DependsOnTargets="CheckMavenInstall">
     <Exec Command="$(M2_HOME)\bin\mvn -TC1 -DskipTests clean" Condition="Exists('$(Bridge_JAR)')" WorkingDirectory="$(REEF_Source_Folder)" />
+    <Delete Files="$(OutputPath)\$(Bridge_JAR_Name)" />
   </Target>
 </Project>

--- a/lang/cs/Org.Apache.REEF.Bridge.JAR/Org.Apache.REEF.Bridge.JAR.csproj
+++ b/lang/cs/Org.Apache.REEF.Bridge.JAR/Org.Apache.REEF.Bridge.JAR.csproj
@@ -22,11 +22,6 @@ under the License.
     <REEF_Source_Folder>$([System.IO.Path]::GetFullPath($(MSBuildProjectDirectory)\..\..\..))</REEF_Source_Folder>
     <!--The shaded jar of the bridge -->
     <Bridge_JAR>$(REEF_Source_Folder)\lang\java\reef-bridge-java\target\reef-bridge-java-$(REEF_Version)-shaded.jar</Bridge_JAR>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
-    <OldToolsVersion>2.0</OldToolsVersion>
   </PropertyGroup>
   <Target Name="CheckMavenInstall">
     <!--Check that maven is installed-->

--- a/lang/cs/Org.Apache.REEF.Bridge.JAR/Org.Apache.REEF.Bridge.JAR.csproj
+++ b/lang/cs/Org.Apache.REEF.Bridge.JAR/Org.Apache.REEF.Bridge.JAR.csproj
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
+  <Import Project="..\build.props" />
+  <PropertyGroup>
+    <!--The folder where the REEF sources have been checked out to.-->
+    <REEF_Source_Folder>$([System.IO.Path]::GetFullPath($(MSBuildProjectDirectory)\..\..\..))</REEF_Source_Folder>
+    <!--The shaded jar of the bridge -->
+    <Bridge_JAR>$(REEF_Source_Folder)\lang\java\reef-bridge-java\target\reef-bridge-java-$(REEF_Version)-shaded.jar</Bridge_JAR>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>2.0</OldToolsVersion>
+  </PropertyGroup>
+  <Target Name="CheckMavenInstall">
+    <!--Check that maven is installed-->
+    <Error Condition=" '$(M2_HOME)' == '' " Text="$M2_HOME is not set. Please make sure that Maven is installed and configured. See https://cwiki.apache.org/confluence/display/REEF/Compiling+REEF for details." />
+    <Message Text="Using the maven installation found in $(M2_HOME)" />
+  </Target>
+  <!--
+    Executes 'mvn install', if the JAR does not exist.
+  -->
+  <Target Name="Build" DependsOnTargets="CheckMavenInstall">
+    <Exec Command="$(M2_HOME)\bin\mvn -TC1 -DskipTests install" Condition="!Exists('$(Bridge_JAR)')" WorkingDirectory="$(REEF_Source_Folder)" />
+  </Target>
+  <!--
+    Executes 'mvn clean', if the JAR exists.
+  -->
+  <Target Name="Clean" DependsOnTargets="CheckMavenInstall">
+    <Exec Command="$(M2_HOME)\bin\mvn -TC1 -DskipTests clean" Condition="Exists('$(Bridge_JAR)')" WorkingDirectory="$(REEF_Source_Folder)" />
+  </Target>
+</Project>

--- a/lang/cs/Org.Apache.REEF.sln
+++ b/lang/cs/Org.Apache.REEF.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{2B7EE9D5-CA54-4204-B89D-B48A7FC6E3CD}"
 	ProjectSection(SolutionItems) = preProject
@@ -41,6 +41,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Org.Apache.REEF.Examples", "Org.Apache.REEF.Examples\Org.Apache.REEF.Examples.csproj", "{75503F90-7B82-4762-9997-94B5C68F15DB}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Org.Apache.REEF.Common.Tests", "Org.Apache.REEF.Common.Tests\Org.Apache.REEF.Common.Tests.csproj", "{F1A3495C-2CBD-4F3B-AEDC-9C1A43D9F238}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Org.Apache.REEF.Bridge.JAR", "Org.Apache.REEF.Bridge.JAR\Org.Apache.REEF.Bridge.JAR.csproj", "{62905C7C-1A7E-4923-B78D-1BF42D7FAD40}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -176,6 +178,12 @@ Global
 		{F1A3495C-2CBD-4F3B-AEDC-9C1A43D9F238}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F1A3495C-2CBD-4F3B-AEDC-9C1A43D9F238}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F1A3495C-2CBD-4F3B-AEDC-9C1A43D9F238}.Release|x64.ActiveCfg = Release|Any CPU
+		{62905C7C-1A7E-4923-B78D-1BF42D7FAD40}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62905C7C-1A7E-4923-B78D-1BF42D7FAD40}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62905C7C-1A7E-4923-B78D-1BF42D7FAD40}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{62905C7C-1A7E-4923-B78D-1BF42D7FAD40}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{62905C7C-1A7E-4923-B78D-1BF42D7FAD40}.Release|Any CPU.Build.0 = Release|Any CPU
+		{62905C7C-1A7E-4923-B78D-1BF42D7FAD40}.Release|x64.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/lang/cs/build.props
+++ b/lang/cs/build.props
@@ -70,6 +70,12 @@ under the License.
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
 
+  <!-- REEF Version -->
+  <PropertyGroup>
+    <!--TODO: Fetch this from the POM-->
+    <REEF_Version>0.11.0-incubating-SNAPSHOT</REEF_Version>
+  </PropertyGroup>
+  
   <!-- REEF NuGet properties -->
   <PropertyGroup>
     <IsSnapshot>true</IsSnapshot>

--- a/lang/java/reef-bridge-java/pom.xml
+++ b/lang/java/reef-bridge-java/pom.xml
@@ -84,6 +84,35 @@ under the License.
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <outputFile>
+                        ${project.build.directory}/${project.artifactId}-${project.version}-shaded.jar
+                    </outputFile>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>yarn-default.xml</exclude>
+                                <exclude>yarn-version-info.properties</exclude>
+                                <exclude>core-default.xml</exclude>
+                                <exclude>LICENSE</exclude>
+                                <exclude>META-INF/*</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>


### PR DESCRIPTION
This adds a new project to the .NET solution: `Org.Apache.REEF.Bridge.JAR`. Upon build, it checks whether the shaded jar for `reef-bridge-java` exists. If not, it will be built. The build will fail if M2_HOME isn't set and.

Also, this PR adds the shaded jar to `reef-bridge-java`.

JIRA: [REEF-205](https://issues.apache.org/jira/browse/REEF-205)