### PR TITLE
[REEF-207] Make REEF Version(s) available as MSBuild properties

### DIFF
--- a/lang/cs/Org.Apache.REEF.Bridge.JAR/Org.Apache.REEF.Bridge.JAR.csproj
+++ b/lang/cs/Org.Apache.REEF.Bridge.JAR/Org.Apache.REEF.Bridge.JAR.csproj
@@ -24,17 +24,10 @@ under the License.
     <RootNameSpace>$(MSBuildProjectName)</RootNameSpace>
   </PropertyGroup>
   <Import Project="..\build.props" />
-  <PropertyGroup>
-    <!--The folder where the REEF sources have been checked out to.-->
-    <REEF_Source_Folder>$([System.IO.Path]::GetFullPath($(MSBuildProjectDirectory)\..\..\..))</REEF_Source_Folder>
-    <!--The shaded jar of the bridge -->
-    <Bridge_JAR_Name>reef-bridge-java-$(REEF_Version)-shaded.jar</Bridge_JAR_Name>
-    <Bridge_JAR>$(REEF_Source_Folder)\lang\java\reef-bridge-java\target\$(Bridge_JAR_Name)</Bridge_JAR>
-    <!--The destination folder where to put the JAR file -->
-  </PropertyGroup>
-  
+  <!--
+    Check that maven is installed
+  -->
   <Target Name="CheckMavenInstall">
-    <!--Check that maven is installed-->
     <Error Condition=" '$(M2_HOME)' == '' " Text="$M2_HOME is not set. Please make sure that Maven is installed and configured. See https://cwiki.apache.org/confluence/display/REEF/Compiling+REEF for details." />
     <Message Text="Using the maven installation found in $(M2_HOME)" />
   </Target>
@@ -42,6 +35,11 @@ under the License.
     Executes 'mvn install', if the JAR does not exist.
   -->
   <Target Name="Build" DependsOnTargets="CheckMavenInstall">
+    <PropertyGroup>
+      <!--The shaded jar of the bridge -->
+      <Bridge_JAR_Name>reef-bridge-java-$(REEF_Version)-shaded.jar</Bridge_JAR_Name>
+      <Bridge_JAR>$(REEF_Source_Folder)\lang\java\reef-bridge-java\target\$(Bridge_JAR_Name)</Bridge_JAR>
+    </PropertyGroup>
     <Exec Command="$(M2_HOME)\bin\mvn -TC1 -DskipTests install" Condition="!Exists('$(Bridge_JAR)')" WorkingDirectory="$(REEF_Source_Folder)" />
     <Copy DestinationFolder="$(OutputPath)" SourceFiles="$(Bridge_JAR)"/>
   </Target>
@@ -49,6 +47,11 @@ under the License.
     Executes 'mvn clean', if the JAR exists.
   -->
   <Target Name="Clean" DependsOnTargets="CheckMavenInstall">
+    <PropertyGroup>
+      <!--The shaded jar of the bridge -->
+      <Bridge_JAR_Name>reef-bridge-java-$(REEF_Version)-shaded.jar</Bridge_JAR_Name>
+      <Bridge_JAR>$(REEF_Source_Folder)\lang\java\reef-bridge-java\target\$(Bridge_JAR_Name)</Bridge_JAR>
+    </PropertyGroup>
     <Exec Command="$(M2_HOME)\bin\mvn -TC1 -DskipTests clean" Condition="Exists('$(Bridge_JAR)')" WorkingDirectory="$(REEF_Source_Folder)" />
     <Delete Files="$(OutputPath)\$(Bridge_JAR_Name)" />
   </Target>

--- a/lang/cs/build.props
+++ b/lang/cs/build.props
@@ -15,8 +15,8 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- Common build paths --> 
+<Project InitialTargets="ExtractPOMVersion" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Common build paths -->
   <PropertyGroup>
     <BinDir Condition="$(BinDir) == '' Or $(BinDir) == '*Undefined*'">$(SolutionDir)\bin</BinDir>
     <PackagesDir Condition="$(PackagesDir) == '' Or $(PackagesDir) == '*Undefined*'">$(SolutionDir)\packages</PackagesDir>
@@ -70,12 +70,6 @@ under the License.
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
 
-  <!-- REEF Version -->
-  <PropertyGroup>
-    <!--TODO: Fetch this from the POM-->
-    <REEF_Version>0.11.0-incubating-SNAPSHOT</REEF_Version>
-  </PropertyGroup>
-  
   <!-- REEF NuGet properties -->
   <PropertyGroup>
     <IsSnapshot>true</IsSnapshot>
@@ -86,10 +80,56 @@ under the License.
 
   <!-- Package versions -->
   <PropertyGroup>
-    <AvroVersion>1.4.0.0</AvroVersion> 
-    <NewtonsoftJsonVersion>6.0.8</NewtonsoftJsonVersion> 
-    <ProtobufVersion>2.0.0.668</ProtobufVersion> 
-    <RxVersion>2.2.5</RxVersion> 
+    <AvroVersion>1.4.0.0</AvroVersion>
+    <NewtonsoftJsonVersion>6.0.8</NewtonsoftJsonVersion>
+    <ProtobufVersion>2.0.0.668</ProtobufVersion>
+    <RxVersion>2.2.5</RxVersion>
   </PropertyGroup>
 
+  <!-- Locations -->
+  <PropertyGroup>
+    <!--The root directory of the REEF source tree. -->
+    <REEF_Source_Folder>$([System.IO.Path]::GetFullPath($(SolutionDir)\..\..))</REEF_Source_Folder>
+  </PropertyGroup>
+
+  <!-- 
+       ########################################################################
+         Extract the REEF Version from the POM file 
+       ######################################################################## 
+  -->
+  <!--A Task that extracts the version from the pom in a given folder.-->
+  <UsingTask
+    TaskName="GetMavenProjectVersion"
+    TaskFactory="CodeTaskFactory"
+    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll" >
+    <ParameterGroup>
+      <ProjectFolder Required="true"/>
+      <Version Output="true"/>
+    </ParameterGroup>
+    <Task>
+      <Reference Include="System.Xml"/>
+      <Reference Include="System.Xml.Linq"/>
+      <Using Namespace="System"/>
+      <Using Namespace="System.IO"/>
+      <Using Namespace="System.Linq"/>
+      <Using Namespace="System.Xml.Linq"/>
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+Version = XDocument.Load(Path.Combine(ProjectFolder, "pom.xml")).Descendants()
+            .Where(x => x.Name.ToString().Contains("version"))
+            .FirstOrDefault().Value;
+]]>
+      </Code>
+    </Task>
+  </UsingTask>
+  <!--
+    A Target that extract the REEF version from the pom and makes it available as REEF_Version
+  -->
+  <Target Name="ExtractPOMVersion">
+    <Message Text="The root directory of the source tree is $(REEF_Source_Folder)" />
+    <GetMavenProjectVersion ProjectFolder="$(REEF_Source_Folder)">
+      <Output PropertyName="REEF_Version" TaskParameter="Version"/>
+    </GetMavenProjectVersion>
+    <Message Text="Extracted the following version from the POM: $(REEF_Version)"/>
+  </Target>
 </Project>


### PR DESCRIPTION
The updates `build.props` with a task and init target that extracts the version from the `pom.xml` file in the root of our source tree. The version is made available in the property `REEF_Version`.

In order to use it, I had to delay the construction of derived properties in `Org.Apache.REEF.Bridge.Jar` into the targets themselves. This unfortunately creates some code duplication.

JIRA:
  [REEF-207](https://issues.apache.org/jira/browse/REEF-207)