### PR TITLE
[REEF-221]  Fix NuGet publish issue

### DIFF
--- a/lang/cs/.nuget/NuGet.targets
+++ b/lang/cs/.nuget/NuGet.targets
@@ -175,21 +175,36 @@ under the License.
         <RemoveDir Directories="$(NuspecFilesDir);$(PackagesDir)" />
     </Target>
 
+    <Choose>
+        <When Condition="'$(SolutionDir)'=='..'">
+            <PropertyGroup>
+                <SolutionDir2>..\</SolutionDir2>
+            </PropertyGroup>
+        </When>
+        <Otherwise>
+            <PropertyGroup>
+                <SolutionDir2>$(SolutionDir)</SolutionDir2>
+            </PropertyGroup>
+        </Otherwise>
+    </Choose>
+
     <Target Name="PushPackages" >
         <ItemGroup>
-            <PackageFile Include="$(SolutionDir).nuget\packages\$(RootNamespace)*.nupkg" />
+            <PackageFile Include="$(SolutionDir2).nuget\packages\$(RootNamespace).$(REEF_NugetVersion)$(SnapshotNumber).nupkg" />
         </ItemGroup>
 
         <PropertyGroup>
-            <PushCommand Condition="'$(NuGetApiKey)' == '' OR '$(NuGetApiKey)' == '*Undefined*'">$(NuGetCommand) push @(PackageFile) -Source $(NuGetRepository)</PushCommand>
+           <PushCommand Condition="'$(NuGetApiKey)' == '' OR '$(NuGetApiKey)' == '*Undefined*'">$(NuGetCommand) push @(PackageFile) -Source $(NuGetRepository)</PushCommand>
             <PushCommand Condition="'$(NuGetApiKey)' != '' AND '$(NuGetApiKey)' != '*Undefined*'">$(NuGetCommand) push @(PackageFile) $(NuGetApiKey) -Source $(NuGetRepository)</PushCommand>
+
         </PropertyGroup>
 
-        <Exec 
+        <Exec
             Condition="'$(BuildPackage)' == 'true'"
             Command="$(PushCommand)"
             LogStandardErrorAsError="true">
         </Exec>
+
     </Target>
 
     <UsingTask TaskName="DownloadNuGet" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">

--- a/lang/cs/Org.Apache.REEF.Bridge.JAR/Org.Apache.REEF.Bridge.JAR.csproj
+++ b/lang/cs/Org.Apache.REEF.Bridge.JAR/Org.Apache.REEF.Bridge.JAR.csproj
@@ -108,6 +108,5 @@ under the License.
             Command="$(PushCommand)"
             LogStandardErrorAsError="true">
         </Exec>
-	<Message Text="xxx PackageFile is [$(PackageFile)]"/>
     </Target>
 </Project>

--- a/lang/cs/Org.Apache.REEF.Bridge.JAR/Org.Apache.REEF.Bridge.JAR.csproj
+++ b/lang/cs/Org.Apache.REEF.Bridge.JAR/Org.Apache.REEF.Bridge.JAR.csproj
@@ -20,7 +20,7 @@ under the License.
   <PropertyGroup>
     <!--Set configuration parameters usually set in the Solution. This is needed for build.props to work.-->
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..</SolutionDir>
-    <RootNameSpace>$(MSBuildProjectName)</RootNameSpace>
+    <RootNamespace>Org.Apache.REEF.Bridge.JAR</RootNamespace>
     <ProjectGuid>{62905C7C-1A7E-4923-B78D-1BF42D7FAD40}</ProjectGuid>
     <AssemblyName>Org.Apache.REEF.Bridge.JAR</AssemblyName>
     <RestorePackages>true</RestorePackages>
@@ -93,5 +93,21 @@ under the License.
               LogStandardErrorAsError="true"
               Condition=" '$(OS)' == 'Windows_NT' " />
     </Target>
-  
+    <Target Name="PushPackages" Condition="'$(PushPackages)' == 'true'" DependsOnTargets="BuildPackage"  AfterTargets="BuildPackage">
+        <ItemGroup>
+            <PackageFile Include="$(SolutionDir).nuget\packages\$(RootNamespace).$(REEF_NugetVersion)$(SnapshotNumber).nupkg" />
+        </ItemGroup>
+
+        <PropertyGroup>
+            <PushCommand Condition="'$(NuGetApiKey)' == '' OR '$(NuGetApiKey)' == '*Undefined*'">$(NuGetCommand) push @(PackageFile) -Source $(NuGetRepository)</PushCommand>
+            <PushCommand Condition="'$(NuGetApiKey)' != '' AND '$(NuGetApiKey)' != '*Undefined*'">$(NuGetCommand) push @(PackageFile) $(NuGetApiKey) -Source $(NuGetRepository)</PushCommand>
+        </PropertyGroup>
+
+       <Exec
+            Condition="'$(BuildPackage)' == 'true'"
+            Command="$(PushCommand)"
+            LogStandardErrorAsError="true">
+        </Exec>
+	<Message Text="xxx PackageFile is [$(PackageFile)]"/>
+    </Target>
 </Project>

--- a/lang/cs/Org.Apache.REEF.Bridge.JAR/Org.Apache.REEF.Bridge.JAR.nuspec
+++ b/lang/cs/Org.Apache.REEF.Bridge.JAR/Org.Apache.REEF.Bridge.JAR.nuspec
@@ -13,6 +13,6 @@
     <copyright>The Apache Software Foundation and the respective owners of the packaged libraries.</copyright>
   </metadata>
   <files>
-      <file src="..\bin\$Platform$\$Configuration$\Org.Apache.REEF.Bridge.JAR\reef-bridge-java-$REEF_Version$-shaded.jar" target="jars" />
+      <file src="..\bin\$Platform$\$Configuration$\Org.Apache.REEF.Bridge.JAR\reef-bridge-java-$REEF_Version$-shaded.jar" target="content" />
   </files>
 </package>

--- a/lang/cs/Org.Apache.REEF.Bridge/Org.Apache.REEF.Bridge.vcxproj
+++ b/lang/cs/Org.Apache.REEF.Bridge/Org.Apache.REEF.Bridge.vcxproj
@@ -38,7 +38,7 @@ under the License.
     <ProjectGuid>{4E69D40A-26D6-4D4A-B96D-729946C07FE1}</ProjectGuid>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <Keyword>ManagedCProj</Keyword>
-    <RootNamespace>OrgApacheREEFBridge</RootNamespace>
+    <RootNamespace>Org.Apache.REEF.Bridge</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/lang/cs/build.props
+++ b/lang/cs/build.props
@@ -52,9 +52,10 @@ under the License.
   <!-- REEF NuGet properties -->
   <PropertyGroup>
     <IsSnapshot>true</IsSnapshot>
-    <SnapshotNumber>7</SnapshotNumber>
+    <SnapshotNumber>9</SnapshotNumber>
     <PushPackages>false</PushPackages>
-    <NuGetRepository>https://www.nuget.org</NuGetRepository>
+    <!--NuGetRepository>https://www.nuget.org</NuGetRepository-->
+    <NuGetRepository>http://localhost:46824</NuGetRepository>
   </PropertyGroup>
 
   <!-- Package versions -->
@@ -82,8 +83,10 @@ under the License.
     TaskFactory="CodeTaskFactory"
     AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll" >
     <ParameterGroup>
+      <SnapshotNumber/>
       <ProjectFolder Required="true"/>
       <Version Output="true"/>
+      <NugetVersion Output="true"/>
     </ParameterGroup>
     <Task>
       <Reference Include="System.Xml"/>
@@ -94,10 +97,11 @@ under the License.
       <Using Namespace="System.Xml.Linq"/>
       <Code Type="Fragment" Language="cs">
         <![CDATA[
-Version = XDocument.Load(Path.Combine(ProjectFolder, "pom.xml")).Descendants()
+          Version = XDocument.Load(Path.Combine(ProjectFolder, "pom.xml")).Descendants()
             .Where(x => x.Name.ToString().Contains("version"))
             .FirstOrDefault().Value;
-]]>
+          NugetVersion = Version.Replace("-incubating","") + "-" + SnapshotNumber;
+        ]]>
       </Code>
     </Task>
   </UsingTask>
@@ -108,6 +112,7 @@ Version = XDocument.Load(Path.Combine(ProjectFolder, "pom.xml")).Descendants()
     <Message Text="The root directory of the source tree is $(REEF_Source_Folder)" />
     <GetMavenProjectVersion ProjectFolder="$(REEF_Source_Folder)">
       <Output PropertyName="REEF_Version" TaskParameter="Version"/>
+      <Output PropertyName="REEF_NugetVersion" TaskParameter="NugetVersion"/>
     </GetMavenProjectVersion>
     <Message Text="Extracted the following version from the POM: $(REEF_Version)"/>
   </Target>

--- a/lang/cs/build.props
+++ b/lang/cs/build.props
@@ -54,8 +54,7 @@ under the License.
     <IsSnapshot>true</IsSnapshot>
     <SnapshotNumber>9</SnapshotNumber>
     <PushPackages>false</PushPackages>
-    <!--NuGetRepository>https://www.nuget.org</NuGetRepository-->
-    <NuGetRepository>http://localhost:46824</NuGetRepository>
+    <NuGetRepository>https://www.nuget.org</NuGetRepository>
   </PropertyGroup>
 
   <!-- Package versions -->


### PR DESCRIPTION
This PR includes:

The fixes for pushing NuGet to NuGet repository automatically for Bridge Nugets
Update the NuGet number to next one that is 9
Changed the jar file location in the NuGet to use "content"

JIRA: REEF-221. (https://issues.apache.org/jira/browse/REEF-221)

Author: Julia Wang  Email: jwang98052@yahoo.com