### PR TITLE
[REEF-211]  Make all csproj files default to x64

### DIFF
--- a/lang/cs/build.props
+++ b/lang/cs/build.props
@@ -26,7 +26,7 @@ under the License.
 
   <!-- Common build configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x64</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -34,13 +34,12 @@ under the License.
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <BuildPackage>true</BuildPackage>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)\keyfile.snk</AssemblyOriginatorKeyFile>
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x64</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>$(BinDir)\$(Platform)\$(Configuration)\$(RootNamespace)</OutputPath>
@@ -52,7 +51,7 @@ under the License.
   <!-- REEF NuGet properties -->
   <PropertyGroup>
     <IsSnapshot>true</IsSnapshot>
-    <SnapshotNumber>9</SnapshotNumber>
+    <SnapshotNumber>10</SnapshotNumber>
     <PushPackages>false</PushPackages>
     <NuGetRepository>https://www.nuget.org</NuGetRepository>
   </PropertyGroup>

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/LibLoader.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/LibLoader.java
@@ -138,14 +138,12 @@ public class LibLoader {
    * @param folder
    */
   private void loadAllManagedDLLs(final File folder) {
-    LOG.log(Level.FINE, "Loading all managed DLLs from {0}", folder.getAbsolutePath());
+    LOG.log(Level.INFO, "Loading all managed DLLs from {0}", folder.getAbsolutePath());
     final File[] files = folder.listFiles(new FilenameFilter() {
       public boolean accept(File dir, String name) {
         return name.toLowerCase().endsWith(DLL_EXTENSION);
       }
     });
-
-    LOG.log(Level.FINE, "file size: {0}", files.length);
 
     for (final File f : files) {
       loadManagedDLL(f);


### PR DESCRIPTION
This PR includes
Make all csproj files default to x64, remove AnyCPU
Update NuGet number to next 9
Remove a log in libLoaderto avoid null reference exception in case files is null.

JIRA: REEF-211. (https://issues.apache.org/jira/browse/REEF-211)

Author: Julia Wang  Email: jwang98052@yahoo.com

This Closes #