### PR TITLE
[REEF-169] Add ForkINjector with only one parameter

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Context/ContextRuntime.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Context/ContextRuntime.cs
@@ -139,7 +139,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Context
                 }
                 try
                 {
-                    IInjector childServiceInjector = _serviceInjector.ForkInjector(new IConfiguration[] { serviceConfiguration });
+                    IInjector childServiceInjector = _serviceInjector.ForkInjector(serviceConfiguration);
                     childContext = new ContextRuntime(childServiceInjector, contextConfiguration, Optional<ContextRuntime>.Of(this));
                     _childContext = Optional<ContextRuntime>.Of(childContext);
                     return childContext;
@@ -226,7 +226,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Context
                 }
                 try
                 {
-                    IInjector taskInjector = _contextInjector.ForkInjector(new IConfiguration[] { taskConfiguration.TangConfig });
+                    IInjector taskInjector = _contextInjector.ForkInjector(taskConfiguration.TangConfig);
                     LOGGER.Log(Level.Info, "Trying to inject task with configuration" + taskConfiguration.ToString());
                     TaskRuntime taskRuntime = new TaskRuntime(taskInjector, contextId, taskConfiguration.TaskId, heartBeatManager); // taskInjector.getInstance(TaskRuntime.class);
                     taskRuntime.Initialize();

--- a/lang/cs/Org.Apache.REEF.Tang.Examples/ForksInjectorInConstructor.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Examples/ForksInjectorInConstructor.cs
@@ -48,7 +48,7 @@ namespace Org.Apache.REEF.Tang.Examples
         {
             ICsConfigurationBuilder cb = TangFactory.GetTang().NewConfigurationBuilder(new string[] { @"Org.Apache.REEF.Tang.Examples" });
             //cb.BindImplementation(Number.class, typeof(Int32));
-            i.ForkInjector(new IConfiguration[] { cb.Build() });
+            i.ForkInjector(cb.Build());
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/InjectionPlan/InjectorImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/InjectionPlan/InjectorImpl.cs
@@ -905,7 +905,7 @@ namespace Org.Apache.REEF.Tang.Implementations.InjectionPlan
             }
         }
 
-        public IInjector ForkInjector(IConfiguration[] configurations)
+        public IInjector ForkInjector(params IConfiguration[] configurations)
         {
             InjectorImpl ret;
             ret = Copy(this, configurations);

--- a/lang/cs/Org.Apache.REEF.Tang/Interface/IInjector.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Interface/IInjector.cs
@@ -136,7 +136,7 @@ namespace Org.Apache.REEF.Tang.Interface
         /// </summary>
         /// <param name="configurations">The configurations.</param>
         /// <returns></returns>
-        IInjector ForkInjector(IConfiguration[] configurations);
+        IInjector ForkInjector(params IConfiguration[] configurations);
 
         /// <summary>
         /// Binds the volatile instance.


### PR DESCRIPTION
This PR changes the the parameter of `ForkInjector()` from
`IConfiguration[]` to `param IConfiguration[]`. That way it can be
called with only a single parameter.

This also changes all the callsites that created an array with only one
element to just pass the one `IConfiguration`

JIRA:
  [REEF-169](https://issues.apache.org/jira/browse/REEF-169)