### PR TITLE
[REEF-231]  rat checking doesn't work for cs projects

### DIFF
--- a/lang/cs/pom.xml
+++ b/lang/cs/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>reef-dotnet</artifactId>
+    <name>REEF Dot Net</name>
+    <description>Reef Dot Net</description>
+    <parent>
+        <groupId>org.apache.reef</groupId>
+        <artifactId>reef-project</artifactId>
+        <version>0.11.0-incubating-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -623,6 +623,7 @@ under the License.
     </dependencyManagement>
 
     <modules>
+        <module>lang/cs</module>
         <module>lang/java/reef-annotations</module>
      	<module>lang/java/reef-bridge-java</module>
         <module>lang/java/reef-checkpoint</module>


### PR DESCRIPTION
This PR put pom file at lang/cs folder back so that it can inherit rat exclusion settings for rat checking.
Profile content are removed as they are not eeded any more

JIRA: REEF-231. (https://issues.apache.org/jira/browse/REEF-231)

This closes #

Author: Julia Wang  Email: jwang98052@yahoo.com