### PR TITLE
[REEF-232]  Resolving race condition in Communication Group

### DIFF
--- a/lang/cs/Org.Apache.REEF.Network/Group/Config/MpiConfigurationOptions.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Config/MpiConfigurationOptions.cs
@@ -49,6 +49,16 @@ namespace Org.Apache.REEF.Network.Group.Config
         {
         }
 
+        [NamedParameter("sleep time to wait for handlers to be registered", defaultValue: "500")]
+        public class SleepTimeWaitingForHandler : Name<int>
+        {
+        }
+
+        [NamedParameter("Retry times to wait for handlers to be registered", defaultValue: "5")]
+        public class RetryCountWaitingForHanler : Name<int>
+        {
+        }
+
         [NamedParameter("Master task identifier")]
         public class MasterTaskId : Name<string>
         {

--- a/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/CommunicationGroupClient.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/CommunicationGroupClient.cs
@@ -70,7 +70,8 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
             [Parameter(typeof(MpiConfigurationOptions.SerializedOperatorConfigs))] ISet<string> operatorConfigs,
             IMpiNetworkObserver mpiNetworkObserver,
             NetworkService<GroupCommunicationMessage> networkService,
-            AvroConfigurationSerializer configSerializer)
+            AvroConfigurationSerializer configSerializer,
+            CommunicationGroupNetworkObserver commGroupNetworkHandler)
         {
             _taskId = taskId;
             _driverId = driverId;
@@ -81,7 +82,7 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
 
             _networkService = networkService;
             _mpiNetworkHandler = mpiNetworkObserver;
-            _commGroupNetworkHandler = new CommunicationGroupNetworkObserver();
+            _commGroupNetworkHandler = commGroupNetworkHandler;
             _mpiNetworkHandler.Register(groupName, _commGroupNetworkHandler);
 
             // Deserialize operator configuration and store each injector.

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/BroadcastReduceTest/BroadcastReduceTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/MPI/BroadcastReduceTest/BroadcastReduceTest.cs
@@ -53,7 +53,7 @@ namespace Org.Apache.REEF.Tests.Functional.MPI.BroadcastReduceTest
         [TestMethod]
         public void TestBroadcastAndReduce()
         {
-            int numTasks = 4;
+            int numTasks = 9;
 
             IConfiguration driverConfig = TangFactory.GetTang().NewConfigurationBuilder(
                 DriverBridgeConfiguration.ConfigurationModule

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/TransportServer.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/TransportServer.cs
@@ -184,9 +184,11 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
 
                     if (message == null)
                     {
+                        LOGGER.Log(Level.Error, "ProcessClient, no message received, break." + link.RemoteEndpoint + " - " + link.LocalEndpoint);
                         break;
                     }
                 }
+                LOGGER.Log(Level.Error, "ProcessClient close the Link. IsCancellationRequested: " + token.IsCancellationRequested);
             }
         }
     }


### PR DESCRIPTION
When CommunicationGroupNetworkObserver receives message from other nodes, handlers for operators may not be registered yet. This race condition may cause exception therefore resulting in sockets to be closed. When some nodes are not able to receive message from children or parents, entire communication get stuck. This can be repro when adding more nodes with tree topology.

This PR is to resolve this issue by adding waiting and retry for handlers to be registered before processing the message.

JIRA: REEF-232. (https://issues.apache.org/jira/browse/REEF-232)

This closes #

Author: Julia Wang  Email: jwang98052@yahoo.com