### PR TITLE
[REEF-239] Catch all Throwables when trying to create symlinks

### DIFF
--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/DriverFiles.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/DriverFiles.java
@@ -141,7 +141,8 @@ final class DriverFiles {
       this.localLibs.createSymbolicLinkTo(localFolder);
       this.globalLibs.createSymbolicLinkTo(globalFolder);
       this.globalFiles.createSymbolicLinkTo(globalFolder);
-    } catch (IOException e) {
+    } catch (final Throwable t) {
+      LOG.log(Level.FINE, "Can't symlink the files, copying them instead.", t);
       this.localFiles.copyTo(localFolder);
       this.localLibs.copyTo(localFolder);
       this.globalLibs.copyTo(globalFolder);


### PR DESCRIPTION
This attempts to copy files if the symbolic linking throws any `Throwable`, not just `IOException`.

JIRA:
  [REEF-239](https://issues.apache.org/jira/browse/REEF-239)