### PR TITLE
[REEF-251]  Update NuGet version from 10 to 11 for next push

### DIFF
--- a/lang/cs/Org.Apache.REEF.Bridge.JAR/Org.Apache.REEF.Bridge.JAR.csproj
+++ b/lang/cs/Org.Apache.REEF.Bridge.JAR/Org.Apache.REEF.Bridge.JAR.csproj
@@ -96,15 +96,19 @@ under the License.
             <BuildCommand>$(NuGetCommand) pack "$(FinalizedNuspecFile)" -BasePath $(NugetProjectPath) -Properties "Configuration=$(Configuration);Platform=$(Platform);REEF_Version=$(REEF_Version)" $(NonInteractiveSwitch) -OutputDirectory "$(PackageOutputDir)" </BuildCommand>
             <ReefVer>$([System.String]::Copy('$(REEF_NugetVersion)').Replace('-SNAPSHOT-',''))</ReefVer>
         </PropertyGroup>
+<Message Text="zzzz REEF_Version [$(REEF_Version)]" />
+<Message Text="zzzz REEF_NugetVersion [$(REEF_NugetVersion)]" />
+<Message Text="zzzz ReefVer [$(ReefVer)]" />
+
   <ItemGroup>
     <Line Include="line01"><Text>param($installPath, $toolsPath, $package, $project)</Text></Line>
     <Line Include="line02"><Text>$file1 = $project.ProjectItems.Item("reef-bridge-java-$(ReefVer)-incubating-SNAPSHOT-shaded.jar")</Text></Line>
     <Line Include="line03"><Text>$copyToOutput1 = $file1.Properties.Item("CopyToOutputDirectory")</Text></Line>
     <Line Include="line04"><Text>$copyToOutput1.Value = 2</Text></Line>
     <!--Copy the client JAR-->
-    <Line Include="line02"><Text>$file1 = $project.ProjectItems.Item("reef-bridge-client-$(ReefVer)-incubating-SNAPSHOT-shaded.jar")</Text></Line>
-    <Line Include="line03"><Text>$copyToOutput1 = $file1.Properties.Item("CopyToOutputDirectory")</Text></Line>
-    <Line Include="line04"><Text>$copyToOutput1.Value = 2</Text></Line>
+    <Line Include="line05"><Text>$file2 = $project.ProjectItems.Item("reef-bridge-client-$(ReefVer)-incubating-SNAPSHOT-shaded.jar")</Text></Line>
+    <Line Include="line06"><Text>$copyToOutput2 = $file2.Properties.Item("CopyToOutputDirectory")</Text></Line>
+    <Line Include="line07"><Text>$copyToOutput2.Value = 2</Text></Line>
     <LineText Include="%(Line.Text)" />
   </ItemGroup>
   <WriteLinesToFile

--- a/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
+++ b/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
@@ -61,7 +61,9 @@ under the License.
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-    <None Include="run.cmd" />
+    <None Include="run.cmd">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Utilities\Org.Apache.REEF.Utilities.csproj">

--- a/lang/cs/Org.Apache.REEF.Client/run.cmd
+++ b/lang/cs/Org.Apache.REEF.Client/run.cmd
@@ -33,7 +33,7 @@
 
 
 :: RUNTIME
-set SHADED_JAR=%REEF_HOME%\lang\reef-bridge\target\reef-bridge-java-0.11.0-incubating-SNAPSHOT-shaded.jar
+set SHADED_JAR=.\reef-bridge-java-0.11.0-incubating-SNAPSHOT-shaded.jar
 
 set LOGGING_CONFIG=-Djava.util.logging.config.class=org.apache.reef.util.logging.CLRLoggingConfig
 

--- a/lang/cs/build.props
+++ b/lang/cs/build.props
@@ -53,7 +53,7 @@ under the License.
   <!-- REEF NuGet properties -->
   <PropertyGroup>
     <IsSnapshot>true</IsSnapshot>
-    <SnapshotNumber>10</SnapshotNumber>
+    <SnapshotNumber>11</SnapshotNumber>
     <PushPackages>false</PushPackages>
     <NuGetRepository>https://www.nuget.org</NuGetRepository>
   </PropertyGroup>


### PR DESCRIPTION
This PR contains a few small changes:
- Update  NuGet version from 10 to 11 for next push
- Fixe install script for reef-bridge-client in Org.Apache.REEF.Bridge.JAR.csproj file
- Update client run.cmd

JIRA: REEF-251. (https://issues.apache.org/jira/browse/REEF-251)

This closes #

Author: Julia Wang  Email: jwang98052@yahoo.com