### PR TITLE
[REEF-252]  Make NuGet to REEF.Client

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/NugetExeFix.txt
+++ b/lang/cs/Org.Apache.REEF.Client/NugetExeFix.txt
@@ -1,0 +1,19 @@
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+
+Nuget hack, don't delete this

--- a/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
+++ b/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
@@ -30,7 +30,6 @@ under the License.
   </PropertyGroup>
   <Import Project="$(SolutionDir)\build.props" />
   <PropertyGroup>
-    <BuildPackage>false</BuildPackage>
     <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <ItemGroup>
@@ -60,7 +59,13 @@ under the License.
     <Compile Include="YARN\YarnCommandLineEnvironment.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="NugetExeFix.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
     <None Include="packages.config" />
+    <None Include="Org.Apache.REEF.Client.nuspec" />
     <None Include="run.cmd">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -90,10 +95,6 @@ under the License.
       <Project>{cdfb3464-4041-42b1-9271-83af24cd5008}</Project>
       <Name>Org.Apache.REEF.Wake</Name>
     </ProjectReference>
-    <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Examples\Org.Apache.REEF.Examples.csproj">
-      <Project>{75503f90-7b82-4762-9997-94b5c68f15db}</Project>
-      <Name>Org.Apache.REEF.Examples</Name>
-    </ProjectReference>
     <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Bridge\Org.Apache.REEF.Bridge.vcxproj">
       <Project>{4e69d40a-26d6-4d4a-b96d-729946c07fe1}</Project>
       <Name>Org.Apache.REEF.Bridge</Name>
@@ -101,6 +102,10 @@ under the License.
     <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Evaluator\Org.Apache.REEF.Evaluator.csproj">
       <Project>{1b983182-9c30-464c-948d-f87eb93a8240}</Project>
       <Name>Org.Apache.REEF.Evaluator</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Examples\Org.Apache.REEF.Examples.csproj">
+      <Project>{75503f90-7b82-4762-9997-94b5c68f15db}</Project>
+      <Name>Org.Apache.REEF.Examples</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.nuspec
+++ b/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.nuspec
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<package >
+  <metadata>
+    <id>Org.Apache.REEF.Client</id>
+    <version>$version$</version>
+    <title>Org.Apache.REEF.Client</title>
+    <authors>The Apache REEF project</authors>
+    <owners>The Apache REEF project</owners>
+    <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+    <projectUrl>http://reef.incubator.apache.org/</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Client for REEF.NET</description>
+    <copyright>The Apache Software Foundation</copyright>
+    <dependencies>
+      <dependency id="Org.Apache.REEF.Utilities" version="$version$" />
+      <dependency id="Org.Apache.REEF.Tang" version="$version$" />
+      <dependency id="Org.Apache.REEF.Wake" version="$version$" />
+      <dependency id="Org.Apache.REEF.Common" version="$version$" />
+      <dependency id="Org.Apache.REEF.Network" version="$version$" />
+      <dependency id="Org.Apache.REEF.Driver" version="$version$" />
+      <dependency id="Org.Apache.REEF.Bridge" version="$version$" />
+      <dependency id="Org.Apache.REEF.Examples" version="$version$" />
+      <dependency id="Rx-Core" version="2.2.5" />
+      <dependency id="protobuf-net" version="2.0.0.668" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="..\bin\$Platform$\$Configuration$\Org.Apache.REEF.Client\Org.Apache.REEF.Client.exe" target="tools" />
+    <file src="..\bin\$Platform$\$Configuration$\Org.Apache.REEF.Client\NugetExeFix.txt" target="lib\net45" />
+  </files>
+</package>
+

--- a/lang/cs/Org.Apache.REEF.Examples/Org.Apache.REEF.Examples.csproj
+++ b/lang/cs/Org.Apache.REEF.Examples/Org.Apache.REEF.Examples.csproj
@@ -29,9 +29,6 @@ under the License.
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..</SolutionDir>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\build.props" />
-  <PropertyGroup>
-    <BuildPackage>false</BuildPackage>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -112,6 +109,7 @@ under the License.
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/lang/cs/Org.Apache.REEF.Examples/Org.Apache.REEF.Examples.nuspec
+++ b/lang/cs/Org.Apache.REEF.Examples/Org.Apache.REEF.Examples.nuspec
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<package >
+  <metadata>
+    <id>Org.Apache.REEF.Examples</id>
+    <version>$version$</version>
+    <title>Org.Apache.REEF.Examples</title>
+    <authors>The Apache REEF project</authors>
+    <owners>The Apache REEF project</owners>
+    <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+    <projectUrl>http://reef.incubator.apache.org/</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>REEF Examples</description>
+    <copyright>The Apache Software Foundation</copyright>
+     <dependencies>
+      <dependency id="Org.Apache.REEF.Tang" version="$version$" />
+      <dependency id="Org.Apache.REEF.Wake" version="$version$" />
+      <dependency id="Org.Apache.REEF.Utilities" version="$version$" />
+      <dependency id="Microsoft.Hadoop.Avro" version="1.4.0.0" />
+      <dependency id="protobuf-net" version="2.0.0.668" />
+      <dependency id="Rx-Core" version="2.2.5" />
+      <dependency id="Org.Apache.REEF.Common" version="$version$" />
+      <dependency id="Org.Apache.REEF.Driver" version="$version$" />
+      <dependency id="Org.Apache.REEF.Network" version="$version$" />
+    </dependencies>
+  </metadata>
+  <files>
+      <file src="..\bin\$Platform$\$Configuration$\Org.Apache.REEF.Examples\Org.Apache.REEF.Examples.dll" target="lib\net45" />
+      <file src="..\bin\$Platform$\$Configuration$\Org.Apache.REEF.Examples\Org.Apache.REEF.Examples.pdb" target="lib\net45" />
+  </files>
+</package>

--- a/lang/cs/build.props
+++ b/lang/cs/build.props
@@ -53,7 +53,7 @@ under the License.
   <!-- REEF NuGet properties -->
   <PropertyGroup>
     <IsSnapshot>true</IsSnapshot>
-    <SnapshotNumber>11</SnapshotNumber>
+    <SnapshotNumber>92</SnapshotNumber>
     <PushPackages>false</PushPackages>
     <NuGetRepository>https://www.nuget.org</NuGetRepository>
   </PropertyGroup>


### PR DESCRIPTION
- This PR adds NuGet spec and NuGet for REEF.Client
- As REEF.Client currently depends on REEF.Examples, it makes NuGet for REEF.Examples as well.
- It also updates the Nuget version for next push

JIRA: REEF-252. (https://issues.apache.org/jira/browse/REEF-252)

This closes #

Author: Julia Wang  Email: jwang98052@yahoo.com