### PR TITLE
[REEF-268] Simplify Configuration passthrough from Client to Driver to Evaluator

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/parameters/DriverConfigurationProviders.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/parameters/DriverConfigurationProviders.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.client.parameters;
+
+import org.apache.reef.common.ConfigurationProvider;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+import java.util.Set;
+
+/**
+ * Configuration provides whose Configurations will be mixed into the Driver Configuration.
+ */
+@NamedParameter(doc = "Configuration provides whose Configurations will be mixed into the Driver Configuration.")
+public final class DriverConfigurationProviders implements Name<Set<ConfigurationProvider>> {
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/common/ConfigurationProvider.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/common/ConfigurationProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.common;
+
+import org.apache.reef.tang.Configuration;
+
+/**
+ * Objects that can provide a Configuration implement this interface.
+ */
+public interface ConfigurationProvider {
+
+  /**
+   * @return a Configuration provided by this instance.
+   */
+  Configuration getConfiguration();
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/EvaluatorConfigurationProviders.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/EvaluatorConfigurationProviders.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.driver.parameters;
+
+import org.apache.reef.common.ConfigurationProvider;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+import java.util.Set;
+
+/**
+ * Configuration provides whose Configurations will be mixed into the Evaluator Configuration.
+ */
+@NamedParameter(doc = "Configuration provides whose Configurations will be mixed into the Evaluator Configuration.")
+public final class EvaluatorConfigurationProviders implements Name<Set<ConfigurationProvider>> {
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/CommonRuntimeConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/CommonRuntimeConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runtime.common.client;
+
+import org.apache.reef.annotations.audience.RuntimeAuthor;
+import org.apache.reef.client.REEF;
+import org.apache.reef.client.RunningJob;
+import org.apache.reef.runtime.common.launch.REEFMessageCodec;
+import org.apache.reef.tang.formats.ConfigurationModule;
+import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
+import org.apache.reef.wake.remote.RemoteConfiguration;
+
+/**
+ * A ConfigurationModule to be merged in by all runtimes into their client configuration.
+ */
+@RuntimeAuthor
+public final class CommonRuntimeConfiguration extends ConfigurationModuleBuilder {
+  public static final ConfigurationModule CONF = new CommonRuntimeConfiguration()
+      .bindImplementation(REEF.class, REEFImplementation.class)
+      .bindImplementation(RunningJob.class, RunningJobImpl.class)
+      .bindNamedParameter(RemoteConfiguration.MessageCodec.class, REEFMessageCodec.class)
+      .build();
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/REEFImplementation.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/REEFImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -22,17 +22,24 @@ import org.apache.reef.annotations.Provided;
 import org.apache.reef.annotations.audience.ClientSide;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.client.REEF;
+import org.apache.reef.client.parameters.DriverConfigurationProviders;
+import org.apache.reef.common.ConfigurationProvider;
 import org.apache.reef.proto.ClientRuntimeProtocol.JobSubmissionProto;
 import org.apache.reef.runtime.common.client.api.JobSubmissionHandler;
 import org.apache.reef.runtime.common.launch.parameters.ErrorHandlerRID;
 import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.ConfigurationBuilder;
+import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
+import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.util.REEFVersion;
+import org.apache.reef.util.logging.Config;
 import org.apache.reef.util.logging.LoggingScope;
 import org.apache.reef.util.logging.LoggingScopeFactory;
 
 import javax.inject.Inject;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -48,6 +55,7 @@ public final class REEFImplementation implements REEF {
   private final JobSubmissionHelper jobSubmissionHelper;
   private final ClientWireUp clientWireUp;
   private final LoggingScopeFactory loggingScopeFactory;
+  private final Set<ConfigurationProvider> configurationProviders;
 
   /**
    * @param jobSubmissionHandler
@@ -56,6 +64,7 @@ public final class REEFImplementation implements REEF {
    * @param jobStatusMessageHandler is passed only to make sure it is instantiated
    * @param clientWireUp
    * @param reefVersion             provides the current version of REEF.
+   * @param configurationProviders
    */
   @Inject
   REEFImplementation(final JobSubmissionHandler jobSubmissionHandler,
@@ -64,11 +73,13 @@ public final class REEFImplementation implements REEF {
                      final JobStatusMessageHandler jobStatusMessageHandler,
                      final ClientWireUp clientWireUp,
                      final LoggingScopeFactory loggingScopeFactory,
-                     final REEFVersion reefVersion) {
+                     final REEFVersion reefVersion,
+                     final @Parameter(DriverConfigurationProviders.class) Set<ConfigurationProvider> configurationProviders) {
     this.jobSubmissionHandler = jobSubmissionHandler;
     this.runningJobs = runningJobs;
     this.jobSubmissionHelper = jobSubmissionHelper;
     this.clientWireUp = clientWireUp;
+    this.configurationProviders = configurationProviders;
     clientWireUp.performWireUp();
     this.loggingScopeFactory = loggingScopeFactory;
     reefVersion.logVersion();
@@ -83,14 +94,15 @@ public final class REEFImplementation implements REEF {
   @Override
   public void submit(final Configuration driverConf) {
     try (LoggingScope ls = this.loggingScopeFactory.reefSubmit()) {
+      final Configuration driverConfiguration = createDriverConfiguration(driverConf);
       final JobSubmissionProto submissionMessage;
       try {
         if (this.clientWireUp.isClientPresent()) {
-          submissionMessage = this.jobSubmissionHelper.getJobsubmissionProto(driverConf)
+          submissionMessage = this.jobSubmissionHelper.getJobsubmissionProto(driverConfiguration)
               .setRemoteId(this.clientWireUp.getRemoteManagerIdentifier())
               .build();
         } else {
-          submissionMessage = this.jobSubmissionHelper.getJobsubmissionProto(driverConf)
+          submissionMessage = this.jobSubmissionHelper.getJobsubmissionProto(driverConfiguration)
               .setRemoteId(ErrorHandlerRID.NONE)
               .build();
         }
@@ -100,6 +112,21 @@ public final class REEFImplementation implements REEF {
 
       this.jobSubmissionHandler.onNext(submissionMessage);
     }
+  }
+
+  /**
+   * Assembles the final Driver Configuration by merging in all the Configurations provided by ConfigurationProviders.
+   *
+   * @param driverConfiguration
+   * @return
+   */
+  private Configuration createDriverConfiguration(final Configuration driverConfiguration) {
+    final ConfigurationBuilder configurationBuilder = Tang.Factory.getTang()
+        .newConfigurationBuilder(driverConfiguration);
+    for (final ConfigurationProvider configurationProvider : this.configurationProviders) {
+      configurationBuilder.addConfiguration(configurationProvider.getConfiguration());
+    }
+    return configurationBuilder.build();
   }
 
   @NamedParameter(doc = "The driver remote identifier.")

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -20,11 +20,13 @@ package org.apache.reef.runtime.common.driver.evaluator;
 
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.common.ConfigurationProvider;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.context.FailedContext;
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
 import org.apache.reef.driver.evaluator.EvaluatorDescriptor;
 import org.apache.reef.driver.evaluator.EvaluatorType;
+import org.apache.reef.driver.parameters.EvaluatorConfigurationProviders;
 import org.apache.reef.driver.task.FailedTask;
 import org.apache.reef.exception.EvaluatorException;
 import org.apache.reef.exception.EvaluatorKilledByResourceManagerException;
@@ -56,6 +58,7 @@ import org.apache.reef.wake.time.event.Alarm;
 import javax.inject.Inject;
 import java.io.File;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -115,7 +118,8 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
       final DriverStatusManager driverStatusManager,
       final ExceptionCodec exceptionCodec,
       final EventHandlerIdlenessSource idlenessSource,
-      final LoggingScopeFactory loggingScopeFactory) {
+      final LoggingScopeFactory loggingScopeFactory,
+      final @Parameter(EvaluatorConfigurationProviders.class) Set<ConfigurationProvider> evaluatorConfigurationProviders) {
     this.contextRepresenters = contextRepresenters;
     this.idlenessSource = idlenessSource;
     LOG.log(Level.FINEST, "Instantiating 'EvaluatorManager' for evaluator: {0}", evaluatorId);
@@ -134,7 +138,7 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
     this.loggingScopeFactory = loggingScopeFactory;
 
     final AllocatedEvaluator allocatedEvaluator =
-        new AllocatedEvaluatorImpl(this, remoteManager.getMyIdentifier(), configurationSerializer, getJobIdentifier(), loggingScopeFactory);
+        new AllocatedEvaluatorImpl(this, remoteManager.getMyIdentifier(), configurationSerializer, getJobIdentifier(), loggingScopeFactory, evaluatorConfigurationProviders);
     LOG.log(Level.FINEST, "Firing AllocatedEvaluator event for Evaluator with ID [{0}]", evaluatorId);
     this.messageDispatcher.onEvaluatorAllocated(allocatedEvaluator);
     LOG.log(Level.FINEST, "Instantiated 'EvaluatorManager' for evaluator: [{0}]", this.getId());

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/HDInsightRuntimeConfigurationStatic.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/HDInsightRuntimeConfigurationStatic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -19,19 +19,14 @@
 package org.apache.reef.runtime.hdinsight.client;
 
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.reef.client.REEF;
-import org.apache.reef.client.RunningJob;
-import org.apache.reef.runtime.common.client.REEFImplementation;
-import org.apache.reef.runtime.common.client.RunningJobImpl;
+import org.apache.reef.runtime.common.client.CommonRuntimeConfiguration;
 import org.apache.reef.runtime.common.client.api.JobSubmissionHandler;
 import org.apache.reef.runtime.common.files.RuntimeClasspathProvider;
-import org.apache.reef.runtime.common.launch.REEFMessageCodec;
 import org.apache.reef.runtime.hdinsight.HDInsightClasspathProvider;
 import org.apache.reef.runtime.hdinsight.client.sslhacks.DefaultClientConstructor;
 import org.apache.reef.tang.formats.ConfigurationModule;
 import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
 import org.apache.reef.util.logging.LoggingSetup;
-import org.apache.reef.wake.remote.RemoteConfiguration;
 
 /**
  * The static part of the HDInsightRuntimeConfiguration.
@@ -42,9 +37,7 @@ public final class HDInsightRuntimeConfigurationStatic extends ConfigurationModu
   }
 
   public static final ConfigurationModule CONF = new HDInsightRuntimeConfigurationStatic()
-      .bindImplementation(REEF.class, REEFImplementation.class)
-      .bindImplementation(RunningJob.class, RunningJobImpl.class)
-      .bindNamedParameter(RemoteConfiguration.MessageCodec.class, REEFMessageCodec.class)
+      .merge(CommonRuntimeConfiguration.CONF)
       .bindImplementation(JobSubmissionHandler.class, HDInsightJobSubmissionHandler.class)
       .bindConstructor(CloseableHttpClient.class, DefaultClientConstructor.class)
       .bindImplementation(RuntimeClasspathProvider.class, HDInsightClasspathProvider.class)

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/LocalRuntimeConfiguration.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/LocalRuntimeConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -18,21 +18,19 @@
  */
 package org.apache.reef.runtime.local.client;
 
-import org.apache.reef.client.REEF;
-import org.apache.reef.client.RunningJob;
-import org.apache.reef.runtime.common.client.REEFImplementation;
-import org.apache.reef.runtime.common.client.RunningJobImpl;
+import org.apache.reef.client.parameters.DriverConfigurationProviders;
+import org.apache.reef.common.ConfigurationProvider;
+import org.apache.reef.runtime.common.client.CommonRuntimeConfiguration;
 import org.apache.reef.runtime.common.client.api.JobSubmissionHandler;
 import org.apache.reef.runtime.common.files.RuntimeClasspathProvider;
-import org.apache.reef.runtime.common.launch.REEFMessageCodec;
 import org.apache.reef.runtime.common.parameters.JVMHeapSlack;
 import org.apache.reef.runtime.local.LocalClasspathProvider;
 import org.apache.reef.runtime.local.client.parameters.MaxNumberOfEvaluators;
 import org.apache.reef.runtime.local.client.parameters.RootFolder;
 import org.apache.reef.tang.formats.ConfigurationModule;
 import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
+import org.apache.reef.tang.formats.OptionalImpl;
 import org.apache.reef.tang.formats.OptionalParameter;
-import org.apache.reef.wake.remote.RemoteConfiguration;
 
 import java.util.concurrent.ExecutorService;
 
@@ -63,18 +61,21 @@ public class LocalRuntimeConfiguration extends ConfigurationModuleBuilder {
   public static final OptionalParameter<Double> JVM_HEAP_SLACK = new OptionalParameter<>();
 
   /**
+   * Configuration provides whose Configuration will be merged into all Driver Configuration.
+   */
+  public static final OptionalImpl<ConfigurationProvider> DRIVER_CONFIGURATION_PROVIDERS = new OptionalImpl<>();
+
+  /**
    * The ConfigurationModule for the local resourcemanager.
    */
   public static final ConfigurationModule CONF = new LocalRuntimeConfiguration()
-      .bindImplementation(REEF.class, REEFImplementation.class)
-      .bindImplementation(RunningJob.class, RunningJobImpl.class)
+      .merge(CommonRuntimeConfiguration.CONF)
       .bindImplementation(JobSubmissionHandler.class, LocalJobSubmissionHandler.class)
       .bindConstructor(ExecutorService.class, ExecutorServiceConstructor.class)
-          // Bind the message codec for REEF.
-      .bindNamedParameter(RemoteConfiguration.MessageCodec.class, REEFMessageCodec.class)
       .bindNamedParameter(MaxNumberOfEvaluators.class, MAX_NUMBER_OF_EVALUATORS)
       .bindNamedParameter(RootFolder.class, RUNTIME_ROOT_FOLDER)
       .bindNamedParameter(JVMHeapSlack.class, JVM_HEAP_SLACK)
+      .bindSetEntry(DriverConfigurationProviders.class, DRIVER_CONFIGURATION_PROVIDERS)
       .bindImplementation(RuntimeClasspathProvider.class, LocalClasspathProvider.class)
       .build();
 

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/client/MesosClientConfiguration.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/client/MesosClientConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -21,13 +21,9 @@ package org.apache.reef.runtime.mesos.client;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.reef.annotations.audience.ClientSide;
 import org.apache.reef.annotations.audience.Public;
-import org.apache.reef.client.REEF;
-import org.apache.reef.client.RunningJob;
-import org.apache.reef.runtime.common.client.REEFImplementation;
-import org.apache.reef.runtime.common.client.RunningJobImpl;
+import org.apache.reef.runtime.common.client.CommonRuntimeConfiguration;
 import org.apache.reef.runtime.common.client.api.JobSubmissionHandler;
 import org.apache.reef.runtime.common.files.RuntimeClasspathProvider;
-import org.apache.reef.runtime.common.launch.REEFMessageCodec;
 import org.apache.reef.runtime.mesos.MesosClasspathProvider;
 import org.apache.reef.runtime.mesos.client.parameters.MasterIp;
 import org.apache.reef.runtime.mesos.client.parameters.RootFolder;
@@ -36,7 +32,6 @@ import org.apache.reef.tang.formats.ConfigurationModule;
 import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
 import org.apache.reef.tang.formats.OptionalParameter;
 import org.apache.reef.tang.formats.RequiredParameter;
-import org.apache.reef.wake.remote.RemoteConfiguration;
 
 /**
  * A ConfigurationModule for the Mesos resource manager
@@ -56,9 +51,7 @@ public class MesosClientConfiguration extends ConfigurationModuleBuilder {
   public static final RequiredParameter<String> MASTER_IP = new RequiredParameter<>();
 
   public static final ConfigurationModule CONF = new MesosClientConfiguration()
-      .bindImplementation(REEF.class, REEFImplementation.class)
-      .bindImplementation(RunningJob.class, RunningJobImpl.class)
-      .bindNamedParameter(RemoteConfiguration.MessageCodec.class, REEFMessageCodec.class)
+      .merge(CommonRuntimeConfiguration.CONF)
       .bindImplementation(JobSubmissionHandler.class, MesosJobSubmissionHandler.class)
       .bindNamedParameter(RootFolder.class, ROOT_FOLDER)
       .bindNamedParameter(MasterIp.class, MASTER_IP)

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/YarnClientConfiguration.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/YarnClientConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -20,13 +20,11 @@ package org.apache.reef.runtime.yarn.client;
 
 import org.apache.reef.annotations.audience.ClientSide;
 import org.apache.reef.annotations.audience.Public;
-import org.apache.reef.client.REEF;
-import org.apache.reef.client.RunningJob;
-import org.apache.reef.runtime.common.client.REEFImplementation;
-import org.apache.reef.runtime.common.client.RunningJobImpl;
+import org.apache.reef.client.parameters.DriverConfigurationProviders;
+import org.apache.reef.common.ConfigurationProvider;
+import org.apache.reef.runtime.common.client.CommonRuntimeConfiguration;
 import org.apache.reef.runtime.common.client.api.JobSubmissionHandler;
 import org.apache.reef.runtime.common.files.RuntimeClasspathProvider;
-import org.apache.reef.runtime.common.launch.REEFMessageCodec;
 import org.apache.reef.runtime.common.parameters.JVMHeapSlack;
 import org.apache.reef.runtime.yarn.YarnClasspathProvider;
 import org.apache.reef.runtime.yarn.client.parameters.JobPriority;
@@ -34,9 +32,9 @@ import org.apache.reef.runtime.yarn.client.parameters.JobQueue;
 import org.apache.reef.runtime.yarn.util.YarnConfigurationConstructor;
 import org.apache.reef.tang.formats.ConfigurationModule;
 import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
+import org.apache.reef.tang.formats.OptionalImpl;
 import org.apache.reef.tang.formats.OptionalParameter;
 import org.apache.reef.util.logging.LoggingSetup;
-import org.apache.reef.wake.remote.RemoteConfiguration;
 
 /**
  * A ConfigurationModule for the YARN resourcemanager.
@@ -53,12 +51,13 @@ public class YarnClientConfiguration extends ConfigurationModuleBuilder {
 
   public static final OptionalParameter<Double> JVM_HEAP_SLACK = new OptionalParameter<>();
 
+  /**
+   * Configuration provides whose Configuration will be merged into all Driver Configuration.
+   */
+  public static final OptionalImpl<ConfigurationProvider> DRIVER_CONFIGURATION_PROVIDERS = new OptionalImpl<>();
+
   public static final ConfigurationModule CONF = new YarnClientConfiguration()
-      // Bind the common resourcemanager
-      .bindImplementation(REEF.class, REEFImplementation.class)
-      .bindImplementation(RunningJob.class, RunningJobImpl.class)
-          // Bind the message codec for REEF.
-      .bindNamedParameter(RemoteConfiguration.MessageCodec.class, REEFMessageCodec.class)
+      .merge(CommonRuntimeConfiguration.CONF)
           // Bind YARN
       .bindImplementation(JobSubmissionHandler.class, YarnJobSubmissionHandler.class)
           // Bind the parameters given by the user
@@ -68,6 +67,7 @@ public class YarnClientConfiguration extends ConfigurationModuleBuilder {
       .bindImplementation(RuntimeClasspathProvider.class, YarnClasspathProvider.class)
           // Bind external constructors. Taken from  YarnExternalConstructors.registerClientConstructors
       .bindConstructor(org.apache.hadoop.yarn.conf.YarnConfiguration.class, YarnConfigurationConstructor.class)
+      .bindSetEntry(DriverConfigurationProviders.class, DRIVER_CONFIGURATION_PROVIDERS)
       .build();
 
 }


### PR DESCRIPTION
This simplifies the passthrough of Configuration from the Client to the Driver to the Evaluators. To do so, it adds the new interface `ConfigurationProvider` for classes that provide Configurations. This also adds two new named sets:

  * `DriverConfigurationProviders` for `ConfigurationProvider`s to be considered when producing the Driver Configuration in the Client.
  * `EvaluatorConfigurationProviders` for `ConfigurationProvider`s to be considered when producing the Evaluator Configuration in the Driver.

This change also adds a new common configuration module to be merged into all runtime client configuration modules, `CommonRuntimeConfiguration`. For now, this only binds the basic REEF
implementations shared by all runtimes. It is included in this change because it provides a good handle for us to add `ConfigurationProvider`s to `DriverConfigurationProviders` in the future, e.g. in [REEF-246] and [REEF-247].

JIRA: [REEF-268](https://issues.apache.org/jira/browse/REEF-268)