### PR TITLE
[REEF-262]  Passing Configuration to Group Communication Driver

### DIFF
--- a/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/KMeansDriverHandlers.cs
+++ b/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/KMeansDriverHandlers.cs
@@ -84,31 +84,31 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
             _groupCommDriver = groupCommDriver;
 
             IConfiguration conf1 = CodecConfiguration<Centroids>.Conf
-                .Set(CodecConfiguration<Centroids>.CodecRequiredImpl, GenericType<CentroidsCodec>.Class)
+                .Set(CodecConfiguration<Centroids>.Codec, GenericType<CentroidsCodec>.Class)
                 .Build();
 
             IConfiguration dataConverterConfig1 = PipelineDataConverterConfiguration<Centroids>.Conf
-                .Set(PipelineDataConverterConfiguration<Centroids>.dataConverterRequiredImpl, GenericType<DefaultPipelineDataConverter<Centroids>>.Class)
+                .Set(PipelineDataConverterConfiguration<Centroids>.DataConverter, GenericType<DefaultPipelineDataConverter<Centroids>>.Class)
                 .Build();
 
             IConfiguration conf2 = CodecConfiguration<ControlMessage>.Conf
-                .Set(CodecConfiguration<ControlMessage>.CodecRequiredImpl, GenericType<ControlMessageCodec>.Class)
+                .Set(CodecConfiguration<ControlMessage>.Codec, GenericType<ControlMessageCodec>.Class)
                 .Build();
 
             IConfiguration dataConverterConfig2 = PipelineDataConverterConfiguration<ControlMessage>.Conf
-                .Set(PipelineDataConverterConfiguration<ControlMessage>.dataConverterRequiredImpl, GenericType<DefaultPipelineDataConverter<ControlMessage>>.Class)
+                .Set(PipelineDataConverterConfiguration<ControlMessage>.DataConverter, GenericType<DefaultPipelineDataConverter<ControlMessage>>.Class)
                 .Build();
 
             IConfiguration conf3 = CodecConfiguration<ProcessedResults>.Conf
-                .Set(CodecConfiguration<ProcessedResults>.CodecRequiredImpl, GenericType<ProcessedResultsCodec>.Class)
+                .Set(CodecConfiguration<ProcessedResults>.Codec, GenericType<ProcessedResultsCodec>.Class)
                 .Build();
 
             IConfiguration reduceFunctionConfig = ReduceFunctionConfiguration<ProcessedResults>.Conf
-                .Set(ReduceFunctionConfiguration<ProcessedResults>.ReduceFunctionRequiredImpl, GenericType<KMeansMasterTask.AggregateMeans>.Class)
+                .Set(ReduceFunctionConfiguration<ProcessedResults>.ReduceFunction, GenericType<KMeansMasterTask.AggregateMeans>.Class)
                 .Build();
 
             IConfiguration dataConverterConfig3 = PipelineDataConverterConfiguration<ProcessedResults>.Conf
-                .Set(PipelineDataConverterConfiguration<ProcessedResults>.dataConverterRequiredImpl, GenericType<DefaultPipelineDataConverter<ProcessedResults>>.Class)
+                .Set(PipelineDataConverterConfiguration<ProcessedResults>.DataConverter, GenericType<DefaultPipelineDataConverter<ProcessedResults>>.Class)
                 .Build();
 
             _commGroup = _groupCommDriver.DefaultGroup

--- a/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/KMeansDriverHandlers.cs
+++ b/lang/cs/Org.Apache.REEF.Examples/MachineLearning/KMeans/KMeansDriverHandlers.cs
@@ -44,6 +44,7 @@ using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Logging;
+using Org.Apache.REEF.Network.Group.Topology;
 
 namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
 {
@@ -110,12 +111,10 @@ namespace Org.Apache.REEF.Examples.MachineLearning.KMeans
                 .Set(PipelineDataConverterConfiguration<ProcessedResults>.dataConverterRequiredImpl, GenericType<DefaultPipelineDataConverter<ProcessedResults>>.Class)
                 .Build();
 
-            IConfiguration merged = Configurations.Merge(conf3, reduceFunctionConfig, dataConverterConfig3);
-
             _commGroup = _groupCommDriver.DefaultGroup
-                   .AddBroadcast<Centroids>(Configurations.Merge(conf1, dataConverterConfig1), Constants.CentroidsBroadcastOperatorName, Constants.MasterTaskId)
-                   .AddBroadcast<ControlMessage>(Configurations.Merge(conf2, dataConverterConfig2), Constants.ControlMessageBroadcastOperatorName, Constants.MasterTaskId)
-                   .AddReduce<ProcessedResults>(merged, Constants.MeansReduceOperatorName, Constants.MasterTaskId)
+                   .AddBroadcast<Centroids>(Constants.CentroidsBroadcastOperatorName, Constants.MasterTaskId, TopologyTypes.Flat, conf1, dataConverterConfig1)
+                   .AddBroadcast<ControlMessage>(Constants.ControlMessageBroadcastOperatorName, Constants.MasterTaskId, TopologyTypes.Flat, conf2, dataConverterConfig2)
+                   .AddReduce<ProcessedResults>(Constants.MeansReduceOperatorName, Constants.MasterTaskId, TopologyTypes.Flat, conf3, reduceFunctionConfig, dataConverterConfig3)
                    .Build();
 
             _groupCommTaskStarter = new TaskStarter(_groupCommDriver, _totalEvaluators);

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/BroadcastReduceDriverAndTasks/BroadcastReduceDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/BroadcastReduceDriverAndTasks/BroadcastReduceDriver.cs
@@ -79,19 +79,20 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.BroadcastReduceDri
                 .Set(PipelineDataConverterConfiguration<int>.dataConverterRequiredImpl, GenericType<DefaultPipelineDataConverter<int>>.Class)
                 .Build();
 
-            IConfiguration merged = Configurations.Merge(codecConfig, reduceFunctionConfig, dataConverterConfig);
-
             _commGroup = _groupCommDriver.DefaultGroup
                     .AddBroadcast<int>(
-                        merged,
                         GroupTestConstants.BroadcastOperatorName,
                         GroupTestConstants.MasterTaskId, 
-                        TopologyTypes.Tree)
+                        TopologyTypes.Tree,
+                        codecConfig,
+                        dataConverterConfig)
                     .AddReduce<int>(
-                        merged,
                         GroupTestConstants.ReduceOperatorName,
                         GroupTestConstants.MasterTaskId,
-                        TopologyTypes.Tree)
+                        TopologyTypes.Tree,
+                        codecConfig,
+                        reduceFunctionConfig,
+                        dataConverterConfig)
                     .Build();
 
             _groupCommTaskStarter = new TaskStarter(_groupCommDriver, numEvaluators);

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/BroadcastReduceDriverAndTasks/BroadcastReduceDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/BroadcastReduceDriverAndTasks/BroadcastReduceDriver.cs
@@ -27,15 +27,20 @@ using Org.Apache.REEF.Driver;
 using Org.Apache.REEF.Driver.Bridge;
 using Org.Apache.REEF.Driver.Context;
 using Org.Apache.REEF.Driver.Evaluator;
+using Org.Apache.REEF.Network.Group.Config;
 using Org.Apache.REEF.Network.Group.Driver;
 using Org.Apache.REEF.Network.Group.Driver.Impl;
 using Org.Apache.REEF.Network.Group.Operators;
+using Org.Apache.REEF.Network.Group.Pipelining.Impl;
+using Org.Apache.REEF.Network.Group.Topology;
 using Org.Apache.REEF.Network.NetworkService;
 using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Tang.Implementations.Configuration;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Logging;
+using Org.Apache.REEF.Wake.Remote;
 using Org.Apache.REEF.Wake.Remote.Impl;
 
 namespace Org.Apache.REEF.Network.Examples.GroupCommunication.BroadcastReduceDriverAndTasks
@@ -61,14 +66,32 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.BroadcastReduceDri
             _numEvaluators = numEvaluators;
             _numIterations = numIterations;
             _groupCommDriver = groupCommDriver;
+
+            IConfiguration codecConfig = CodecConfiguration<int>.Conf
+                .Set(CodecConfiguration<int>.CodecRequiredImpl, GenericType<IntCodec>.Class)
+                .Build();
+
+            IConfiguration reduceFunctionConfig = ReduceFunctionConfiguration<int>.Conf
+                .Set(ReduceFunctionConfiguration<int>.ReduceFunctionRequiredImpl, GenericType<SumFunction>.Class)
+                .Build();
+
+            IConfiguration dataConverterConfig = PipelineDataConverterConfiguration<int>.Conf
+                .Set(PipelineDataConverterConfiguration<int>.dataConverterRequiredImpl, GenericType<DefaultPipelineDataConverter<int>>.Class)
+                .Build();
+
+            IConfiguration merged = Configurations.Merge(codecConfig, reduceFunctionConfig, dataConverterConfig);
+
             _commGroup = _groupCommDriver.DefaultGroup
-                    .AddBroadcast<int, IntCodec>(
+                    .AddBroadcast<int>(
+                        merged,
                         GroupTestConstants.BroadcastOperatorName,
-                       GroupTestConstants.MasterTaskId)
-                    .AddReduce<int, IntCodec>(
+                        GroupTestConstants.MasterTaskId, 
+                        TopologyTypes.Tree)
+                    .AddReduce<int>(
+                        merged,
                         GroupTestConstants.ReduceOperatorName,
-                            GroupTestConstants.MasterTaskId,
-                            new SumFunction())
+                        GroupTestConstants.MasterTaskId,
+                        TopologyTypes.Tree)
                     .Build();
 
             _groupCommTaskStarter = new TaskStarter(_groupCommDriver, numEvaluators);

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/BroadcastReduceDriverAndTasks/BroadcastReduceDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/BroadcastReduceDriverAndTasks/BroadcastReduceDriver.cs
@@ -68,15 +68,15 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.BroadcastReduceDri
             _groupCommDriver = groupCommDriver;
 
             IConfiguration codecConfig = CodecConfiguration<int>.Conf
-                .Set(CodecConfiguration<int>.CodecRequiredImpl, GenericType<IntCodec>.Class)
+                .Set(CodecConfiguration<int>.Codec, GenericType<IntCodec>.Class)
                 .Build();
 
             IConfiguration reduceFunctionConfig = ReduceFunctionConfiguration<int>.Conf
-                .Set(ReduceFunctionConfiguration<int>.ReduceFunctionRequiredImpl, GenericType<SumFunction>.Class)
+                .Set(ReduceFunctionConfiguration<int>.ReduceFunction, GenericType<SumFunction>.Class)
                 .Build();
 
             IConfiguration dataConverterConfig = PipelineDataConverterConfiguration<int>.Conf
-                .Set(PipelineDataConverterConfiguration<int>.dataConverterRequiredImpl, GenericType<DefaultPipelineDataConverter<int>>.Class)
+                .Set(PipelineDataConverterConfiguration<int>.DataConverter, GenericType<DefaultPipelineDataConverter<int>>.Class)
                 .Build();
 
             _commGroup = _groupCommDriver.DefaultGroup

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedBroadcastReduceDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedBroadcastReduceDriver.cs
@@ -90,23 +90,22 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastR
                     GroupTestConstants.ChunkSize.ToString(CultureInfo.InvariantCulture))
                 .Build();
 
-            IConfiguration merged = Configurations.Merge(codecConfig, reduceFunctionConfig, dataConverterConfig);
-
             _groupCommDriver = groupCommDriver;
 
             _commGroup = _groupCommDriver.DefaultGroup
                 .AddBroadcast<int[]>(
-                    merged,
                     GroupTestConstants.BroadcastOperatorName,
                     GroupTestConstants.MasterTaskId,
-                    TopologyTypes.Tree)
-                    //new PipelineIntDataConverter(_chunkSize))
+                    TopologyTypes.Tree,
+                    codecConfig,
+                    dataConverterConfig)
                 .AddReduce<int[]>(
-                    merged,
                     GroupTestConstants.ReduceOperatorName,
                     GroupTestConstants.MasterTaskId,
-                    TopologyTypes.Tree)
-                    //new PipelineIntDataConverter(_chunkSize))
+                    TopologyTypes.Tree,
+                    codecConfig,
+                    reduceFunctionConfig,
+                    dataConverterConfig)
                 .Build();
 
             _groupCommTaskStarter = new TaskStarter(_groupCommDriver, numEvaluators);

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedBroadcastReduceDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedBroadcastReduceDriver.cs
@@ -27,6 +27,8 @@ using Org.Apache.REEF.Driver;
 using Org.Apache.REEF.Driver.Bridge;
 using Org.Apache.REEF.Driver.Context;
 using Org.Apache.REEF.Driver.Evaluator;
+using Org.Apache.REEF.Network.Examples.GroupCommunication.BroadcastReduceDriverAndTasks;
+using Org.Apache.REEF.Network.Group.Config;
 using Org.Apache.REEF.Network.Group.Driver;
 using Org.Apache.REEF.Network.Group.Driver.Impl;
 using Org.Apache.REEF.Network.Group.Operators;
@@ -34,11 +36,13 @@ using Org.Apache.REEF.Network.Group.Pipelining;
 using Org.Apache.REEF.Network.Group.Topology;
 using Org.Apache.REEF.Network.NetworkService;
 using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Tang.Implementations.Configuration;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Logging;
 using Org.Apache.REEF.Wake.Remote;
+using Org.Apache.REEF.Wake.Remote.Impl;
 
 namespace Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastReduceDriverAndTasks
 {
@@ -61,27 +65,48 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastR
             [Parameter(typeof(GroupTestConfig.ChunkSize))] int chunkSize,
             GroupCommDriver groupCommDriver)
         {
-            Logger.Log(Level.Info, "*******entering the driver code " + chunkSize);
+            Logger.Log(Level.Info, "entering the driver code " + chunkSize);
 
             Identifier = "BroadcastStartHandler";
             _numEvaluators = numEvaluators;
             _numIterations = numIterations;
             _chunkSize = chunkSize;
 
+            IConfiguration codecConfig = CodecConfiguration<int[]>.Conf
+                .Set(CodecConfiguration<int[]>.CodecRequiredImpl, GenericType<IntArrayCodec>.Class)
+                .Build();
+
+            IConfiguration reduceFunctionConfig = ReduceFunctionConfiguration<int[]>.Conf
+                .Set(ReduceFunctionConfiguration<int[]>.ReduceFunctionRequiredImpl, GenericType<ArraySumFunction>.Class)
+                .Build();
+
+            IConfiguration dataConverterConfig = TangFactory.GetTang().NewConfigurationBuilder(
+                PipelineDataConverterConfiguration<int[]>.Conf
+                    .Set(PipelineDataConverterConfiguration<int[]>.dataConverterRequiredImpl,
+                        GenericType<PipelineIntDataConverter>.Class)
+                    .Build())
+                .BindNamedParameter<GroupTestConfig.ChunkSize, int>(
+                    GenericType<GroupTestConfig.ChunkSize>.Class,
+                    GroupTestConstants.ChunkSize.ToString(CultureInfo.InvariantCulture))
+                .Build();
+
+            IConfiguration merged = Configurations.Merge(codecConfig, reduceFunctionConfig, dataConverterConfig);
+
             _groupCommDriver = groupCommDriver;
 
             _commGroup = _groupCommDriver.DefaultGroup
-                .AddBroadcast<int[], IntArrayCodec>(
+                .AddBroadcast<int[]>(
+                    merged,
                     GroupTestConstants.BroadcastOperatorName,
                     GroupTestConstants.MasterTaskId,
-                    TopologyTypes.Tree,
-                    new PipelineIntDataConverter(_chunkSize))
-                .AddReduce<int[], IntArrayCodec>(
+                    TopologyTypes.Tree)
+                    //new PipelineIntDataConverter(_chunkSize))
+                .AddReduce<int[]>(
+                    merged,
                     GroupTestConstants.ReduceOperatorName,
                     GroupTestConstants.MasterTaskId,
-                    new ArraySumFunction(),
-                    TopologyTypes.Tree,
-                    new PipelineIntDataConverter(_chunkSize))
+                    TopologyTypes.Tree)
+                    //new PipelineIntDataConverter(_chunkSize))
                 .Build();
 
             _groupCommTaskStarter = new TaskStarter(_groupCommDriver, numEvaluators);
@@ -309,12 +334,12 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastR
                 return data;
             }
 
-            public IConfiguration GetConfiguration()
-            {
-                return TangFactory.GetTang().NewConfigurationBuilder()
-                .BindNamedParameter<GroupTestConfig.ChunkSize, int>(GenericType<GroupTestConfig.ChunkSize>.Class, _chunkSize.ToString(CultureInfo.InvariantCulture))
-                .Build();
-            }
+            //public IConfiguration GetConfiguration()
+            //{
+            //    return TangFactory.GetTang().NewConfigurationBuilder()
+            //    .BindNamedParameter<GroupTestConfig.ChunkSize, int>(GenericType<GroupTestConfig.ChunkSize>.Class, _chunkSize.ToString(CultureInfo.InvariantCulture))
+            //    .Build();
+            //}
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedBroadcastReduceDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedBroadcastReduceDriver.cs
@@ -73,16 +73,16 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastR
             _chunkSize = chunkSize;
 
             IConfiguration codecConfig = CodecConfiguration<int[]>.Conf
-                .Set(CodecConfiguration<int[]>.CodecRequiredImpl, GenericType<IntArrayCodec>.Class)
+                .Set(CodecConfiguration<int[]>.Codec, GenericType<IntArrayCodec>.Class)
                 .Build();
 
             IConfiguration reduceFunctionConfig = ReduceFunctionConfiguration<int[]>.Conf
-                .Set(ReduceFunctionConfiguration<int[]>.ReduceFunctionRequiredImpl, GenericType<ArraySumFunction>.Class)
+                .Set(ReduceFunctionConfiguration<int[]>.ReduceFunction, GenericType<ArraySumFunction>.Class)
                 .Build();
 
             IConfiguration dataConverterConfig = TangFactory.GetTang().NewConfigurationBuilder(
                 PipelineDataConverterConfiguration<int[]>.Conf
-                    .Set(PipelineDataConverterConfiguration<int[]>.dataConverterRequiredImpl,
+                    .Set(PipelineDataConverterConfiguration<int[]>.DataConverter,
                         GenericType<PipelineIntDataConverter>.Class)
                     .Build())
                 .BindNamedParameter<GroupTestConfig.ChunkSize, int>(
@@ -332,13 +332,6 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastR
 
                 return data;
             }
-
-            //public IConfiguration GetConfiguration()
-            //{
-            //    return TangFactory.GetTang().NewConfigurationBuilder()
-            //    .BindNamedParameter<GroupTestConfig.ChunkSize, int>(GenericType<GroupTestConfig.ChunkSize>.Class, _chunkSize.ToString(CultureInfo.InvariantCulture))
-            //    .Build();
-            //}
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/ScatterReduceDriverAndTasks/ScatterReduceDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/ScatterReduceDriverAndTasks/ScatterReduceDriver.cs
@@ -66,15 +66,15 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.ScatterReduceDrive
             _groupCommDriver = groupCommDriver;
 
             IConfiguration codecConfig = CodecConfiguration<int>.Conf
-                .Set(CodecConfiguration<int>.CodecRequiredImpl, GenericType<IntCodec>.Class)
+                .Set(CodecConfiguration<int>.Codec, GenericType<IntCodec>.Class)
                 .Build();
 
             IConfiguration reduceFunctionConfig = ReduceFunctionConfiguration<int>.Conf
-                .Set(ReduceFunctionConfiguration<int>.ReduceFunctionRequiredImpl, GenericType<SumFunction>.Class)
+                .Set(ReduceFunctionConfiguration<int>.ReduceFunction, GenericType<SumFunction>.Class)
                 .Build();
 
             IConfiguration dataConverterConfig = PipelineDataConverterConfiguration<int>.Conf
-                .Set(PipelineDataConverterConfiguration<int>.dataConverterRequiredImpl, GenericType<DefaultPipelineDataConverter<int>>.Class)
+                .Set(PipelineDataConverterConfiguration<int>.DataConverter, GenericType<DefaultPipelineDataConverter<int>>.Class)
                 .Build();
 
             _commGroup = _groupCommDriver.DefaultGroup

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/ScatterReduceDriverAndTasks/ScatterReduceDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/ScatterReduceDriverAndTasks/ScatterReduceDriver.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Org.Apache.REEF.Common.Io;
 using Org.Apache.REEF.Common.Tasks;
@@ -26,12 +27,18 @@ using Org.Apache.REEF.Driver;
 using Org.Apache.REEF.Driver.Bridge;
 using Org.Apache.REEF.Driver.Context;
 using Org.Apache.REEF.Driver.Evaluator;
+using Org.Apache.REEF.Network.Examples.GroupCommunication.BroadcastReduceDriverAndTasks;
+using Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastReduceDriverAndTasks;
+using Org.Apache.REEF.Network.Group.Config;
 using Org.Apache.REEF.Network.Group.Driver;
 using Org.Apache.REEF.Network.Group.Driver.Impl;
 using Org.Apache.REEF.Network.Group.Operators;
+using Org.Apache.REEF.Network.Group.Pipelining.Impl;
 using Org.Apache.REEF.Network.Group.Topology;
 using Org.Apache.REEF.Network.NetworkService;
 using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Tang.Implementations.Configuration;
+using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Logging;
@@ -56,16 +63,32 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.ScatterReduceDrive
         {
             Identifier = "BroadcastStartHandler";
             _numEvaluators = numEvaluators;
-            _groupCommDriver = groupCommDriver; 
+            _groupCommDriver = groupCommDriver;
+
+            IConfiguration codecConfig = CodecConfiguration<int>.Conf
+                .Set(CodecConfiguration<int>.CodecRequiredImpl, GenericType<IntCodec>.Class)
+                .Build();
+
+            IConfiguration reduceFunctionConfig = ReduceFunctionConfiguration<int>.Conf
+                .Set(ReduceFunctionConfiguration<int>.ReduceFunctionRequiredImpl, GenericType<SumFunction>.Class)
+                .Build();
+
+            IConfiguration dataConverterConfig = PipelineDataConverterConfiguration<int>.Conf
+                .Set(PipelineDataConverterConfiguration<int>.dataConverterRequiredImpl, GenericType<DefaultPipelineDataConverter<int>>.Class)
+                .Build();
+
+            IConfiguration merged = Configurations.Merge(codecConfig, reduceFunctionConfig, dataConverterConfig);
+
             _commGroup = _groupCommDriver.DefaultGroup
-                    .AddScatter<int, IntCodec>(
+                    .AddScatter<int>(
+                        merged,
                         GroupTestConstants.ScatterOperatorName,
                             GroupTestConstants.MasterTaskId,
                             TopologyTypes.Tree)
-                    .AddReduce<int, IntCodec>(
+                    .AddReduce<int>(
+                        merged,
                         GroupTestConstants.ReduceOperatorName,
-                            GroupTestConstants.MasterTaskId,
-                            new SumFunction())
+                        GroupTestConstants.MasterTaskId)
                     .Build();
 
             _groupCommTaskStarter = new TaskStarter(_groupCommDriver, numEvaluators);

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/ScatterReduceDriverAndTasks/ScatterReduceDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/ScatterReduceDriverAndTasks/ScatterReduceDriver.cs
@@ -77,18 +77,21 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.ScatterReduceDrive
                 .Set(PipelineDataConverterConfiguration<int>.dataConverterRequiredImpl, GenericType<DefaultPipelineDataConverter<int>>.Class)
                 .Build();
 
-            IConfiguration merged = Configurations.Merge(codecConfig, reduceFunctionConfig, dataConverterConfig);
-
             _commGroup = _groupCommDriver.DefaultGroup
                     .AddScatter<int>(
-                        merged,
                         GroupTestConstants.ScatterOperatorName,
                             GroupTestConstants.MasterTaskId,
-                            TopologyTypes.Tree)
+                            TopologyTypes.Tree, 
+                            codecConfig,
+                            dataConverterConfig)
                     .AddReduce<int>(
-                        merged,
                         GroupTestConstants.ReduceOperatorName,
-                        GroupTestConstants.MasterTaskId)
+                        GroupTestConstants.MasterTaskId,
+                        TopologyTypes.Tree, 
+                        codecConfig,
+                        reduceFunctionConfig,
+                        dataConverterConfig)
+
                     .Build();
 
             _groupCommTaskStarter = new TaskStarter(_groupCommDriver, numEvaluators);

--- a/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTests.cs
@@ -235,19 +235,19 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IGroupCommDriver groupCommDriver = GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, 2, 5);
 
             IConfiguration conf1 = CodecConfiguration<Centroids>.Conf
-                .Set(CodecConfiguration<Centroids>.CodecRequiredImpl, GenericType<CentroidsCodec>.Class)
+                .Set(CodecConfiguration<Centroids>.Codec, GenericType<CentroidsCodec>.Class)
                 .Build();
 
             IConfiguration conf2 = CodecConfiguration<ControlMessage>.Conf
-                .Set(CodecConfiguration<ControlMessage>.CodecRequiredImpl, GenericType<ControlMessageCodec>.Class)
+                .Set(CodecConfiguration<ControlMessage>.Codec, GenericType<ControlMessageCodec>.Class)
                 .Build();
 
             IConfiguration conf3 = CodecConfiguration<ProcessedResults>.Conf
-                .Set(CodecConfiguration<ProcessedResults>.CodecRequiredImpl, GenericType<ProcessedResultsCodec>.Class)
+                .Set(CodecConfiguration<ProcessedResults>.Codec, GenericType<ProcessedResultsCodec>.Class)
                 .Build();
 
             IConfiguration reduceFunctionConfig = ReduceFunctionConfiguration<ProcessedResults>.Conf
-                .Set(ReduceFunctionConfiguration<ProcessedResults>.ReduceFunctionRequiredImpl, GenericType<KMeansMasterTask.AggregateMeans>.Class)
+                .Set(ReduceFunctionConfiguration<ProcessedResults>.ReduceFunction, GenericType<KMeansMasterTask.AggregateMeans>.Class)
                 .Build();
 
             IConfiguration merged = Configurations.Merge(conf3, reduceFunctionConfig);
@@ -770,21 +770,21 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
         private IConfiguration GetDefaulCodecConfig()
         {
             return CodecConfiguration<int>.Conf
-                .Set(CodecConfiguration<int>.CodecRequiredImpl, GenericType<IntCodec>.Class)
+                .Set(CodecConfiguration<int>.Codec, GenericType<IntCodec>.Class)
                 .Build();
         }
 
         private IConfiguration GetDefaulReduceFuncConfig()
         {
             return ReduceFunctionConfiguration<int>.Conf
-                .Set(ReduceFunctionConfiguration<int>.ReduceFunctionRequiredImpl, GenericType<SumFunction>.Class)
+                .Set(ReduceFunctionConfiguration<int>.ReduceFunction, GenericType<SumFunction>.Class)
                 .Build();
         }
 
         private IConfiguration GetDefaulDataConverterConfig()
         {
             return PipelineDataConverterConfiguration<int>.Conf
-                .Set(PipelineDataConverterConfiguration<int>.dataConverterRequiredImpl, GenericType<DefaultPipelineDataConverter<int>>.Class)
+                .Set(PipelineDataConverterConfiguration<int>.DataConverter, GenericType<DefaultPipelineDataConverter<int>>.Class)
                 .Build();
         }
     }

--- a/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTests.cs
@@ -106,16 +106,20 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
 
             var groupCommunicationDriver = GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
 
-            IConfiguration conf = GetDefaulConfiguration();
             ICommunicationGroupDriver commGroup = groupCommunicationDriver.DefaultGroup
                 .AddBroadcast<int>(
-                    conf,       
                     broadcastOperatorName,
-                    masterTaskId)
+                    masterTaskId,
+                    TopologyTypes.Flat,
+                    GetDefaulCodecConfig(),
+                    GetDefaulDataConverterConfig())
                 .AddReduce<int>(
-                    conf,
                     reduceOperatorName,
-                    masterTaskId)
+                    masterTaskId,
+                    TopologyTypes.Flat,
+                    GetDefaulCodecConfig(),
+                    GetDefaulDataConverterConfig(),
+                    GetDefaulReduceFuncConfig())
                 .Build();
 
             var commGroups = CommGroupClients(groupName, numTasks, groupCommunicationDriver, commGroup);
@@ -163,16 +167,20 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
 
             IGroupCommDriver groupCommDriver = GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
 
-            IConfiguration conf = GetDefaulConfiguration();
             ICommunicationGroupDriver commGroup = groupCommDriver.DefaultGroup
                 .AddScatter<int>(
-                    conf,
                     scatterOperatorName,
-                    masterTaskId)
+                    masterTaskId,
+                    TopologyTypes.Flat,
+                    GetDefaulCodecConfig(),
+                    GetDefaulDataConverterConfig())
                 .AddReduce<int>(
-                        conf,
                         reduceOperatorName,
-                        masterTaskId)
+                        masterTaskId,
+                        TopologyTypes.Flat,
+                        GetDefaulCodecConfig(),
+                        GetDefaulReduceFuncConfig(),
+                        GetDefaulDataConverterConfig())
                 .Build();
 
             List<ICommunicationGroupClient> commGroups = CommGroupClients(groupName, numTasks, groupCommDriver, commGroup);
@@ -244,9 +252,9 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
 
             IConfiguration merged = Configurations.Merge(conf3, reduceFunctionConfig);
             var group = groupCommDriver.DefaultGroup
-                   .AddBroadcast<Centroids>(conf1, centroidsBroadcastOperatorName, masterTaskId)
-                   .AddBroadcast<ControlMessage>(conf2, controlMessageBroadcastOperatorName, masterTaskId)
-                   .AddReduce<ProcessedResults>(merged, meansReduceOperatorName, masterTaskId)
+                   .AddBroadcast<Centroids>(centroidsBroadcastOperatorName, masterTaskId, TopologyTypes.Flat, GetDefaulCodecConfig(), GetDefaulDataConverterConfig())
+                   .AddBroadcast<ControlMessage>(controlMessageBroadcastOperatorName, masterTaskId, TopologyTypes.Flat, GetDefaulCodecConfig(), GetDefaulDataConverterConfig())
+                   .AddReduce<ProcessedResults>(meansReduceOperatorName, masterTaskId, TopologyTypes.Flat, GetDefaulCodecConfig(), GetDefaulDataConverterConfig(), GetDefaulReduceFuncConfig())
                    .Build();
         }
 
@@ -373,7 +381,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IGroupCommDriver groupCommDriver = GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
 
             var commGroup = groupCommDriver.DefaultGroup
-                .AddReduce<int>(GetDefaulConfiguration(), operatorName, "task0")
+                .AddReduce<int>(operatorName, "task0", TopologyTypes.Flat, GetDefaulCodecConfig(), GetDefaulDataConverterConfig(), GetDefaulReduceFuncConfig())
                 .Build();
 
             List<ICommunicationGroupClient> commGroups = CommGroupClients(groupName, numTasks, groupCommDriver, commGroup);
@@ -408,7 +416,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IGroupCommDriver groupCommDriver = GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
 
             var commGroup = groupCommDriver.DefaultGroup
-                .AddReduce<int>(GetDefaulConfiguration(), operatorName, "task0")
+                .AddReduce<int>(operatorName, "task0", TopologyTypes.Flat, GetDefaulCodecConfig(),GetDefaulDataConverterConfig(), GetDefaulReduceFuncConfig())
                 .Build();
 
             List<ICommunicationGroupClient> commGroups = CommGroupClients(groupName, numTasks, groupCommDriver, commGroup);
@@ -530,7 +538,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IGroupCommDriver groupCommDriver = GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
 
             var commGroup = groupCommDriver.DefaultGroup
-                .AddScatter<int>(GetDefaulConfiguration(), operatorName, masterTaskId)
+                .AddScatter<int>(operatorName, masterTaskId, TopologyTypes.Flat, GetDefaulCodecConfig(), GetDefaulDataConverterConfig(), GetDefaulReduceFuncConfig())
                 .Build();
 
             List<ICommunicationGroupClient> commGroups = CommGroupClients(groupName, numTasks, groupCommDriver, commGroup);
@@ -580,7 +588,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IGroupCommDriver groupCommDriver = GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
 
             var commGroup = groupCommDriver.DefaultGroup
-                .AddScatter<int>(GetDefaulConfiguration(), operatorName, masterTaskId)
+                .AddScatter<int>(operatorName, masterTaskId, TopologyTypes.Flat, GetDefaulCodecConfig(), GetDefaulDataConverterConfig())
                 .Build();
 
             List<ICommunicationGroupClient> commGroups = CommGroupClients(groupName, numTasks, groupCommDriver, commGroup);
@@ -627,7 +635,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IGroupCommDriver groupCommDriver = GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
 
             var commGroup = groupCommDriver.DefaultGroup
-                .AddScatter<int>(GetDefaulConfiguration(), operatorName, masterTaskId)
+                .AddScatter<int>(operatorName, masterTaskId, TopologyTypes.Flat, GetDefaulCodecConfig(), GetDefaulDataConverterConfig())
                 .Build();
 
             List<ICommunicationGroupClient> commGroups = CommGroupClients(groupName, numTasks, groupCommDriver, commGroup);
@@ -665,7 +673,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
         public void TestConfigurationBroadcastSpec()
         {
             FlatTopology<int> topology = new FlatTopology<int>("Operator", "Operator", "task1", "driverid",
-                new BroadcastOperatorSpec("Sender", GetDefaulConfiguration()));
+                new BroadcastOperatorSpec("Sender", GetDefaulCodecConfig(), GetDefaulDataConverterConfig()));
 
             topology.AddTask("task1");
             var conf = topology.GetTaskConfiguration("task1");
@@ -678,7 +686,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
         public void TestConfigurationReduceSpec()
         {
             FlatTopology<int> topology = new FlatTopology<int>("Operator", "Group", "task1", "driverid",
-                new ReduceOperatorSpec("task1", GetDefaulConfiguration()));
+                new ReduceOperatorSpec("task1", Configurations.Merge(GetDefaulCodecConfig(), GetDefaulDataConverterConfig(),  GetDefaulReduceFuncConfig())));
 
             topology.AddTask("task1");
             var conf2 = topology.GetTaskConfiguration("task1");
@@ -758,21 +766,26 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
         {
             return Enumerable.Range(1, n).Sum();
         }
-        private IConfiguration GetDefaulConfiguration()
+
+        private IConfiguration GetDefaulCodecConfig()
         {
-            IConfiguration codecConfiguration = CodecConfiguration<int>.Conf
+            return CodecConfiguration<int>.Conf
                 .Set(CodecConfiguration<int>.CodecRequiredImpl, GenericType<IntCodec>.Class)
                 .Build();
+        }
 
-            IConfiguration reduceFunctionConfig = ReduceFunctionConfiguration<int>.Conf
+        private IConfiguration GetDefaulReduceFuncConfig()
+        {
+            return ReduceFunctionConfiguration<int>.Conf
                 .Set(ReduceFunctionConfiguration<int>.ReduceFunctionRequiredImpl, GenericType<SumFunction>.Class)
                 .Build();
+        }
 
-            IConfiguration dataConverterConfig = PipelineDataConverterConfiguration<int>.Conf
+        private IConfiguration GetDefaulDataConverterConfig()
+        {
+            return PipelineDataConverterConfiguration<int>.Conf
                 .Set(PipelineDataConverterConfiguration<int>.dataConverterRequiredImpl, GenericType<DefaultPipelineDataConverter<int>>.Class)
                 .Build();
-
-            return Configurations.Merge(codecConfiguration, reduceFunctionConfig, dataConverterConfig);
         }
     }
 

--- a/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTreeTopologyTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTreeTopologyTests.cs
@@ -42,7 +42,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
         public void TestTreeTopology()
         {
             TreeTopology<int> topology = new TreeTopology<int>("Operator", "Operator", "task1", "driverid",
-                new BroadcastOperatorSpec("task1", GetDefaulConfiguration()), 2);
+                new BroadcastOperatorSpec("task1", GetDefaulCodecConfig(), GetDefaulDataConverterConfig()), 2);
             for (int i = 1; i < 8; i++)
             {
                 string taskid = "task" + i;
@@ -68,7 +68,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             var groupCommDriver = GroupCommunicationTests.GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
 
             ICommunicationGroupDriver commGroup = groupCommDriver.DefaultGroup
-                .AddReduce<int>(GetDefaulConfiguration(), operatorName, masterTaskId, TopologyTypes.Tree)
+                .AddReduce<int>(operatorName, masterTaskId, TopologyTypes.Tree, GetDefaulCodecConfig(), GetDefaulDataConverterConfig(), GetDefaulReduceFuncConfig())
                 .Build();
 
             var commGroups = GroupCommunicationTests.CommGroupClients(groupName, numTasks, groupCommDriver, commGroup);
@@ -124,7 +124,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             var groupCommDriver = GroupCommunicationTests.GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
 
             ICommunicationGroupDriver commGroup = groupCommDriver.DefaultGroup
-                .AddBroadcast<int>(GetDefaulConfiguration(), operatorName, masterTaskId, TopologyTypes.Tree)
+                .AddBroadcast<int>(operatorName, masterTaskId, TopologyTypes.Tree, GetDefaulCodecConfig(), GetDefaulDataConverterConfig(), GetDefaulReduceFuncConfig())
                 .Build();
 
             var commGroups = GroupCommunicationTests.CommGroupClients(groupName, numTasks, groupCommDriver, commGroup);
@@ -199,18 +199,20 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
 
             var groupCommDriver = GroupCommunicationTests.GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
 
-            IConfiguration conf = GetDefaulConfiguration();
             ICommunicationGroupDriver commGroup = groupCommDriver.DefaultGroup
                 .AddBroadcast<int>(
-                    conf,
                     broadcastOperatorName,
                     masterTaskId,
-                    TopologyTypes.Tree)
+                    TopologyTypes.Tree,
+                    GetDefaulCodecConfig(),
+                    GetDefaulDataConverterConfig())
                 .AddReduce<int>(
-                    conf,
                     reduceOperatorName,
                     masterTaskId,
-                    TopologyTypes.Tree)
+                    TopologyTypes.Tree,
+                    GetDefaulCodecConfig(),
+                    GetDefaulDataConverterConfig(),
+                    GetDefaulReduceFuncConfig())
                 .Build();
 
             var commGroups = GroupCommunicationTests.CommGroupClients(groupName, numTasks, groupCommDriver, commGroup);
@@ -315,7 +317,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             var groupCommDriver = GroupCommunicationTests.GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
 
             ICommunicationGroupDriver commGroup = groupCommDriver.DefaultGroup
-                .AddScatter<int>(GetDefaulConfiguration(), operatorName, masterTaskId, TopologyTypes.Tree)
+                .AddScatter<int>(operatorName, masterTaskId, TopologyTypes.Tree, GetDefaulCodecConfig(), GetDefaulDataConverterConfig())
                 .Build();
 
             var commGroups = GroupCommunicationTests.CommGroupClients(groupName, numTasks, groupCommDriver, commGroup);
@@ -360,7 +362,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             var groupCommDriver = GroupCommunicationTests.GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
 
             ICommunicationGroupDriver commGroup = groupCommDriver.DefaultGroup
-                .AddScatter<int>(GetDefaulConfiguration(), operatorName, masterTaskId, TopologyTypes.Tree)
+                .AddScatter<int>(operatorName, masterTaskId, TopologyTypes.Tree, GetDefaulCodecConfig(), GetDefaulDataConverterConfig())
                 .Build();
 
             var commGroups = GroupCommunicationTests.CommGroupClients(groupName, numTasks, groupCommDriver, commGroup);
@@ -414,7 +416,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             var groupCommDriver = GroupCommunicationTests.GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
 
             ICommunicationGroupDriver commGroup = groupCommDriver.DefaultGroup
-                .AddScatter<int>(GetDefaulConfiguration(), operatorName, masterTaskId, TopologyTypes.Tree)
+                .AddScatter<int>(operatorName, masterTaskId, TopologyTypes.Tree, GetDefaulCodecConfig(), GetDefaulDataConverterConfig())
                 .Build();
 
             var commGroups = GroupCommunicationTests.CommGroupClients(groupName, numTasks, groupCommDriver, commGroup);
@@ -465,7 +467,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             var groupCommDriver = GroupCommunicationTests.GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
 
             ICommunicationGroupDriver commGroup = groupCommDriver.DefaultGroup
-                .AddScatter<int>(GetDefaulConfiguration(), operatorName, masterTaskId, TopologyTypes.Tree)
+                .AddScatter<int>(operatorName, masterTaskId, TopologyTypes.Tree, GetDefaulCodecConfig(), GetDefaulDataConverterConfig())
                 .Build();
 
             var commGroups = GroupCommunicationTests.CommGroupClients(groupName, numTasks, groupCommDriver, commGroup);
@@ -517,7 +519,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             var groupCommDriver = GroupCommunicationTests.GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
 
             ICommunicationGroupDriver commGroup = groupCommDriver.DefaultGroup
-                .AddScatter<int>(GetDefaulConfiguration(), operatorName, masterTaskId, TopologyTypes.Tree)
+                .AddScatter<int>(operatorName, masterTaskId, TopologyTypes.Tree, GetDefaulCodecConfig(), GetDefaulDataConverterConfig())
                 .Build();
 
             var commGroups = GroupCommunicationTests.CommGroupClients(groupName, numTasks, groupCommDriver, commGroup);
@@ -579,18 +581,21 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             int fanOut = 2;
 
             var groupCommDriver = GroupCommunicationTests.GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
-            IConfiguration conf = GetDefaulConfiguration();
             ICommunicationGroupDriver commGroup = groupCommDriver.DefaultGroup
               .AddScatter<int>(
-                    conf,
                     scatterOperatorName,
                     masterTaskId,
-                    TopologyTypes.Tree)
+                    TopologyTypes.Tree,
+                    GetDefaulCodecConfig(),
+                    GetDefaulDataConverterConfig())
                 .AddReduce<int>(
-                    conf,
                     reduceOperatorName,
                     masterTaskId,
-                    TopologyTypes.Tree).Build();
+                    TopologyTypes.Tree,
+                    GetDefaulCodecConfig(),
+                    GetDefaulDataConverterConfig(),
+                    GetDefaulReduceFuncConfig())
+                .Build();
 
             var commGroups = GroupCommunicationTests.CommGroupClients(groupName, numTasks, groupCommDriver, commGroup);
 
@@ -641,21 +646,25 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             Assert.AreEqual(sum, 6325);
         }
 
-        private IConfiguration GetDefaulConfiguration()
+        private IConfiguration GetDefaulCodecConfig()
         {
-            IConfiguration codecConfiguration = CodecConfiguration<int>.Conf
+            return CodecConfiguration<int>.Conf
                 .Set(CodecConfiguration<int>.CodecRequiredImpl, GenericType<IntCodec>.Class)
                 .Build();
+        }
 
-            IConfiguration reduceFunctionConfig = ReduceFunctionConfiguration<int>.Conf
+        private IConfiguration GetDefaulReduceFuncConfig()
+        {
+            return ReduceFunctionConfiguration<int>.Conf
                 .Set(ReduceFunctionConfiguration<int>.ReduceFunctionRequiredImpl, GenericType<SumFunction>.Class)
                 .Build();
+        }
 
-            IConfiguration dataConverterConfig = PipelineDataConverterConfiguration<int>.Conf
+        private IConfiguration GetDefaulDataConverterConfig()
+        {
+            return PipelineDataConverterConfiguration<int>.Conf
                 .Set(PipelineDataConverterConfiguration<int>.dataConverterRequiredImpl, GenericType<DefaultPipelineDataConverter<int>>.Class)
                 .Build();
-
-            return Configurations.Merge(codecConfiguration, reduceFunctionConfig, dataConverterConfig);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTreeTopologyTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTreeTopologyTests.cs
@@ -18,12 +18,19 @@
  */
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Org.Apache.REEF.Network.Group.Config;
 using Org.Apache.REEF.Network.Group.Driver;
 using Org.Apache.REEF.Network.Group.Operators;
 using Org.Apache.REEF.Network.Group.Operators.Impl;
+using Org.Apache.REEF.Network.Group.Pipelining.Impl;
 using Org.Apache.REEF.Network.Group.Topology;
+using Org.Apache.REEF.Tang.Implementations.Configuration;
+using Org.Apache.REEF.Tang.Implementations.Tang;
+using Org.Apache.REEF.Tang.Interface;
+using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Wake.Remote.Impl;
 
 namespace Org.Apache.REEF.Network.Tests.GroupCommunication
@@ -34,8 +41,8 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
         [TestMethod]
         public void TestTreeTopology()
         {
-            TreeTopology<int, IntCodec> topology = new TreeTopology<int, IntCodec>("Operator", "Operator", "task1", "driverid",
-                new BroadcastOperatorSpec<int, IntCodec>("task1"), 2);
+            TreeTopology<int> topology = new TreeTopology<int>("Operator", "Operator", "task1", "driverid",
+                new BroadcastOperatorSpec("task1", GetDefaulConfiguration()), 2);
             for (int i = 1; i < 8; i++)
             {
                 string taskid = "task" + i;
@@ -61,7 +68,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             var groupCommDriver = GroupCommunicationTests.GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
 
             ICommunicationGroupDriver commGroup = groupCommDriver.DefaultGroup
-                .AddReduce<int, IntCodec>(operatorName, masterTaskId, new SumFunction(), TopologyTypes.Tree)
+                .AddReduce<int>(GetDefaulConfiguration(), operatorName, masterTaskId, TopologyTypes.Tree)
                 .Build();
 
             var commGroups = GroupCommunicationTests.CommGroupClients(groupName, numTasks, groupCommDriver, commGroup);
@@ -117,7 +124,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             var groupCommDriver = GroupCommunicationTests.GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
 
             ICommunicationGroupDriver commGroup = groupCommDriver.DefaultGroup
-                .AddBroadcast<int, IntCodec>(operatorName, masterTaskId, TopologyTypes.Tree)
+                .AddBroadcast<int>(GetDefaulConfiguration(), operatorName, masterTaskId, TopologyTypes.Tree)
                 .Build();
 
             var commGroups = GroupCommunicationTests.CommGroupClients(groupName, numTasks, groupCommDriver, commGroup);
@@ -192,15 +199,17 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
 
             var groupCommDriver = GroupCommunicationTests.GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
 
+            IConfiguration conf = GetDefaulConfiguration();
             ICommunicationGroupDriver commGroup = groupCommDriver.DefaultGroup
-                .AddBroadcast<int, IntCodec>(
+                .AddBroadcast<int>(
+                    conf,
                     broadcastOperatorName,
                     masterTaskId,
                     TopologyTypes.Tree)
-                .AddReduce<int, IntCodec>(
+                .AddReduce<int>(
+                    conf,
                     reduceOperatorName,
                     masterTaskId,
-                    new SumFunction(),
                     TopologyTypes.Tree)
                 .Build();
 
@@ -306,7 +315,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             var groupCommDriver = GroupCommunicationTests.GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
 
             ICommunicationGroupDriver commGroup = groupCommDriver.DefaultGroup
-                .AddScatter<int, IntCodec>(operatorName, masterTaskId, TopologyTypes.Tree)
+                .AddScatter<int>(GetDefaulConfiguration(), operatorName, masterTaskId, TopologyTypes.Tree)
                 .Build();
 
             var commGroups = GroupCommunicationTests.CommGroupClients(groupName, numTasks, groupCommDriver, commGroup);
@@ -351,7 +360,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             var groupCommDriver = GroupCommunicationTests.GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
 
             ICommunicationGroupDriver commGroup = groupCommDriver.DefaultGroup
-                .AddScatter<int, IntCodec>(operatorName, masterTaskId, TopologyTypes.Tree)
+                .AddScatter<int>(GetDefaulConfiguration(), operatorName, masterTaskId, TopologyTypes.Tree)
                 .Build();
 
             var commGroups = GroupCommunicationTests.CommGroupClients(groupName, numTasks, groupCommDriver, commGroup);
@@ -405,7 +414,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             var groupCommDriver = GroupCommunicationTests.GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
 
             ICommunicationGroupDriver commGroup = groupCommDriver.DefaultGroup
-                .AddScatter<int, IntCodec>(operatorName, masterTaskId, TopologyTypes.Tree)
+                .AddScatter<int>(GetDefaulConfiguration(), operatorName, masterTaskId, TopologyTypes.Tree)
                 .Build();
 
             var commGroups = GroupCommunicationTests.CommGroupClients(groupName, numTasks, groupCommDriver, commGroup);
@@ -456,7 +465,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             var groupCommDriver = GroupCommunicationTests.GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
 
             ICommunicationGroupDriver commGroup = groupCommDriver.DefaultGroup
-                .AddScatter<int, IntCodec>(operatorName, masterTaskId, TopologyTypes.Tree)
+                .AddScatter<int>(GetDefaulConfiguration(), operatorName, masterTaskId, TopologyTypes.Tree)
                 .Build();
 
             var commGroups = GroupCommunicationTests.CommGroupClients(groupName, numTasks, groupCommDriver, commGroup);
@@ -508,7 +517,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             var groupCommDriver = GroupCommunicationTests.GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
 
             ICommunicationGroupDriver commGroup = groupCommDriver.DefaultGroup
-                .AddScatter<int, IntCodec>(operatorName, masterTaskId, TopologyTypes.Tree)
+                .AddScatter<int>(GetDefaulConfiguration(), operatorName, masterTaskId, TopologyTypes.Tree)
                 .Build();
 
             var commGroups = GroupCommunicationTests.CommGroupClients(groupName, numTasks, groupCommDriver, commGroup);
@@ -570,16 +579,17 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             int fanOut = 2;
 
             var groupCommDriver = GroupCommunicationTests.GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
-
+            IConfiguration conf = GetDefaulConfiguration();
             ICommunicationGroupDriver commGroup = groupCommDriver.DefaultGroup
-              .AddScatter<int, IntCodec>(
+              .AddScatter<int>(
+                    conf,
                     scatterOperatorName,
                     masterTaskId,
                     TopologyTypes.Tree)
-                .AddReduce<int, IntCodec>(
+                .AddReduce<int>(
+                    conf,
                     reduceOperatorName,
                     masterTaskId,
-                    new SumFunction(),
                     TopologyTypes.Tree).Build();
 
             var commGroups = GroupCommunicationTests.CommGroupClients(groupName, numTasks, groupCommDriver, commGroup);
@@ -629,6 +639,23 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
 
             int sum = sumReducer.Reduce();
             Assert.AreEqual(sum, 6325);
+        }
+
+        private IConfiguration GetDefaulConfiguration()
+        {
+            IConfiguration codecConfiguration = CodecConfiguration<int>.Conf
+                .Set(CodecConfiguration<int>.CodecRequiredImpl, GenericType<IntCodec>.Class)
+                .Build();
+
+            IConfiguration reduceFunctionConfig = ReduceFunctionConfiguration<int>.Conf
+                .Set(ReduceFunctionConfiguration<int>.ReduceFunctionRequiredImpl, GenericType<SumFunction>.Class)
+                .Build();
+
+            IConfiguration dataConverterConfig = PipelineDataConverterConfiguration<int>.Conf
+                .Set(PipelineDataConverterConfiguration<int>.dataConverterRequiredImpl, GenericType<DefaultPipelineDataConverter<int>>.Class)
+                .Build();
+
+            return Configurations.Merge(codecConfiguration, reduceFunctionConfig, dataConverterConfig);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTreeTopologyTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTreeTopologyTests.cs
@@ -649,21 +649,21 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
         private IConfiguration GetDefaulCodecConfig()
         {
             return CodecConfiguration<int>.Conf
-                .Set(CodecConfiguration<int>.CodecRequiredImpl, GenericType<IntCodec>.Class)
+                .Set(CodecConfiguration<int>.Codec, GenericType<IntCodec>.Class)
                 .Build();
         }
 
         private IConfiguration GetDefaulReduceFuncConfig()
         {
             return ReduceFunctionConfiguration<int>.Conf
-                .Set(ReduceFunctionConfiguration<int>.ReduceFunctionRequiredImpl, GenericType<SumFunction>.Class)
+                .Set(ReduceFunctionConfiguration<int>.ReduceFunction, GenericType<SumFunction>.Class)
                 .Build();
         }
 
         private IConfiguration GetDefaulDataConverterConfig()
         {
             return PipelineDataConverterConfiguration<int>.Conf
-                .Set(PipelineDataConverterConfiguration<int>.dataConverterRequiredImpl, GenericType<DefaultPipelineDataConverter<int>>.Class)
+                .Set(PipelineDataConverterConfiguration<int>.DataConverter, GenericType<DefaultPipelineDataConverter<int>>.Class)
                 .Build();
         }
     }

--- a/lang/cs/Org.Apache.REEF.Network.Tests/Org.Apache.REEF.Network.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/Org.Apache.REEF.Network.Tests.csproj
@@ -61,6 +61,10 @@ under the License.
       <Project>{545a0582-4105-44ce-b99c-b1379514a630}</Project>
       <Name>Org.Apache.REEF.Common</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Org.Apache.REEF.Examples\Org.Apache.REEF.Examples.csproj">
+      <Project>{75503f90-7b82-4762-9997-94b5c68f15db}</Project>
+      <Name>Org.Apache.REEF.Examples</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Org.Apache.REEF.Network\Org.Apache.REEF.Network.csproj">
       <Project>{883ce800-6a6a-4e0a-b7fe-c054f4f2c1dc}</Project>
       <Name>Org.Apache.REEF.Network</Name>

--- a/lang/cs/Org.Apache.REEF.Network/Group/Config/CodecConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Config/CodecConfiguration.cs
@@ -17,21 +17,20 @@
  * under the License.
  */
 
-using Org.Apache.REEF.Network.Group.Operators;
-using Org.Apache.REEF.Tang.Interface;
+using Org.Apache.REEF.Network.Group.Pipelining;
+using Org.Apache.REEF.Tang.Formats;
+using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Wake.Remote;
 
-namespace Org.Apache.REEF.Network.Group.Topology
+namespace Org.Apache.REEF.Network.Group.Config
 {
-    /// <summary>
-    /// Represents a topology graph for IGroupCommOperators.
-    /// </summary>
-    public interface ITopology<T>
+    public class CodecConfiguration<T> : ConfigurationModuleBuilder
     {
-        IOperatorSpec OperatorSpec { get; }
+        public static readonly RequiredImpl<ICodec<T>> CodecRequiredImpl = new RequiredImpl<ICodec<T>>();
 
-        IConfiguration GetTaskConfiguration(string taskId);
-
-        void AddTask(string taskId);
+        public static ConfigurationModule Conf = new CodecConfiguration<T>()
+            .BindImplementation(GenericType<ICodec<T>>.Class, CodecRequiredImpl)
+            .BindImplementation(GenericType<ICodec<PipelineMessage<T>>>.Class, GenericType<PipelineMessageCodec<T>>.Class)
+            .Build();
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Config/CodecConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Config/CodecConfiguration.cs
@@ -26,10 +26,16 @@ namespace Org.Apache.REEF.Network.Group.Config
 {
     public class CodecConfiguration<T> : ConfigurationModuleBuilder
     {
-        public static readonly RequiredImpl<ICodec<T>> CodecRequiredImpl = new RequiredImpl<ICodec<T>>();
+        /// <summary>
+        /// RequiredImpl for Codec. Client needs to set implementation for this paramter
+        /// </summary>
+        public static readonly RequiredImpl<ICodec<T>> Codec = new RequiredImpl<ICodec<T>>();
 
+        /// <summary>
+        /// Configuration Module for Codec
+        /// </summary>
         public static ConfigurationModule Conf = new CodecConfiguration<T>()
-            .BindImplementation(GenericType<ICodec<T>>.Class, CodecRequiredImpl)
+            .BindImplementation(GenericType<ICodec<T>>.Class, Codec)
             .BindImplementation(GenericType<ICodec<PipelineMessage<T>>>.Class, GenericType<PipelineMessageCodec<T>>.Class)
             .Build();
     }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Config/PipelineDataConverterConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Config/PipelineDataConverterConfiguration.cs
@@ -17,21 +17,18 @@
  * under the License.
  */
 
-using Org.Apache.REEF.Network.Group.Operators;
-using Org.Apache.REEF.Tang.Interface;
-using Org.Apache.REEF.Wake.Remote;
+using Org.Apache.REEF.Network.Group.Pipelining;
+using Org.Apache.REEF.Tang.Formats;
+using Org.Apache.REEF.Tang.Util;
 
-namespace Org.Apache.REEF.Network.Group.Topology
+namespace Org.Apache.REEF.Network.Group.Config
 {
-    /// <summary>
-    /// Represents a topology graph for IGroupCommOperators.
-    /// </summary>
-    public interface ITopology<T>
+    public class PipelineDataConverterConfiguration<T> : ConfigurationModuleBuilder
     {
-        IOperatorSpec OperatorSpec { get; }
+        public static readonly RequiredImpl<IPipelineDataConverter<T>> dataConverterRequiredImpl = new RequiredImpl<IPipelineDataConverter<T>>();
 
-        IConfiguration GetTaskConfiguration(string taskId);
-
-        void AddTask(string taskId);
+        public static ConfigurationModule Conf = new PipelineDataConverterConfiguration<T>()
+            .BindImplementation(GenericType<IPipelineDataConverter<T>>.Class, dataConverterRequiredImpl)
+            .Build();
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Config/PipelineDataConverterConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Config/PipelineDataConverterConfiguration.cs
@@ -25,10 +25,16 @@ namespace Org.Apache.REEF.Network.Group.Config
 {
     public class PipelineDataConverterConfiguration<T> : ConfigurationModuleBuilder
     {
-        public static readonly RequiredImpl<IPipelineDataConverter<T>> dataConverterRequiredImpl = new RequiredImpl<IPipelineDataConverter<T>>();
+        /// <summary>
+        /// Required Imple parameter for Pipeline Data Converter. Client needs to set an implementation for it. 
+        /// </summary>
+        public static readonly RequiredImpl<IPipelineDataConverter<T>> DataConverter = new RequiredImpl<IPipelineDataConverter<T>>();
 
+        /// <summary>
+        /// Confgiuration Module for Pipeline Data Converter
+        /// </summary>
         public static ConfigurationModule Conf = new PipelineDataConverterConfiguration<T>()
-            .BindImplementation(GenericType<IPipelineDataConverter<T>>.Class, dataConverterRequiredImpl)
+            .BindImplementation(GenericType<IPipelineDataConverter<T>>.Class, DataConverter)
             .Build();
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Config/ReduceFunctionConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Config/ReduceFunctionConfiguration.cs
@@ -30,10 +30,16 @@ namespace Org.Apache.REEF.Network.Group.Config
 {
     public class ReduceFunctionConfiguration<T> : ConfigurationModuleBuilder
     {
-        public static readonly RequiredImpl<IReduceFunction<T>> ReduceFunctionRequiredImpl = new RequiredImpl<IReduceFunction<T>>();
-
+        /// <summary>
+        /// RequiredImpl for Reduced Function. Client needs to set implementation for this paramter
+        /// </summary>
+        public static readonly RequiredImpl<IReduceFunction<T>> ReduceFunction = new RequiredImpl<IReduceFunction<T>>();
+        
+        /// <summary>
+        /// Configuration Module for Reduced Function
+        /// </summary>
         public static ConfigurationModule Conf = new ReduceFunctionConfiguration<T>()
-            .BindImplementation(GenericType<IReduceFunction<T>>.Class, ReduceFunctionRequiredImpl)
+            .BindImplementation(GenericType<IReduceFunction<T>>.Class, ReduceFunction)
             .Build();
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Config/ReduceFunctionConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Config/ReduceFunctionConfiguration.cs
@@ -17,21 +17,23 @@
  * under the License.
  */
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 using Org.Apache.REEF.Network.Group.Operators;
-using Org.Apache.REEF.Tang.Interface;
-using Org.Apache.REEF.Wake.Remote;
+using Org.Apache.REEF.Tang.Formats;
+using Org.Apache.REEF.Tang.Util;
 
-namespace Org.Apache.REEF.Network.Group.Topology
+namespace Org.Apache.REEF.Network.Group.Config
 {
-    /// <summary>
-    /// Represents a topology graph for IGroupCommOperators.
-    /// </summary>
-    public interface ITopology<T>
+    public class ReduceFunctionConfiguration<T> : ConfigurationModuleBuilder
     {
-        IOperatorSpec OperatorSpec { get; }
+        public static readonly RequiredImpl<IReduceFunction<T>> ReduceFunctionRequiredImpl = new RequiredImpl<IReduceFunction<T>>();
 
-        IConfiguration GetTaskConfiguration(string taskId);
-
-        void AddTask(string taskId);
+        public static ConfigurationModule Conf = new ReduceFunctionConfiguration<T>()
+            .BindImplementation(GenericType<IReduceFunction<T>>.Class, ReduceFunctionRequiredImpl)
+            .Build();
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Driver/ICommunicationGroupDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Driver/ICommunicationGroupDriver.cs
@@ -43,25 +43,13 @@ namespace Org.Apache.REEF.Network.Group.Driver
         /// <summary>
         /// Adds the Broadcast Group Communication operator to the communication group.
         /// </summary>
-        /// <typeparam name="TMessage">The type of messages that operators will send</typeparam>
-        /// <typeparam name="TMessageCodec">The codec used for serializing messages</typeparam>
-        /// <param name="operatorName">The name of the broadcast operator</param>
-        /// <param name="masterTaskId">The master task id in broadcast operator</param>
-        /// <param name="topologyType">The topology type for the operator</param>
-        /// <param name="pipelineDataConverter">The class used to convert data back and forth to pipelined one</param>
-        /// <returns>The same CommunicationGroupDriver with the added Broadcast operator info</returns>
-        ICommunicationGroupDriver AddBroadcast<TMessage, TMessageCodec>(string operatorName, string masterTaskId, TopologyTypes topologyType, IPipelineDataConverter<TMessage> pipelineDataConverter) where TMessageCodec : ICodec<TMessage>;
-
-        /// <summary>
-        /// Adds the Broadcast Group Communication operator to the communication group.
-        /// </summary>
-        /// <typeparam name="TMessage">The type of messages that operators will send</typeparam>
-        /// <typeparam name="TMessageCodec">The codec used for serializing messages</typeparam>
+        /// <typeparam name="T">The type of messages that operators will send</typeparam>
+        /// <param name="configuration">The configuration for task</param>
         /// <param name="operatorName">The name of the broadcast operator</param>
         /// <param name="masterTaskId">The master task id in broadcast operator</param>
         /// <param name="topologyType">The topology type for the operator</param>
         /// <returns>The same CommunicationGroupDriver with the added Broadcast operator info</returns>
-        ICommunicationGroupDriver AddBroadcast<TMessage, TMessageCodec>(string operatorName, string masterTaskId, TopologyTypes topologyType = TopologyTypes.Flat) where TMessageCodec : ICodec<TMessage>;
+        ICommunicationGroupDriver AddBroadcast<T>(IConfiguration configuration, string operatorName, string masterTaskId, TopologyTypes topologyType = TopologyTypes.Flat);
 
         /// <summary>
         /// Adds the Broadcast Group Communication operator to the communication group. Default to IntCodec
@@ -75,48 +63,13 @@ namespace Org.Apache.REEF.Network.Group.Driver
         /// <summary>
         /// Adds the Reduce Group Communication operator to the communication group.
         /// </summary>
-        /// <typeparam name="TMessage">The type of messages that operators will send</typeparam>
-        /// <typeparam name="TMessageCodec">The codec used for serializing messages</typeparam>
+        /// <typeparam name="T">The type of messages that operators will send</typeparam>
+        /// <param name="configuration">The configuration for task</param>
         /// <param name="operatorName">The name of the reduce operator</param>
         /// <param name="masterTaskId">The master task id for the typology</param>
-        /// <param name="reduceFunction">The class used to aggregate all messages.</param>
         /// <param name="topologyType">The topology for the operator</param>
         /// <returns>The same CommunicationGroupDriver with the added Reduce operator info</returns>
-        ICommunicationGroupDriver AddReduce<TMessage, TMessageCodec>(string operatorName, string masterTaskId, IReduceFunction<TMessage> reduceFunction, TopologyTypes topologyType, IPipelineDataConverter<TMessage> pipelineDataConverter) where TMessageCodec : ICodec<TMessage>;
-
-        /// <summary>
-        /// Adds the Reduce Group Communication operator to the communication group.
-        /// </summary>
-        /// <typeparam name="TMessage">The type of messages that operators will send</typeparam>
-        /// <typeparam name="TMessageCodec">The codec used for serializing messages</typeparam>
-        /// <param name="operatorName">The name of the reduce operator</param>
-        /// <param name="masterTaskId">The master task id for the typology</param>
-        /// <param name="reduceFunction">The class used to aggregate all messages.</param>
-        /// <param name="topologyType">The topology for the operator</param>
-        /// <returns>The same CommunicationGroupDriver with the added Reduce operator info</returns>
-        ICommunicationGroupDriver AddReduce<TMessage, TMessageCodec>(string operatorName, string masterTaskId, IReduceFunction<TMessage> reduceFunction, TopologyTypes topologyType = TopologyTypes.Flat) where TMessageCodec : ICodec<TMessage>;
-
-
-        /// <summary>
-        /// Adds the Reduce Group Communication operator to the communication group with default IntCodec
-        /// </summary>
-        /// <param name="operatorName">The name of the reduce operator</param>
-        /// <param name="masterTaskId">The master task id for the typology</param>
-        /// <param name="reduceFunction">The class used to aggregate all messages.</param>
-        /// <param name="topologyType">The topology for the operator</param>
-        /// <returns>The same CommunicationGroupDriver with the added Reduce operator info</returns>
-        ICommunicationGroupDriver AddReduce(string operatorName, string masterTaskId, IReduceFunction<int> reduceFunction, TopologyTypes topologyType = TopologyTypes.Flat);
-
-        /// <summary>
-        /// Adds the Scatter Group Communication operator to the communication group.
-        /// </summary>
-        /// <typeparam name="TMessage">The type of messages that operators will send</typeparam>
-        /// <typeparam name="TMessageCodec">The codec used for serializing messages</typeparam>
-        /// <param name="operatorName">The name of the scatter operator</param>
-        /// <param name="senderId">The sender id</param>
-        /// <param name="topologyType">type of topology used in the operaor</param>
-        /// <returns>The same CommunicationGroupDriver with the added Scatter operator info</returns>
-        ICommunicationGroupDriver AddScatter<TMessage, TMessageCodec>(string operatorName, string senderId, TopologyTypes topologyType = TopologyTypes.Flat) where TMessageCodec : ICodec<TMessage>;
+        ICommunicationGroupDriver AddReduce<T>(IConfiguration configuration, string operatorName, string masterTaskId, TopologyTypes topologyType = TopologyTypes.Flat);
 
         /// <summary>
         /// Adds the Scatter Group Communication operator to the communication group with default Codec
@@ -126,6 +79,17 @@ namespace Org.Apache.REEF.Network.Group.Driver
         /// <param name="topologyType">type of topology used in the operaor</param>
         /// <returns>The same CommunicationGroupDriver with the added Scatter operator info</returns>
         ICommunicationGroupDriver AddScatter(string operatorName, string senderId, TopologyTypes topologyType = TopologyTypes.Flat);
+
+        /// <summary>
+        /// Adds the Scatter Group Communication operator to the communication group.
+        /// </summary>
+        /// <typeparam name="T">The type of messages that operators will send</typeparam>
+        /// <param name="configuration">The configuration for task</param>
+        /// <param name="operatorName">The name of the scatter operator</param>
+        /// <param name="senderId">The sender id</param>
+        /// <param name="topologyType">type of topology used in the operaor</param>
+        /// <returns>The same CommunicationGroupDriver with the added Scatter operator info</returns>
+        ICommunicationGroupDriver AddScatter<T>(IConfiguration configuration, string operatorName, string senderId, TopologyTypes topologyType = TopologyTypes.Flat);
 
         /// <summary>
         /// Finalizes the CommunicationGroupDriver.

--- a/lang/cs/Org.Apache.REEF.Network/Group/Driver/ICommunicationGroupDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Driver/ICommunicationGroupDriver.cs
@@ -44,12 +44,12 @@ namespace Org.Apache.REEF.Network.Group.Driver
         /// Adds the Broadcast Group Communication operator to the communication group.
         /// </summary>
         /// <typeparam name="T">The type of messages that operators will send</typeparam>
-        /// <param name="configuration">The configuration for task</param>
+        /// <param name="configurations">The configuration for task</param>
         /// <param name="operatorName">The name of the broadcast operator</param>
         /// <param name="masterTaskId">The master task id in broadcast operator</param>
         /// <param name="topologyType">The topology type for the operator</param>
         /// <returns>The same CommunicationGroupDriver with the added Broadcast operator info</returns>
-        ICommunicationGroupDriver AddBroadcast<T>(IConfiguration configuration, string operatorName, string masterTaskId, TopologyTypes topologyType = TopologyTypes.Flat);
+        ICommunicationGroupDriver AddBroadcast<T>(string operatorName, string masterTaskId, TopologyTypes topologyType, params IConfiguration[] configurations);
 
         /// <summary>
         /// Adds the Broadcast Group Communication operator to the communication group. Default to IntCodec
@@ -64,12 +64,12 @@ namespace Org.Apache.REEF.Network.Group.Driver
         /// Adds the Reduce Group Communication operator to the communication group.
         /// </summary>
         /// <typeparam name="T">The type of messages that operators will send</typeparam>
-        /// <param name="configuration">The configuration for task</param>
+        /// <param name="configurations">The configurations for task</param>
         /// <param name="operatorName">The name of the reduce operator</param>
         /// <param name="masterTaskId">The master task id for the typology</param>
         /// <param name="topologyType">The topology for the operator</param>
         /// <returns>The same CommunicationGroupDriver with the added Reduce operator info</returns>
-        ICommunicationGroupDriver AddReduce<T>(IConfiguration configuration, string operatorName, string masterTaskId, TopologyTypes topologyType = TopologyTypes.Flat);
+        ICommunicationGroupDriver AddReduce<T>(string operatorName, string masterTaskId, TopologyTypes topologyType, params IConfiguration[] configurations);
 
         /// <summary>
         /// Adds the Scatter Group Communication operator to the communication group with default Codec
@@ -84,12 +84,12 @@ namespace Org.Apache.REEF.Network.Group.Driver
         /// Adds the Scatter Group Communication operator to the communication group.
         /// </summary>
         /// <typeparam name="T">The type of messages that operators will send</typeparam>
-        /// <param name="configuration">The configuration for task</param>
+        /// <param name="configurations">The configuration for task</param>
         /// <param name="operatorName">The name of the scatter operator</param>
         /// <param name="senderId">The sender id</param>
         /// <param name="topologyType">type of topology used in the operaor</param>
         /// <returns>The same CommunicationGroupDriver with the added Scatter operator info</returns>
-        ICommunicationGroupDriver AddScatter<T>(IConfiguration configuration, string operatorName, string senderId, TopologyTypes topologyType = TopologyTypes.Flat);
+        ICommunicationGroupDriver AddScatter<T>(string operatorName, string senderId, TopologyTypes topologyType, params IConfiguration[] configurations);
 
         /// <summary>
         /// Finalizes the CommunicationGroupDriver.

--- a/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/CommunicationGroupDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/CommunicationGroupDriver.cs
@@ -350,11 +350,11 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
         {
             List<IConfiguration> list = new List<IConfiguration>(); 
             IConfiguration codecConfig = CodecConfiguration<int>.Conf
-                .Set(CodecConfiguration<int>.CodecRequiredImpl, GenericType<IntCodec>.Class)
+                .Set(CodecConfiguration<int>.Codec, GenericType<IntCodec>.Class)
                 .Build();
 
             IConfiguration dataConverterConfig = PipelineDataConverterConfiguration<int>.Conf
-                .Set(PipelineDataConverterConfiguration<int>.dataConverterRequiredImpl, GenericType<DefaultPipelineDataConverter<int>>.Class)
+                .Set(PipelineDataConverterConfiguration<int>.DataConverter, GenericType<DefaultPipelineDataConverter<int>>.Class)
                 .Build();
 
             list.Add(codecConfig);

--- a/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/CommunicationGroupDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/CommunicationGroupDriver.cs
@@ -20,13 +20,13 @@
 using System.Collections.Generic;
 using System.Reflection;
 using Org.Apache.REEF.Network.Group.Config;
-using Org.Apache.REEF.Network.Group.Operators;
 using Org.Apache.REEF.Network.Group.Operators.Impl;
 using Org.Apache.REEF.Network.Group.Pipelining;
 using Org.Apache.REEF.Network.Group.Pipelining.Impl;
 using Org.Apache.REEF.Network.Group.Topology;
 using Org.Apache.REEF.Tang.Exceptions;
 using Org.Apache.REEF.Tang.Formats;
+using Org.Apache.REEF.Tang.Implementations.Configuration;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
@@ -43,7 +43,7 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
     /// </summary>
     public class CommunicationGroupDriver : ICommunicationGroupDriver
     {
-        private static readonly Logger LOGGER = Logger.GetLogger(typeof(CommunicationGroupDriver));
+        private static readonly Logger LOGGER = Logger.GetLogger(typeof (CommunicationGroupDriver));
 
         private readonly string _groupName;
         private readonly string _driverId;
@@ -94,70 +94,35 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
 
         /// <summary>
         /// </summary>
-        /// <typeparam name="TMessage">The type of messages that operators will send</typeparam>
-        /// <typeparam name="TMessageCodec">The codec used for serializing messages</typeparam>
-        /// <param name="operatorName">The name of the broadcast operator</param>
-        /// <param name="masterTaskId">The master task id in broadcast operator</param>
-        /// <param name="topologyType">The topology type for the operator</param>
-        /// <param name="pipelineDataConverter">The class type used to convert data back and forth to pipelined one</param>
-        /// <returns>The same CommunicationGroupDriver with the added Broadcast operator info</returns>
-        /// <returns></returns>
-        public ICommunicationGroupDriver AddBroadcast<TMessage, TMessageCodec>(string operatorName, string masterTaskId, TopologyTypes topologyType, IPipelineDataConverter<TMessage> pipelineDataConverter) where TMessageCodec : ICodec<TMessage>
-        {
-            if (_finalized)
-            {
-                throw new IllegalStateException("Can't add operators once the spec has been built.");
-            }
-
-            var spec = new BroadcastOperatorSpec<TMessage, TMessageCodec>(
-                masterTaskId,
-                pipelineDataConverter);
-
-            ITopology<TMessage, TMessageCodec> topology;
-            if (topologyType == TopologyTypes.Flat)
-            {
-                topology = new FlatTopology<TMessage, TMessageCodec>(operatorName, _groupName, spec.SenderId, _driverId, spec);
-            }
-            else
-            {
-                topology = new TreeTopology<TMessage, TMessageCodec>(operatorName, _groupName, spec.SenderId, _driverId, spec,
-                    _fanOut);
-            }
-
-            _topologies[operatorName] = topology;
-            _operatorSpecs[operatorName] = spec;
-
-            return this;
-        }
-
-        /// <summary>
-        /// </summary>
-        /// <typeparam name="TMessage">The type of messages that operators will send</typeparam>
-        /// <typeparam name="TMessageCodec">The codec used for serializing messages</typeparam>
+        /// <typeparam name="T">The type of messages that operators will send</typeparam>
+        /// <param name="configuration">The configuration send to Evaluator</param>
         /// <param name="operatorName">The name of the broadcast operator</param>
         /// <param name="masterTaskId">The master task id in broadcast operator</param>
         /// <param name="topologyType">The topology type for the operator</param>
         /// <returns>The same CommunicationGroupDriver with the added Broadcast operator info</returns>
         /// <returns></returns>
-        public ICommunicationGroupDriver AddBroadcast<TMessage, TMessageCodec>(string operatorName, string masterTaskId, TopologyTypes topologyType = TopologyTypes.Flat) where TMessageCodec : ICodec<TMessage>
+        public ICommunicationGroupDriver AddBroadcast<T>(IConfiguration configuration,
+            string operatorName, string masterTaskId, TopologyTypes topologyType = TopologyTypes.Flat)
         {
             if (_finalized)
             {
                 throw new IllegalStateException("Can't add operators once the spec has been built.");
             }
 
-            var spec = new BroadcastOperatorSpec<TMessage, TMessageCodec>(
+            var spec = new BroadcastOperatorSpec(
                 masterTaskId,
-                new DefaultPipelineDataConverter<TMessage>());
+                configuration);
 
-            ITopology<TMessage, TMessageCodec> topology;
+            ITopology<T> topology;
             if (topologyType == TopologyTypes.Flat)
             {
-                topology = new FlatTopology<TMessage, TMessageCodec>(operatorName, _groupName, spec.SenderId, _driverId, spec);
+                topology = new FlatTopology<T>(operatorName, _groupName, spec.SenderId, _driverId,
+                    spec);
             }
             else
             {
-                topology = new TreeTopology<TMessage, TMessageCodec>(operatorName, _groupName, spec.SenderId, _driverId, spec,
+                topology = new TreeTopology<T>(operatorName, _groupName, spec.SenderId, _driverId,
+                    spec,
                     _fanOut);
             }
 
@@ -168,54 +133,52 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
         }
 
         /// <summary>
-        /// Adds the Broadcast Group Communication operator to the communication group. Default to IntCodec
+        /// Adds the Broadcast Group Communication operator to the communication group. Default to Int message type
         /// </summary>
         /// <param name="operatorName">The name of the broadcast operator</param>
         /// <param name="masterTaskId">The master task id in broadcast operator</param>
         /// <param name="topologyType">The topology type for the operator</param>
         /// <returns>The same CommunicationGroupDriver with the added Broadcast operator info</returns>
-        public ICommunicationGroupDriver AddBroadcast(string operatorName, string masterTaskId,
-            TopologyTypes topologyType = TopologyTypes.Flat)
+        public ICommunicationGroupDriver AddBroadcast(string operatorName, string masterTaskId, TopologyTypes topologyType = TopologyTypes.Flat)
         {
-            return AddBroadcast<int, IntCodec>(operatorName, masterTaskId, topologyType);
+            return AddBroadcast<int>(GetDefaulConfiguration(), operatorName, masterTaskId, topologyType);
         }
 
         /// <summary>
         /// Adds the Reduce Group Communication operator to the communication group.
         /// </summary>
-        /// <typeparam name="TMessage">The type of messages that operators will send</typeparam>
-        /// <typeparam name="TMessageCodec">The codec used for serializing messages</typeparam>
+        /// <typeparam name="T">The type of messages that operators will send</typeparam>
+        /// <param name="configuration">The configuration for the reduce operator</param>
         /// <param name="operatorName">The name of the reduce operator</param>
         /// <param name="masterTaskId">The master task id for the typology</param>
-        /// <param name="reduceFunction">The class used to aggregate all messages.</param>
         /// <param name="topologyType">The topology for the operator</param>
         /// <returns>The same CommunicationGroupDriver with the added Reduce operator info</returns>
-        public ICommunicationGroupDriver AddReduce<TMessage, TMessageCodec>(
+        public ICommunicationGroupDriver AddReduce<T>(
+            IConfiguration configuration,
             string operatorName,
             string masterTaskId,
-            IReduceFunction<TMessage> reduceFunction,
-            TopologyTypes topologyType,
-            IPipelineDataConverter<TMessage> pipelineDataConverter) where TMessageCodec : ICodec<TMessage>
+            TopologyTypes topologyType = TopologyTypes.Flat) 
         {
             if (_finalized)
             {
                 throw new IllegalStateException("Can't add operators once the spec has been built.");
             }
 
-            var spec = new ReduceOperatorSpec<TMessage, TMessageCodec>(
+            var spec = new ReduceOperatorSpec(
                 masterTaskId,
-                pipelineDataConverter,
-                reduceFunction);
+                configuration);
 
-            ITopology<TMessage, TMessageCodec> topology;
+            ITopology<T> topology;
 
             if (topologyType == TopologyTypes.Flat)
             {
-                topology = new FlatTopology<TMessage, TMessageCodec>(operatorName, _groupName, spec.ReceiverId, _driverId, spec);
+                topology = new FlatTopology<T>(operatorName, _groupName, spec.ReceiverId,
+                    _driverId, spec);
             }
             else
             {
-                topology = new TreeTopology<TMessage, TMessageCodec>(operatorName, _groupName, spec.ReceiverId, _driverId, spec,
+                topology = new TreeTopology<T>(operatorName, _groupName, spec.ReceiverId,
+                    _driverId, spec,
                     _fanOut);
             }
 
@@ -223,96 +186,38 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
             _operatorSpecs[operatorName] = spec;
 
             return this;
-        }
-
-               /// <summary>
-        /// Adds the Reduce Group Communication operator to the communication group.
-        /// </summary>
-        /// <typeparam name="TMessage">The type of messages that operators will send</typeparam>
-        /// <typeparam name="TMessageCodec">The codec used for serializing messages</typeparam>
-        /// <param name="operatorName">The name of the reduce operator</param>
-        /// <param name="masterTaskId">The master task id for the typology</param>
-        /// <param name="reduceFunction">The class used to aggregate all messages.</param>
-        /// <param name="topologyType">The topology for the operator</param>
-        /// <returns>The same CommunicationGroupDriver with the added Reduce operator info</returns>
-        public ICommunicationGroupDriver AddReduce<TMessage, TMessageCodec>(
-            string operatorName,
-            string masterTaskId,
-            IReduceFunction<TMessage> reduceFunction,
-            TopologyTypes topologyType = TopologyTypes.Flat) where TMessageCodec : ICodec<TMessage>
-        {
-            if (_finalized)
-            {
-                throw new IllegalStateException("Can't add operators once the spec has been built.");
-            }
-
-            var spec = new ReduceOperatorSpec<TMessage, TMessageCodec>(
-                masterTaskId,
-                new DefaultPipelineDataConverter<TMessage>(),
-                reduceFunction);
-
-            ITopology<TMessage, TMessageCodec> topology;
-
-            if (topologyType == TopologyTypes.Flat)
-            {
-                topology = new FlatTopology<TMessage, TMessageCodec>(operatorName, _groupName, spec.ReceiverId, _driverId, spec);
-            }
-            else
-            {
-                topology = new TreeTopology<TMessage, TMessageCodec>(operatorName, _groupName, spec.ReceiverId, _driverId, spec,
-                    _fanOut);
-            }
-
-            _topologies[operatorName] = topology;
-            _operatorSpecs[operatorName] = spec;
-
-            return this;
-        }
-
-        /// <summary>
-        /// Adds the Reduce Group Communication operator to the communication group with default IntCodec
-        /// </summary>
-        /// <param name="operatorName">The name of the reduce operator</param>
-        /// <param name="masterTaskId">The master task id for the typology</param>
-        /// <param name="reduceFunction">The class used to aggregate all messages.</param>
-        /// <param name="topologyType">The topology for the operator</param>
-        /// <returns>The same CommunicationGroupDriver with the added Reduce operator info</returns>
-        public ICommunicationGroupDriver AddReduce(
-            string operatorName,
-            string masterTaskId,
-            IReduceFunction<int> reduceFunction,
-            TopologyTypes topologyType = TopologyTypes.Flat)
-        {
-            return AddReduce<int, IntCodec>(operatorName, masterTaskId, reduceFunction, topologyType);
         }
 
         /// <summary>
         /// Adds the Scatter Group Communication operator to the communication group.
         /// </summary>
-        /// <typeparam name="TMessage">The type of messages that operators will send</typeparam>
-        /// <typeparam name="TMessageCodec">The codec used for serializing messages</typeparam>
+        /// <typeparam name="T">The type of messages that operators will send</typeparam>
+        /// <param name="configuration">The configuration for the scatter operator</param>
         /// <param name="operatorName">The name of the scatter operator</param>
         /// <param name="senderId">The sender id</param>
         /// <param name="topologyType">type of topology used in the operaor</param>
         /// <returns>The same CommunicationGroupDriver with the added Scatter operator info</returns>
-        public ICommunicationGroupDriver AddScatter<TMessage, TMessageCodec>(string operatorName, string senderId, TopologyTypes topologyType = TopologyTypes.Flat) where TMessageCodec : ICodec<TMessage>
+        public ICommunicationGroupDriver AddScatter<T>(IConfiguration configuration, string operatorName, string senderId,
+            TopologyTypes topologyType = TopologyTypes.Flat) 
         {
             if (_finalized)
             {
                 throw new IllegalStateException("Can't add operators once the spec has been built.");
             }
 
-            var spec = new ScatterOperatorSpec<TMessage, TMessageCodec>(senderId);
+            var spec = new ScatterOperatorSpec(senderId, configuration);
 
-            ITopology<TMessage, TMessageCodec> topology;
+            ITopology<T> topology;
 
             if (topologyType == TopologyTypes.Flat)
             {
-                topology = new FlatTopology<TMessage, TMessageCodec>(operatorName, _groupName, spec.SenderId, _driverId, spec);
+                topology = new FlatTopology<T>(operatorName, _groupName, spec.SenderId, _driverId,
+                    spec);
             }
             else
             {
-                topology = new TreeTopology<TMessage, TMessageCodec>(operatorName, _groupName, spec.SenderId, _driverId, spec,
+                topology = new TreeTopology<T>(operatorName, _groupName, spec.SenderId, _driverId,
+                    spec,
                     _fanOut);
             }
             _topologies[operatorName] = topology;
@@ -322,15 +227,16 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
         }
 
         /// <summary>
-        /// Adds the Scatter Group Communication operator to the communication group with default IntCodec
+        /// Adds the Scatter Group Communication operator to the communication group with default Int message type
         /// </summary>
         /// <param name="operatorName">The name of the scatter operator</param>
         /// <param name="senderId">The sender id</param>
         /// <param name="topologyType">type of topology used in the operaor</param>
         /// <returns>The same CommunicationGroupDriver with the added Scatter operator info</returns>
-        public ICommunicationGroupDriver AddScatter(string operatorName, string senderId, TopologyTypes topologyType = TopologyTypes.Flat)
+        public ICommunicationGroupDriver AddScatter(string operatorName, string senderId,
+            TopologyTypes topologyType = TopologyTypes.Flat)
         {
-            return AddScatter<int, IntCodec>(operatorName, senderId, topologyType);
+            return AddScatter<int>(GetDefaulConfiguration(), operatorName, senderId, topologyType);
         }
 
         /// <summary>
@@ -354,7 +260,8 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
         {
             if (!_finalized)
             {
-                throw new IllegalStateException("CommunicationGroupDriver must call Build() before adding tasks to the group.");
+                throw new IllegalStateException(
+                    "CommunicationGroupDriver must call Build() before adding tasks to the group.");
             }
 
             lock (_topologyLock)
@@ -362,7 +269,8 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
                 _tasksAdded++;
                 if (_tasksAdded > _numTasks)
                 {
-                    throw new IllegalStateException("Added too many tasks to Communication Group, expected: " + _numTasks);
+                    throw new IllegalStateException("Added too many tasks to Communication Group, expected: " +
+                                                    _numTasks);
                 }
 
                 TaskIds.Add(taskId);
@@ -406,14 +314,15 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
 
             foreach (var operatorName in _topologies.Keys)
             {
-                var innerConf = TangFactory.GetTang().NewConfigurationBuilder(GetOperatorConfiguration(operatorName, taskId))
-                    .BindNamedParameter<GroupCommConfigurationOptions.DriverId, string>(
-                        GenericType<GroupCommConfigurationOptions.DriverId>.Class,
-                        _driverId)
-                    .BindNamedParameter<GroupCommConfigurationOptions.OperatorName, string>(
-                        GenericType<GroupCommConfigurationOptions.OperatorName>.Class,
-                        operatorName)
-                    .Build();
+                var innerConf =
+                    TangFactory.GetTang().NewConfigurationBuilder(GetOperatorConfiguration(operatorName, taskId))
+                        .BindNamedParameter<GroupCommConfigurationOptions.DriverId, string>(
+                            GenericType<GroupCommConfigurationOptions.DriverId>.Class,
+                            _driverId)
+                        .BindNamedParameter<GroupCommConfigurationOptions.OperatorName, string>(
+                            GenericType<GroupCommConfigurationOptions.OperatorName>.Class,
+                            operatorName)
+                        .Build();
 
                 confBuilder.BindSetEntry<GroupCommConfigurationOptions.SerializedOperatorConfigs, string>(
                     GenericType<GroupCommConfigurationOptions.SerializedOperatorConfigs>.Class,
@@ -427,14 +336,27 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
         {
             var topology = _topologies[operatorName];
             MethodInfo info = topology.GetType().GetMethod("AddTask");
-            info.Invoke(topology, new[] { (object)taskId });
+            info.Invoke(topology, new[] {(object) taskId});
         }
 
         private IConfiguration GetOperatorConfiguration(string operatorName, string taskId)
         {
             var topology = _topologies[operatorName];
             MethodInfo info = topology.GetType().GetMethod("GetTaskConfiguration");
-            return (IConfiguration)info.Invoke(topology, new[] { (object)taskId });
+            return (IConfiguration) info.Invoke(topology, new[] {(object) taskId});
+        }
+
+        private IConfiguration GetDefaulConfiguration()
+        {
+            IConfiguration codecConfig = CodecConfiguration<int>.Conf
+                .Set(CodecConfiguration<int>.CodecRequiredImpl, GenericType<IntCodec>.Class)
+                .Build();
+
+            IConfiguration dataConverterConfig = PipelineDataConverterConfiguration<int>.Conf
+                .Set(PipelineDataConverterConfiguration<int>.dataConverterRequiredImpl, GenericType<DefaultPipelineDataConverter<int>>.Class)
+                .Build();
+
+            return Configurations.Merge(codecConfig, dataConverterConfig);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/IOperatorSpec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/IOperatorSpec.cs
@@ -17,19 +17,15 @@
  * under the License.
  */
 
-using System;
-using Org.Apache.REEF.Wake.Remote;
+using Org.Apache.REEF.Tang.Interface;
 
 namespace Org.Apache.REEF.Network.Group.Operators
 {
     /// <summary>
     /// The specification used to define Broadcast Operators.
     /// </summary>
-    public interface IOperatorSpec<T1, T2> where T2 : ICodec<T1>
+    public interface IOperatorSpec
     {
-        /// <summary>
-        /// Returns the codec type used to serialize and deserialize messages.
-        /// </summary>
-        Type Codec { get; }
+        IConfiguration Configiration { get; }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/BroadcastOperatorSpec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/BroadcastOperatorSpec.cs
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+using Org.Apache.REEF.Tang.Implementations.Configuration;
 using Org.Apache.REEF.Tang.Interface;
 
 namespace Org.Apache.REEF.Network.Group.Operators.Impl
@@ -26,10 +27,15 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
     /// </summary>
     public class BroadcastOperatorSpec : IOperatorSpec
     {
-        public BroadcastOperatorSpec(string senderId, IConfiguration configuration)
+        /// <summary>
+        /// Specification for Broadcast Operator
+        /// </summary>
+        /// <param name="senderId"></param>
+        /// <param name="configurations"></param>
+        public BroadcastOperatorSpec(string senderId, params IConfiguration[] configurations)
         {
             SenderId = senderId;
-            Configiration = configuration;
+            Configiration = Configurations.Merge(configurations);
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/BroadcastOperatorSpec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/BroadcastOperatorSpec.cs
@@ -17,49 +17,20 @@
  * under the License.
  */
 
-using System;
-using Org.Apache.REEF.Wake.Remote;
-using Org.Apache.REEF.Network.Group.Pipelining;
-using Org.Apache.REEF.Network.Group.Pipelining.Impl;
+using Org.Apache.REEF.Tang.Interface;
 
 namespace Org.Apache.REEF.Network.Group.Operators.Impl
 {
     /// <summary>
     /// The specification used to define Broadcast Operators.
     /// </summary>
-    public class BroadcastOperatorSpec<T1, T2> : IOperatorSpec<T1, T2> where T2 : ICodec<T1>
+    public class BroadcastOperatorSpec : IOperatorSpec
     {
-        /// <summary>
-        /// Create a new BroadcastOperatorSpec.
-        /// </summary>
-        /// <param name="senderId">The identifier of the root sending Task.</param>
-        /// <param name="codecType">The codec used to serialize messages.</param>
-        public BroadcastOperatorSpec(string senderId)
+        public BroadcastOperatorSpec(string senderId, IConfiguration configuration)
         {
             SenderId = senderId;
-             Codec = typeof(T2);
-            PipelineDataConverter = new DefaultPipelineDataConverter<T1>();
+            Configiration = configuration;
         }
-
-        /// <summary>
-        /// Create a new BroadcastOperatorSpec.
-        /// </summary>
-        /// <param name="senderId">The identifier of the root sending Task.</param>
-        /// <param name="dataConverter">The converter used to convert original
-        /// message to pipelined ones and vice versa.</param>
-        public BroadcastOperatorSpec(
-            string senderId,
-            IPipelineDataConverter<T1> dataConverter)
-        {
-            SenderId = senderId;
-            Codec = typeof(T2);;
-            PipelineDataConverter = dataConverter ?? new DefaultPipelineDataConverter<T1>();
-        }
-
-        /// <summary>
-        /// Returns the IPipelineDataConverter class type used to convert messages to pipeline form and vice-versa
-        /// </summary>
-        public IPipelineDataConverter<T1> PipelineDataConverter { get; private set; }
 
         /// <summary>
         /// Returns the identifier of the Task that will broadcast data to other Tasks.
@@ -67,8 +38,8 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         public string SenderId { get; private set; }
 
         /// <summary>
-        /// Returns the ICodec used to serialize messages.
+        /// Returns the Configuration for Codec, ReduceFunction and DataConverter
         /// </summary>
-        public Type Codec { get; private set; }
+        public IConfiguration Configiration { get; private set; }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceOperatorSpec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceOperatorSpec.cs
@@ -21,54 +21,27 @@ using System;
 using Org.Apache.REEF.Wake.Remote;
 using Org.Apache.REEF.Network.Group.Pipelining.Impl;
 using Org.Apache.REEF.Network.Group.Pipelining;
+using Org.Apache.REEF.Tang.Interface;
 
 namespace Org.Apache.REEF.Network.Group.Operators.Impl
 {
     /// <summary>
     /// The specification used to define Reduce Group Communication Operators.
     /// </summary>
-    public class ReduceOperatorSpec<T1, T2> : IOperatorSpec<T1, T2> where T2 : ICodec<T1>
+    public class ReduceOperatorSpec : IOperatorSpec
     {
         /// <summary>
         /// Creates a new ReduceOperatorSpec.
         /// </summary>
-        /// <param name="receiverId">The identifier of the task that
-        /// will receive and reduce incoming messages.</param>
-        /// <param name="codec">The codec used for serializing messages.</param>
-        /// <param name="reduceFunction">The class used to aggregate all messages.</param>
-        public ReduceOperatorSpec(
-            string receiverId, 
-            IReduceFunction<T1> reduceFunction)
-        {
-            ReceiverId = receiverId;
-            Codec = typeof(T2);
-            ReduceFunction = reduceFunction;
-            PipelineDataConverter = new DefaultPipelineDataConverter<T1>();
-        }
-
-        /// <summary>
-        /// Creates a new ReduceOperatorSpec.
-        /// </summary>
-        /// <param name="receiverId">The identifier of the task that
-        /// will receive and reduce incoming messages.</param>
-        /// <param name="reduceFunction">The class used to aggregate all messages.</param>
-        /// <param name="dataConverter">The converter used to convert original
-        /// message to pipelined ones and vice versa.</param>
+        /// <param name="receiverId">The identifier of the task that will receive and reduce incoming messages.</param>
+        /// <param name="configuration">The configuration used for Codec, ReduceFunction and DataConverter.</param>
         public ReduceOperatorSpec(
             string receiverId,
-            IPipelineDataConverter<T1> dataConverter,
-            IReduceFunction<T1> reduceFunction)
+            IConfiguration configuration)
         {
             ReceiverId = receiverId;
-            Codec = typeof(T2);
-            ReduceFunction = reduceFunction;
-            PipelineDataConverter = dataConverter ?? new DefaultPipelineDataConverter<T1>();
+            Configiration = configuration;
         }
-
-        /// <summary>
-        /// Returns the IPipelineDataConvert used to convert messages to pipeline form and vice-versa
-        /// </summary>
-        public IPipelineDataConverter<T1> PipelineDataConverter { get; private set; }
 
         /// <summary>
         /// Returns the identifier for the task that receives and reduces
@@ -77,13 +50,8 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         public string ReceiverId { get; private set; }
 
         /// <summary>
-        /// The codec used to serialize and deserialize messages.
+        /// Returns the Configuration for Codec, ReduceFunction and DataConverter
         /// </summary>
-        public Type Codec { get; private set; }
-
-        /// <summary>
-        /// The class used to aggregate incoming messages.
-        /// </summary>
-        public IReduceFunction<T1> ReduceFunction { get; private set; }
+        public IConfiguration Configiration { get; private set; }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceOperatorSpec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceOperatorSpec.cs
@@ -21,6 +21,7 @@ using System;
 using Org.Apache.REEF.Wake.Remote;
 using Org.Apache.REEF.Network.Group.Pipelining.Impl;
 using Org.Apache.REEF.Network.Group.Pipelining;
+using Org.Apache.REEF.Tang.Implementations.Configuration;
 using Org.Apache.REEF.Tang.Interface;
 
 namespace Org.Apache.REEF.Network.Group.Operators.Impl
@@ -34,13 +35,13 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         /// Creates a new ReduceOperatorSpec.
         /// </summary>
         /// <param name="receiverId">The identifier of the task that will receive and reduce incoming messages.</param>
-        /// <param name="configuration">The configuration used for Codec, ReduceFunction and DataConverter.</param>
+        /// <param name="configurations">The configuration used for Codec, ReduceFunction and DataConverter.</param>
         public ReduceOperatorSpec(
             string receiverId,
-            IConfiguration configuration)
+            params IConfiguration[] configurations)
         {
             ReceiverId = receiverId;
-            Configiration = configuration;
+            Configiration = Configurations.Merge(configurations);
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ScatterOperatorSpec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ScatterOperatorSpec.cs
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+using Org.Apache.REEF.Tang.Implementations.Configuration;
 using Org.Apache.REEF.Tang.Interface;
 
 namespace Org.Apache.REEF.Network.Group.Operators.Impl
@@ -30,11 +31,11 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         /// Creates a new ScatterOperatorSpec.
         /// </summary>
         /// <param name="senderId">The identifier of the task that will be sending messages</param>
-        /// <param name="configuration">The configuration Codec, ReduceFunction and DataConverter used for group communication client</param>
-        public ScatterOperatorSpec(string senderId, IConfiguration configuration)
+        /// <param name="configurations">The configuration Codec, ReduceFunction and DataConverter used for group communication client</param>
+        public ScatterOperatorSpec(string senderId, params IConfiguration[] configurations)
         {
             SenderId = senderId;
-            Configiration = configuration;
+            Configiration = Configurations.Merge(configurations);
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ScatterOperatorSpec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ScatterOperatorSpec.cs
@@ -17,51 +17,25 @@
  * under the License.
  */
 
-using System;
-using Org.Apache.REEF.Wake.Remote;
-using Org.Apache.REEF.Network.Group.Pipelining;
+using Org.Apache.REEF.Tang.Interface;
 
 namespace Org.Apache.REEF.Network.Group.Operators.Impl
 {
     /// <summary>
     /// The specification used to define Scatter Group Communication Operators.
     /// </summary>
-    public class ScatterOperatorSpec<T1, T2> : IOperatorSpec<T1, T2> where T2 : ICodec<T1>
+    public class ScatterOperatorSpec : IOperatorSpec
     {
         /// <summary>
         /// Creates a new ScatterOperatorSpec.
         /// </summary>
-        /// <param name="senderId">The identifier of the task that will
-        /// be sending messages</param>
-        /// <param name="codec">The codec used to serialize and 
-        /// deserialize messages</param>
-        public ScatterOperatorSpec(string senderId)
+        /// <param name="senderId">The identifier of the task that will be sending messages</param>
+        /// <param name="configuration">The configuration Codec, ReduceFunction and DataConverter used for group communication client</param>
+        public ScatterOperatorSpec(string senderId, IConfiguration configuration)
         {
             SenderId = senderId;
-            Codec = typeof(T2);
+            Configiration = configuration;
         }
-
-        /// <summary>
-        /// Creates a new ScatterOperatorSpec.
-        /// </summary>
-        /// <param name="senderId">The identifier of the task that will
-        /// be sending messages</param>
-        /// deserialize messages</param>
-        /// <param name="dataConverter">The converter used to convert original
-        /// message to pipelined ones and vice versa.</param>
-        public ScatterOperatorSpec(
-            string senderId,
-            IPipelineDataConverter<T1> dataConverter)
-        {
-            SenderId = senderId;
-            Codec = typeof(T2);
-            PipelineDataConverter = dataConverter;
-        }
-
-        /// <summary>
-        /// Returns the IPipelineDataConvert used to convert messages to pipeline form and vice-versa
-        /// </summary>
-        public IPipelineDataConverter<T1> PipelineDataConverter { get; private set; }
 
         /// <summary>
         /// Returns the identifier for the task that splits and scatters a list
@@ -70,8 +44,8 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         public string SenderId { get; private set; }
 
         /// <summary>
-        /// The codec used to serialize and deserialize messages.
+        /// Returns the Configuration for Codec, ReduceFunction and DataConverter
         /// </summary>
-        public Type Codec { get; private set; }
+        public IConfiguration Configiration { get; private set; }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Pipelining/IPipelineDataConverter.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Pipelining/IPipelineDataConverter.cs
@@ -48,11 +48,11 @@ namespace Org.Apache.REEF.Network.Group.Pipelining
         /// <returns>The full constructed message</returns>
         T FullMessage(List<PipelineMessage<T>> pipelineMessage);
 
-        /// <summary>
-        /// Constructs the configuration of the class. Basically the arguments of the class like chunksize
-        /// </summary>
-        /// <returns>The configuration for this data converter class</returns>
-        IConfiguration GetConfiguration();
+        ///// <summary>
+        ///// Constructs the configuration of the class. Basically the arguments of the class like chunksize
+        ///// </summary>
+        ///// <returns>The configuration for this data converter class</returns>
+        //IConfiguration GetConfiguration();
 
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Pipelining/IPipelineDataConverter.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Pipelining/IPipelineDataConverter.cs
@@ -47,12 +47,5 @@ namespace Org.Apache.REEF.Network.Group.Pipelining
         /// <param name="pipelineMessage">The enumerator over received pipelined messages</param>
         /// <returns>The full constructed message</returns>
         T FullMessage(List<PipelineMessage<T>> pipelineMessage);
-
-        ///// <summary>
-        ///// Constructs the configuration of the class. Basically the arguments of the class like chunksize
-        ///// </summary>
-        ///// <returns>The configuration for this data converter class</returns>
-        //IConfiguration GetConfiguration();
-
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Pipelining/Impl/DefaultPipelineDataConverter.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Pipelining/Impl/DefaultPipelineDataConverter.cs
@@ -65,10 +65,5 @@ namespace Org.Apache.REEF.Network.Group.Pipelining.Impl
 
             return pipelineMessage[0].Data;
         }
-
-        public IConfiguration GetConfiguration()
-        {
-            return TangFactory.GetTang().NewConfigurationBuilder().Build();
-        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Topology/FlatTopology.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Topology/FlatTopology.cs
@@ -27,6 +27,7 @@ using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Wake.Remote;
 using Org.Apache.REEF.Network.Group.Pipelining;
+using Org.Apache.REEF.Tang.Implementations.Configuration;
 
 namespace Org.Apache.REEF.Network.Group.Topology
 {
@@ -35,7 +36,7 @@ namespace Org.Apache.REEF.Network.Group.Topology
     /// nodes: the root and all children extending from the root.
     /// </summary>
     /// <typeparam name="T">The message type</typeparam>
-    public class FlatTopology<T1, T2> : ITopology<T1, T2> where T2 : ICodec<T1>
+    public class FlatTopology<T> : ITopology<T> 
     {
         private readonly string _groupName;
         private readonly string _operatorName;
@@ -59,7 +60,7 @@ namespace Org.Apache.REEF.Network.Group.Topology
             string groupName, 
             string rootId,
             string driverId,
-            IOperatorSpec<T1, T2> operatorSpec)
+            IOperatorSpec operatorSpec)
         {
             _groupName = groupName;
             _operatorName = operatorName;
@@ -74,7 +75,7 @@ namespace Org.Apache.REEF.Network.Group.Topology
         /// <summary>
         /// Gets the Operator specification
         /// </summary>
-        public IOperatorSpec<T1, T2> OperatorSpec { get; set; }
+        public IOperatorSpec OperatorSpec { get; set; }
 
         /// <summary>
         /// Gets the task configuration for the operator topology.
@@ -83,11 +84,11 @@ namespace Org.Apache.REEF.Network.Group.Topology
         /// <returns>The task configuration</returns>
         public IConfiguration GetTaskConfiguration(string taskId)
         {
-            var confBuilder = TangFactory.GetTang().NewConfigurationBuilder()
-                .BindImplementation(typeof(ICodec<T1>), OperatorSpec.Codec)
+            ICsConfigurationBuilder confBuilder;
+            confBuilder = TangFactory.GetTang().NewConfigurationBuilder()
                 .BindNamedParameter<GroupCommConfigurationOptions.TopologyRootTaskId, string>(
-                    GenericType<GroupCommConfigurationOptions.TopologyRootTaskId>.Class,
-                    _rootId);
+                GenericType<GroupCommConfigurationOptions.TopologyRootTaskId>.Class,
+                _rootId);
 
             if (taskId.Equals(_rootId))
             {
@@ -102,50 +103,41 @@ namespace Org.Apache.REEF.Network.Group.Topology
                 }
             }
 
-            if (OperatorSpec is BroadcastOperatorSpec<T1, T2>)
+            if (OperatorSpec is BroadcastOperatorSpec)
             {
-                var broadcastSpec = OperatorSpec as BroadcastOperatorSpec<T1, T2>;
-
-                confBuilder.AddConfiguration(broadcastSpec.PipelineDataConverter.GetConfiguration());
-                confBuilder.BindImplementation(typeof(IPipelineDataConverter<T1>), broadcastSpec.PipelineDataConverter.GetType())
-                .BindImplementation(GenericType<ICodec<PipelineMessage<T1>>>.Class, GenericType<PipelineMessageCodec<T1>>.Class);
+                var broadcastSpec = OperatorSpec as BroadcastOperatorSpec;
 
                 if (taskId.Equals(broadcastSpec.SenderId))
                 {
-                    confBuilder.BindImplementation(GenericType<IGroupCommOperator<T1>>.Class, GenericType<BroadcastSender<T1>>.Class);
+                    confBuilder.BindImplementation(GenericType<IGroupCommOperator<T>>.Class, GenericType<BroadcastSender<T>>.Class);
                 }
                 else
                 {
-                    confBuilder.BindImplementation(GenericType<IGroupCommOperator<T1>>.Class, GenericType<BroadcastReceiver<T1>>.Class);
+                    confBuilder.BindImplementation(GenericType<IGroupCommOperator<T>>.Class, GenericType<BroadcastReceiver<T>>.Class);
                 }
             }
-            else if (OperatorSpec is ReduceOperatorSpec<T1, T2>)
+            else if (OperatorSpec is ReduceOperatorSpec)
             {
-                var reduceSpec = OperatorSpec as ReduceOperatorSpec<T1, T2>;
-                confBuilder.AddConfiguration(reduceSpec.PipelineDataConverter.GetConfiguration());
-                confBuilder.BindImplementation(typeof(IPipelineDataConverter<T1>), reduceSpec.PipelineDataConverter.GetType())
-                .BindImplementation(typeof(IReduceFunction<T1>), reduceSpec.ReduceFunction.GetType())
-                .BindImplementation(GenericType<ICodec<PipelineMessage<T1>>>.Class, GenericType<PipelineMessageCodec<T1>>.Class);
-                
+                var reduceSpec = OperatorSpec as ReduceOperatorSpec;
                 if (taskId.Equals(reduceSpec.ReceiverId))
                 {
-                    confBuilder.BindImplementation(GenericType<IGroupCommOperator<T1>>.Class, GenericType<ReduceReceiver<T1>>.Class);
+                    confBuilder.BindImplementation(GenericType<IGroupCommOperator<T>>.Class, GenericType<ReduceReceiver<T>>.Class);
                 }
                 else
                 {
-                    confBuilder.BindImplementation(GenericType<IGroupCommOperator<T1>>.Class, GenericType<ReduceSender<T1>>.Class);
+                    confBuilder.BindImplementation(GenericType<IGroupCommOperator<T>>.Class, GenericType<ReduceSender<T>>.Class);
                 }
             }
-            else if (OperatorSpec is ScatterOperatorSpec<T1, T2>)
+            else if (OperatorSpec is ScatterOperatorSpec)
             {
-                ScatterOperatorSpec<T1, T2> scatterSpec = OperatorSpec as ScatterOperatorSpec<T1, T2>;
+                ScatterOperatorSpec scatterSpec = OperatorSpec as ScatterOperatorSpec;
                 if (taskId.Equals(scatterSpec.SenderId))
                 {
-                    confBuilder.BindImplementation(GenericType<IGroupCommOperator<T1>>.Class, GenericType<ScatterSender<T1>>.Class);
+                    confBuilder.BindImplementation(GenericType<IGroupCommOperator<T>>.Class, GenericType<ScatterSender<T>>.Class);
                 }
                 else
                 {
-                    confBuilder.BindImplementation(GenericType<IGroupCommOperator<T1>>.Class, GenericType<ScatterReceiver<T1>>.Class);
+                    confBuilder.BindImplementation(GenericType<IGroupCommOperator<T>>.Class, GenericType<ScatterReceiver<T>>.Class);
                 }
             }
             else
@@ -153,7 +145,7 @@ namespace Org.Apache.REEF.Network.Group.Topology
                 throw new NotSupportedException("Spec type not supported");
             }
 
-            return confBuilder.Build();
+            return Configurations.Merge(confBuilder.Build(), OperatorSpec.Configiration);
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
+++ b/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
@@ -52,7 +52,10 @@ under the License.
   <ItemGroup>
     <Compile Include="Group\Codec\GcmMessageProto.cs" />
     <Compile Include="Group\Codec\GroupCommunicationMessageCodec.cs" />
+    <Compile Include="Group\Config\CodecConfiguration.cs" />
     <Compile Include="Group\Config\GroupCommConfigurationOptions.cs" />
+    <Compile Include="Group\Config\PipelineDataConverterConfiguration.cs" />
+    <Compile Include="Group\Config\ReduceFunctionConfiguration.cs" />
     <Compile Include="Group\Driver\ICommunicationGroupDriver.cs" />
     <Compile Include="Group\Driver\IGroupCommDriver.cs" />
     <Compile Include="Group\Driver\Impl\CommunicationGroupDriver.cs" />

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/ML/KMeans/TestKMeans.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/ML/KMeans/TestKMeans.cs
@@ -174,9 +174,9 @@ namespace Org.Apache.REEF.Tests.Functional.ML.KMeans
         private HashSet<string> AssembliesToCopy()
         {
             HashSet<string> appDlls = new HashSet<string>();
-            appDlls.Add(typeof(KMeansDriverHandlers).Assembly.GetName().Name);
             appDlls.Add(typeof(LegacyKMeansTask).Assembly.GetName().Name);
             appDlls.Add(typeof(INameClient).Assembly.GetName().Name);
+            appDlls.Add(typeof(KMeansDriverHandlers).Assembly.GetName().Name);
             appDlls.Add(typeof(INetworkService<>).Assembly.GetName().Name);
             return appDlls;
         }


### PR DESCRIPTION
Today clients pass Codec and ReduceFunction object to Group Communication driver and inside Group Communication driver, we create configurations for Codec, Reduce Functions and DataConverters. This doesn't provide flexibility for clients to set parameters in the reduce function also make the Group code complex. This PR is move all those settings to Tang Configuration. Allow clients to bind their own implementations and parameters, then passing the configuration to Group Communication Driver.

This PR includes:-
-Added Configuration Module for Codec, ReduceFunction and DadtaConverter
-Updated GroupCommunicationDriver APIs to accept Configuration
-Simplified GroupCommunicationDriver to remove unnecessary overloading methods
-Updated specification to wrap Configuration and removed Codec and DataConverter
-Removed generic from specifications as it is not needed any more
-Removed Codec type as generic from GroupCommunicationDriver API
-Updated unit tests, functional tests and KMean tests

JIRA: REEF-262. (https://issues.apache.org/jira/browse/REEF-262)