### PR TITLE
[REEF-268] Moved `ConfigurationProvider` into Tang

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/parameters/DriverConfigurationProviders.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/parameters/DriverConfigurationProviders.java
@@ -18,7 +18,7 @@
  */
 package org.apache.reef.client.parameters;
 
-import org.apache.reef.common.ConfigurationProvider;
+import org.apache.reef.tang.ConfigurationProvider;
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/EvaluatorConfigurationProviders.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/EvaluatorConfigurationProviders.java
@@ -18,7 +18,7 @@
  */
 package org.apache.reef.driver.parameters;
 
-import org.apache.reef.common.ConfigurationProvider;
+import org.apache.reef.tang.ConfigurationProvider;
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/REEFImplementation.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/REEFImplementation.java
@@ -23,7 +23,7 @@ import org.apache.reef.annotations.audience.ClientSide;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.client.REEF;
 import org.apache.reef.client.parameters.DriverConfigurationProviders;
-import org.apache.reef.common.ConfigurationProvider;
+import org.apache.reef.tang.ConfigurationProvider;
 import org.apache.reef.proto.ClientRuntimeProtocol.JobSubmissionProto;
 import org.apache.reef.runtime.common.client.api.JobSubmissionHandler;
 import org.apache.reef.runtime.common.launch.parameters.ErrorHandlerRID;
@@ -34,13 +34,11 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.util.REEFVersion;
-import org.apache.reef.util.logging.Config;
 import org.apache.reef.util.logging.LoggingScope;
 import org.apache.reef.util.logging.LoggingScopeFactory;
 
 import javax.inject.Inject;
 import java.util.Set;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 @ClientSide

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/AllocatedEvaluatorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/AllocatedEvaluatorImpl.java
@@ -20,7 +20,7 @@ package org.apache.reef.runtime.common.driver.evaluator;
 
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
-import org.apache.reef.common.ConfigurationProvider;
+import org.apache.reef.tang.ConfigurationProvider;
 import org.apache.reef.driver.context.ContextConfiguration;
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
 import org.apache.reef.driver.evaluator.EvaluatorDescriptor;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
@@ -20,7 +20,7 @@ package org.apache.reef.runtime.common.driver.evaluator;
 
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
-import org.apache.reef.common.ConfigurationProvider;
+import org.apache.reef.tang.ConfigurationProvider;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.context.FailedContext;
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/tang/ConfigurationProvider.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/tang/ConfigurationProvider.java
@@ -16,9 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.common;
-
-import org.apache.reef.tang.Configuration;
+package org.apache.reef.tang;
 
 /**
  * Objects that can provide a Configuration implement this interface.

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/LocalRuntimeConfiguration.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/LocalRuntimeConfiguration.java
@@ -19,7 +19,7 @@
 package org.apache.reef.runtime.local.client;
 
 import org.apache.reef.client.parameters.DriverConfigurationProviders;
-import org.apache.reef.common.ConfigurationProvider;
+import org.apache.reef.tang.ConfigurationProvider;
 import org.apache.reef.runtime.common.client.CommonRuntimeConfiguration;
 import org.apache.reef.runtime.common.client.api.JobSubmissionHandler;
 import org.apache.reef.runtime.common.files.RuntimeClasspathProvider;

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/YarnClientConfiguration.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/YarnClientConfiguration.java
@@ -21,7 +21,7 @@ package org.apache.reef.runtime.yarn.client;
 import org.apache.reef.annotations.audience.ClientSide;
 import org.apache.reef.annotations.audience.Public;
 import org.apache.reef.client.parameters.DriverConfigurationProviders;
-import org.apache.reef.common.ConfigurationProvider;
+import org.apache.reef.tang.ConfigurationProvider;
 import org.apache.reef.runtime.common.client.CommonRuntimeConfiguration;
 import org.apache.reef.runtime.common.client.api.JobSubmissionHandler;
 import org.apache.reef.runtime.common.files.RuntimeClasspathProvider;


### PR DESCRIPTION
This moves the `ConfigurationProvider` interface into Tang such that e.g. Wake can use it.

JIRA:
  [REEF-268](https://issues.apache.org/jira/browse/REEF-268)