### PR TITLE
[REEF-270] Missing @Inject annotation in NetworkService, GroupCommDriver...

### DIFF
--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/GroupCommDriverImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/GroupCommDriverImpl.java
@@ -108,6 +108,7 @@ public class GroupCommDriverImpl implements GroupCommServiceDriver {
    * @deprecated Have an instance injected instead.
    */
   @Deprecated
+  @Inject
   public GroupCommDriverImpl(final ConfigurationSerializer confSerializer,
                              @Parameter(DriverIdentifier.class) final String driverId,
                              @Parameter(TreeTopologyFanOut.class) final int fanOut) {

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkService.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkService.java
@@ -125,6 +125,7 @@ public final class NetworkService<T> implements Stage, ConnectionFactory<T> {
    * @deprecated have an instance injected instead.
    */
   @Deprecated
+  @Inject
   public NetworkService(
       final @Parameter(NetworkServiceParameters.NetworkServiceIdentifierFactory.class) IdentifierFactory factory,
       final @Parameter(NetworkServiceParameters.NetworkServicePort.class) int nsPort,


### PR DESCRIPTION
...Impl

  The @Inject annotations in deprecated constructors in NetworkService and
  GroupCommDriverImpl were removed, and which caused a Tang exception when executing
  BroadcastREEF example. This pull request simply brings back @Inject annotations
  to address the issue.

JIRA:
  [REEF-270] https://issues.apache.org/jira/browse/REEF-270

Author:
  Geon Woo Kim, gwsshs22@gmail.com