### PR TITLE
[REEF-275] Only use ConfigurationProvider for JVM Evaluators

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/AllocatedEvaluatorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/AllocatedEvaluatorImpl.java
@@ -235,6 +235,13 @@ final class AllocatedEvaluatorImpl implements AllocatedEvaluator {
    * @return
    */
   private Configuration makeRootContextConfiguration(final Configuration contextConfiguration) {
+
+    final EvaluatorType evaluatorType = this.evaluatorManager.getEvaluatorDescriptor().getType();
+    if (EvaluatorType.JVM != evaluatorType) {
+      LOG.log(Level.FINE, "Not using the ConfigurationProviders as we are configuring a {0} Evaluator.", evaluatorType);
+      return contextConfiguration;
+    }
+
     final ConfigurationBuilder configurationBuilder = Tang.Factory.getTang()
         .newConfigurationBuilder(contextConfiguration);
     for (final ConfigurationProvider configurationProvider : this.evaluatorConfigurationProviders) {

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameServerImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameServerImpl.java
@@ -95,8 +95,8 @@ public class NameServerImpl implements NameServer {
    */
   @Deprecated
   public NameServerImpl(
-      final @Parameter(NameServerParameters.NameServerPort.class) int port,
-      final @Parameter(NameServerParameters.NameServerIdentifierFactory.class) IdentifierFactory factory,
+      final int port,
+      final IdentifierFactory factory,
       final ReefEventStateManager reefEventStateManager) {
     this(port, factory, reefEventStateManager, LocalAddressProviderFactory.getInstance());
   }


### PR DESCRIPTION
In `AllocatedEvaluatorImpl#launch`, [REEF-268] added a new call to `AllocatedEvaluatorImpl#makeRootContextConfiguration`. That method merges the given `Configuration` with the ones provided by the `ConfigurationProvider` instances configured.

In the case of a CLR Evaluator launch, this means that we attempt to merge JVM Configuration with CLR Configuration. Which is not (yet) supported in Tang.

REEF-273 and REEF-274 will need to add a similar mechanism in .NET to the one REEF-268 introduced for Java. Hence, this PR adds a check of the type of Evaluator launched and only merge the configurations when we indeed have a JVM launch at hand.

Also, this PR removes a few `@Parameter` annotations on a constructor of `NameServerImpl` that isn't actually injectable.

JIRA:
  [REEF-275](https://issues.apache.org/jira/browse/REEF-275)