### PR TITLE
[REEF-286] Improved logging in the Evaluator

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Utils/EvaluatorConfigurations.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Runtime/Evaluator/Utils/EvaluatorConfigurations.cs
@@ -1,4 +1,4 @@
-﻿/**
+﻿/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -20,8 +20,12 @@
 using System;
 using System.IO;
 using System.Linq;
+using Org.Apache.REEF.Common.Runtime.Evaluator.Context;
+using Org.Apache.REEF.Common.Services;
+using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.Tang.Formats;
 using Org.Apache.REEF.Tang.Formats.AvroConfigurationDataContract;
+using Org.Apache.REEF.Utilities;
 using Org.Apache.REEF.Utilities.Logging;
 
 namespace Org.Apache.REEF.Common.Runtime.Evaluator.Utils
@@ -62,7 +66,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Utils
             }
         }
 
-        public string TaskConfiguration
+        public string TaskConfigurationString
         {
             get
             {
@@ -70,6 +74,21 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Utils
                 return _taskConfiguration;
             }
         }
+
+        /// <summary>
+        /// The TaskConfiguration submitted with the evaluator configuration, if any.
+        /// </summary>
+        public Optional<TaskConfiguration> TaskConfiguration
+        {
+            get
+            {
+                var taskConfig = TaskConfigurationString;
+                return string.IsNullOrEmpty(taskConfig)
+                    ? Optional<TaskConfiguration>.Empty()
+                    : Optional<TaskConfiguration>.Of(
+                        new TaskConfiguration(taskConfig));
+            }
+        } 
 
         public string EvaluatorId
         {
@@ -89,7 +108,7 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Utils
             }
         }
 
-        public string RootContextConfiguration
+        public string RootContextConfigurationString
         {
             get
             {
@@ -97,8 +116,25 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Utils
                 return _rootContextConfiguration;
             }
         }
+        /// <summary>
+        /// The ContextConfiguration for the root context.
+        /// </summary>
+        /// <exception cref="ArgumentException">If the underlying string parameter isn't set.</exception>
+        public ContextConfiguration RootContextConfiguration
+        {
+            get
+            {
+                string rootContextConfigString = RootContextConfigurationString;
+                if (string.IsNullOrWhiteSpace(rootContextConfigString))
+                {
+                    Utilities.Diagnostics.Exceptions.Throw(
+                        new ArgumentException("empty or null rootContextConfigString"), LOGGER);
+                }
+                return new ContextConfiguration(rootContextConfigString);
+            }
+        }
 
-        public string RootServiceConfiguration
+        public string RootServiceConfigurationString
         {
             get
             {
@@ -106,6 +142,23 @@ namespace Org.Apache.REEF.Common.Runtime.Evaluator.Utils
                 return _rootServiceConfiguration;
             }
         }
+
+        /// <summary>
+        /// The ServiceConfiguration for the root context.
+        /// </summary>
+        /// <exception cref="ArgumentException">If the underlying string parameter isn't set.</exception>
+        public Optional<ServiceConfiguration> RootServiceConfiguration
+        {
+            get
+            {
+                var rootServiceConfigString = RootServiceConfigurationString;
+                return string.IsNullOrEmpty(rootServiceConfigString)
+                    ? Optional<ServiceConfiguration>.Empty()
+                    : Optional<ServiceConfiguration>.Of(
+                        new ServiceConfiguration(
+                            rootServiceConfigString));
+            }
+        } 
 
         private string GetSettingValue(string settingKey)
         {

--- a/lang/cs/Org.Apache.REEF.Evaluator/Exceptions/ClockInstantiationException.cs
+++ b/lang/cs/Org.Apache.REEF.Evaluator/Exceptions/ClockInstantiationException.cs
@@ -1,0 +1,32 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+using System;
+
+namespace Org.Apache.REEF.Evaluator.Exceptions
+{
+    /// <summary>
+    /// Thrown when the Evaluator cannot instantiate the Clock.
+    /// </summary>
+    internal sealed class ClockInstantiationException : Exception
+    {
+        internal ClockInstantiationException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Evaluator/Exceptions/EvaluatorConfigurationFileNotFoundException.cs
+++ b/lang/cs/Org.Apache.REEF.Evaluator/Exceptions/EvaluatorConfigurationFileNotFoundException.cs
@@ -1,0 +1,39 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+using System;
+using System.IO;
+
+namespace Org.Apache.REEF.Evaluator.Exceptions
+{
+    /// <summary>
+    /// Thrown when the Evaluator configuration file can't be found.
+    /// </summary>
+    internal sealed class EvaluatorConfigurationFileNotFoundException : FileNotFoundException
+    {
+        internal EvaluatorConfigurationFileNotFoundException(string fileName, Exception innerException)
+            : base("Unable to find the evaluator configuration file.", fileName, innerException)
+        {
+        }
+
+        internal EvaluatorConfigurationFileNotFoundException(string fileName)
+            : base("Unable to find the evaluator configuration file.", fileName, new FileNotFoundException())
+        {
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Evaluator/Exceptions/EvaluatorConfigurationParseException.cs
+++ b/lang/cs/Org.Apache.REEF.Evaluator/Exceptions/EvaluatorConfigurationParseException.cs
@@ -1,0 +1,34 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+using System;
+using System.IO;
+
+namespace Org.Apache.REEF.Evaluator.Exceptions
+{
+    /// <summary>
+    /// Thrown when the Evaluator Configuration cannot be read.
+    /// </summary>
+    internal sealed class EvaluatorConfigurationParseException : IOException
+    {
+        internal EvaluatorConfigurationParseException(Exception innerException)
+            : base("Unable to read evaluator configuration file.", innerException)
+        {
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Evaluator/Exceptions/EvaluatorInjectorInstantiationException.cs
+++ b/lang/cs/Org.Apache.REEF.Evaluator/Exceptions/EvaluatorInjectorInstantiationException.cs
@@ -1,0 +1,34 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System;
+
+namespace Org.Apache.REEF.Evaluator.Exceptions
+{
+    /// <summary>
+    /// Thrown when the root injector for an Evaluator cannot be instantiated.
+    /// </summary>
+    internal sealed class EvaluatorInjectorInstantiationException : Exception
+    {
+        internal EvaluatorInjectorInstantiationException(Exception innerException)
+            : base("Unable to instantiate the Evaluator injector.", innerException)
+        {
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Evaluator/Exceptions/UnhandledException.cs
+++ b/lang/cs/Org.Apache.REEF.Evaluator/Exceptions/UnhandledException.cs
@@ -1,0 +1,33 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+using System;
+
+namespace Org.Apache.REEF.Evaluator.Exceptions
+{
+    /// <summary>
+    /// Thrown when the Evaluator's default Exception handler catches an Exception.
+    /// </summary>
+    internal sealed class UnhandledException : Exception
+    {
+        internal UnhandledException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Evaluator/Org.Apache.REEF.Evaluator.csproj
+++ b/lang/cs/Org.Apache.REEF.Evaluator/Org.Apache.REEF.Evaluator.csproj
@@ -49,6 +49,11 @@ under the License.
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Evaluator.cs" />
+    <Compile Include="Exceptions\ClockInstantiationException.cs" />
+    <Compile Include="Exceptions\EvaluatorConfigurationFileNotFoundException.cs" />
+    <Compile Include="Exceptions\EvaluatorConfigurationParseException.cs" />
+    <Compile Include="Exceptions\EvaluatorInjectorInstantiationException.cs" />
+    <Compile Include="Exceptions\UnhandledException.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/lang/cs/Org.Apache.REEF.Tests/Evaluator/EvaluatorConfigurationsTests.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Evaluator/EvaluatorConfigurationsTests.cs
@@ -35,7 +35,7 @@ namespace Org.Apache.REEF.Tests.Evaluator
 
             Assert.IsTrue(evaluatorConfigurations.ApplicationId.Equals("REEF_LOCAL_RUNTIME"));
 
-            string rootContextConfigString = evaluatorConfigurations.RootContextConfiguration;
+            string rootContextConfigString = evaluatorConfigurations.RootContextConfigurationString;
             Assert.IsFalse(string.IsNullOrWhiteSpace(rootContextConfigString));
         }
     }


### PR DESCRIPTION
This improves logging in the .NET Evaluator. To do so, the following changes were made:

 * Refactor `Evaluator.Main` into a series of smaller methods. Each of these throws specific exceptions about what went wrong.
 * Add a `try/catch` block around `Evaluator.Main` that catches all exceptions thrown and logs them.
 * The new method `Evaluator.Fail()` logs the contents of the current working directory of the Evaluator.
 * Use that same method for the app domain exception handler.

This also moves some of the configuration parsing logic from `Evaluator.Main` to `EvaluatorConfigurations` to improve the legibility of `Evaluator.Main`.

*Note:* This doesn't use `Exceptions.Throws`. Instead, all exceptions are logged in `Evaluator.Fail`

JIRA:
  [REEF-286](https://issues.apache.org/jira/browse/REEF-286)