### PR TITLE
[REEF-296]  clean up bridge.jar.csproj

### DIFF
--- a/lang/cs/Org.Apache.REEF.Bridge.JAR/Org.Apache.REEF.Bridge.JAR.csproj
+++ b/lang/cs/Org.Apache.REEF.Bridge.JAR/Org.Apache.REEF.Bridge.JAR.csproj
@@ -95,7 +95,6 @@ under the License.
 
     <PropertyGroup>
         <BuildCommand>$(NuGetCommand) pack "$(FinalizedNuspecFile)" -BasePath $(NugetProjectPath) -Properties "Configuration=$(Configuration);Platform=$(Platform);REEF_Version=$(REEF_Version);Version=$(REEF_NugetVersion)" $(NonInteractiveSwitch) -OutputDirectory "$(PackageOutputDir)" </BuildCommand>
-        <ReefVer>$([System.String]::Copy('$(REEF_NugetVersion)').Replace('-SNAPSHOT-',''))</ReefVer>
     </PropertyGroup>
 
     <ItemGroup>
@@ -104,8 +103,8 @@ under the License.
         <Line Include="line03"><Text>$copyToOutput1 = $file1.Properties.Item("CopyToOutputDirectory")</Text></Line>
         <Line Include="line04"><Text>$copyToOutput1.Value = 2</Text></Line>
         <!--Copy the client JAR-->
-       <Line Include="line05"><Text>$file2 = $project.ProjectItems.Item("reef-bridge-client-$(ReefVer)-incubating-SNAPSHOT-shaded.jar")</Text></Line>
         <Line Include="line05"><Text>$file2 = $project.ProjectItems.Item("reef-bridge-client-$(REEF_Version)-shaded.jar")</Text></Line>
+        <Line Include="line05"><Text>$copyToOutput2 = $file2.Properties.Item("CopyToOutputDirectory")</Text></Line>
         <Line Include="line07"><Text>$copyToOutput2.Value = 2</Text></Line>
         <LineText Include="%(Line.Text)" />
     </ItemGroup>


### PR DESCRIPTION
This is to fix/clean up "Copy the client JAR session" in bridge.jar.csproj file

JIRA: REEF-296(https://issues.apache.org/jira/browse/REEF-296)

This closes #

Author: Julia Wang  Email: jwang98052@yahoo.com