### PR TITLE
[REEF-310] Improve memory efficiency of the Driver bridge.

### DIFF
--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ActiveContextBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ActiveContextBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -27,21 +27,19 @@ import org.apache.reef.tang.formats.AvroConfigurationSerializer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-public class ActiveContextBridge extends NativeBridge implements Identifiable {
+public final class ActiveContextBridge extends NativeBridge implements Identifiable {
   private static final Logger LOG = Logger.getLogger(ActiveContextBridge.class.getName());
 
   private final ActiveContext jactiveContext;
   private final AvroConfigurationSerializer serializer;
-  private final String contextId;
-  private final String evaluatorId;
   private final ClassHierarchy clrClassHierarchy;
 
-  public ActiveContextBridge(ActiveContext activeContext) {
-    jactiveContext = activeContext;
-    serializer = new AvroConfigurationSerializer();
-    contextId = activeContext.getId();
-    evaluatorId = activeContext.getEvaluatorId();
-    clrClassHierarchy = Utilities.loadClassHierarchy(NativeInterop.CLASS_HIERARCHY_FILENAME);
+  ActiveContextBridge(final ActiveContext activeContext,
+                      final ClassHierarchy clrClassHierarchy,
+                      final AvroConfigurationSerializer serializer) {
+    this.jactiveContext = activeContext;
+    this.clrClassHierarchy = clrClassHierarchy;
+    this.serializer = serializer;
   }
 
   public void submitTaskString(final String taskConfigurationString) {
@@ -73,6 +71,6 @@ public class ActiveContextBridge extends NativeBridge implements Identifiable {
 
   @Override
   public String getId() {
-    return contextId;
+    return jactiveContext.getId();
   }
 }

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ActiveContextBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ActiveContextBridge.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p/>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -47,7 +47,7 @@ public final class ActiveContextBridge extends NativeBridge implements Identifia
       throw new RuntimeException("empty taskConfigurationString provided.");
     }
 
-    Configuration taskConfiguration;
+    final Configuration taskConfiguration;
     try {
       taskConfiguration = serializer.fromString(taskConfigurationString, clrClassHierarchy);
     } catch (final Exception e) {

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ActiveContextBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ActiveContextBridge.java
@@ -32,6 +32,8 @@ public final class ActiveContextBridge extends NativeBridge implements Identifia
 
   private final ActiveContext jactiveContext;
   private final AvroConfigurationSerializer serializer;
+  private final String contextId;
+  private final String evaluatorId;
   private final ClassHierarchy clrClassHierarchy;
 
   ActiveContextBridge(final ActiveContext activeContext,
@@ -40,6 +42,8 @@ public final class ActiveContextBridge extends NativeBridge implements Identifia
     this.jactiveContext = activeContext;
     this.clrClassHierarchy = clrClassHierarchy;
     this.serializer = serializer;
+    this.contextId = activeContext.getId();
+    this.evaluatorId = activeContext.getEvaluatorId();
   }
 
   public void submitTaskString(final String taskConfigurationString) {

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ActiveContextBridgeFactory.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ActiveContextBridgeFactory.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p/>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ActiveContextBridgeFactory.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ActiveContextBridgeFactory.java
@@ -23,6 +23,7 @@ import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.context.ClosedContext;
+import org.apache.reef.driver.context.ContextBase;
 import org.apache.reef.tang.ClassHierarchy;
 import org.apache.reef.tang.formats.AvroConfigurationSerializer;
 
@@ -63,7 +64,7 @@ public final class ActiveContextBridgeFactory {
    * @return a new ActiveContextBridge or returns the one created earlier.
    */
   public synchronized ActiveContextBridge getActiveContextBridge(final ActiveContext context) {
-    final String contextId = context.getId();
+    final String contextId = getUniqueContextId(context);
 
     ActiveContextBridge result = activeContextBridgeCache.get(contextId);
     if (null == result) {
@@ -79,10 +80,20 @@ public final class ActiveContextBridgeFactory {
    * @param context the context whose ActiveContextBridge instance shall be removed from the cache.
    */
   public synchronized void ForgetContext(final ClosedContext context) {
-    final String contextId = context.getEvaluatorId();
+    final String contextId = getUniqueContextId(context);
     final ActiveContextBridge removed = this.activeContextBridgeCache.remove(contextId);
     if (null != removed) {
       LOG.warning("Called with context previously unknown: " + contextId);
     }
+  }
+
+  /**
+   * Constructs a unique ID for the given context by combining the evaluator and context ids.
+   *
+   * @param contextBase
+   * @return
+   */
+  private static String getUniqueContextId(final ContextBase contextBase) {
+    return contextBase.getEvaluatorId() + "/" + contextBase.getId();
   }
 }

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ActiveContextBridgeFactory.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ActiveContextBridgeFactory.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.javabridge;
+
+import net.jcip.annotations.ThreadSafe;
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.driver.context.ActiveContext;
+import org.apache.reef.driver.context.ClosedContext;
+import org.apache.reef.tang.ClassHierarchy;
+import org.apache.reef.tang.formats.AvroConfigurationSerializer;
+
+import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
+/**
+ * Factory for ActiveContextBridge instances.
+ * <p/>
+ * This class is thread safe because all its methods are synchronized. It should only be used within the bridge code.
+ */
+@DriverSide
+@ThreadSafe
+@Private
+public final class ActiveContextBridgeFactory {
+  private static final Logger LOG = Logger.getLogger(ActiveContextBridge.class.getName());
+
+  private final Map<String, ActiveContextBridge> activeContextBridgeCache = new HashMap<>();
+  private final ClassHierarchy clrClassHierarchy = Utilities.loadClassHierarchy(NativeInterop.CLASS_HIERARCHY_FILENAME);
+  private final AvroConfigurationSerializer configurationSerializer;
+
+  /**
+   * This is always instantiated via Tang.
+   *
+   * @param configurationSerializer passed to the ActiveContextBridge instances for configuration serialization.
+   */
+  @Inject
+  private ActiveContextBridgeFactory(final AvroConfigurationSerializer configurationSerializer) {
+    this.configurationSerializer = configurationSerializer;
+  }
+
+  /**
+   * Instantiates a new ActiveContextBridge or returns the one created earlier.
+   *
+   * @param context the context for which to return an ActiveContextBridge instance.
+   * @return a new ActiveContextBridge or returns the one created earlier.
+   */
+  public synchronized ActiveContextBridge getActiveContextBridge(final ActiveContext context) {
+    final String contextId = context.getId();
+
+    ActiveContextBridge result = activeContextBridgeCache.get(contextId);
+    if (null == result) {
+      result = new ActiveContextBridge(context, this.clrClassHierarchy, this.configurationSerializer);
+      activeContextBridgeCache.put(contextId, result);
+    }
+    return result;
+  }
+
+  /**
+   * Removes the ActiveContextBridge associated with the given Context from the cache.
+   *
+   * @param context the context whose ActiveContextBridge instance shall be removed from the cache.
+   */
+  public synchronized void ForgetContext(final ClosedContext context) {
+    final String contextId = context.getEvaluatorId();
+    final ActiveContextBridge removed = this.activeContextBridgeCache.remove(contextId);
+    if (null != removed) {
+      LOG.warning("Called with context previously unknown: " + contextId);
+    }
+  }
+}

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ClosedContextBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ClosedContextBridge.java
@@ -42,9 +42,6 @@ public class ClosedContextBridge extends NativeBridge implements ClosedContext {
     contextId = closedContext.getId();
     evaluatorId = closedContext.getEvaluatorId();
     evaluatorDescriptor = closedContext.getEvaluatorDescriptor();
-
-    // Inform the ActiveContextBridgeFactory that it can remove this context from the cache.
-    activeContextBridgeFactory.ForgetContext(closedContext);
   }
 
   @Override

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ClosedContextBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ClosedContextBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p/>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ClosedContextBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ClosedContextBridge.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -36,12 +36,15 @@ public class ClosedContextBridge extends NativeBridge implements ClosedContext {
   private final String evaluatorId;
   private final EvaluatorDescriptor evaluatorDescriptor;
 
-  public ClosedContextBridge(final ClosedContext closedContext) {
+  public ClosedContextBridge(final ClosedContext closedContext, final ActiveContextBridgeFactory activeContextBridgeFactory) {
     jcloseContext = closedContext;
-    parentContext = new ActiveContextBridge(closedContext.getParentContext());
+    parentContext = activeContextBridgeFactory.getActiveContextBridge(closedContext.getParentContext());
     contextId = closedContext.getId();
     evaluatorId = closedContext.getEvaluatorId();
     evaluatorDescriptor = closedContext.getEvaluatorDescriptor();
+
+    // Inform the ActiveContextBridgeFactory that it can remove this context from the cache.
+    activeContextBridgeFactory.ForgetContext(closedContext);
   }
 
   @Override

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/CompletedTaskBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/CompletedTaskBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p/>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -26,10 +26,13 @@ public class CompletedTaskBridge extends NativeBridge {
 
   private final String taskId;
 
+  // used by the C++ code
+  private final ActiveContextBridge jactiveContext;
 
-  public CompletedTaskBridge(final CompletedTask completedTask) {
+  public CompletedTaskBridge(final CompletedTask completedTask, final ActiveContextBridgeFactory factory) {
     jcompletedTask = completedTask;
     taskId = completedTask.getId();
+    jactiveContext = factory.getActiveContextBridge(completedTask.getActiveContext());
   }
 
   @Override

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/CompletedTaskBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/CompletedTaskBridge.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -22,16 +22,14 @@ import org.apache.reef.driver.task.CompletedTask;
 
 public class CompletedTaskBridge extends NativeBridge {
 
-  private CompletedTask jcompletedTask;
+  private final CompletedTask jcompletedTask;
 
-  private String taskId;
+  private final String taskId;
 
-  private ActiveContextBridge jactiveContext;
 
-  public CompletedTaskBridge(CompletedTask completedTask) {
+  public CompletedTaskBridge(final CompletedTask completedTask) {
     jcompletedTask = completedTask;
     taskId = completedTask.getId();
-    jactiveContext = new ActiveContextBridge(completedTask.getActiveContext());
   }
 
   @Override

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/FailedContextBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/FailedContextBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p/>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -27,26 +27,31 @@ import org.apache.reef.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-public class FailedContextBridge extends NativeBridge implements ContextBase {
+public final class FailedContextBridge extends NativeBridge implements ContextBase {
 
   private static final Logger LOG = Logger.getLogger(FailedContextBridge.class.getName());
 
+  private final ActiveContextBridge parentContext;
   private final EvaluatorDescriptor evaluatorDescriptor;
   private final String evaluatorId;
   private final String contextId;
   private final String parentContextId;
   private final FailedContext jfailedContext;
 
-  public FailedContextBridge(final FailedContext failedContext) {
+  public FailedContextBridge(final FailedContext failedContext, final ActiveContextBridgeFactory factory) {
     jfailedContext = failedContext;
     evaluatorDescriptor = failedContext.getEvaluatorDescriptor();
     evaluatorId = failedContext.getEvaluatorId();
     contextId = failedContext.getId();
     if (failedContext.getParentContext().isPresent()) {
-      this.parentContextId = failedContext.getParentContext().get().getId();
+      final ActiveContext parent = failedContext.getParentContext().get();
+      this.parentContextId = parent.getId();
+      this.parentContext = factory.getActiveContextBridge(parent);
     } else {
       this.parentContextId = null;
+      this.parentContext = null;
     }
+
   }
 
   @Override

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/FailedContextBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/FailedContextBridge.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,6 +18,7 @@
  */
 package org.apache.reef.javabridge;
 
+import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.context.ContextBase;
 import org.apache.reef.driver.context.FailedContext;
 import org.apache.reef.driver.evaluator.EvaluatorDescriptor;
@@ -30,7 +31,6 @@ public class FailedContextBridge extends NativeBridge implements ContextBase {
 
   private static final Logger LOG = Logger.getLogger(FailedContextBridge.class.getName());
 
-  private final ActiveContextBridge parentContext;
   private final EvaluatorDescriptor evaluatorDescriptor;
   private final String evaluatorId;
   private final String contextId;
@@ -42,9 +42,11 @@ public class FailedContextBridge extends NativeBridge implements ContextBase {
     evaluatorDescriptor = failedContext.getEvaluatorDescriptor();
     evaluatorId = failedContext.getEvaluatorId();
     contextId = failedContext.getId();
-    parentContext = failedContext.getParentContext().isPresent() ?
-        new ActiveContextBridge(failedContext.getParentContext().get()) : null;
-    parentContextId = parentContext != null ? parentContext.getId() : null;
+    if (failedContext.getParentContext().isPresent()) {
+      this.parentContextId = failedContext.getParentContext().get().getId();
+    } else {
+      this.parentContextId = null;
+    }
   }
 
   @Override
@@ -63,11 +65,7 @@ public class FailedContextBridge extends NativeBridge implements ContextBase {
 
   @Override
   public Optional<String> getParentId() {
-    if (parentContextId != null) {
-      return Optional.of(parentContextId);
-    } else {
-      return Optional.empty();
-    }
+    return Optional.ofNullable(this.parentContextId);
   }
 
   @Override

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/FailedTaskBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/FailedTaskBridge.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -29,12 +29,10 @@ public class FailedTaskBridge extends NativeBridge {
   private static final Logger LOG = Logger.getLogger(FailedTaskBridge.class.getName());
 
   private FailedTask jfailedTask;
-  private ActiveContextBridge jactiveContext;
 
   public FailedTaskBridge(FailedTask failedTask) {
     jfailedTask = failedTask;
     Optional<ActiveContext> activeContext = failedTask.getActiveContext();
-    jactiveContext = activeContext.isPresent() ? new ActiveContextBridge(activeContext.get()) : null;
   }
 
   public String getFailedTaskString() {

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/FailedTaskBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/FailedTaskBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p/>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,21 +18,24 @@
  */
 package org.apache.reef.javabridge;
 
-import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.task.FailedTask;
-import org.apache.reef.util.Optional;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-public class FailedTaskBridge extends NativeBridge {
+public final class FailedTaskBridge extends NativeBridge {
   private static final Logger LOG = Logger.getLogger(FailedTaskBridge.class.getName());
 
   private FailedTask jfailedTask;
+  private ActiveContextBridge jactiveContext;
 
-  public FailedTaskBridge(FailedTask failedTask) {
-    jfailedTask = failedTask;
-    Optional<ActiveContext> activeContext = failedTask.getActiveContext();
+  public FailedTaskBridge(final FailedTask failedTask, final ActiveContextBridgeFactory factory) {
+    this.jfailedTask = failedTask;
+    if (failedTask.getActiveContext().isPresent()) {
+      this.jactiveContext = factory.getActiveContextBridge(failedTask.getActiveContext().get());
+    } else {
+      this.jactiveContext = null;
+    }
   }
 
   public String getFailedTaskString() {

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/RunningTaskBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/RunningTaskBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p/>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,19 +18,19 @@
  */
 package org.apache.reef.javabridge;
 
-import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.task.RunningTask;
 
 import java.util.logging.Logger;
 
-public class RunningTaskBridge extends NativeBridge {
+public final class RunningTaskBridge extends NativeBridge {
   private static final Logger LOG = Logger.getLogger(RunningTaskBridge.class.getName());
 
   final private RunningTask jrunningTask;
+  final private ActiveContextBridge jactiveContext;
 
-  public RunningTaskBridge(RunningTask runningTask) {
-    jrunningTask = runningTask;
-    final ActiveContext activeContext = runningTask.getActiveContext();
+  public RunningTaskBridge(final RunningTask runningTask, final ActiveContextBridgeFactory factory) {
+    this.jrunningTask = runningTask;
+    this.jactiveContext = factory.getActiveContextBridge(runningTask.getActiveContext());
   }
 
   public final String getId() {

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/RunningTaskBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/RunningTaskBridge.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -27,12 +27,10 @@ public class RunningTaskBridge extends NativeBridge {
   private static final Logger LOG = Logger.getLogger(RunningTaskBridge.class.getName());
 
   final private RunningTask jrunningTask;
-  final private ActiveContextBridge jactiveContext;
 
   public RunningTaskBridge(RunningTask runningTask) {
     jrunningTask = runningTask;
     final ActiveContext activeContext = runningTask.getActiveContext();
-    jactiveContext = new ActiveContextBridge(activeContext);
   }
 
   public final String getId() {

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/SuspendedTaskBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/SuspendedTaskBridge.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -28,10 +28,10 @@ public class SuspendedTaskBridge extends NativeBridge implements Identifiable, M
   private final String taskId;
   private final ActiveContextBridge jactiveContext;
 
-  public SuspendedTaskBridge(SuspendedTask suspendedTask) {
+  public SuspendedTaskBridge(final SuspendedTask suspendedTask, final ActiveContextBridgeFactory activeContextBridgeFactory) {
     jsuspendedTask = suspendedTask;
     taskId = suspendedTask.getId();
-    jactiveContext = new ActiveContextBridge(jsuspendedTask.getActiveContext());
+    jactiveContext = activeContextBridgeFactory.getActiveContextBridge(jsuspendedTask.getActiveContext());
   }
 
   public ActiveContextBridge getActiveContext() {

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/SuspendedTaskBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/SuspendedTaskBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p/>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -22,7 +22,7 @@ import org.apache.reef.driver.task.SuspendedTask;
 import org.apache.reef.io.Message;
 import org.apache.reef.io.naming.Identifiable;
 
-public class SuspendedTaskBridge extends NativeBridge implements Identifiable, Message {
+public final class SuspendedTaskBridge extends NativeBridge implements Identifiable, Message {
 
   private final SuspendedTask jsuspendedTask;
   private final String taskId;

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
@@ -323,7 +323,7 @@ public final class JobDriver {
           LOG.log(Level.INFO, "No CLR handler bound to handle completed task.");
         } else {
           LOG.log(Level.INFO, "CLR CompletedTaskHandler handler set, handling things with CLR handler.");
-          CompletedTaskBridge completedTaskBridge = new CompletedTaskBridge(task);
+          CompletedTaskBridge completedTaskBridge = new CompletedTaskBridge(task, activeContextBridgeFactory);
           NativeInterop.ClrSystemCompletedTaskHandlerOnNext(JobDriver.this.completedTaskHandler, completedTaskBridge, JobDriver.this.interopLogger);
         }
       }
@@ -442,7 +442,7 @@ public final class JobDriver {
         throw new RuntimeException("Failed Task Handler not initialized by CLR.");
       }
       try {
-        FailedTaskBridge failedTaskBridge = new FailedTaskBridge(task);
+        FailedTaskBridge failedTaskBridge = new FailedTaskBridge(task, activeContextBridgeFactory);
         NativeInterop.ClrSystemFailedTaskHandlerOnNext(JobDriver.this.failedTaskHandler, failedTaskBridge, JobDriver.this.interopLogger);
       } catch (final Exception ex) {
         LOG.log(Level.SEVERE, "Fail to invoke CLR failed task handler");
@@ -463,7 +463,7 @@ public final class JobDriver {
         } else {
           LOG.log(Level.INFO, "RunningTask will be handled by CLR handler. Task Id: {0}", task.getId());
           try {
-            final RunningTaskBridge runningTaskBridge = new RunningTaskBridge(task);
+            final RunningTaskBridge runningTaskBridge = new RunningTaskBridge(task, activeContextBridgeFactory);
             NativeInterop.ClrSystemRunningTaskHandlerOnNext(JobDriver.this.runningTaskHandler, runningTaskBridge, JobDriver.this.interopLogger);
           } catch (final Exception ex) {
             LOG.log(Level.WARNING, "Fail to invoke CLR running task handler");
@@ -487,7 +487,7 @@ public final class JobDriver {
             if (JobDriver.this.clrBridgeSetup) {
               if (JobDriver.this.driverRestartRunningTaskHandler != 0) {
                 LOG.log(Level.INFO, "CLR driver restart RunningTask handler implemented, now handle it in CLR.");
-                NativeInterop.ClrSystemDriverRestartRunningTaskHandlerOnNext(JobDriver.this.driverRestartRunningTaskHandler, new RunningTaskBridge(task));
+                NativeInterop.ClrSystemDriverRestartRunningTaskHandlerOnNext(JobDriver.this.driverRestartRunningTaskHandler, new RunningTaskBridge(task, activeContextBridgeFactory));
               } else {
                 LOG.log(Level.WARNING, "No CLR driver restart RunningTask handler implemented, done with DriverRestartRunningTaskHandler.");
               }
@@ -696,7 +696,7 @@ public final class JobDriver {
       LOG.log(Level.SEVERE, "FailedContext", context);
       try (final LoggingScope ls = loggingScopeFactory.evaluatorFailed(context.getId())) {
         if (JobDriver.this.failedContextHandler != 0) {
-          FailedContextBridge failedContextBridge = new FailedContextBridge(context);
+          FailedContextBridge failedContextBridge = new FailedContextBridge(context, activeContextBridgeFactory);
           // if CLR implements the failed context handler, handle it in CLR
           LOG.log(Level.INFO, "Handling the event of failed context in CLR bridge.");
           NativeInterop.ClrSystemFailedContextHandlerOnNext(JobDriver.this.failedContextHandler, failedContextBridge);


### PR DESCRIPTION
This change introduces the `ActiveContextBridgeFactory` to instantiate and cache `ActiveContextBridge` instances:

  * Removed unused instances of `ActiveContextBridge`.
  * Replaced the remaining constructor calls with calls to `ActiveContextBridgeFactory.getActiveContextBridge`.

`ActiveContextBridge` instances are removed from the cache in `ActiveContextBridgeFactory` by the `ClosedContextBridge`. This should limit the
size of the cache.

JIRA: [REEF-310](https://issues.apache.org/jira/browse/REEF-310)