### PR TITLE
[REEF-309] Add deadlock information to thread dump on driver force close

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultClientCloseHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultClientCloseHandler.java
@@ -38,9 +38,12 @@ public final class DefaultClientCloseHandler implements EventHandler<Void> {
 
   @Override
   public void onNext(final Void aVoid) {
-    final String message = ThreadLogger.getFormattedThreadList(
+    final String threads = ThreadLogger.getFormattedThreadList(
         "Received a close message from the client, but no handler was bound for it. Active threads: ");
-    LOG.log(Level.WARNING, message);
-    throw new RuntimeException(message);
+    LOG.log(Level.WARNING, threads);
+    final String deadlocks = ThreadLogger.getFormattedDeadlockInfo("Deadlocked threads: ");
+    LOG.log(Level.WARNING, deadlocks);
+
+    throw new RuntimeException(threads + "\n" + deadlocks);
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/DeadlockInfo.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/DeadlockInfo.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.util;
+
+import javax.annotation.Nullable;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MonitorInfo;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Provides a view into deadlocked threads for logging or debugging purposes.
+ * Backed by ThreadMXBean
+ */
+public final class DeadlockInfo {
+  private final ThreadMXBean mxBean;
+  private final ThreadInfo[] deadlockedThreads;
+  private final Map<ThreadInfo, Map<StackTraceElement, List<MonitorInfo>>> monitorLockedElements;
+
+  public DeadlockInfo() {
+    mxBean = ManagementFactory.getThreadMXBean();
+    deadlockedThreads = mxBean.getThreadInfo(mxBean.findDeadlockedThreads(), true, true);
+    monitorLockedElements = new HashMap<>();
+    for (final ThreadInfo threadInfo : deadlockedThreads) {
+      monitorLockedElements.put(threadInfo, constructMonitorLockedElements(threadInfo));
+    }
+  }
+
+  /**
+   * @return An array of deadlocked threads
+   */
+  public ThreadInfo[] getDeadlockedThreads() {
+    return deadlockedThreads;
+  }
+
+  /**
+   * Get a list of monitor locks that were acquired by this thread at this stack element
+   * @param threadInfo The thread that created the stack element
+   * @param stackTraceElement The stack element
+   * @return List of monitor locks that were acquired by this thread at this stack element or an empty list if none were acquired
+   */
+  public List<MonitorInfo> getMonitorLockedElements(final ThreadInfo threadInfo, final StackTraceElement stackTraceElement) {
+    final Map<StackTraceElement, List<MonitorInfo>> elementMap = monitorLockedElements.get(threadInfo);
+    if (null == elementMap) {
+      return Collections.EMPTY_LIST;
+    }
+
+    final List<MonitorInfo> monitorList = elementMap.get(stackTraceElement);
+    if (null == monitorList) {
+      return Collections.EMPTY_LIST;
+    }
+
+    return monitorList;
+  }
+
+  /**
+   * Get a string identifying the lock that this thread is waiting on
+   * @param threadInfo
+   * @return A string identifying the lock that this thread is waiting on, or null if the thread is not waiting on a lock
+   */
+  @Nullable
+  public String getWaitingLockString(final ThreadInfo threadInfo) {
+    if (null == threadInfo.getLockInfo()) {
+      return null;
+    } else {
+      return threadInfo.getLockName() + " held by " + threadInfo.getLockOwnerName();
+    }
+  }
+
+  private static Map<StackTraceElement, List<MonitorInfo>> constructMonitorLockedElements(final ThreadInfo threadInfo) {
+    final Map<StackTraceElement, List<MonitorInfo>> monitorLockedElements = new HashMap<>();
+    for (final MonitorInfo monitorInfo : threadInfo.getLockedMonitors()) {
+      final List<MonitorInfo> monitorInfoList = monitorLockedElements.containsKey(monitorInfo.getLockedStackFrame()) ?
+          monitorLockedElements.get(monitorInfo.getLockedStackFrame()) : new LinkedList<MonitorInfo>();
+      monitorInfoList.add(monitorInfo);
+      monitorLockedElements.put(monitorInfo.getLockedStackFrame(), monitorInfoList);
+    }
+    return monitorLockedElements;
+  }
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/DeadlockInfo.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/DeadlockInfo.java
@@ -33,7 +33,7 @@ import java.util.Map;
  * Provides a view into deadlocked threads for logging or debugging purposes.
  * Backed by ThreadMXBean
  */
-public final class DeadlockInfo {
+final class DeadlockInfo {
   private final ThreadMXBean mxBean;
   private final ThreadInfo[] deadlockedThreads;
   private final Map<ThreadInfo, Map<StackTraceElement, List<MonitorInfo>>> monitorLockedElements;

--- a/lang/java/reef-common/src/test/java/org/apache/reef/util/DeadlockInfoTest.java
+++ b/lang/java/reef-common/src/test/java/org/apache/reef/util/DeadlockInfoTest.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.fail;
 public final class DeadlockInfoTest {
   private static final Logger LOG = Logger.getLogger(DeadlockInfoTest.class.getName());
 
-  private static final long timeoutMillis = 10;
+  private static final long timeoutMillis = 50;
 
   /**
    * Create a deadlock consisting of two threads.

--- a/lang/java/reef-common/src/test/java/org/apache/reef/util/DeadlockInfoTest.java
+++ b/lang/java/reef-common/src/test/java/org/apache/reef/util/DeadlockInfoTest.java
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.util;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.management.ThreadInfo;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+/**
+ * Test DeadlockInfo
+ */
+public final class DeadlockInfoTest {
+  private static final Logger LOG = Logger.getLogger(DeadlockInfoTest.class.getName());
+
+  private final long millisBeforeDeadlock = 100;
+  private final long millisBeforeLog = 5 * millisBeforeDeadlock;
+
+  @Before
+  public void setUp() {
+    createDeadlock(millisBeforeDeadlock);
+    threadSleep(millisBeforeLog);
+  }
+
+  /**
+   * Create a deadlock consisting of two threads,
+   * then test that DeadlockInfo returns the expected values given the deadlock.
+   *
+   * One thread holds an Object and Long lock, and is waiting on an Integer lock.
+   * The other thread holds the Integer lock and is waiting on the Long lock.
+   */
+  @Test
+  public void testDeadlockInfo() {
+    final DeadlockInfo deadlockInfo = new DeadlockInfo();
+
+    final ThreadInfo[] threadInfos = deadlockInfo.getDeadlockedThreads();
+    assertEquals(2, threadInfos.length);
+
+    for (final ThreadInfo threadInfo : deadlockInfo.getDeadlockedThreads()) {
+      final String waitingLockString = deadlockInfo.getWaitingLockString(threadInfo);
+      assertNotNull("Each thread is expected to have a waiting lock", waitingLockString);
+      if (waitingLockString.contains("Integer")) {
+        assertNumberOfLocksHeld(2, deadlockInfo, threadInfo);
+      } else if (waitingLockString.contains("Long")) {
+        assertNumberOfLocksHeld(1, deadlockInfo, threadInfo);
+      } else {
+        fail("Unexpected waitingLockString of "+waitingLockString);
+      }
+    }
+  }
+
+  @Test
+  public void testLogDeadlockInfo() {
+    LOG.log(Level.INFO, ThreadLogger.getFormattedDeadlockInfo("Deadlock test, this deadlock is expected"));
+  }
+
+  private static void assertNumberOfLocksHeld(
+      final int expected, final DeadlockInfo deadlockInfo, final ThreadInfo threadInfo) {
+    int sum = 0;
+    for (final StackTraceElement stackTraceElement : threadInfo.getStackTrace()) {
+      sum += deadlockInfo.getMonitorLockedElements(threadInfo, stackTraceElement).size();
+    }
+    assertEquals(expected, sum);
+  }
+
+  private static void createDeadlock(final long millis) {
+    final Integer lock1 = new Integer(0);
+    final Long lock2 = new Long(0);
+
+    final Thread thread1 = new Thread() {
+      @Override
+      public void run() {
+        synchronized (lock1) {
+          threadSleep(millis);
+          lockLeaf(lock2);
+        }
+      }
+    };
+
+    final Thread thread2 = new Thread() {
+      @Override
+      public void run() {
+        synchronized (new Object()) {
+          synchronized (lock2) {
+            threadSleep(millis);
+            lockLeaf(lock1);
+          }
+        }
+      }
+    };
+
+    thread1.start();
+    thread2.start();
+  }
+
+  private static void threadSleep(final long millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+      fail("Interrupted");
+    }
+  }
+
+  private static void lockLeaf(final Object lock) {
+    synchronized (lock) {
+      fail("The unit test failed to create a deadlock");
+    }
+  }
+}


### PR DESCRIPTION
This PR adds deadlock information by adding a new static method to ThreadLogger.
The information will only be logged when a deadlock exists.

JIRA:
  [REEF-309](https://issues.apache.org/jira/browse/REEF-309)

Sample actual output of the new output from ThreadLogger after a deadlock:
```
May 07, 2015 8:08:59 AM org.apache.reef.runtime.common.driver.defaults.DefaultClientCloseHandler onNext
WARNING: Deadlocked threads:
        Thread 'Node-1-1430986082981-pool-13-thread-1' with state BLOCKED
                at org.apache.reef.wake.time.runtime.RuntimeClock.stop(RuntimeClock.java:103)
                - waiting to lock: java.util.TreeSet@25a732a4 held by main
                at org.apache.reef.runtime.common.driver.DriverStatusManager.onError(DriverStatusManager.java:146)
                - locked: org.apache.reef.runtime.common.driver.DriverStatusManager@23dc652
                at org.apache.reef.runtime.common.driver.DriverExceptionHandler.onNext(DriverExceptionHandler.java:51)
                at org.apache.reef.runtime.common.driver.DriverExceptionHandler.onNext(DriverExceptionHandler.java:33)
                at org.apache.reef.util.ExceptionHandlingEventHandler.onNext(ExceptionHandlingEventHandler.java:47)
                at org.apache.reef.runtime.common.utils.DispatchingEStage$1.onNext(DispatchingEStage.java:67)
                at org.apache.reef.runtime.common.utils.DispatchingEStage$1.onNext(DispatchingEStage.java:64)
                at org.apache.reef.wake.impl.ThreadPoolStage$1.run(ThreadPoolStage.java:180)
                at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
                at java.util.concurrent.FutureTask.run(FutureTask.java:262)
                at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
                at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
                at java.lang.Thread.run(Thread.java:745)
                * holds locked synchronizer: java.util.concurrent.ThreadPoolExecutor$Worker@38797817
        Thread 'main' with state BLOCKED
                at org.apache.reef.runtime.common.driver.idle.DriverIdleManager.onPotentiallyIdle(DriverIdleManager.java:49)
                - waiting to lock: org.apache.reef.runtime.common.driver.DriverStatusManager@23dc652 held by Node-1-1430986082981-pool-13-thread-1
                - locked: org.apache.reef.runtime.common.driver.idle.DriverIdleManager@3edc04c
                at org.apache.reef.runtime.common.driver.idle.ClockIdlenessSource.onNext(ClockIdlenessSource.java:58)
                - locked: org.apache.reef.runtime.common.driver.idle.ClockIdlenessSource@5ca39971
                at org.apache.reef.runtime.common.driver.idle.ClockIdlenessSource.onNext(ClockIdlenessSource.java:31)
                at org.apache.reef.wake.impl.PubSubEventHandler.onNext(PubSubEventHandler.java:98)
                at org.apache.reef.wake.time.runtime.RuntimeClock.run(RuntimeClock.java:199)
                - locked: java.util.TreeSet@25a732a4
                at org.apache.reef.runtime.common.launch.LaunchClass.run(LaunchClass.java:161)
                at org.apache.reef.runtime.common.Launcher.main(Launcher.java:111)
```