### PR TITLE
[REEF-297] Tests and fixes for the Configuration Provider

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/REEFImplementation.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/REEFImplementation.java
@@ -96,11 +96,11 @@ public final class REEFImplementation implements REEF {
       final JobSubmissionEvent submissionMessage;
       try {
         if (this.clientWireUp.isClientPresent()) {
-          submissionMessage = this.jobSubmissionHelper.getJobSubmissionBuilder(driverConf)
+          submissionMessage = this.jobSubmissionHelper.getJobSubmissionBuilder(driverConfiguration)
               .setRemoteId(this.clientWireUp.getRemoteManagerIdentifier())
               .build();
         } else {
-          submissionMessage = this.jobSubmissionHelper.getJobSubmissionBuilder(driverConf)
+          submissionMessage = this.jobSubmissionHelper.getJobSubmissionBuilder(driverConfiguration)
               .setRemoteId(ErrorHandlerRID.NONE)
               .build();
         }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceLaunchEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceLaunchEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -19,10 +19,13 @@
 package org.apache.reef.runtime.common.driver.api;
 
 import org.apache.reef.runtime.common.files.FileResource;
+import org.apache.reef.runtime.common.files.FileResourceImpl;
+import org.apache.reef.runtime.common.files.FileType;
 import org.apache.reef.runtime.common.launch.ProcessType;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.util.BuilderUtils;
 
+import java.io.File;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -119,10 +122,47 @@ public final class ResourceLaunchEventImpl implements ResourceLaunchEvent {
 
     /**
      * Add an entry to the fileSet
+     *
      * @see ResourceLaunchEvent#getFileSet()
      */
     public Builder addFile(final FileResource file) {
       this.fileSet.add(file);
+      return this;
+    }
+
+    /**
+     * Utility method that adds files to the fileSet
+     *
+     * @param files the files to add.
+     * @return this
+     * @see ResourceLaunchEvent#getFileSet()
+     */
+    public Builder addFiles(final Iterable<File> files) {
+      for (final File file : files) {
+        this.addFile(FileResourceImpl.newBuilder()
+            .setName(file.getName())
+            .setPath(file.getPath())
+            .setType(FileType.PLAIN)
+            .build());
+      }
+      return this;
+    }
+
+    /**
+     * Utility method that adds Libraries to the fileSet
+     *
+     * @param files the files to add.
+     * @return this
+     * @see ResourceLaunchEvent#getFileSet()
+     */
+    public Builder addLibraries(final Iterable<File> files) {
+      for (final File file : files) {
+        this.addFile(FileResourceImpl.newBuilder()
+            .setName(file.getName())
+            .setPath(file.getPath())
+            .setType(FileType.LIB)
+            .build());
+      }
       return this;
     }
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/AllocatedEvaluatorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/AllocatedEvaluatorImpl.java
@@ -20,20 +20,17 @@ package org.apache.reef.runtime.common.driver.evaluator;
 
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
-import org.apache.reef.tang.ConfigurationProvider;
 import org.apache.reef.driver.context.ContextConfiguration;
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
 import org.apache.reef.driver.evaluator.EvaluatorDescriptor;
 import org.apache.reef.driver.evaluator.EvaluatorType;
 import org.apache.reef.runtime.common.driver.api.ResourceLaunchEventImpl;
 import org.apache.reef.runtime.common.evaluator.EvaluatorConfiguration;
-import org.apache.reef.runtime.common.files.FileResourceImpl;
-import org.apache.reef.runtime.common.files.FileType;
 import org.apache.reef.runtime.common.launch.ProcessType;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.ConfigurationBuilder;
+import org.apache.reef.tang.ConfigurationProvider;
 import org.apache.reef.tang.Tang;
-import org.apache.reef.tang.exceptions.BindException;
 import org.apache.reef.tang.formats.ConfigurationModule;
 import org.apache.reef.tang.formats.ConfigurationSerializer;
 import org.apache.reef.util.Optional;
@@ -154,100 +151,94 @@ final class AllocatedEvaluatorImpl implements AllocatedEvaluator {
                             final Optional<Configuration> serviceConfiguration,
                             final Optional<Configuration> taskConfiguration) {
     try (final LoggingScope lb = loggingScopeFactory.evaluatorLaunch(this.getId())) {
-      try {
-        final Configuration rootContextConfiguration = makeRootContextConfiguration(contextConfiguration);
-        final ConfigurationModule evaluatorConfigurationModule = EvaluatorConfiguration.CONF
-            .set(EvaluatorConfiguration.APPLICATION_IDENTIFIER, this.jobIdentifier)
-            .set(EvaluatorConfiguration.DRIVER_REMOTE_IDENTIFIER, this.remoteID)
-            .set(EvaluatorConfiguration.EVALUATOR_IDENTIFIER, this.getId());
+      final Configuration evaluatorConfiguration =
+          makeEvaluatorConfiguration(contextConfiguration, serviceConfiguration, taskConfiguration);
 
-        final String encodedContextConfigurationString = this.configurationSerializer.toString(rootContextConfiguration);
-        // Add the (optional) service configuration
-        final ConfigurationModule contextConfigurationModule;
-        if (serviceConfiguration.isPresent()) {
-          // With service configuration
-          final String encodedServiceConfigurationString = this.configurationSerializer.toString(serviceConfiguration.get());
-          contextConfigurationModule = evaluatorConfigurationModule
-              .set(EvaluatorConfiguration.ROOT_SERVICE_CONFIGURATION, encodedServiceConfigurationString)
-              .set(EvaluatorConfiguration.ROOT_CONTEXT_CONFIGURATION, encodedContextConfigurationString);
-        } else {
-          // No service configuration
-          contextConfigurationModule = evaluatorConfigurationModule
-              .set(EvaluatorConfiguration.ROOT_CONTEXT_CONFIGURATION, encodedContextConfigurationString);
+      final ResourceLaunchEventImpl.Builder rbuilder =
+          ResourceLaunchEventImpl.newBuilder()
+              .setIdentifier(this.evaluatorManager.getId())
+              .setRemoteId(this.remoteID)
+              .setEvaluatorConf(evaluatorConfiguration)
+              .addFiles(this.files)
+              .addLibraries(this.libraries);
+
+      { // Set the type
+        switch (this.evaluatorManager.getEvaluatorDescriptor().getType()) {
+          case CLR:
+            rbuilder.setType(ProcessType.CLR);
+            break;
+          default:
+            rbuilder.setType(ProcessType.JVM);
         }
-
-        // Add the (optional) task configuration
-        final Configuration evaluatorConfiguration;
-        if (taskConfiguration.isPresent()) {
-          final String encodedTaskConfigurationString = this.configurationSerializer.toString(taskConfiguration.get());
-          evaluatorConfiguration = contextConfigurationModule
-              .set(EvaluatorConfiguration.TASK_CONFIGURATION, encodedTaskConfigurationString).build();
-        } else {
-          evaluatorConfiguration = contextConfigurationModule.build();
-        }
-
-        final ResourceLaunchEventImpl.Builder rbuilder =
-            ResourceLaunchEventImpl.newBuilder()
-                .setIdentifier(this.evaluatorManager.getId())
-                .setRemoteId(this.remoteID)
-                .setEvaluatorConf(evaluatorConfiguration);
-
-        for (final File file : this.files) {
-          rbuilder.addFile(FileResourceImpl.newBuilder()
-                  .setName(file.getName())
-                  .setPath(file.getPath())
-                  .setType(FileType.PLAIN)
-                  .build());
-        }
-
-        for (final File lib : this.libraries) {
-          rbuilder.addFile(FileResourceImpl.newBuilder()
-                  .setName(lib.getName())
-                  .setPath(lib.getPath().toString())
-                  .setType(FileType.LIB)
-                  .build());
-        }
-
-        { // Set the type
-          switch (this.evaluatorManager.getEvaluatorDescriptor().getType()) {
-            case CLR:
-              rbuilder.setType(ProcessType.CLR);
-              break;
-            default:
-              rbuilder.setType(ProcessType.JVM);
-          }
-        }
-
-        this.evaluatorManager.onResourceLaunch(rbuilder.build());
-
-      } catch (final BindException ex) {
-        LOG.log(Level.SEVERE, "Bad Evaluator configuration", ex);
-        throw new RuntimeException("Bad Evaluator configuration", ex);
       }
+      this.evaluatorManager.onResourceLaunch(rbuilder.build());
     }
+  }
+
+
+  private Configuration makeEvaluatorConfiguration(final Configuration contextConfiguration,
+                                                   final Optional<Configuration> serviceConfiguration,
+                                                   final Optional<Configuration> taskConfiguration) {
+
+    final String contextConfigurationString = this.configurationSerializer.toString(contextConfiguration);
+    ConfigurationModule evaluatorConfigurationModule = EvaluatorConfiguration.CONF
+        .set(EvaluatorConfiguration.APPLICATION_IDENTIFIER, this.jobIdentifier)
+        .set(EvaluatorConfiguration.DRIVER_REMOTE_IDENTIFIER, this.remoteID)
+        .set(EvaluatorConfiguration.EVALUATOR_IDENTIFIER, this.getId())
+        .set(EvaluatorConfiguration.ROOT_CONTEXT_CONFIGURATION, contextConfigurationString);
+
+    // Add the (optional) service configuration
+    final Optional<Configuration> mergedServiceConfiguration = makeRootServiceConfiguration(serviceConfiguration);
+    if (mergedServiceConfiguration.isPresent()) {
+      final String serviceConfigurationString = this.configurationSerializer.toString(mergedServiceConfiguration.get());
+      evaluatorConfigurationModule = evaluatorConfigurationModule
+          .set(EvaluatorConfiguration.ROOT_SERVICE_CONFIGURATION, serviceConfigurationString);
+    }
+
+    // Add the (optional) task configuration
+    if (taskConfiguration.isPresent()) {
+      final String taskConfigurationString = this.configurationSerializer.toString(taskConfiguration.get());
+      evaluatorConfigurationModule = evaluatorConfigurationModule
+          .set(EvaluatorConfiguration.TASK_CONFIGURATION, taskConfigurationString);
+    }
+
+    // Create the evaluator configuration.
+    return evaluatorConfigurationModule.build();
   }
 
   /**
    * Merges the Configurations provided by the evaluatorConfigurationProviders into the given
-   * contextConfiguration.
-   *
-   * @param contextConfiguration
-   * @return
+   * serviceConfiguration, if any.
    */
-  private Configuration makeRootContextConfiguration(final Configuration contextConfiguration) {
-
+  private Optional<Configuration> makeRootServiceConfiguration(final Optional<Configuration> serviceConfiguration) {
     final EvaluatorType evaluatorType = this.evaluatorManager.getEvaluatorDescriptor().getType();
-    if (EvaluatorType.JVM != evaluatorType) {
+    if (EvaluatorType.CLR == evaluatorType) {
       LOG.log(Level.FINE, "Not using the ConfigurationProviders as we are configuring a {0} Evaluator.", evaluatorType);
-      return contextConfiguration;
+      return serviceConfiguration;
     }
 
-    final ConfigurationBuilder configurationBuilder = Tang.Factory.getTang()
-        .newConfigurationBuilder(contextConfiguration);
-    for (final ConfigurationProvider configurationProvider : this.evaluatorConfigurationProviders) {
-      configurationBuilder.addConfiguration(configurationProvider.getConfiguration());
+    if ((!serviceConfiguration.isPresent()) && this.evaluatorConfigurationProviders.isEmpty()) {
+      // No configurations to merge.
+      LOG.info("No service configuration given and no ConfigurationProviders set.");
+      return Optional.empty();
+    } else {
+      final ConfigurationBuilder configurationBuilder = getConfigurationBuilder(serviceConfiguration);
+      for (final ConfigurationProvider configurationProvider : this.evaluatorConfigurationProviders) {
+        configurationBuilder.addConfiguration(configurationProvider.getConfiguration());
+      }
+      return Optional.of(configurationBuilder.build());
     }
-    return configurationBuilder.build();
+  }
+
+  /**
+   * Utility to build a ConfigurationBuilder from an Optional<Configuration></Configuration>
+   */
+  private static ConfigurationBuilder getConfigurationBuilder(final Optional<Configuration> configuration) {
+    if (configuration.isPresent()) {
+      return Tang.Factory.getTang().newConfigurationBuilder(configuration.get());
+    } else {
+      return Tang.Factory.getTang().newConfigurationBuilder();
+    }
   }
 
   @Override

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/AllTestsSuite.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/AllTestsSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -19,6 +19,7 @@
 package org.apache.reef.tests;
 
 import org.apache.reef.tests.close_eval.CloseEvaluatorTest;
+import org.apache.reef.tests.configurationproviders.ConfigurationProviderTest;
 import org.apache.reef.tests.driver.DriverTest;
 import org.apache.reef.tests.evaluatorfailure.EvaluatorFailureTest;
 import org.apache.reef.tests.evaluatorreuse.EvaluatorReuseTest;
@@ -48,7 +49,8 @@ import org.junit.runners.Suite;
     TaskResubmitTest.class,
     CloseEvaluatorTest.class,
     EvaluatorFailureTest.class,
-    ExamplesTestSuite.class
+    ExamplesTestSuite.class,
+    ConfigurationProviderTest.class
 })
 public final class AllTestsSuite {
 }

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/configurationproviders/ConfigurationProviderTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/configurationproviders/ConfigurationProviderTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.configurationproviders;
+
+import org.apache.reef.client.DriverConfiguration;
+import org.apache.reef.client.DriverLauncher;
+import org.apache.reef.client.LauncherStatus;
+import org.apache.reef.client.parameters.DriverConfigurationProviders;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.apache.reef.tests.TestEnvironment;
+import org.apache.reef.tests.TestEnvironmentFactory;
+import org.apache.reef.util.EnvironmentUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests the ConfigurationProvider mechanism
+ */
+public final class ConfigurationProviderTest {
+  private final TestEnvironment testEnvironment = TestEnvironmentFactory.getNewTestEnvironment();
+
+  /**
+   * Uses the TestEnvironment to get the base config and adds the DriverConfigurationProvider.
+   *
+   * @return the runtime configuration.
+   */
+  private final Configuration getRuntimeConfiguration() {
+    return Tang.Factory.getTang()
+        .newConfigurationBuilder(testEnvironment.getRuntimeConfiguration())
+        .bindSetEntry(DriverConfigurationProviders.class, TestDriverConfigurationProvider.class)
+        .build();
+  }
+
+  /**
+   * Assembles the Driver configuration.
+   *
+   * @return the Driver configuration.
+   */
+  private final Configuration getDriverConfiguration() {
+    return DriverConfiguration.CONF
+        .set(DriverConfiguration.DRIVER_IDENTIFIER, "ConfigurationProviderTest")
+        .set(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getClassLocation(ConfigurationProviderTestDriver.class))
+        .set(DriverConfiguration.ON_DRIVER_STARTED, ConfigurationProviderTestDriver.StartHandler.class)
+        .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, ConfigurationProviderTestDriver.EvaluatorAllocatedHandler.class)
+        .build();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    testEnvironment.setUp();
+  }
+
+  /**
+   * Tests whether parameters get propagated correctly when set via the ConfigurationProvider mechanism.
+   *
+   * @throws InjectionException
+   */
+  @Test
+  public void testConfigurationProviders() throws InjectionException {
+    final LauncherStatus status = DriverLauncher.getLauncher(getRuntimeConfiguration())
+        .run(getDriverConfiguration(), testEnvironment.getTestTimeout());
+    Assert.assertTrue("ConfigurationProviderTest completed with status: " + status, status.isSuccess());
+  }
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/configurationproviders/ConfigurationProviderTestDriver.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/configurationproviders/ConfigurationProviderTestDriver.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.configurationproviders;
+
+import org.apache.reef.driver.evaluator.AllocatedEvaluator;
+import org.apache.reef.driver.evaluator.EvaluatorRequest;
+import org.apache.reef.driver.evaluator.EvaluatorRequestor;
+import org.apache.reef.driver.task.TaskConfiguration;
+import org.apache.reef.tang.Injector;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.Unit;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.apache.reef.tests.configurationproviders.parameters.DriverAndEvaluatorParameter;
+import org.apache.reef.tests.configurationproviders.parameters.DriverParameter;
+import org.apache.reef.tests.library.exceptions.DriverSideFailure;
+import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.time.event.StartTime;
+
+import javax.inject.Inject;
+
+@Unit
+final class ConfigurationProviderTestDriver {
+  private final EvaluatorRequestor evaluatorRequestor;
+  private final Injector injector;
+
+  @Inject
+  private ConfigurationProviderTestDriver(EvaluatorRequestor evaluatorRequestor, Injector injector) {
+    this.evaluatorRequestor = evaluatorRequestor;
+    this.injector = injector;
+  }
+
+
+  final class StartHandler implements EventHandler<StartTime> {
+    @Override
+    public void onNext(final StartTime startTime) {
+
+      // Check that the parameters were set
+      checkParameter(DriverParameter.class, DriverParameter.TEST_VALUE);
+      checkParameter(DriverAndEvaluatorParameter.class, DriverAndEvaluatorParameter.TEST_VALUE);
+
+      // If we got here, the parameters were set correctly and we can proceed.
+      evaluatorRequestor.submit(EvaluatorRequest.newBuilder()
+          .setNumber(1)
+          .setMemory(32)
+          .build());
+    }
+
+
+  }
+
+  final class EvaluatorAllocatedHandler implements EventHandler<AllocatedEvaluator> {
+
+    @Override
+    public void onNext(final AllocatedEvaluator allocatedEvaluator) {
+      allocatedEvaluator.submitTask(TaskConfiguration.CONF
+          .set(TaskConfiguration.TASK, ConfigurationProviderTestTask.class)
+          .set(TaskConfiguration.IDENTIFIER, "ConfigurationProviderTestTask")
+          .build());
+    }
+  }
+
+  private void checkParameter(final Class<? extends Name<String>> name, final String expectedValue) {
+    try {
+      final String value = injector.getNamedInstance(name);
+      if (!expectedValue.equals(value)) {
+        throw new DriverSideFailure(name.toString() + " not set correctly");
+      }
+    } catch (final InjectionException e) {
+      throw new DriverSideFailure(name.toString() + " not set.", e);
+    }
+  }
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/configurationproviders/ConfigurationProviderTestTask.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/configurationproviders/ConfigurationProviderTestTask.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.configurationproviders;
+
+import org.apache.reef.tang.Injector;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.apache.reef.task.Task;
+import org.apache.reef.tests.configurationproviders.parameters.DriverAndEvaluatorParameter;
+import org.apache.reef.tests.configurationproviders.parameters.EvaluatorParameter;
+import org.apache.reef.tests.library.exceptions.TaskSideFailure;
+
+import javax.inject.Inject;
+
+final class ConfigurationProviderTestTask implements Task {
+
+  private final Injector injector;
+
+  @Inject
+  private ConfigurationProviderTestTask(final Injector injector) {
+    this.injector = injector;
+  }
+
+  @Override
+  public byte[] call(final byte[] memento) throws Exception {
+
+    // Check the parameters
+    checkParameter(EvaluatorParameter.class, EvaluatorParameter.TEST_VALUE);
+    checkParameter(DriverAndEvaluatorParameter.class, DriverAndEvaluatorParameter.TEST_VALUE);
+    return new byte[0];
+  }
+
+  private void checkParameter(final Class<? extends Name<String>> name, final String expectedValue) {
+    try {
+      final String value = injector.getNamedInstance(name);
+      if (!expectedValue.equals(value)) {
+        throw new TaskSideFailure(name.toString() + " not set correctly");
+      }
+    } catch (final InjectionException e) {
+      throw new TaskSideFailure(name.toString() + " not set.", e);
+    }
+  }
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/configurationproviders/TestDriverConfigurationProvider.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/configurationproviders/TestDriverConfigurationProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.configurationproviders;
+
+import org.apache.reef.driver.parameters.EvaluatorConfigurationProviders;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.ConfigurationProvider;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tests.configurationproviders.parameters.DriverAndEvaluatorParameter;
+import org.apache.reef.tests.configurationproviders.parameters.DriverParameter;
+
+import javax.inject.Inject;
+
+/**
+ * A ConfigurationProvider used in the test to bind parameters to the Driver Configuration.
+ */
+final class TestDriverConfigurationProvider implements ConfigurationProvider {
+
+  @Inject
+  private TestDriverConfigurationProvider() {
+  }
+
+  @Override
+  public Configuration getConfiguration() {
+    return Tang.Factory.getTang().newConfigurationBuilder()
+        .bindSetEntry(EvaluatorConfigurationProviders.class, TestEvaluatorConfigurationProvider.class)
+        .bindNamedParameter(DriverParameter.class, DriverParameter.TEST_VALUE)
+        .bindNamedParameter(DriverAndEvaluatorParameter.class, DriverAndEvaluatorParameter.TEST_VALUE)
+        .build();
+  }
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/configurationproviders/TestEvaluatorConfigurationProvider.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/configurationproviders/TestEvaluatorConfigurationProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.configurationproviders;
+
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.ConfigurationProvider;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tests.configurationproviders.parameters.DriverAndEvaluatorParameter;
+import org.apache.reef.tests.configurationproviders.parameters.EvaluatorParameter;
+
+import javax.inject.Inject;
+
+
+/**
+ * A ConfigurationProvider used in the test to bind parameters to the Evaluator Configuration.
+ */
+final class TestEvaluatorConfigurationProvider implements ConfigurationProvider {
+  @Inject
+  private TestEvaluatorConfigurationProvider() {
+  }
+
+  @Override
+  public Configuration getConfiguration() {
+    return Tang.Factory.getTang().newConfigurationBuilder()
+        .bindNamedParameter(EvaluatorParameter.class, EvaluatorParameter.TEST_VALUE)
+        .bindNamedParameter(DriverAndEvaluatorParameter.class, DriverAndEvaluatorParameter.TEST_VALUE)
+        .build();
+  }
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/configurationproviders/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/configurationproviders/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Tests for the ConfigurationProvider mechanism.
+ */
+package org.apache.reef.tests.configurationproviders;

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/configurationproviders/parameters/DriverAndEvaluatorParameter.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/configurationproviders/parameters/DriverAndEvaluatorParameter.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.configurationproviders.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+/**
+ * This is a parameter to be bound in the Driver and Evaluator config.
+ */
+@NamedParameter
+public final class DriverAndEvaluatorParameter implements Name<String> {
+  public static final String TEST_VALUE = "This is a parameter to be bound in the Driver and Evaluator config";
+
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/configurationproviders/parameters/DriverParameter.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/configurationproviders/parameters/DriverParameter.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.configurationproviders.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+/**
+ * This is a parameter only to be bound in the Driver config.
+ */
+@NamedParameter
+public class DriverParameter implements Name<String> {
+  public static final String TEST_VALUE = "This is a parameter only to be bound in the Driver config.";
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/configurationproviders/parameters/EvaluatorParameter.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/configurationproviders/parameters/EvaluatorParameter.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.configurationproviders.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+/**
+ * This is a parameter only to be bound in the Evaluator config.
+ */
+@NamedParameter
+public class EvaluatorParameter implements Name<String> {
+  public static final String TEST_VALUE = "This is a parameter only to be bound in the Evaluator config";
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/configurationproviders/parameters/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/configurationproviders/parameters/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Parameters used in ConfigurationProviderTest
+ */
+package org.apache.reef.tests.configurationproviders.parameters;


### PR DESCRIPTION
This change adds `ConfigurationProviderTest` to test the configuration provider mechanism. As it turns out, the test also unearthed bugs in this mechanism fixed in this change:

 * Fixed a typo in `REEFImplementation` where the wrong (unmerged) driver configuration was used.
 * Fixed `AllocatedEvaluatorImpl` to merge the Configurations from the `ConfigurationProvider`s into the service configuration to make sure the bindings make it past the root context / task.
 * Fixed `AllocatedEvaluatorImpl` to merge the Configurations in all cases but a `CLR` Evaluator. They end up being `Undecided` by default, which in the case of a Java Driver is synonymous to `JVM`

While adding those fixes, I also cleaned up `AllocatedEvaluatorImpl` and moved some of the more mundane features into `ResourceLaunchEventImpl.Builder`

JIRA:
  [REEF-297](https://issues.apache.org/jira/browse/REEF-297)