### PR TITLE
[REEF-329]  Improve Injection in Communication Group

### DIFF
--- a/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTests.cs
@@ -158,16 +158,19 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             }
         }
 
+        /// <summary>
+        /// This is to test operator injection in CommunicationGroupClient with int[] as message type
+        /// </summary>
         [TestMethod]
         public void TestGetBroadcastReduceOperatorsForIntArrayMessageType()
         {
-            string groupName = "group1";
-            string broadcastOperatorName = "broadcast";
-            string reduceOperatorName = "reduce";
-            string masterTaskId = "task0";
-            string driverId = "Driver Id";
-            int numTasks = 3;
-            int fanOut = 2;
+            const string groupName = "group1";
+            const string broadcastOperatorName = "broadcast";
+            const string reduceOperatorName = "reduce";
+            const string masterTaskId = "task0";
+            const string driverId = "Driver Id";
+            const int numTasks = 3;
+            const int fanOut = 2;
 
             IConfiguration codecConfig = CodecConfiguration<int[]>.Conf
                 .Set(CodecConfiguration<int[]>.Codec, GenericType<IntArrayCodec>.Class)
@@ -215,6 +218,13 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
 
             IBroadcastReceiver<int[]> broadcastReceiver2 = commGroups[2].GetBroadcastReceiver<int[]>(broadcastOperatorName);
             IReduceSender<int[]> triangleNumberSender2 = commGroups[2].GetReduceSender<int[]>(reduceOperatorName);
+
+            Assert.IsNotNull(broadcastSender);
+            Assert.IsNotNull(sumReducer);
+            Assert.IsNotNull(broadcastReceiver1);
+            Assert.IsNotNull(triangleNumberSender1);
+            Assert.IsNotNull(broadcastReceiver2);
+            Assert.IsNotNull(triangleNumberSender2);
         }
 
         [TestMethod]
@@ -796,7 +806,12 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
                 string taskId = "task" + i;
                 IConfiguration groupCommTaskConfig = groupCommDriver.GetGroupCommTaskConfiguration(taskId);
                 IConfiguration mergedConf = Configurations.Merge(groupCommTaskConfig, partialConfigs[i], serviceConfig);
-                IInjector injector = TangFactory.GetTang().NewInjector(mergedConf);
+
+                var conf = TangFactory.GetTang()
+                    .NewConfigurationBuilder(mergedConf)
+                    .BindNamedParameter(typeof(GroupCommConfigurationOptions.Initialize), "false")
+                    .Build();
+                IInjector injector = TangFactory.GetTang().NewInjector(conf);
 
                 //simulate injection at evaluator side
                 IGroupCommClient groupCommClient = injector.GetInstance<IGroupCommClient>();

--- a/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTests.cs
@@ -111,20 +111,20 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
 
             var groupCommunicationDriver = GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
             ICommunicationGroupDriver commGroup = groupCommunicationDriver.DefaultGroup
-                    .AddBroadcast<int>(
-                        broadcastOperatorName,
-                        masterTaskId,
-                        TopologyTypes.Flat,
-                        GetDefaulCodecConfig(),
-                        GetDefaulDataConverterConfig())
-                    .AddReduce<int>(
-                        reduceOperatorName,
-                        masterTaskId,
-                        TopologyTypes.Flat,
-                        GetDefaulCodecConfig(),
-                        GetDefaulDataConverterConfig(),
-                        GetDefaulReduceFuncConfig())
-                    .Build();
+                .AddBroadcast<int>(
+                    broadcastOperatorName,
+                    masterTaskId,
+                    TopologyTypes.Flat,
+                    GetDefaulCodecConfig(),
+                    GetDefaulDataConverterConfig())
+                .AddReduce<int>(
+                    reduceOperatorName,
+                    masterTaskId,
+                    TopologyTypes.Flat,
+                    GetDefaulCodecConfig(),
+                    GetDefaulDataConverterConfig(),
+                    GetDefaulReduceFuncConfig())
+                .Build();
 
             var commGroups = CommGroupClients(groupName, numTasks, groupCommunicationDriver, commGroup);
 
@@ -193,7 +193,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
                         broadcastOperatorName,
                         masterTaskId,
                         TopologyTypes.Flat,
-                       codecConfig,
+                        codecConfig,
                         dataConverterConfig)
                     .AddReduce<int[]>(
                         reduceOperatorName,

--- a/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTests.cs
@@ -20,6 +20,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Reactive;
@@ -29,12 +30,14 @@ using Org.Apache.REEF.Common.Io;
 using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.Examples.MachineLearning.KMeans;
 using Org.Apache.REEF.Examples.MachineLearning.KMeans.codecs;
+using Org.Apache.REEF.Network.Examples.GroupCommunication;
 using Org.Apache.REEF.Network.Group.Codec;
 using Org.Apache.REEF.Network.Group.Config;
 using Org.Apache.REEF.Network.Group.Driver;
 using Org.Apache.REEF.Network.Group.Driver.Impl;
 using Org.Apache.REEF.Network.Group.Operators;
 using Org.Apache.REEF.Network.Group.Operators.Impl;
+using Org.Apache.REEF.Network.Group.Pipelining;
 using Org.Apache.REEF.Network.Group.Pipelining.Impl;
 using Org.Apache.REEF.Network.Group.Task;
 using Org.Apache.REEF.Network.Group.Topology;
@@ -107,22 +110,21 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             int fanOut = 2;
 
             var groupCommunicationDriver = GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
-
             ICommunicationGroupDriver commGroup = groupCommunicationDriver.DefaultGroup
-                .AddBroadcast<int>(
-                    broadcastOperatorName,
-                    masterTaskId,
-                    TopologyTypes.Flat,
-                    GetDefaulCodecConfig(),
-                    GetDefaulDataConverterConfig())
-                .AddReduce<int>(
-                    reduceOperatorName,
-                    masterTaskId,
-                    TopologyTypes.Flat,
-                    GetDefaulCodecConfig(),
-                    GetDefaulDataConverterConfig(),
-                    GetDefaulReduceFuncConfig())
-                .Build();
+                    .AddBroadcast<int>(
+                        broadcastOperatorName,
+                        masterTaskId,
+                        TopologyTypes.Flat,
+                        GetDefaulCodecConfig(),
+                        GetDefaulDataConverterConfig())
+                    .AddReduce<int>(
+                        reduceOperatorName,
+                        masterTaskId,
+                        TopologyTypes.Flat,
+                        GetDefaulCodecConfig(),
+                        GetDefaulDataConverterConfig(),
+                        GetDefaulReduceFuncConfig())
+                    .Build();
 
             var commGroups = CommGroupClients(groupName, numTasks, groupCommunicationDriver, commGroup);
 
@@ -155,7 +157,66 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
                 Assert.AreEqual(sum, expected);
             }
         }
- 
+
+        [TestMethod]
+        public void TestGetBroadcastReduceOperatorsForIntArrayMessageType()
+        {
+            string groupName = "group1";
+            string broadcastOperatorName = "broadcast";
+            string reduceOperatorName = "reduce";
+            string masterTaskId = "task0";
+            string driverId = "Driver Id";
+            int numTasks = 3;
+            int fanOut = 2;
+
+            IConfiguration codecConfig = CodecConfiguration<int[]>.Conf
+                .Set(CodecConfiguration<int[]>.Codec, GenericType<IntArrayCodec>.Class)
+                .Build();
+
+            IConfiguration reduceFunctionConfig = ReduceFunctionConfiguration<int[]>.Conf
+                .Set(ReduceFunctionConfiguration<int[]>.ReduceFunction, GenericType<ArraySumFunction>.Class)
+                .Build();
+
+            IConfiguration dataConverterConfig = TangFactory.GetTang().NewConfigurationBuilder(
+                PipelineDataConverterConfiguration<int[]>.Conf
+                    .Set(PipelineDataConverterConfiguration<int[]>.DataConverter,
+                        GenericType<PipelineIntDataConverter>.Class)
+                    .Build())
+                .BindNamedParameter<GroupTestConfig.ChunkSize, int>(
+                    GenericType<GroupTestConfig.ChunkSize>.Class,
+                    GroupTestConstants.ChunkSize.ToString(CultureInfo.InvariantCulture))
+                .Build();
+
+            var groupCommunicationDriver = GetInstanceOfGroupCommDriver(driverId, masterTaskId, groupName, fanOut, numTasks);
+            ICommunicationGroupDriver commGroup = groupCommunicationDriver.DefaultGroup
+                    .AddBroadcast<int[]>(
+                        broadcastOperatorName,
+                        masterTaskId,
+                        TopologyTypes.Flat,
+                       codecConfig,
+                        dataConverterConfig)
+                    .AddReduce<int[]>(
+                        reduceOperatorName,
+                        masterTaskId,
+                        TopologyTypes.Flat,
+                        codecConfig,
+                        dataConverterConfig,
+                        reduceFunctionConfig)
+                    .Build();
+
+            var commGroups = CommGroupClients(groupName, numTasks, groupCommunicationDriver, commGroup);
+
+            //for master task
+            IBroadcastSender<int[]> broadcastSender = commGroups[0].GetBroadcastSender<int[]>(broadcastOperatorName);
+            IReduceReceiver<int[]> sumReducer = commGroups[0].GetReduceReceiver<int[]>(reduceOperatorName);
+
+            IBroadcastReceiver<int[]> broadcastReceiver1 = commGroups[1].GetBroadcastReceiver<int[]>(broadcastOperatorName);
+            IReduceSender<int[]> triangleNumberSender1 = commGroups[1].GetReduceSender<int[]>(reduceOperatorName);
+
+            IBroadcastReceiver<int[]> broadcastReceiver2 = commGroups[2].GetBroadcastReceiver<int[]>(broadcastOperatorName);
+            IReduceSender<int[]> triangleNumberSender2 = commGroups[2].GetReduceSender<int[]>(reduceOperatorName);
+        }
+
         [TestMethod]
         public void TestScatterReduceOperators()
         {
@@ -710,7 +771,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             return groupCommDriver;
         }
 
-        public static List<ICommunicationGroupClient> CommGroupClients(string groupName, int numTasks, IGroupCommDriver groupCommDriver, ICommunicationGroupDriver commGroup)
+        public static List<ICommunicationGroupClient> CommGroupClients(string groupName, int numTasks, IGroupCommDriver groupCommDriver, ICommunicationGroupDriver commGroupDriver)
         {
             List<ICommunicationGroupClient> commGroups = new List<ICommunicationGroupClient>();
             IConfiguration serviceConfig = groupCommDriver.GetServiceConfiguration();
@@ -725,17 +786,19 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
                         .Set(TaskConfiguration.Task, GenericType<MyTask>.Class)
                         .Build())
                     .Build();
-                commGroup.AddTask(taskId);
+                commGroupDriver.AddTask(taskId);
                 partialConfigs.Add(partialTaskConfig);
             }
 
             for (int i = 0; i < numTasks; i++)
             {
+                //get task configuration at driver side
                 string taskId = "task" + i;
                 IConfiguration groupCommTaskConfig = groupCommDriver.GetGroupCommTaskConfiguration(taskId);
                 IConfiguration mergedConf = Configurations.Merge(groupCommTaskConfig, partialConfigs[i], serviceConfig);
                 IInjector injector = TangFactory.GetTang().NewInjector(mergedConf);
 
+                //simulate injection at evaluator side
                 IGroupCommClient groupCommClient = injector.GetInstance<IGroupCommClient>();
                 commGroups.Add(groupCommClient.GetCommunicationGroup(groupName));
             }
@@ -819,6 +882,122 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
         public byte[] Call(byte[] memento)
         {
             throw new NotImplementedException();
+        }
+    }
+
+    class ArraySumFunction : IReduceFunction<int[]>
+    {
+        [Inject]
+        private ArraySumFunction()
+        {
+        }
+
+        public int[] Reduce(IEnumerable<int[]> elements)
+        {
+            int[] result = null;
+            int count = 0;
+
+            foreach (var element in elements)
+            {
+                if (count == 0)
+                {
+                    result = element.Clone() as int[];
+                }
+                else
+                {
+                    if (element.Length != result.Length)
+                    {
+                        throw new Exception("integer arrays are of different sizes");
+                    }
+
+                    for (int i = 0; i < result.Length; i++)
+                    {
+                        result[i] += element[i];
+                    }
+                }
+                count++;
+            }
+
+            return result;
+        }
+    }
+
+    class IntArrayCodec : ICodec<int[]>
+    {
+        [Inject]
+        private IntArrayCodec()
+        {
+        }
+
+        public byte[] Encode(int[] obj)
+        {
+            byte[] result = new byte[sizeof(Int32) * obj.Length];
+            Buffer.BlockCopy(obj, 0, result, 0, result.Length);
+            return result;
+        }
+
+        public int[] Decode(byte[] data)
+        {
+            if (data.Length % sizeof(Int32) != 0)
+            {
+                throw new Exception("error inside integer array decoder, byte array length not a multiple of interger size");
+            }
+
+            int[] result = new int[data.Length / sizeof(Int32)];
+            Buffer.BlockCopy(data, 0, result, 0, data.Length);
+            return result;
+        }
+    }
+
+    class PipelineIntDataConverter : IPipelineDataConverter<int[]>
+    {
+        readonly int _chunkSize;
+
+        [Inject]
+        private PipelineIntDataConverter([Parameter(typeof(GroupTestConfig.ChunkSize))] int chunkSize)
+        {
+            _chunkSize = chunkSize;
+        }
+
+        public List<PipelineMessage<int[]>> PipelineMessage(int[] message)
+        {
+            List<PipelineMessage<int[]>> messageList = new List<PipelineMessage<int[]>>();
+            int totalChunks = message.Length / _chunkSize;
+
+            if (message.Length % _chunkSize != 0)
+            {
+                totalChunks++;
+            }
+
+            int counter = 0;
+            for (int i = 0; i < message.Length; i += _chunkSize)
+            {
+                int[] data = new int[Math.Min(_chunkSize, message.Length - i)];
+                Buffer.BlockCopy(message, i * sizeof(int), data, 0, data.Length * sizeof(int));
+
+                messageList.Add(counter == totalChunks - 1
+                    ? new PipelineMessage<int[]>(data, true)
+                    : new PipelineMessage<int[]>(data, false));
+
+                counter++;
+            }
+
+            return messageList;
+        }
+
+        public int[] FullMessage(List<PipelineMessage<int[]>> pipelineMessage)
+        {
+            int size = pipelineMessage.Select(x => x.Data.Length).Sum();
+            int[] data = new int[size];
+            int offset = 0;
+
+            foreach (var message in pipelineMessage)
+            {
+                Buffer.BlockCopy(message.Data, 0, data, offset, message.Data.Length * sizeof(int));
+                offset += message.Data.Length * sizeof(int);
+            }
+
+            return data;
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network.Tests/Org.Apache.REEF.Network.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/Org.Apache.REEF.Network.Tests.csproj
@@ -59,23 +59,27 @@ under the License.
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Org.Apache.REEF.Common\Org.Apache.REEF.Common.csproj">
+    <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Common\Org.Apache.REEF.Common.csproj">
       <Project>{545a0582-4105-44ce-b99c-b1379514a630}</Project>
       <Name>Org.Apache.REEF.Common</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Org.Apache.REEF.Examples\Org.Apache.REEF.Examples.csproj">
+    <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Examples\Org.Apache.REEF.Examples.csproj">
       <Project>{75503f90-7b82-4762-9997-94b5c68f15db}</Project>
       <Name>Org.Apache.REEF.Examples</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Org.Apache.REEF.Network\Org.Apache.REEF.Network.csproj">
+    <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Network.Examples\Org.Apache.REEF.Network.Examples.csproj">
+      <Project>{b1b43b60-ddd0-4805-a9b4-ba84a0ccb7c7}</Project>
+      <Name>Org.Apache.REEF.Network.Examples</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Network\Org.Apache.REEF.Network.csproj">
       <Project>{883ce800-6a6a-4e0a-b7fe-c054f4f2c1dc}</Project>
       <Name>Org.Apache.REEF.Network</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Org.Apache.REEF.Tang\Org.Apache.REEF.Tang.csproj">
+    <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Tang\Org.Apache.REEF.Tang.csproj">
       <Project>{97dbb573-3994-417a-9f69-ffa25f00d2a6}</Project>
       <Name>Org.Apache.REEF.Tang</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Org.Apache.REEF.Wake\Org.Apache.REEF.Wake.csproj">
+    <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Wake\Org.Apache.REEF.Wake.csproj">
       <Project>{cdfb3464-4041-42b1-9271-83af24cd5008}</Project>
       <Name>Org.Apache.REEF.Wake</Name>
     </ProjectReference>

--- a/lang/cs/Org.Apache.REEF.Network/Group/Config/GroupCommConfigurationOptions.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Config/GroupCommConfigurationOptions.cs
@@ -103,5 +103,10 @@ namespace Org.Apache.REEF.Network.Group.Config
         public class MessageType : Name<string>
         {
         }
+
+        [NamedParameter("Wether or not to call topology initialize", defaultValue: "true")]
+        public class Initialize : Name<bool>
+        {
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Config/GroupCommConfigurationOptions.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Config/GroupCommConfigurationOptions.cs
@@ -98,5 +98,10 @@ namespace Org.Apache.REEF.Network.Group.Config
         public class TopologyChildTaskIds : Name<ISet<string>>
         {
         }
+
+        [NamedParameter("Type of the message")]
+        public class MessageType : Name<string>
+        {
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/CommunicationGroupDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/CommunicationGroupDriver.cs
@@ -316,9 +316,6 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
             {
                 var innerConf =
                     TangFactory.GetTang().NewConfigurationBuilder(GetOperatorConfiguration(operatorName, taskId))
-                        .BindNamedParameter<GroupCommConfigurationOptions.DriverId, string>(
-                            GenericType<GroupCommConfigurationOptions.DriverId>.Class,
-                            _driverId)
                         .BindNamedParameter<GroupCommConfigurationOptions.OperatorName, string>(
                             GenericType<GroupCommConfigurationOptions.OperatorName>.Class,
                             operatorName)

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/IGroupCommOperator.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/IGroupCommOperator.cs
@@ -39,10 +39,5 @@ namespace Org.Apache.REEF.Network.Group.Operators
         /// The operator version number.
         /// </summary>
         int Version { get; }
-
-        /// <summary>
-        /// It does necessary checks to make sure the operator is ready to send/receive messages from/to tasks
-        /// </summary>
-        void Initialize();
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/IGroupCommOperator.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/IGroupCommOperator.cs
@@ -40,6 +40,9 @@ namespace Org.Apache.REEF.Network.Group.Operators
         /// </summary>
         int Version { get; }
 
+        /// <summary>
+        /// It does necessary checks to make sure the operator is ready to send/receive messages from/to tasks
+        /// </summary>
         void Initialize();
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/IGroupCommOperator.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/IGroupCommOperator.cs
@@ -39,5 +39,7 @@ namespace Org.Apache.REEF.Network.Group.Operators
         /// The operator version number.
         /// </summary>
         int Version { get; }
+
+        void Initialize();
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/BroadcastReceiver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/BroadcastReceiver.cs
@@ -50,7 +50,7 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         /// <param name="networkHandler">The incoming message handler</param>
         /// <param name="dataConverter">The converter used to convert original message to pipelined ones and vice versa.</param>
         [Inject]
-        public BroadcastReceiver(
+        private BroadcastReceiver(
             [Parameter(typeof(GroupCommConfigurationOptions.OperatorName))] string operatorName,
             [Parameter(typeof(GroupCommConfigurationOptions.CommunicationGroupName))] string groupName,
             [Parameter(typeof(GroupCommConfigurationOptions.Initialize))] bool initialize,

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/BroadcastReceiver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/BroadcastReceiver.cs
@@ -36,26 +36,24 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
     public class BroadcastReceiver<T> : IBroadcastReceiver<T>
     {
         private const int PipelineVersion = 2;
-        private readonly ICommunicationGroupNetworkObserver _networkHandler;
         private readonly OperatorTopology<PipelineMessage<T>> _topology;
-        private static readonly Logger Logger = Logger.GetLogger(typeof (BroadcastReceiver<T>));
-        private bool _isInitialized = false;
-        private object initializeLock = new object();
+        private static readonly Logger Logger = Logger.GetLogger(typeof(BroadcastReceiver<T>));
 
         /// <summary>
         /// Creates a new BroadcastReceiver.
         /// </summary>
         /// <param name="operatorName">The operator identifier</param>
-        /// <param name="groupName">The name of the CommunicationGroup that the
-        /// operator belongs to</param>
+        /// <param name="groupName">The name of the CommunicationGroup that the operator belongs to</param>
+        /// <param name="initialize">Require Topology Initialize to be called to wait for all task being registered. 
+        /// Default is true. For unit testing, it can be set to false.</param>
         /// <param name="topology">The node's topology graph</param>
         /// <param name="networkHandler">The incoming message handler</param>
-        /// <param name="dataConverter">The converter used to convert original
-        /// message to pipelined ones and vice versa.</param>
+        /// <param name="dataConverter">The converter used to convert original message to pipelined ones and vice versa.</param>
         [Inject]
         public BroadcastReceiver(
             [Parameter(typeof(GroupCommConfigurationOptions.OperatorName))] string operatorName,
             [Parameter(typeof(GroupCommConfigurationOptions.CommunicationGroupName))] string groupName,
+            [Parameter(typeof(GroupCommConfigurationOptions.Initialize))] bool initialize,
             OperatorTopology<PipelineMessage<T>> topology,
             ICommunicationGroupNetworkObserver networkHandler,
             IPipelineDataConverter<T> dataConverter)
@@ -63,14 +61,16 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
             OperatorName = operatorName;
             GroupName = groupName;
             Version = PipelineVersion;
-
-            _networkHandler = networkHandler;
+            PipelineDataConverter = dataConverter;
             _topology = topology;
 
             var msgHandler = Observer.Create<GroupCommunicationMessage>(message => _topology.OnNext(message));
-            _networkHandler.Register(operatorName, msgHandler);
+            networkHandler.Register(operatorName, msgHandler);
 
-            PipelineDataConverter = dataConverter;
+            if (initialize)
+            {
+                topology.Initialize();
+            }
         }
 
         /// <summary>
@@ -92,24 +92,6 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         /// Returns the IPipelineDataConvert used to convert messages to pipeline form and vice-versa
         /// </summary>
         public IPipelineDataConverter<T> PipelineDataConverter { get; private set; }
-
-        /// <summary>
-        /// It does necessary checks in topology to make sure the operator is ready to send/receive messages from/to tasks
-        /// </summary>
-        public void Initialize()
-        {
-            if (!_isInitialized)
-            {
-                lock (initializeLock)
-                {
-                    if (!_isInitialized)
-                    {
-                        _topology.Initialize();
-                        _isInitialized = true;
-                    }
-                }
-            }
-        }
 
         /// <summary>
         /// Receive a message from parent BroadcastSender.

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/BroadcastReceiver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/BroadcastReceiver.cs
@@ -38,7 +38,9 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         private const int PipelineVersion = 2;
         private readonly ICommunicationGroupNetworkObserver _networkHandler;
         private readonly OperatorTopology<PipelineMessage<T>> _topology;
-        private static readonly Logger Logger = Logger.GetLogger(typeof(BroadcastReceiver<T>));
+        private static readonly Logger Logger = Logger.GetLogger(typeof (BroadcastReceiver<T>));
+        private bool _isInitialize = false;
+
         /// <summary>
         /// Creates a new BroadcastReceiver.
         /// </summary>
@@ -51,8 +53,8 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         /// message to pipelined ones and vice versa.</param>
         [Inject]
         public BroadcastReceiver(
-            [Parameter(typeof(GroupCommConfigurationOptions.OperatorName))] string operatorName,
-            [Parameter(typeof(GroupCommConfigurationOptions.CommunicationGroupName))] string groupName,
+            [Parameter(typeof (GroupCommConfigurationOptions.OperatorName))] string operatorName,
+            [Parameter(typeof (GroupCommConfigurationOptions.CommunicationGroupName))] string groupName,
             OperatorTopology<PipelineMessage<T>> topology,
             ICommunicationGroupNetworkObserver networkHandler,
             IPipelineDataConverter<T> dataConverter)
@@ -63,7 +65,6 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
 
             _networkHandler = networkHandler;
             _topology = topology;
-            _topology.Initialize();
 
             var msgHandler = Observer.Create<GroupCommunicationMessage>(message => _topology.OnNext(message));
             _networkHandler.Register(operatorName, msgHandler);
@@ -91,6 +92,14 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         /// </summary>
         public IPipelineDataConverter<T> PipelineDataConverter { get; private set; }
 
+        public void Initialize()
+        {
+            if (!_isInitialize)
+            {
+                _topology.Initialize();
+                _isInitialize = true;
+            }
+        }
 
         /// <summary>
         /// Receive a message from parent BroadcastSender.
@@ -115,6 +124,5 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
 
             return PipelineDataConverter.FullMessage(messageList);
         }
-
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/BroadcastSender.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/BroadcastSender.cs
@@ -38,6 +38,7 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         private static readonly Logger Logger = Logger.GetLogger(typeof(BroadcastSender<T>));
         private const int PipelineVersion = 2;
         private readonly OperatorTopology<PipelineMessage<T>> _topology;
+        private bool _isInitialize = false;
 
         /// <summary>
         /// Creates a new BroadcastSender to send messages to other Tasks.
@@ -57,17 +58,14 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
             ICommunicationGroupNetworkObserver networkHandler,
             IPipelineDataConverter<T> dataConverter)
         {
+            _topology = topology;
             OperatorName = operatorName;
             GroupName = groupName;
             Version = PipelineVersion;
-
-            _topology = topology;
-            _topology.Initialize();
+            PipelineDataConverter = dataConverter;
 
             var msgHandler = Observer.Create<GroupCommunicationMessage>(message => _topology.OnNext(message));
             networkHandler.Register(operatorName, msgHandler);
-
-            PipelineDataConverter = dataConverter;
         }
 
         /// <summary>
@@ -89,6 +87,18 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         /// Returns the IPipelineDataConvert used to convert messages to pipeline form and vice-versa
         /// </summary>
         public IPipelineDataConverter<T> PipelineDataConverter { get; private set; }
+
+        /// <summary>
+        /// Initialize topology
+        /// </summary>
+        public void Initialize()
+        {
+            if (!_isInitialize)
+            {
+                _topology.Initialize();
+                _isInitialize = true;
+            }
+        }
 
         /// <summary>
         /// Send the data to all BroadcastReceivers.

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/BroadcastSender.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/BroadcastSender.cs
@@ -38,7 +38,8 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         private static readonly Logger Logger = Logger.GetLogger(typeof(BroadcastSender<T>));
         private const int PipelineVersion = 2;
         private readonly OperatorTopology<PipelineMessage<T>> _topology;
-        private bool _isInitialize = false;
+        private bool _isInitialized = false;
+        private object initializeLock = new object();
 
         /// <summary>
         /// Creates a new BroadcastSender to send messages to other Tasks.
@@ -89,14 +90,20 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         public IPipelineDataConverter<T> PipelineDataConverter { get; private set; }
 
         /// <summary>
-        /// Initialize topology
+        /// It does necessary checks in topology to make sure the operator is ready to send/receive messages from/to tasks
         /// </summary>
         public void Initialize()
         {
-            if (!_isInitialize)
+            if (!_isInitialized)
             {
-                _topology.Initialize();
-                _isInitialize = true;
+                lock (initializeLock)
+                {
+                    if (!_isInitialized)
+                    {
+                        _topology.Initialize();
+                        _isInitialized = true;
+                    }
+                }
             }
         }
 

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceReceiver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceReceiver.cs
@@ -53,7 +53,7 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         /// <param name="dataConverter">The converter used to convert original
         /// message to pipelined ones and vice versa.</param>
         [Inject]
-        public ReduceReceiver(
+        private ReduceReceiver(
             [Parameter(typeof(GroupCommConfigurationOptions.OperatorName))] string operatorName,
             [Parameter(typeof(GroupCommConfigurationOptions.CommunicationGroupName))] string groupName,
             [Parameter(typeof(GroupCommConfigurationOptions.Initialize))] bool initialize,

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceReceiver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceReceiver.cs
@@ -39,7 +39,8 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         private const int PipelineVersion = 2;
         private readonly OperatorTopology<PipelineMessage<T>> _topology;
         private readonly PipelinedReduceFunction<T> _pipelinedReduceFunc;
-        private bool _isInitialize = false;
+        private bool _isInitialized = false;
+        private object initializeLock = new object();
 
         /// <summary>
         /// Creates a new ReduceReceiver.
@@ -74,12 +75,21 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
             PipelineDataConverter = dataConverter;
         }
 
+        /// <summary>
+        /// It does necessary checks in topology to make sure the operator is ready to send/receive messages from/to tasks
+        /// </summary>
         public void Initialize()
         {
-            if (!_isInitialize)
+            if (!_isInitialized)
             {
-                _topology.Initialize();
-                _isInitialize = true;
+                lock (initializeLock)
+                {
+                    if (!_isInitialized)
+                    {
+                        _topology.Initialize();
+                        _isInitialized = true;
+                    }
+                }
             }
         }
 

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceReceiver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceReceiver.cs
@@ -39,6 +39,7 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         private const int PipelineVersion = 2;
         private readonly OperatorTopology<PipelineMessage<T>> _topology;
         private readonly PipelinedReduceFunction<T> _pipelinedReduceFunc;
+        private bool _isInitialize = false;
 
         /// <summary>
         /// Creates a new ReduceReceiver.
@@ -66,12 +67,20 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
 
             _pipelinedReduceFunc = new PipelinedReduceFunction<T>(ReduceFunction);
             _topology = topology;
-            _topology.Initialize();
 
             var msgHandler = Observer.Create<GroupCommunicationMessage>(message => _topology.OnNext(message));
             networkHandler.Register(operatorName, msgHandler);
 
             PipelineDataConverter = dataConverter;
+        }
+
+        public void Initialize()
+        {
+            if (!_isInitialize)
+            {
+                _topology.Initialize();
+                _isInitialize = true;
+            }
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceSender.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceSender.cs
@@ -40,8 +40,6 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         private const int PipelineVersion = 2;
         private readonly OperatorTopology<PipelineMessage<T>> _topology;
         private readonly PipelinedReduceFunction<T> _pipelinedReduceFunc;
-        private bool _isInitialized = false;
-        private object initializeLock = new object();
 
         /// <summary>
         /// Creates a new ReduceSender.
@@ -109,24 +107,6 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         /// Returns the IPipelineDataConvert used to convert messages to pipeline form and vice-versa
         /// </summary>
         public IPipelineDataConverter<T> PipelineDataConverter { get; private set; }
-
-        /// <summary>
-        /// It does necessary checks in topology to make sure the operator is ready to send/receive messages from/to tasks
-        /// </summary>
-        public void Initialize()
-        {
-            if (!_isInitialized)
-            {
-                lock (initializeLock)
-                {
-                    if (!_isInitialized)
-                    {
-                        _topology.Initialize();
-                        _isInitialized = true;
-                    }
-                }
-            }
-        }
 
         /// <summary>
         /// Sends the data to the operator's ReduceReceiver to be aggregated.

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceSender.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceSender.cs
@@ -40,6 +40,7 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         private const int PipelineVersion = 2;
         private readonly OperatorTopology<PipelineMessage<T>> _topology;
         private readonly PipelinedReduceFunction<T> _pipelinedReduceFunc;
+        private bool _isInitialize = false;
 
         /// <summary>
         /// Creates a new ReduceSender.
@@ -68,7 +69,6 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
 
             _pipelinedReduceFunc = new PipelinedReduceFunction<T>(ReduceFunction);
             _topology = topology;
-            _topology.Initialize();
 
             var msgHandler = Observer.Create<GroupCommunicationMessage>(message => _topology.OnNext(message));
             networkHandler.Register(operatorName, msgHandler);
@@ -100,6 +100,15 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         /// Returns the IPipelineDataConvert used to convert messages to pipeline form and vice-versa
         /// </summary>
         public IPipelineDataConverter<T> PipelineDataConverter { get; private set; }
+
+        public void Initialize()
+        {
+            if (!_isInitialize)
+            {
+                _topology.Initialize();
+                _isInitialize = true;
+            }
+        }
 
         /// <summary>
         /// Sends the data to the operator's ReduceReceiver to be aggregated.

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceSender.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceSender.cs
@@ -56,7 +56,7 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         /// <param name="dataConverter">The converter used to convert original
         /// message to pipelined ones and vice versa.</param>
         [Inject]
-        public ReduceSender(
+        private ReduceSender(
             [Parameter(typeof(GroupCommConfigurationOptions.OperatorName))] string operatorName,
             [Parameter(typeof(GroupCommConfigurationOptions.CommunicationGroupName))] string groupName,
             [Parameter(typeof(GroupCommConfigurationOptions.Initialize))] bool initialize,

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceSender.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceSender.cs
@@ -40,7 +40,8 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         private const int PipelineVersion = 2;
         private readonly OperatorTopology<PipelineMessage<T>> _topology;
         private readonly PipelinedReduceFunction<T> _pipelinedReduceFunc;
-        private bool _isInitialize = false;
+        private bool _isInitialized = false;
+        private object initializeLock = new object();
 
         /// <summary>
         /// Creates a new ReduceSender.
@@ -101,12 +102,21 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         /// </summary>
         public IPipelineDataConverter<T> PipelineDataConverter { get; private set; }
 
+        /// <summary>
+        /// It does necessary checks in topology to make sure the operator is ready to send/receive messages from/to tasks
+        /// </summary>
         public void Initialize()
         {
-            if (!_isInitialize)
+            if (!_isInitialized)
             {
-                _topology.Initialize();
-                _isInitialize = true;
+                lock (initializeLock)
+                {
+                    if (!_isInitialized)
+                    {
+                        _topology.Initialize();
+                        _isInitialized = true;
+                    }
+                }
             }
         }
 

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceSender.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ReduceSender.cs
@@ -36,7 +36,7 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
     /// <typeparam name="T">The message type</typeparam>
     public class ReduceSender<T> : IReduceSender<T>
     {
-        private static readonly Logger Logger = Logger.GetLogger(typeof (ReduceSender<T>));
+        private static readonly Logger Logger = Logger.GetLogger(typeof(ReduceSender<T>));
         private const int PipelineVersion = 2;
         private readonly OperatorTopology<PipelineMessage<T>> _topology;
         private readonly PipelinedReduceFunction<T> _pipelinedReduceFunc;
@@ -48,6 +48,8 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         /// </summary>
         /// <param name="operatorName">The name of the reduce operator</param>
         /// <param name="groupName">The name of the reduce operator's CommunicationGroup</param>
+        /// <param name="initialize">Require Topology Initialize to be called to wait for all task being registered. 
+        /// Default is true. For unit testing, it can be set to false.</param>
         /// <param name="topology">The Task's operator topology graph</param>
         /// <param name="networkHandler">The handler used to handle incoming messages</param>
         /// <param name="reduceFunction">The function used to reduce the incoming messages</param>
@@ -57,6 +59,7 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         public ReduceSender(
             [Parameter(typeof(GroupCommConfigurationOptions.OperatorName))] string operatorName,
             [Parameter(typeof(GroupCommConfigurationOptions.CommunicationGroupName))] string groupName,
+            [Parameter(typeof(GroupCommConfigurationOptions.Initialize))] bool initialize,
             OperatorTopology<PipelineMessage<T>> topology,
             ICommunicationGroupNetworkObserver networkHandler,
             IReduceFunction<T> reduceFunction,
@@ -75,6 +78,11 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
             networkHandler.Register(operatorName, msgHandler);
 
             PipelineDataConverter = dataConverter;
+
+            if (initialize)
+            {
+                topology.Initialize();
+            }
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ScatterReceiver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ScatterReceiver.cs
@@ -38,6 +38,7 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
 
         private readonly ICommunicationGroupNetworkObserver _networkHandler;
         private readonly OperatorTopology<T> _topology;
+        private bool _isInitialize = false;
 
         /// <summary>
         /// Creates a new ScatterReceiver.
@@ -59,7 +60,6 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
 
             _networkHandler = networkHandler;
             _topology = topology;
-            _topology.Initialize();
 
             var msgHandler = Observer.Create<GroupCommunicationMessage>(message => _topology.OnNext(message));
             _networkHandler.Register(operatorName, msgHandler);
@@ -79,6 +79,15 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         /// Returns the operator version.
         /// </summary>
         public int Version { get; private set; }
+
+        public void Initialize()
+        {
+            if (!_isInitialize)
+            {
+                _topology.Initialize();
+                _isInitialize = true;
+            }
+        }
 
         /// <summary>
         /// Returns the class used to reduce incoming messages sent by ReduceSenders.

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ScatterReceiver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ScatterReceiver.cs
@@ -38,7 +38,8 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
 
         private readonly ICommunicationGroupNetworkObserver _networkHandler;
         private readonly OperatorTopology<T> _topology;
-        private bool _isInitialize = false;
+        private bool _isInitialized = false;
+        private object initializeLock = new object();
 
         /// <summary>
         /// Creates a new ScatterReceiver.
@@ -80,12 +81,21 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         /// </summary>
         public int Version { get; private set; }
 
+        /// <summary>
+        /// It does necessary checks in topology to make sure the operator is ready to send/receive messages from/to tasks
+        /// </summary>
         public void Initialize()
         {
-            if (!_isInitialize)
+            if (!_isInitialized)
             {
-                _topology.Initialize();
-                _isInitialize = true;
+                lock (initializeLock)
+                {
+                    if (!_isInitialized)
+                    {
+                        _topology.Initialize();
+                        _isInitialized = true;
+                    }
+                }
             }
         }
 

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ScatterReceiver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ScatterReceiver.cs
@@ -47,7 +47,7 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         /// <param name="topology">The task's operator topology graph</param>
         /// <param name="networkHandler">Handles incoming messages from other tasks</param>
         [Inject]
-        public ScatterReceiver(
+        private ScatterReceiver(
             [Parameter(typeof(GroupCommConfigurationOptions.OperatorName))] string operatorName,
             [Parameter(typeof(GroupCommConfigurationOptions.CommunicationGroupName))] string groupName,
             [Parameter(typeof(GroupCommConfigurationOptions.Initialize))] bool initialize,

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ScatterSender.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ScatterSender.cs
@@ -36,35 +36,36 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
     public class ScatterSender<T> : IScatterSender<T>
     {
         private const int DefaultVersion = 1;
-
-        private readonly ICommunicationGroupNetworkObserver _networkHandler;
         private readonly OperatorTopology<T> _topology;
-        private bool _isInitialized = false;
-        private object initializeLock = new object();
 
         /// <summary>
         /// Creates a new ScatterSender.
         /// </summary>
         /// <param name="operatorName">The name of the scatter operator</param>
         /// <param name="groupName">The name of the operator's Communication Group</param>
+        /// <param name="initialize">Require Topology Initialize to be called to wait for all task being registered. Default is true. For unit testing, it can be set to false.</param>
         /// <param name="topology">The operator topology</param>
         /// <param name="networkHandler">The network handler</param>
         [Inject]
         public ScatterSender(
             [Parameter(typeof(GroupCommConfigurationOptions.OperatorName))] string operatorName,
             [Parameter(typeof(GroupCommConfigurationOptions.CommunicationGroupName))] string groupName,
+            [Parameter(typeof(GroupCommConfigurationOptions.Initialize))] bool initialize,
             OperatorTopology<T> topology,
             ICommunicationGroupNetworkObserver networkHandler)
         {
             OperatorName = operatorName;
             GroupName = groupName;
             Version = DefaultVersion;
-
-            _networkHandler = networkHandler;
             _topology = topology;
 
             var msgHandler = Observer.Create<GroupCommunicationMessage>(message => _topology.OnNext(message));
-            _networkHandler.Register(operatorName, msgHandler);
+            networkHandler.Register(operatorName, msgHandler);
+
+            if (initialize)
+            {
+                topology.Initialize();
+            }
         }
 
         public string OperatorName { get; private set; }
@@ -72,24 +73,6 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         public string GroupName { get; private set; }
 
         public int Version { get; private set; }
-
-        /// <summary>
-        /// It does necessary checks in topology to make sure the operator is ready to send/receive messages from/to tasks
-        /// </summary>
-        public void Initialize()
-        {
-            if (!_isInitialized)
-            {
-                lock (initializeLock)
-                {
-                    if (!_isInitialized)
-                    {
-                        _topology.Initialize();
-                        _isInitialized = true;
-                    }
-                }
-            }
-        }
 
         /// <summary>
         /// Split up the list of elements evenly and scatter each chunk

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ScatterSender.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ScatterSender.cs
@@ -38,6 +38,7 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
 
         private readonly ICommunicationGroupNetworkObserver _networkHandler;
         private readonly OperatorTopology<T> _topology;
+        private bool _isInitialize = false;
 
         /// <summary>
         /// Creates a new ScatterSender.
@@ -59,7 +60,6 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
 
             _networkHandler = networkHandler;
             _topology = topology;
-            _topology.Initialize();
 
             var msgHandler = Observer.Create<GroupCommunicationMessage>(message => _topology.OnNext(message));
             _networkHandler.Register(operatorName, msgHandler);
@@ -70,6 +70,15 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         public string GroupName { get; private set; }
 
         public int Version { get; private set; }
+
+        public void Initialize()
+        {
+            if (!_isInitialize)
+            {
+                _topology.Initialize();
+                _isInitialize = true;
+            }
+        }
 
         /// <summary>
         /// Split up the list of elements evenly and scatter each chunk

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ScatterSender.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ScatterSender.cs
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+using System;
 using System.Collections.Generic;
 using System.Reactive;
 using Org.Apache.REEF.Network.Group.Config;
@@ -38,7 +39,8 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
 
         private readonly ICommunicationGroupNetworkObserver _networkHandler;
         private readonly OperatorTopology<T> _topology;
-        private bool _isInitialize = false;
+        private bool _isInitialized = false;
+        private object initializeLock = new object();
 
         /// <summary>
         /// Creates a new ScatterSender.
@@ -71,12 +73,21 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
 
         public int Version { get; private set; }
 
+        /// <summary>
+        /// It does necessary checks in topology to make sure the operator is ready to send/receive messages from/to tasks
+        /// </summary>
         public void Initialize()
         {
-            if (!_isInitialize)
+            if (!_isInitialized)
             {
-                _topology.Initialize();
-                _isInitialize = true;
+                lock (initializeLock)
+                {
+                    if (!_isInitialized)
+                    {
+                        _topology.Initialize();
+                        _isInitialized = true;
+                    }
+                }
             }
         }
 

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ScatterSender.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ScatterSender.cs
@@ -43,11 +43,12 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         /// </summary>
         /// <param name="operatorName">The name of the scatter operator</param>
         /// <param name="groupName">The name of the operator's Communication Group</param>
-        /// <param name="initialize">Require Topology Initialize to be called to wait for all task being registered. Default is true. For unit testing, it can be set to false.</param>
+        /// <param name="initialize">Require Topology Initialize to be called to wait for all task being registered. 
+        /// Default is true. For unit testing, it can be set to false.</param>
         /// <param name="topology">The operator topology</param>
         /// <param name="networkHandler">The network handler</param>
         [Inject]
-        public ScatterSender(
+        private ScatterSender(
             [Parameter(typeof(GroupCommConfigurationOptions.OperatorName))] string operatorName,
             [Parameter(typeof(GroupCommConfigurationOptions.CommunicationGroupName))] string groupName,
             [Parameter(typeof(GroupCommConfigurationOptions.Initialize))] bool initialize,

--- a/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/CommunicationGroupClient.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/CommunicationGroupClient.cs
@@ -50,7 +50,7 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
         /// <param name="commGroupNetworkHandler">Communication group network observer that holds all the handlers for each operator.</param>
         /// <param name="injector">injector forked from the injector that creates this instance</param>
         [Inject]
-        public CommunicationGroupClient(
+        private CommunicationGroupClient(
             [Parameter(typeof(GroupCommConfigurationOptions.CommunicationGroupName))] string groupName,
             [Parameter(typeof(GroupCommConfigurationOptions.SerializedOperatorConfigs))] ISet<string> operatorConfigs,
             IGroupCommNetworkObserver groupCommNetworkObserver,
@@ -74,9 +74,9 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
                     GenericType<GroupCommConfigurationOptions.MessageType>.Class);
 
                 Type groupCommOperatorGenericInterface = typeof(IGroupCommOperator<>);
-                Type groupCommOperatorInterface = groupCommOperatorGenericInterface.MakeGenericType(new Type[] { Type.GetType(msgType) });
-                var oeratorObj = operatorInjector.GetInstance(groupCommOperatorInterface);
-                _operators.Add(operatorName, oeratorObj);
+                Type groupCommOperatorInterface = groupCommOperatorGenericInterface.MakeGenericType(Type.GetType(msgType));
+                var operatorObj = operatorInjector.GetInstance(groupCommOperatorInterface);
+                _operators.Add(operatorName, operatorObj);
             }
         }
 
@@ -104,9 +104,7 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
         /// <returns>The BroadcastReceiver</returns>
         public IBroadcastReceiver<T> GetBroadcastReceiver<T>(string operatorName)
         {
-            var o = GetOperatorInstance<BroadcastReceiver<T>>(operatorName);
-            o.Initialize();
-            return o;
+            return GetOperatorInstance<BroadcastReceiver<T>>(operatorName);
         }
 
         /// <summary>
@@ -117,9 +115,7 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
         /// <returns>The ReduceSender</returns>
         public IReduceSender<T> GetReduceSender<T>(string operatorName)
         {
-            var o = GetOperatorInstance<ReduceSender<T>>(operatorName);
-            o.Initialize();
-            return o;
+            return GetOperatorInstance<ReduceSender<T>>(operatorName);
         }
 
         /// <summary>
@@ -130,9 +126,7 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
         /// <returns>The ReduceReceiver</returns>
         public IReduceReceiver<T> GetReduceReceiver<T>(string operatorName)
         {
-            var o = GetOperatorInstance<ReduceReceiver<T>>(operatorName);
-            o.Initialize();
-            return o;
+            return GetOperatorInstance<ReduceReceiver<T>>(operatorName);
         }
 
         /// <summary>
@@ -143,9 +137,7 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
         /// <returns>The ScatterSender</returns>
         public IScatterSender<T> GetScatterSender<T>(string operatorName)
         {
-            var o = GetOperatorInstance<ScatterSender<T>>(operatorName);
-            o.Initialize();
-            return o;
+            return GetOperatorInstance<ScatterSender<T>>(operatorName);
         }
 
         /// <summary>
@@ -156,9 +148,7 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
         /// <returns>The ScatterReceiver</returns>
         public IScatterReceiver<T> GetScatterReceiver<T>(string operatorName)
         {
-            var o = GetOperatorInstance<ScatterReceiver<T>>(operatorName);
-            o.Initialize();
-            return o;
+            return GetOperatorInstance<ScatterReceiver<T>>(operatorName);
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/CommunicationGroupClient.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/CommunicationGroupClient.cs
@@ -19,18 +19,14 @@
 
 using System;
 using System.Collections.Generic;
-using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.Network.Group.Config;
-using Org.Apache.REEF.Network.Group.Driver.Impl;
 using Org.Apache.REEF.Network.Group.Operators;
 using Org.Apache.REEF.Network.Group.Operators.Impl;
-using Org.Apache.REEF.Network.NetworkService;
 using Org.Apache.REEF.Tang.Annotations;
-using Org.Apache.REEF.Tang.Exceptions;
 using Org.Apache.REEF.Tang.Formats;
-using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
+using Org.Apache.REEF.Utilities.Diagnostics;
 using Org.Apache.REEF.Utilities.Logging;
 
 namespace Org.Apache.REEF.Network.Group.Task.Impl
@@ -41,61 +37,46 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
     public class CommunicationGroupClient : ICommunicationGroupClient
     {
         private readonly Logger LOGGER = Logger.GetLogger(typeof(CommunicationGroupClient));
-
-        private readonly string _taskId;
-        private string _driverId;
-
-        private readonly Dictionary<string, IInjector> _operatorInjectors; 
         private readonly Dictionary<string, object> _operators;
-        private readonly NetworkService<GroupCommunicationMessage> _networkService; 
-        private readonly IGroupCommNetworkObserver _groupCommNetworkHandler;
-        private readonly ICommunicationGroupNetworkObserver _commGroupNetworkHandler;
 
         /// <summary>
         /// Creates a new CommunicationGroupClient.
         /// </summary>
-        /// <param name="taskId">The identifier for this Task.</param>
         /// <param name="groupName">The name of the CommunicationGroup</param>
-        /// <param name="driverId">The identifier for the driver</param>
         /// <param name="operatorConfigs">The serialized operator configurations</param>
         /// <param name="groupCommNetworkObserver">The handler for all incoming messages
         /// across all Communication Groups</param>
-        /// <param name="networkService">The network service used to send messages.</param>
         /// <param name="configSerializer">Used to deserialize operator configuration.</param>
+        /// <param name="commGroupNetworkHandler">Communication group network observer that holds all the handlers for each operator.</param>
+        /// <param name="injector">injector forked from the injector that creates this instance</param>
         [Inject]
         public CommunicationGroupClient(
-            [Parameter(typeof(TaskConfigurationOptions.Identifier))] string taskId,
             [Parameter(typeof(GroupCommConfigurationOptions.CommunicationGroupName))] string groupName,
-            [Parameter(typeof(GroupCommConfigurationOptions.DriverId))] string driverId,
             [Parameter(typeof(GroupCommConfigurationOptions.SerializedOperatorConfigs))] ISet<string> operatorConfigs,
             IGroupCommNetworkObserver groupCommNetworkObserver,
-            NetworkService<GroupCommunicationMessage> networkService,
             AvroConfigurationSerializer configSerializer,
-            CommunicationGroupNetworkObserver commGroupNetworkHandler)
+            ICommunicationGroupNetworkObserver commGroupNetworkHandler,
+            IInjector injector)
         {
-            _taskId = taskId;
-            _driverId = driverId;
-            GroupName = groupName;
-
             _operators = new Dictionary<string, object>();
-            _operatorInjectors = new Dictionary<string, IInjector>();
 
-            _networkService = networkService;
-            _groupCommNetworkHandler = groupCommNetworkObserver;
-            _commGroupNetworkHandler = commGroupNetworkHandler;
-            _groupCommNetworkHandler.Register(groupName, _commGroupNetworkHandler);
+            GroupName = groupName;
+            groupCommNetworkObserver.Register(groupName, commGroupNetworkHandler);
 
-            // Deserialize operator configuration and store each injector.
-            // When user requests the Group Communication Operator, use type information to
-            // create the instance.
             foreach (string operatorConfigStr in operatorConfigs)
-            {
+            {                
                 IConfiguration operatorConfig = configSerializer.FromString(operatorConfigStr);
 
-                IInjector injector = TangFactory.GetTang().NewInjector(operatorConfig);
-                string operatorName = injector.GetNamedInstance<GroupCommConfigurationOptions.OperatorName, string>(
+                IInjector operatorInjector = injector.ForkInjector(operatorConfig);
+                string operatorName = operatorInjector.GetNamedInstance<GroupCommConfigurationOptions.OperatorName, string>(
                     GenericType<GroupCommConfigurationOptions.OperatorName>.Class);
-                _operatorInjectors[operatorName] = injector;
+                string msgType = operatorInjector.GetNamedInstance<GroupCommConfigurationOptions.MessageType, string>(
+                    GenericType<GroupCommConfigurationOptions.MessageType>.Class);
+
+                Type groupCommOperatorGenericInterface = typeof(IGroupCommOperator<>);
+                Type groupCommOperatorInterface = groupCommOperatorGenericInterface.MakeGenericType(new Type[] { Type.GetType(msgType) });
+                var oeratorObj = operatorInjector.GetInstance(groupCommOperatorInterface);
+                _operators.Add(operatorName, oeratorObj);
             }
         }
 
@@ -123,7 +104,9 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
         /// <returns>The BroadcastReceiver</returns>
         public IBroadcastReceiver<T> GetBroadcastReceiver<T>(string operatorName)
         {
-            return GetOperatorInstance<BroadcastReceiver<T>>(operatorName);
+            var o = GetOperatorInstance<BroadcastReceiver<T>>(operatorName);
+            o.Initialize();
+            return o;
         }
 
         /// <summary>
@@ -134,7 +117,9 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
         /// <returns>The ReduceSender</returns>
         public IReduceSender<T> GetReduceSender<T>(string operatorName)
         {
-            return GetOperatorInstance<ReduceSender<T>>(operatorName);
+            var o = GetOperatorInstance<ReduceSender<T>>(operatorName);
+            o.Initialize();
+            return o;
         }
 
         /// <summary>
@@ -145,7 +130,9 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
         /// <returns>The ReduceReceiver</returns>
         public IReduceReceiver<T> GetReduceReceiver<T>(string operatorName)
         {
-            return GetOperatorInstance<ReduceReceiver<T>>(operatorName);
+            var o = GetOperatorInstance<ReduceReceiver<T>>(operatorName);
+            o.Initialize();
+            return o;
         }
 
         /// <summary>
@@ -156,7 +143,9 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
         /// <returns>The ScatterSender</returns>
         public IScatterSender<T> GetScatterSender<T>(string operatorName)
         {
-            return GetOperatorInstance<ScatterSender<T>>(operatorName);
+            var o = GetOperatorInstance<ScatterSender<T>>(operatorName);
+            o.Initialize();
+            return o;
         }
 
         /// <summary>
@@ -167,7 +156,9 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
         /// <returns>The ScatterReceiver</returns>
         public IScatterReceiver<T> GetScatterReceiver<T>(string operatorName)
         {
-            return GetOperatorInstance<ScatterReceiver<T>>(operatorName);
+            var o = GetOperatorInstance<ScatterReceiver<T>>(operatorName);
+            o.Initialize();
+            return o;
         }
 
         /// <summary>
@@ -185,32 +176,11 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
             {
                 throw new ArgumentNullException("operatorName");
             }
-            if (!_operatorInjectors.ContainsKey(operatorName))
-            {
-                throw new ArgumentException("Invalid operator name, cannot create CommunicationGroupClient");
-            }
 
             object op;
             if (!_operators.TryGetValue(operatorName, out op))
             {
-                IInjector injector = _operatorInjectors[operatorName];
-
-                injector.BindVolatileParameter(GenericType<TaskConfigurationOptions.Identifier>.Class, _taskId);
-                injector.BindVolatileParameter(GenericType<GroupCommConfigurationOptions.CommunicationGroupName>.Class, GroupName);
-                injector.BindVolatileInstance(GenericType<ICommunicationGroupNetworkObserver>.Class, _commGroupNetworkHandler);
-                injector.BindVolatileInstance(GenericType<NetworkService<GroupCommunicationMessage>>.Class, _networkService);
-                injector.BindVolatileInstance(GenericType<ICommunicationGroupClient>.Class, this);
-
-                try
-                {
-                    op = injector.GetInstance<T>();
-                    _operators[operatorName] = op;
-                }
-                catch (InjectionException)
-                {
-                    LOGGER.Log(Level.Error, "Cannot inject Group Communication operator: No known operator of type: {0}", typeof(T));
-                    throw;
-                }
+                Exceptions.Throw(new ArgumentException("Operator is not added at Driver side:" + operatorName), LOGGER);
             }
 
             return (T) op;

--- a/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/CommunicationGroupNetworkObserver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/CommunicationGroupNetworkObserver.cs
@@ -109,7 +109,7 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
             {
                 if (!_handlers.ContainsKey(operatorName))
                 {
-                    LOGGER.Log(Level.Info, "handler for operator {0} has not been registered." + operatorName);
+                    LOGGER.Log(Level.Warning, "Handler for operator {0} has not been registered. You should never reach here!!!" + operatorName);
                     Thread.Sleep(sleepTime);
                 }
                 else

--- a/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/CommunicationGroupNetworkObserver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/CommunicationGroupNetworkObserver.cs
@@ -35,20 +35,14 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
     {
         private static readonly Logger LOGGER = Logger.GetLogger(typeof(CommunicationGroupNetworkObserver));
         private readonly Dictionary<string, IObserver<GroupCommunicationMessage>> _handlers;
-        private readonly int _retryCount;
-        private readonly int _sleepTime;
 
         /// <summary>
         /// Creates a new CommunicationGroupNetworkObserver.
         /// </summary>
         [Inject]
-        public CommunicationGroupNetworkObserver(
-            [Parameter(typeof(GroupCommConfigurationOptions.RetryCountWaitingForHanler))] int retryCount,
-            [Parameter(typeof(GroupCommConfigurationOptions.SleepTimeWaitingForHandler))] int sleepTime)
+        public CommunicationGroupNetworkObserver()
         {
             _handlers = new Dictionary<string, IObserver<GroupCommunicationMessage>>();
-            _retryCount = retryCount;
-            _sleepTime = sleepTime;
         }
 
         /// <summary>
@@ -83,7 +77,7 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
         {
             string operatorName = message.OperatorName;
 
-            IObserver<GroupCommunicationMessage> handler = GetOperatorHandler(operatorName, _retryCount, _sleepTime);
+            IObserver<GroupCommunicationMessage> handler = GetOperatorHandler(operatorName);
 
             if (handler == null)
             {
@@ -99,30 +93,15 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
         /// GetOperatorHandler for operatorName
         /// </summary>
         /// <param name="operatorName"></param>
-        /// <param name="retry"></param>
-        /// <param name="sleepTime"></param>
         /// <returns></returns>
-        private IObserver<GroupCommunicationMessage> GetOperatorHandler(string operatorName, int retry, int sleepTime)
+        private IObserver<GroupCommunicationMessage> GetOperatorHandler(string operatorName)
         {
-            //registration of handler might be delayed while the Network Service has received message from other servers
-            for (int i = 0; i < retry; i++)
+            IObserver<GroupCommunicationMessage> handler;
+            if (!_handlers.TryGetValue(operatorName, out handler))
             {
-                if (!_handlers.ContainsKey(operatorName))
-                {
-                    LOGGER.Log(Level.Warning, "Handler for operator {0} has not been registered. You should never reach here!!!" + operatorName);
-                    Thread.Sleep(sleepTime);
-                }
-                else
-                {
-                    IObserver<GroupCommunicationMessage> handler;
-                    if (!_handlers.TryGetValue(operatorName, out handler))
-                    {
-                        Exceptions.Throw(new ArgumentException("No handler registered yet with the operator name: " + operatorName), LOGGER);
-                    }
-                    return handler;
-                }
+                Exceptions.Throw(new ApplicationException("No handler registered yet with the operator name: " + operatorName), LOGGER);
             }
-            return null;
+            return handler;
         }
 
         public void OnError(Exception error)

--- a/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/GroupCommClient.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/GroupCommClient.cs
@@ -25,15 +25,13 @@ using Org.Apache.REEF.Network.Group.Driver.Impl;
 using Org.Apache.REEF.Network.NetworkService;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Formats;
-using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
-using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Wake.Remote.Impl;
 
 namespace Org.Apache.REEF.Network.Group.Task.Impl
 {
     /// <summary>
-    /// Used by Tasks to fetch CommunicationGroupClients.
+    /// Container of ommunicationGroupClients
     /// </summary>
     public class GroupCommClient : IGroupCommClient
     {
@@ -46,17 +44,17 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
         /// </summary>
         /// <param name="groupConfigs">The set of serialized Group Communication configurations</param>
         /// <param name="taskId">The identifier for this task</param>
-        /// <param name="groupCommNetworkObserver">The network handler to receive incoming messages
         /// for this task</param>
         /// <param name="networkService">The network service used to send messages</param>
         /// <param name="configSerializer">Used to deserialize Group Communication configuration</param>
+        /// <param name="injector">injector forked from the injector that creates this instance</param>
         [Inject]
         public GroupCommClient(
             [Parameter(typeof(GroupCommConfigurationOptions.SerializedGroupConfigs))] ISet<string> groupConfigs,
             [Parameter(typeof(TaskConfigurationOptions.Identifier))] string taskId,
-            IGroupCommNetworkObserver groupCommNetworkObserver,
             NetworkService<GroupCommunicationMessage> networkService,
-            AvroConfigurationSerializer configSerializer)
+            AvroConfigurationSerializer configSerializer,
+            IInjector injector)
         {
             _commGroups = new Dictionary<string, ICommunicationGroupClient>();
             _networkService = networkService;
@@ -65,14 +63,9 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
             foreach (string serializedGroupConfig in groupConfigs)
             {
                 IConfiguration groupConfig = configSerializer.FromString(serializedGroupConfig);
-
-                IInjector injector = TangFactory.GetTang().NewInjector(groupConfig);
-                injector.BindVolatileParameter(GenericType<TaskConfigurationOptions.Identifier>.Class, taskId);
-                injector.BindVolatileInstance(GenericType<IGroupCommNetworkObserver>.Class, groupCommNetworkObserver);
-                injector.BindVolatileInstance(GenericType<NetworkService<GroupCommunicationMessage>>.Class, networkService);
-
-                ICommunicationGroupClient commGroup = injector.GetInstance<ICommunicationGroupClient>();
-                _commGroups[commGroup.GroupName] = commGroup;
+                IInjector groupInjector = injector.ForkInjector(groupConfig);
+                ICommunicationGroupClient commGroupClient = groupInjector.GetInstance<ICommunicationGroupClient>();
+                _commGroups[commGroupClient.GroupName] = commGroupClient;
             }
         }
 

--- a/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/GroupCommClient.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/GroupCommClient.cs
@@ -41,15 +41,15 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
 
         /// <summary>
         /// Creates a new GroupCommClient and registers the task ID with the Name Server.
+        /// Currently the GroupCommClient is injected in task constructor. When work with REEF-289, we should put the injection at a proepr palce. 
         /// </summary>
         /// <param name="groupConfigs">The set of serialized Group Communication configurations</param>
-        /// <param name="taskId">The identifier for this task</param>
-        /// for this task</param>
+        /// <param name="taskId">The identifier for this taskfor this task</param>
         /// <param name="networkService">The network service used to send messages</param>
         /// <param name="configSerializer">Used to deserialize Group Communication configuration</param>
         /// <param name="injector">injector forked from the injector that creates this instance</param>
         [Inject]
-        public GroupCommClient(
+        private GroupCommClient(
             [Parameter(typeof(GroupCommConfigurationOptions.SerializedGroupConfigs))] ISet<string> groupConfigs,
             [Parameter(typeof(TaskConfigurationOptions.Identifier))] string taskId,
             NetworkService<GroupCommunicationMessage> networkService,

--- a/lang/cs/Org.Apache.REEF.Network/Group/Topology/FlatTopology.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Topology/FlatTopology.cs
@@ -110,10 +110,12 @@ namespace Org.Apache.REEF.Network.Group.Topology
                 if (taskId.Equals(broadcastSpec.SenderId))
                 {
                     confBuilder.BindImplementation(GenericType<IGroupCommOperator<T>>.Class, GenericType<BroadcastSender<T>>.Class);
+                    SetMessageType(typeof(BroadcastSender<T>), confBuilder);
                 }
                 else
                 {
                     confBuilder.BindImplementation(GenericType<IGroupCommOperator<T>>.Class, GenericType<BroadcastReceiver<T>>.Class);
+                    SetMessageType(typeof(BroadcastReceiver<T>), confBuilder);
                 }
             }
             else if (OperatorSpec is ReduceOperatorSpec)
@@ -122,10 +124,12 @@ namespace Org.Apache.REEF.Network.Group.Topology
                 if (taskId.Equals(reduceSpec.ReceiverId))
                 {
                     confBuilder.BindImplementation(GenericType<IGroupCommOperator<T>>.Class, GenericType<ReduceReceiver<T>>.Class);
+                    SetMessageType(typeof(ReduceReceiver<T>), confBuilder);
                 }
                 else
                 {
                     confBuilder.BindImplementation(GenericType<IGroupCommOperator<T>>.Class, GenericType<ReduceSender<T>>.Class);
+                    SetMessageType(typeof(ReduceSender<T>), confBuilder);
                 }
             }
             else if (OperatorSpec is ScatterOperatorSpec)
@@ -134,10 +138,12 @@ namespace Org.Apache.REEF.Network.Group.Topology
                 if (taskId.Equals(scatterSpec.SenderId))
                 {
                     confBuilder.BindImplementation(GenericType<IGroupCommOperator<T>>.Class, GenericType<ScatterSender<T>>.Class);
+                    SetMessageType(typeof(ScatterSender<T>), confBuilder);
                 }
                 else
                 {
                     confBuilder.BindImplementation(GenericType<IGroupCommOperator<T>>.Class, GenericType<ScatterReceiver<T>>.Class);
+                    SetMessageType(typeof(ScatterReceiver<T>), confBuilder);
                 }
             }
             else
@@ -146,6 +152,17 @@ namespace Org.Apache.REEF.Network.Group.Topology
             }
 
             return Configurations.Merge(confBuilder.Build(), OperatorSpec.Configiration);
+        }
+
+        private static void SetMessageType(Type operatorType, ICsConfigurationBuilder confBuilder)
+        {
+            if (operatorType.IsGenericType)
+            {
+                var genericTypes = operatorType.GenericTypeArguments;
+                var msgType = genericTypes[0];
+                confBuilder.BindNamedParameter<GroupCommConfigurationOptions.MessageType, string>(
+                    GenericType<GroupCommConfigurationOptions.MessageType>.Class, msgType.AssemblyQualifiedName);
+            }
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Network/Group/Topology/TreeTopology.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Topology/TreeTopology.cs
@@ -111,7 +111,6 @@ namespace Org.Apache.REEF.Network.Group.Topology
 
             //add parentid, if no parent, add itself
             ICsConfigurationBuilder confBuilder = TangFactory.GetTang().NewConfigurationBuilder()
-                //.BindImplementation(typeof(ICodec<T1>), OperatorSpec.Codec)
                 .BindNamedParameter<GroupCommConfigurationOptions.TopologyRootTaskId, string>(
                     GenericType<GroupCommConfigurationOptions.TopologyRootTaskId>.Class,
                     parentId);
@@ -130,10 +129,12 @@ namespace Org.Apache.REEF.Network.Group.Topology
                 if (taskId.Equals(broadcastSpec.SenderId))
                 {
                     confBuilder.BindImplementation(GenericType<IGroupCommOperator<T>>.Class, GenericType<BroadcastSender<T>>.Class);
+                    SetMessageType(typeof(BroadcastSender<T>), confBuilder);
                 }
                 else
                 {
                     confBuilder.BindImplementation(GenericType<IGroupCommOperator<T>>.Class, GenericType<BroadcastReceiver<T>>.Class);
+                    SetMessageType(typeof(BroadcastReceiver<T>), confBuilder);
                 }
             }
             else if (OperatorSpec is ReduceOperatorSpec)
@@ -142,10 +143,12 @@ namespace Org.Apache.REEF.Network.Group.Topology
                 if (taskId.Equals(reduceSpec.ReceiverId))
                 {
                     confBuilder.BindImplementation(GenericType<IGroupCommOperator<T>>.Class, GenericType<ReduceReceiver<T>>.Class);
+                    SetMessageType(typeof(ReduceReceiver<T>), confBuilder);
                 }
                 else
                 {
                     confBuilder.BindImplementation(GenericType<IGroupCommOperator<T>>.Class, GenericType<ReduceSender<T>>.Class);
+                    SetMessageType(typeof(ReduceSender<T>), confBuilder);
                 }
             }
             else if (OperatorSpec is ScatterOperatorSpec)
@@ -154,10 +157,12 @@ namespace Org.Apache.REEF.Network.Group.Topology
                 if (taskId.Equals(scatterSpec.SenderId))
                 {
                     confBuilder.BindImplementation(GenericType<IGroupCommOperator<T>>.Class, GenericType<ScatterSender<T>>.Class);
+                    SetMessageType(typeof(ScatterSender<T>), confBuilder);
                 }
                 else
                 {
                     confBuilder.BindImplementation(GenericType<IGroupCommOperator<T>>.Class, GenericType<ScatterReceiver<T>>.Class);
+                    SetMessageType(typeof(ScatterReceiver<T>), confBuilder);
                 }
             }
             else
@@ -232,6 +237,17 @@ namespace Org.Apache.REEF.Network.Group.Topology
             _logicalRoot.AddChild(node);
             _prev.Successor = node;
             _prev = node;
+        }
+
+        private static void SetMessageType(Type operatorType, ICsConfigurationBuilder confBuilder)
+        {
+            if (operatorType.IsGenericType)
+            {
+                var genericTypes = operatorType.GenericTypeArguments;
+                var msgType = genericTypes[0];
+                confBuilder.BindNamedParameter<GroupCommConfigurationOptions.MessageType, string>(
+                    GenericType<GroupCommConfigurationOptions.MessageType>.Class, msgType.AssemblyQualifiedName);
+            }
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/Injection/TestInjection.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/Injection/TestInjection.cs
@@ -304,54 +304,56 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
 
             Assert.IsNotNull(o.ExternalObject is ExternalClass);
         }
-        
+
         /// <summary>
-        /// In this test, interface is generic of T. Implementations use different T as type. 
-        /// When doing injection, we need to get type of generic type T so that to get generic interface
+        /// In this test, interface is a generic of T. Implementations have different generic arguments such as int and string. 
+        /// When doing injection, we must specify the interface with a specified argument type
         /// </summary>
         [TestMethod]
-        public void TestInjectionWithT()
+        public void TestInjectionWithGenericArguments()
         {
             var c = TangFactory.GetTang().NewConfigurationBuilder()
                 .BindImplementation(GenericType<IMyOperator<int>>.Class, GenericType<MyOperatorImpl<int>>.Class)
-                .BindImplementation(GenericType<IMyOperator<int[]>>.Class, GenericType<MyOperatorImpl<int[]>>.Class)
                 .BindImplementation(GenericType<IMyOperator<string>>.Class, GenericType<MyOperatorImpl<string>>.Class)
+                .Build();
+
+            var injector = TangFactory.GetTang().NewInjector(c);
+
+            //argument type must be specified in injection
+            var o1 = injector.GetInstance(typeof(IMyOperator<int>));
+            var o2 = injector.GetInstance(typeof(IMyOperator<string>));
+            var o3 = injector.GetInstance(typeof(MyOperatorTopology<int>));
+
+            Assert.IsTrue(o1 is MyOperatorImpl<int>);
+            Assert.IsTrue(o2 is MyOperatorImpl<string>);
+            Assert.IsTrue(o3 is MyOperatorTopology<int>);
+        }
+
+        /// <summary>
+        /// In this test, interface argument type is set through Configuration. We can get the argument type and then 
+        /// make the interface with the argument type on the fly so that to do the injection
+        /// </summary>
+        [TestMethod]
+        public void TestInjectionWithGenericArgumentType()
+        {
+            var c = TangFactory.GetTang().NewConfigurationBuilder()
+                .BindImplementation(GenericType<IMyOperator<int[]>>.Class, GenericType<MyOperatorImpl<int[]>>.Class)
                 .BindNamedParameter(typeof(MessageType), typeof(int[]).AssemblyQualifiedName)
                 .Build();
 
             var injector = TangFactory.GetTang().NewInjector(c);
 
-            var msgType = (string)injector.GetNamedInstance(typeof(MessageType));
-            Type t3 = Type.GetType(msgType);
+            //get argument type from configuration
+            var messageTypeAsString = injector.GetNamedInstance<MessageType, string>(GenericType<MessageType>.Class);
+            Type messageType = Type.GetType(messageTypeAsString);
 
-            string str1 = typeof(int).AssemblyQualifiedName;
-            Type t1 = Type.GetType(str1);
+            //creat interface with generic type on the fly
+            Type genericInterfaceType = typeof(IMyOperator<>);
+            Type interfaceOfMessageType = genericInterfaceType.MakeGenericType(messageType);
 
-            var userType = typeof(IMyOperator<int>);
-            Type genericTypeArgument = null;
-            if (userType.IsGenericType)
-            {
-                var genericTypes = userType.GenericTypeArguments;
-                genericTypeArgument = genericTypes[0];
-            }
+            var o = injector.GetInstance(interfaceOfMessageType);
 
-            Type myGenericParam2 = typeof(string);
-
-            Type myGenericInterface1 = typeof (IMyOperator<>);
-            Type myBakedGenericInterface1 = myGenericInterface1.MakeGenericType(new Type[] { genericTypeArgument });
-            Type myBakedGenericInterface2 = myGenericInterface1.MakeGenericType(new Type[] { typeof(string) });
-            Type myBakedGenericInterface3 = myGenericInterface1.MakeGenericType(new Type[] { t3 });
- 
-            //at the time of injection, you must specify which T to use. This is IMyOperator<int> and IMyOperator<strign> would reperent different interface
-            var o1 = TangFactory.GetTang().NewInjector(c).GetInstance(myBakedGenericInterface1);
-            var o2 = TangFactory.GetTang().NewInjector(c).GetInstance(myBakedGenericInterface2);
-            var o3 = TangFactory.GetTang().NewInjector(c).GetInstance(myBakedGenericInterface3);
-            var o4 = TangFactory.GetTang().NewInjector(c).GetInstance(typeof(MyOperatorTopology<int>));
-
-            Assert.IsNotNull(o1 is MyOperatorImpl<int>);
-            Assert.IsNotNull(o2 is MyOperatorImpl<string>);
-            Assert.IsNotNull(o3 is MyOperatorImpl<int[]>);
-            Assert.IsNotNull(o4 is MyOperatorTopology<int>);
+            Assert.IsTrue(o is MyOperatorImpl<int[]>);
         }
     }
 

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/Injection/TestInjection.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/Injection/TestInjection.cs
@@ -447,8 +447,7 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
     {
         [Inject]
         public MyOperatorImpl()
-        {
-            
+        {           
         }
 
         string IMyOperator<T>.OperatorName
@@ -466,8 +465,7 @@ namespace Org.Apache.REEF.Tang.Tests.Injection
     {
         [Inject]
         public MyOperatorTopology(IMyOperator<T> op)
-        {
-            
+        {           
         }
     }
 }


### PR DESCRIPTION
This PR is to improve injection in Communication Group
*Use Fork Injector in creating CommunicationGroupClient
*Use Fork Injector in Creating GroupCommOperators
*Use configuration data bound at driver side to inject GroupCommOperators at task side instead of letting clients to decide what operator instance to inject
*Resolved race condition issue caused by delayed message handler registration

JIRA: REEF-329(https://issues.apache.org/jira/browse/REEF-329)

This closes #

Author: Julia Wang  Email: jwang98052@yahoo.com