### PR TITLE
[REEF-342]  Lower down the log level for Configuration data at .Net d…

### DIFF
--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/ActiveContext.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/ActiveContext.cs
@@ -90,7 +90,7 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
         {
             LOGGER.Log(Level.Info, "ActiveContext::SubmitTask");
             string task = _serializer.ToString(taskConfiguration);
-            LOGGER.Log(Level.Info, "serialized taskConfiguration: " + task);
+            LOGGER.Log(Level.Verbose, "serialized taskConfiguration: " + task);
             Clr2Java.SubmitTask(task);
         }
 

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/AllocatedEvaluator.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/AllocatedEvaluator.cs
@@ -73,7 +73,7 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
         {
             LOGGER.Log(Level.Info, "AllocatedEvaluator::SubmitContext");
             string context = _serializer.ToString(contextConfiguration);
-            LOGGER.Log(Level.Info, "serialized contextConfiguration: " + context);
+            LOGGER.Log(Level.Verbose, "serialized contextConfiguration: " + context);
             Clr2Java.SubmitContext(context);
         }
 
@@ -86,8 +86,8 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
             string context = _serializer.ToString(contextConfiguration);
             string task = _serializer.ToString(taskConfiguration);
 
-            LOGGER.Log(Level.Info, "serialized contextConfiguration: " + context);
-            LOGGER.Log(Level.Info, "serialized taskConfiguration: " + task);
+            LOGGER.Log(Level.Verbose, "serialized contextConfiguration: " + context);
+            LOGGER.Log(Level.Verbose, "serialized taskConfiguration: " + task);
 
             Clr2Java.SubmitContextAndTask(context, task);
         }
@@ -99,8 +99,8 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
             string context = _serializer.ToString(contextConfiguration);
             string service = _serializer.ToString(serviceConfiguration);
 
-            LOGGER.Log(Level.Info, "serialized contextConfiguration: " + context);
-            LOGGER.Log(Level.Info, "serialized serviceConfiguration: " + service);
+            LOGGER.Log(Level.Verbose, "serialized contextConfiguration: " + context);
+            LOGGER.Log(Level.Verbose, "serialized serviceConfiguration: " + service);
 
             Clr2Java.SubmitContextAndService(context, service);
         }
@@ -115,9 +115,9 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
             string service = _serializer.ToString(serviceConfiguration);
             string task = _serializer.ToString(taskConfiguration);
 
-            LOGGER.Log(Level.Info, "serialized contextConfiguration: " + context);
-            LOGGER.Log(Level.Info, "serialized serviceConfiguration: " + service);
-            LOGGER.Log(Level.Info, "serialized taskConfiguration: " + task);
+            LOGGER.Log(Level.Verbose, "serialized contextConfiguration: " + context);
+            LOGGER.Log(Level.Verbose, "serialized serviceConfiguration: " + service);
+            LOGGER.Log(Level.Verbose, "serialized taskConfiguration: " + task);
 
             Clr2Java.SubmitContextAndServiceAndTask(context, service, task);
         }


### PR DESCRIPTION
…river

Currently, at .Net side, we log Configuration data before submitting it to Context at Info level. It is too much for the log. This PR is to change the log level to Verbose for those logs.

JIRA: REEF-342(https://issues.apache.org/jira/browse/REEF-342)

This closes #

Author: Julia Wang  Email: jwang98052@yahoo.com