### PR TITLE
[Reef-352]  Modify build script to form a proper snapshot number

### DIFF
--- a/lang/cs/build.props
+++ b/lang/cs/build.props
@@ -54,7 +54,7 @@ under the License.
   <PropertyGroup>
     <RemoveIncubating>true</RemoveIncubating>
     <IsSnapshot>true</IsSnapshot>
-    <SnapshotNumber>0</SnapshotNumber>
+    <SnapshotNumber>02</SnapshotNumber>
     <PushPackages>false</PushPackages>
     <NuGetRepository>https://www.nuget.org</NuGetRepository>
   </PropertyGroup>
@@ -102,7 +102,8 @@ under the License.
             .Where(x => x.Name.ToString().Contains("version"))
             .FirstOrDefault().Value;
           var shortVer = $(RemoveIncubating) ? Version.Replace("-incubating","") : Version ;
-          NugetVersion = $(IsSnapshot) ? shortVer + "-" + $(SnapshotNumber) : shortVer.Replace("-SNAPSHOT","");
+          var snapshortNumberAsString = ($(SnapshotNumber) >= 0 && $(SnapshotNumber) <=9) ? "0" + $(SnapshotNumber) : $(SnapshotNumber).ToString();
+          NugetVersion = $(IsSnapshot) ? shortVer + "-" + snapshortNumberAsString : shortVer.Replace("-SNAPSHOT","");
         ]]>
       </Code>
     </Task>

--- a/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/audience/package-info.java
+++ b/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/audience/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * Annotations for interface audience
+ * Annotations for interface audience.
  */
 package org.apache.reef.annotations.audience;

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/YarnJobSubmissionClient.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/YarnJobSubmissionClient.java
@@ -47,7 +47,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * The Java-side of the C# YARN Job Submission API
+ * The Java-side of the C# YARN Job Submission API.
  */
 public final class YarnJobSubmissionClient {
 

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/LibLoader.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/LibLoader.java
@@ -31,7 +31,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Loading CLR libraries
+ * Loading CLR libraries.
  */
 public class LibLoader {
 
@@ -52,7 +52,7 @@ public class LibLoader {
   }
 
   /**
-   * Load CLR libraries
+   * Load CLR libraries.
    */
   public void loadLib() throws IOException {
     LOG.log(Level.INFO, "Loading DLLs for driver at time {0}." + new Date().toString());
@@ -220,7 +220,7 @@ public class LibLoader {
   }
 
   /**
-   * load assembly
+   * load assembly.
    *
    * @param fileOut
    * @param managed

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobClient.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobClient.java
@@ -68,7 +68,7 @@ public class JobClient {
   private ConfigurationModule driverConfigModule;
 
   /**
-   * A reference to the running job that allows client to send messages back to the job driver
+   * A reference to the running job that allows client to send messages back to the job driver.
    */
   private RunningJob runningJob;
 
@@ -84,7 +84,7 @@ public class JobClient {
   private String jobSubmissionDirectory = "reefTmp/job_" + System.currentTimeMillis();
 
   /**
-   * A factory that provides LoggingScope
+   * A factory that provides LoggingScope.
    */
   private final LoggingScopeFactory loggingScopeFactory;
   /**
@@ -211,7 +211,7 @@ public class JobClient {
   }
 
   /**
-   * Set the driver memory
+   * Set the driver memory.
    */
   public void setDriverInfo(final String identifier, final int memory, final String jobSubmissionDirectory) {
     if (identifier == null || identifier.isEmpty()) {

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
@@ -89,17 +89,17 @@ public final class JobDriver {
   private final EvaluatorRequestor evaluatorRequestor;
 
   /**
-   * Driver status manager to monitor driver status
+   * Driver status manager to monitor driver status.
    */
   private final DriverStatusManager driverStatusManager;
 
   /**
-   * NativeInterop has function to load libs when driver starts
+   * NativeInterop has function to load libs when driver starts.
    */
   private final LibLoader libLoader;
 
   /**
-   * Factory to setup new CLR process configurations
+   * Factory to setup new CLR process configurations.
    */
   private final CLRProcessFactory clrProcessFactory;
 
@@ -113,7 +113,7 @@ public final class JobDriver {
   private final Map<String, ActiveContext> contexts = new HashMap<>();
 
   /**
-   * Logging scope factory that provides LoggingScope
+   * Logging scope factory that provides LoggingScope.
    */
   private final LoggingScopeFactory loggingScopeFactory;
 
@@ -278,7 +278,7 @@ public final class JobDriver {
   }
 
   /**
-   * Handles AllocatedEvaluator: Submit an empty context
+   * Handles AllocatedEvaluator: Submit an empty context.
    */
   public final class AllocatedEvaluatorHandler implements EventHandler<AllocatedEvaluator> {
     @Override
@@ -398,7 +398,7 @@ public final class JobDriver {
     private String uriSpecification;
 
     /**
-     * returns URI specification for the handler
+     * returns URI specification for the handler.
      */
     @Override
     public String getUriSpecification() {
@@ -410,7 +410,7 @@ public final class JobDriver {
     }
 
     /**
-     * process http request
+     * process http request.
      */
     @Override
     public void onHttpRequest(final ParsedHttpRequest parsedHttpRequest, final HttpServletResponse response) throws IOException, ServletException {
@@ -509,7 +509,7 @@ public final class JobDriver {
   }
 
   /**
-   * Receive notification that an context is active on Evaluator when the driver restarted
+   * Receive notification that an context is active on Evaluator when the driver restarted.
    */
   public final class DriverRestartActiveContextHandler implements EventHandler<ActiveContext> {
     @Override
@@ -555,7 +555,7 @@ public final class JobDriver {
 
 
   /**
-   * Job driver is restarted after previous crash
+   * Job driver is restarted after previous crash.
    */
   public final class RestartHandler implements EventHandler<StartTime> {
     @Override
@@ -711,7 +711,7 @@ public final class JobDriver {
   }
 
   /**
-   * Receive notification that a ContextMessage has been received
+   * Receive notification that a ContextMessage has been received.
    */
   public final class ContextMessageHandler implements EventHandler<ContextMessage> {
     @Override

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/Launch.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/Launch.java
@@ -46,11 +46,11 @@ import java.util.logging.Logger;
 public final class Launch {
 
   /**
-   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently
+   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently.
    */
   private static final int MAX_NUMBER_OF_EVALUATORS = 10;
   /**
-   * Standard Java logger
+   * Standard Java logger.
    */
   private static final Logger LOG = Logger.getLogger(Launch.class.getName());
 
@@ -136,7 +136,7 @@ public final class Launch {
   }
 
   /**
-   * Main method that starts the CLR Bridge from Java
+   * Main method that starts the CLR Bridge from Java.
    *
    * @param args command line parameters.
    */
@@ -202,7 +202,7 @@ public final class Launch {
   }
 
   /**
-   * Command line parameter, driver memory, in MB
+   * Command line parameter, driver memory, in MB.
    */
   @NamedParameter(doc = "memory allocated to driver JVM",
       short_name = "driver_memory", default_value = "512")
@@ -210,7 +210,7 @@ public final class Launch {
   }
 
   /**
-   * Command line parameter, driver identifier
+   * Command line parameter, driver identifier.
    */
   @NamedParameter(doc = "driver identifier for clr bridge",
       short_name = "driver_id", default_value = "ReefClrBridge")
@@ -218,7 +218,7 @@ public final class Launch {
   }
 
   /**
-   * Command line parameter = true to submit the job with driver config, or false to write config to current directory
+   * Command line parameter = true to submit the job with driver config, or false to write config to current directory.
    */
   @NamedParameter(doc = "Whether or not to submit the reef job after driver config is constructed",
       short_name = "submit", default_value = "true")
@@ -226,7 +226,7 @@ public final class Launch {
   }
 
   /**
-   * Command line parameter, job submission directory, if set, user should guarantee its uniqueness
+   * Command line parameter, job submission directory, if set, user should guarantee its uniqueness.
    */
   @NamedParameter(doc = "driver job submission directory",
       short_name = "submission_directory", default_value = "empty")

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/LaunchHeadless.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/LaunchHeadless.java
@@ -39,7 +39,7 @@ import java.util.logging.Logger;
 public final class LaunchHeadless {
 
   /**
-   * Standard Java logger
+   * Standard Java logger.
    */
   private static final Logger LOG = Logger.getLogger(LaunchHeadless.class.getName());
 
@@ -62,7 +62,7 @@ public final class LaunchHeadless {
    */
 
   /**
-   * Main method that starts the CLR Bridge from Java
+   * Main method that starts the CLR Bridge from Java.
    *
    * @param args command line parameters.
    */

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/package-info.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * Generic java bridge driver/client
+ * Generic java bridge driver/client.
  */
 package org.apache.reef.javabridge.generic;

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/util/logging/package-info.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/util/logging/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * Logging handler for clr bridge
+ * Logging handler for clr bridge.
  */
 package org.apache.reef.util.logging;

--- a/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/CheckpointNamingService.java
+++ b/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/CheckpointNamingService.java
@@ -24,7 +24,7 @@ package org.apache.reef.io.checkpoint;
 public interface CheckpointNamingService {
 
   /**
-   * Generate a new checkpoint Name
+   * Generate a new checkpoint Name.
    *
    * @return the checkpoint name
    */

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/parameters/JobCompletedHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/parameters/JobCompletedHandler.java
@@ -25,7 +25,7 @@ import org.apache.reef.tang.annotations.NamedParameter;
 import org.apache.reef.wake.EventHandler;
 
 /**
- * Event handler for CompletedJob
+ * Event handler for CompletedJob.
  */
 @NamedParameter(doc = "Event handler for CompletedJob",
     default_classes = DefaultCompletedJobHandler.class)

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/catalog/ResourceCatalog.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/catalog/ResourceCatalog.java
@@ -42,7 +42,7 @@ public interface ResourceCatalog {
   public Collection<NodeDescriptor> getNodes();
 
   /**
-   * The global list of racks
+   * The global list of racks.
    *
    * @return list of all rack descriptors
    */

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/ContextConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/ContextConfiguration.java
@@ -84,7 +84,7 @@ public class ContextConfiguration extends ConfigurationModuleBuilder {
   public static final OptionalImpl<ContextMessageHandler> ON_MESSAGE = new OptionalImpl<>();
 
   /**
-   * Implementation for reconnecting to driver after driver restart
+   * Implementation for reconnecting to driver after driver restart.
    */
   public static final OptionalImpl<DriverConnection> ON_DRIVER_RECONNECT = new OptionalImpl<>();
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/CLRProcess.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/CLRProcess.java
@@ -23,13 +23,13 @@ import org.apache.reef.runtime.common.launch.CLRLaunchCommandBuilder;
 import java.util.List;
 
 /**
- * Defines the setup of a CLR process
+ * Defines the setup of a CLR process.
  */
 public final class CLRProcess implements EvaluatorProcess {
   private final CLRLaunchCommandBuilder commandBuilder = new CLRLaunchCommandBuilder();
 
   /**
-   * Instantiated via CLRProcessFactory
+   * Instantiated via CLRProcessFactory.
    */
   CLRProcess() {
   }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/CLRProcessFactory.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/CLRProcessFactory.java
@@ -24,7 +24,7 @@ import org.apache.reef.annotations.audience.Private;
 import javax.inject.Inject;
 
 /**
- * Factory to setup new CLR processes
+ * Factory to setup new CLR processes.
  */
 @Private
 @DriverSide

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorProcess.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorProcess.java
@@ -21,7 +21,7 @@ package org.apache.reef.driver.evaluator;
 import java.util.List;
 
 /**
- * Defines the setup of an evaluator's process
+ * Defines the setup of an evaluator's process.
  */
 public interface EvaluatorProcess {
   /**
@@ -35,7 +35,7 @@ public interface EvaluatorProcess {
   EvaluatorType getType();
 
   /**
-   * Set the error handler remote identifier
+   * Set the error handler remote identifier.
    *
    * @param errorHandlerRID
    * @return this
@@ -43,7 +43,7 @@ public interface EvaluatorProcess {
   EvaluatorProcess setErrorHandlerRID(final String errorHandlerRID);
 
   /**
-   * Set the launch identifier
+   * Set the launch identifier.
    *
    * @param launchID
    * @return this
@@ -51,7 +51,7 @@ public interface EvaluatorProcess {
   EvaluatorProcess setLaunchID(final String launchID);
 
   /**
-   * Set memory size of process in megabytes
+   * Set memory size of process in megabytes.
    *
    * @param megaBytes
    * @return this

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorProcessFactory.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorProcessFactory.java
@@ -23,7 +23,7 @@ import org.apache.reef.annotations.audience.Public;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
 /**
- * Factory to create new evaluator process setups
+ * Factory to create new evaluator process setups.
  */
 @Public
 @DriverSide

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequest.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequest.java
@@ -126,7 +126,7 @@ public final class EvaluatorRequest {
     }
 
     /**
-     * set number of cores
+     * set number of cores.
      *
      * @param cores the number of cores
      * @return

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorType.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorType.java
@@ -23,11 +23,11 @@ package org.apache.reef.driver.evaluator;
  */
 public enum EvaluatorType {
   /**
-   * Indicates an Evaluator that runs on the JVM
+   * Indicates an Evaluator that runs on the JVM.
    */
   JVM,
   /**
-   * Indicates an Evaluator that runs on the CLR
+   * Indicates an Evaluator that runs on the CLR.
    */
   CLR,
   /**

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/JVMProcess.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/JVMProcess.java
@@ -25,7 +25,7 @@ import org.apache.reef.runtime.common.launch.JavaLaunchCommandBuilder;
 import java.util.List;
 
 /**
- * Defines the setup of a JVM process
+ * Defines the setup of a JVM process.
  */
 public final class JVMProcess implements EvaluatorProcess {
   private final JavaLaunchCommandBuilder commandBuilder = new JavaLaunchCommandBuilder();
@@ -33,7 +33,7 @@ public final class JVMProcess implements EvaluatorProcess {
   private final ClasspathProvider classpathProvider;
 
   /**
-   * Instantiated via JVMProcessFactory
+   * Instantiated via JVMProcessFactory.
    */
   JVMProcess(final RuntimePathProvider runtimePathProvider,
                     final ClasspathProvider classpathProvider) {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/JVMProcessFactory.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/JVMProcessFactory.java
@@ -25,7 +25,7 @@ import org.apache.reef.runtime.common.files.RuntimePathProvider;
 import javax.inject.Inject;
 
 /**
- * Factory to setup new JVM processes
+ * Factory to setup new JVM processes.
  */
 @DriverSide
 public final class JVMProcessFactory implements EvaluatorProcessFactory {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ClientCloseWithMessageHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ClientCloseWithMessageHandlers.java
@@ -26,7 +26,7 @@ import org.apache.reef.wake.EventHandler;
 import java.util.Set;
 
 /**
- * Handles client close requests
+ * Handles client close requests.
  */
 @NamedParameter(doc = "Handles client close requests", default_classes = DefaultClientCloseWithMessageHandler.class)
 public final class ClientCloseWithMessageHandlers implements Name<Set<EventHandler<byte[]>>> {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ContextActiveHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ContextActiveHandlers.java
@@ -27,7 +27,7 @@ import org.apache.reef.wake.EventHandler;
 import java.util.Set;
 
 /**
- * Handler for ActiveContext
+ * Handler for ActiveContext.
  */
 @NamedParameter(doc = "Handler for ActiveContext", default_classes = DefaultContextActiveHandler.class)
 public final class ContextActiveHandlers implements Name<Set<EventHandler<ActiveContext>>> {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ContextFailedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ContextFailedHandlers.java
@@ -27,7 +27,7 @@ import org.apache.reef.wake.EventHandler;
 import java.util.Set;
 
 /**
- * Handler for FailedContext
+ * Handler for FailedContext.
  */
 @NamedParameter(doc = "Handler for FailedContext", default_classes = DefaultContextFailureHandler.class)
 public final class ContextFailedHandlers implements Name<Set<EventHandler<FailedContext>>> {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverIdentifier.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverIdentifier.java
@@ -22,7 +22,7 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
- * Driver Identifier
+ * Driver Identifier.
  */
 @NamedParameter(doc = "Driver Identifier", default_value = DriverIdentifier.DEFAULT_VALUE)
 public final class DriverIdentifier implements Name<String> {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverJobSubmissionDirectory.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverJobSubmissionDirectory.java
@@ -22,7 +22,7 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
- * Job submission directory
+ * Job submission directory.
  */
 @NamedParameter(doc = "Job submission directory. This is the folder on the DFS used to stage the files for the Driver and subsequently for the Evaluators. It will be created if it doesn't exist yet.")
 public final class DriverJobSubmissionDirectory implements Name<String> {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverMemory.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverMemory.java
@@ -22,7 +22,7 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
- * Driver RAM allocation in MB
+ * Driver RAM allocation in MB.
  */
 @NamedParameter(doc = "Driver RAM allocation in MB", default_value = "256")
 public final class DriverMemory implements Name<Integer> {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverRestartCompletedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverRestartCompletedHandlers.java
@@ -27,7 +27,7 @@ import org.apache.reef.wake.EventHandler;
 import java.util.Set;
 
 /**
- * Handler for event that all evaluators have checked back in after driver restart and that the restart is completed
+ * Handler for event that all evaluators have checked back in after driver restart and that the restart is completed.
  */
 @NamedParameter(doc = "Handler for event of driver restart completion", default_classes = DefaultDriverRestartCompletedHandler.class)
 public final class DriverRestartCompletedHandlers implements Name<Set<EventHandler<DriverRestartCompleted>>> {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverRestartContextActiveHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverRestartContextActiveHandlers.java
@@ -27,7 +27,7 @@ import org.apache.reef.wake.EventHandler;
 import java.util.Set;
 
 /**
- * Handler for ActiveContext during a driver restart
+ * Handler for ActiveContext during a driver restart.
  */
 @NamedParameter(doc = "Handler for ActiveContext received during a driver restart", default_classes = DefaultDriverRestartContextActiveHandler.class)
 public final class DriverRestartContextActiveHandlers implements Name<Set<EventHandler<ActiveContext>>> {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceContextActiveHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceContextActiveHandlers.java
@@ -26,7 +26,7 @@ import org.apache.reef.wake.EventHandler;
 import java.util.Set;
 
 /**
- * Handler for ActiveContext
+ * Handler for ActiveContext.
  */
 @NamedParameter(doc = "Handler for ActiveContext")
 public final class ServiceContextActiveHandlers implements Name<Set<EventHandler<ActiveContext>>> {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceContextFailedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceContextFailedHandlers.java
@@ -26,7 +26,7 @@ import org.apache.reef.wake.EventHandler;
 import java.util.Set;
 
 /**
- * Handler for FailedContext
+ * Handler for FailedContext.
  */
 @NamedParameter(doc = "Handler for FailedContext")
 public final class ServiceContextFailedHandlers implements Name<Set<EventHandler<FailedContext>>> {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceDriverRestartCompletedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceDriverRestartCompletedHandlers.java
@@ -26,7 +26,7 @@ import org.apache.reef.wake.EventHandler;
 import java.util.Set;
 
 /**
- * Service handler for driver restart completed event
+ * Service handler for driver restart completed event.
  */
 @NamedParameter(doc = "Handler for driver restart completed event")
 public final class ServiceDriverRestartCompletedHandlers implements Name<Set<EventHandler<DriverRestartCompleted>>> {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceDriverRestartContextActiveHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceDriverRestartContextActiveHandlers.java
@@ -26,7 +26,7 @@ import org.apache.reef.wake.EventHandler;
 import java.util.Set;
 
 /**
- * Handler for ActiveContext received during driver restart
+ * Handler for ActiveContext received during driver restart.
  */
 @NamedParameter(doc = "Handler for ActiveContext received during driver restart")
 public final class ServiceDriverRestartContextActiveHandlers implements Name<Set<EventHandler<ActiveContext>>> {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * Named parameters used by the Driver
+ * Named parameters used by the Driver.
  */
 package org.apache.reef.driver.parameters;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/RunningTask.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/RunningTask.java
@@ -25,7 +25,7 @@ import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.io.naming.Identifiable;
 
 /**
- * Represents a running Task
+ * Represents a running Task.
  */
 @DriverSide
 @Public

--- a/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/parameters/Services.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/parameters/Services.java
@@ -26,7 +26,7 @@ import org.apache.reef.util.ObjectInstantiationLogger;
 import java.util.Set;
 
 /**
- * A set of classes to be instantiated and shared as singletons within this context and all child context
+ * A set of classes to be instantiated and shared as singletons within this context and all child context.
  */
 @NamedParameter(doc = "A set of classes to be instantiated and shared as singletons within this context and all child context",
     default_classes = ObjectInstantiationLogger.class)

--- a/lang/java/reef-common/src/main/java/org/apache/reef/exception/EvaluatorKilledByResourceManagerException.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/exception/EvaluatorKilledByResourceManagerException.java
@@ -19,7 +19,7 @@
 package org.apache.reef.exception;
 
 /**
- * Reported as part of a FailedEvaluator when the resource manager killed the Evaluator
+ * Reported as part of a FailedEvaluator when the resource manager killed the Evaluator.
  */
 public final class EvaluatorKilledByResourceManagerException extends EvaluatorException {
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/exception/evaluator/NetworkException.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/exception/evaluator/NetworkException.java
@@ -19,7 +19,7 @@
 package org.apache.reef.exception.evaluator;
 
 /**
- * Network exception
+ * Network exception.
  */
 public class NetworkException extends ServiceException {
   private static final long serialVersionUID = 1L;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/ExternalMap.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/ExternalMap.java
@@ -39,7 +39,7 @@ public interface ExternalMap<T> {
   public boolean containsKey(final CharSequence key);
 
   /**
-   * Element access
+   * Element access.
    *
    * @param key
    * @return the object stored under key nor null if no such object exists
@@ -47,7 +47,7 @@ public interface ExternalMap<T> {
   public T get(final CharSequence key);
 
   /**
-   * Put a record into the map
+   * Put a record into the map.
    *
    * @param key
    * @param value

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/Message.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/Message.java
@@ -21,13 +21,13 @@ package org.apache.reef.io;
 import org.apache.reef.annotations.audience.Public;
 
 /**
- * A message from a REEF component
+ * A message from a REEF component.
  */
 @Public
 public interface Message {
 
   /**
-   * Message payload
+   * Message payload.
    *
    * @return message payload
    */

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/TcpPortConfigurationProvider.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/TcpPortConfigurationProvider.java
@@ -32,7 +32,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Implements ConfigurationProvider for RangeTcpPortProvider
+ * Implements ConfigurationProvider for RangeTcpPortProvider.
  */
 public class TcpPortConfigurationProvider implements ConfigurationProvider {
   private final int portRangeBegin;
@@ -51,7 +51,7 @@ public class TcpPortConfigurationProvider implements ConfigurationProvider {
   }
 
   /**
-   * returns a configuration for the class that implements TcpPortProvider so that class can be instantiated
+   * returns a configuration for the class that implements TcpPortProvider so that class can be instantiated.
    * somewhere else
    *
    * @return Configuration.

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/naming/Identifiable.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/naming/Identifiable.java
@@ -25,7 +25,7 @@ package org.apache.reef.io.naming;
 public interface Identifiable {
 
   /**
-   * Returns an identifier of this object
+   * Returns an identifier of this object.
    *
    * @return an identifier of this object
    */

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/naming/NameAssignment.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/naming/NameAssignment.java
@@ -23,19 +23,19 @@ import org.apache.reef.wake.Identifier;
 import java.net.InetSocketAddress;
 
 /**
- * Pair of an identifier and an address
+ * Pair of an identifier and an address.
  */
 public interface NameAssignment {
 
   /**
-   * Returns an identifier of this object
+   * Returns an identifier of this object.
    *
    * @return an identifier
    */
   public Identifier getIdentifier();
 
   /**
-   * Returns an address of this object
+   * Returns an address of this object.
    *
    * @return a socket address
    */

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/naming/NamingRegistry.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/naming/NamingRegistry.java
@@ -28,7 +28,7 @@ import java.net.InetSocketAddress;
 public interface NamingRegistry {
 
   /**
-   * Register the given Address for the given Identifier
+   * Register the given Address for the given Identifier.
    *
    * @param id
    * @param addr
@@ -37,7 +37,7 @@ public interface NamingRegistry {
   public void register(final Identifier id, final InetSocketAddress addr) throws Exception;
 
   /**
-   * Unregister the given Identifier from the registry
+   * Unregister the given Identifier from the registry.
    *
    * @param id
    * @throws Exception

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/package-info.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 /**
- * APIs for I/O in REEF: {@link org.apache.reef.io.Codec}s and {@link org.apache.reef.io.Serializer}s
+ * APIs for I/O in REEF: {@link org.apache.reef.io.Codec}s and {@link org.apache.reef.io.Serializer}s.
  */
 @Unstable package org.apache.reef.io;
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/serialization/Codec.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/serialization/Codec.java
@@ -28,7 +28,7 @@ package org.apache.reef.io.serialization;
 public interface Codec<T> {
 
   /**
-   * Encodes the given object into a Byte Array
+   * Encodes the given object into a Byte Array.
    *
    * @param obj
    * @return a byte[] representation of the object
@@ -36,7 +36,7 @@ public interface Codec<T> {
   public byte[] encode(T obj);
 
   /**
-   * Decodes the given byte array into an object
+   * Decodes the given byte array into an object.
    *
    * @param buf
    * @return the decoded object

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/CompletedJobImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/CompletedJobImpl.java
@@ -23,7 +23,7 @@ import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.client.CompletedJob;
 
 /**
- * An implementation of CompletedJob
+ * An implementation of CompletedJob.
  */
 @ClientSide
 @Private

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/JobStatusMessageHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/JobStatusMessageHandler.java
@@ -29,7 +29,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * A Handler for JobStatus messages from running jobs
+ * A Handler for JobStatus messages from running jobs.
  */
 @ClientSide
 @Private

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/JobSubmissionHelper.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/JobSubmissionHelper.java
@@ -40,7 +40,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Shared code between job submission with and without client
+ * Shared code between job submission with and without client.
  */
 final class JobSubmissionHelper {
 
@@ -164,7 +164,7 @@ final class JobSubmissionHelper {
   }
 
   /**
-   * Turns temporary folder "foo" into a jar file "foo.jar"
+   * Turns temporary folder "foo" into a jar file "foo.jar".
    *
    * @param file
    * @return

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/RunningJobs.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/RunningJobs.java
@@ -25,7 +25,7 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
 import org.apache.reef.wake.remote.RemoteMessage;
 
 /**
- * Manages the RunningJobs a client knows about
+ * Manages the RunningJobs a client knows about.
  */
 @Private
 @ClientSide

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/RunningJobsImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/RunningJobsImpl.java
@@ -97,7 +97,7 @@ final class RunningJobsImpl implements RunningJobs {
 
 
   /**
-   * A guarded get() that throws an exception if the RunningJob isn't known
+   * A guarded get() that throws an exception if the RunningJob isn't known.
    *
    * @param jobIdentifier
    * @return

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/JobSubmissionEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/JobSubmissionEvent.java
@@ -27,7 +27,7 @@ import org.apache.reef.util.Optional;
 import java.util.Set;
 
 /**
- * Event sent to Driver Runtime
+ * Event sent to Driver Runtime.
  * Submission of a Job to the Driver Runtime
  */
 @RuntimeAuthor

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/JobSubmissionEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/JobSubmissionEventImpl.java
@@ -149,7 +149,7 @@ public final class JobSubmissionEventImpl implements JobSubmissionEvent {
     }
 
     /**
-     * Add an entry to the globalFileSet
+     * Add an entry to the globalFileSet.
      * @see JobSubmissionEvent#getGlobalFileSet()
      */
     public Builder addGlobalFile(final FileResource globalFile) {
@@ -158,7 +158,7 @@ public final class JobSubmissionEventImpl implements JobSubmissionEvent {
     }
 
     /**
-     * Add an entry to the localFileSet
+     * Add an entry to the localFileSet.
      * @see JobSubmissionEvent#getLocalFileSet()
      */
     public Builder addLocalFile(final FileResource localFile) {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * Client-Side Event Handlers to be implemented by a specific resourcemanager
+ * Client-Side Event Handlers to be implemented by a specific resourcemanager.
  */
 package org.apache.reef.runtime.common.client.api;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeConfigurationOptions.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeConfigurationOptions.java
@@ -24,7 +24,7 @@ import org.apache.reef.tang.annotations.NamedParameter;
 import org.apache.reef.wake.EventHandler;
 
 /**
- * Houses the Driver resourcemanager configuration's NamedParameters
+ * Houses the Driver resourcemanager configuration's NamedParameters.
  */
 public class DriverRuntimeConfigurationOptions {
   @NamedParameter(doc = "Called when a job control message is received by the client.")

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceLaunchEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceLaunchEvent.java
@@ -28,7 +28,7 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
 import java.util.Set;
 
 /**
- * Event from Driver Process -> Driver Runtime
+ * Event from Driver Process -> Driver Runtime.
  * A request to the Driver Runtime to launch an Evaluator on the allocated Resource
  */
 @RuntimeAuthor

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceLaunchEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceLaunchEventImpl.java
@@ -121,7 +121,7 @@ public final class ResourceLaunchEventImpl implements ResourceLaunchEvent {
     }
 
     /**
-     * Add an entry to the fileSet
+     * Add an entry to the fileSet.
      *
      * @see ResourceLaunchEvent#getFileSet()
      */
@@ -131,7 +131,7 @@ public final class ResourceLaunchEventImpl implements ResourceLaunchEvent {
     }
 
     /**
-     * Utility method that adds files to the fileSet
+     * Utility method that adds files to the fileSet.
      *
      * @param files the files to add.
      * @return this
@@ -149,7 +149,7 @@ public final class ResourceLaunchEventImpl implements ResourceLaunchEvent {
     }
 
     /**
-     * Utility method that adds Libraries to the fileSet
+     * Utility method that adds Libraries to the fileSet.
      *
      * @param files the files to add.
      * @return this

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceReleaseEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceReleaseEvent.java
@@ -23,7 +23,7 @@ import org.apache.reef.annotations.audience.RuntimeAuthor;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
 /**
- * Event from Driver Process -> Driver Runtime
+ * Event from Driver Process -> Driver Runtime.
  * A request to the Driver Runtime to release this resource
  */
 @RuntimeAuthor

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEvent.java
@@ -26,7 +26,7 @@ import org.apache.reef.util.Optional;
 import java.util.List;
 
 /**
- * Event from Driver Process -> Driver Runtime
+ * Event from Driver Process -> Driver Runtime.
  * A request to the Driver Runtime to allocate resources with the given specification
  */
 @RuntimeAuthor

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEventImpl.java
@@ -99,7 +99,7 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
     private Boolean relaxLocality;
 
     /**
-     * Create a builder from an existing ResourceRequestEvent
+     * Create a builder from an existing ResourceRequestEvent.
      */
     public Builder mergeFrom(final ResourceRequestEvent resourceRequestEvent) {
       this.resourceCount = resourceRequestEvent.getResourceCount();
@@ -121,7 +121,7 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
     }
 
     /**
-     * Add an entry to the nodeNameList
+     * Add an entry to the nodeNameList.
      * @see ResourceRequestEvent#getNodeNameList()
      */
     public Builder addNodeName(final String nodeName) {
@@ -130,7 +130,7 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
     }
 
     /**
-     * Add an entry to rackNameList
+     * Add an entry to rackNameList.
      * @see ResourceRequestEvent#getRackNameList()
      */
     public Builder addRackName(final String rackName) {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/ContextRepresenters.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/ContextRepresenters.java
@@ -101,7 +101,7 @@ public final class ContextRepresenters {
 
 
   /**
-   * Process a heartbeat from a context
+   * Process a heartbeat from a context.
    *
    * @param contextStatusProto
    * @param notifyClientOnNewActiveContext

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/package-info.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 /**
- * Implementations of Driver-Side representations of Contexts running on an Evaluator
+ * Implementations of Driver-Side representations of Contexts running on an Evaluator.
  */
 @DriverSide
 @Private package org.apache.reef.runtime.common.driver.context;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/AllocatedEvaluatorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/AllocatedEvaluatorImpl.java
@@ -70,7 +70,7 @@ final class AllocatedEvaluatorImpl implements AllocatedEvaluator {
    */
   private final Collection<File> files = new HashSet<>();
   /**
-   * The set of libraries
+   * The set of libraries.
    */
   private final Collection<File> libraries = new HashSet<>();
 
@@ -244,7 +244,7 @@ final class AllocatedEvaluatorImpl implements AllocatedEvaluator {
   }
 
   /**
-   * Utility to build a ConfigurationBuilder from an Optional<Configuration></Configuration>
+   * Utility to build a ConfigurationBuilder from an Optional<Configuration></Configuration>.
    */
   private static ConfigurationBuilder getConfigurationBuilder(final Optional<Configuration> configuration) {
     if (configuration.isPresent()) {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorDescriptorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorDescriptorImpl.java
@@ -25,7 +25,7 @@ import org.apache.reef.driver.evaluator.EvaluatorDescriptor;
 import org.apache.reef.driver.evaluator.EvaluatorProcess;
 
 /**
- * A simple all-data implementation of EvaluatorDescriptor
+ * A simple all-data implementation of EvaluatorDescriptor.
  */
 @Private
 @DriverSide

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
@@ -156,7 +156,7 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
   }
 
   /**
-   * Get the id of current job/application
+   * Get the id of current job/application.
    */
   public static String getJobIdentifier() {
     // TODO: currently we obtain the job id directly by parsing execution (container) directory path
@@ -248,7 +248,7 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
   }
 
   /**
-   * EvaluatorException will trigger is FailedEvaluator and state transition to FAILED
+   * EvaluatorException will trigger is FailedEvaluator and state transition to FAILED.
    *
    * @param exception on the EvaluatorRuntime
    */
@@ -428,7 +428,7 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
   }
 
   /**
-   * Packages the ContextControlProto in an EvaluatorControlProto and forward it to the EvaluatorRuntime
+   * Packages the ContextControlProto in an EvaluatorControlProto and forward it to the EvaluatorRuntime.
    *
    * @param contextControlProto message contains context control info.
    */
@@ -440,7 +440,7 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
   }
 
   /**
-   * Forward the EvaluatorControlProto to the EvaluatorRuntime
+   * Forward the EvaluatorControlProto to the EvaluatorRuntime.
    *
    * @param evaluatorControlProto message contains evaluator control information.
    */

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManagerFactory.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManagerFactory.java
@@ -53,7 +53,7 @@ public final class EvaluatorManagerFactory {
   }
 
   /**
-   * Helper method to create a new EvaluatorManager instance
+   * Helper method to create a new EvaluatorManager instance.
    *
    * @param id   identifier of the Evaluator
    * @param desc NodeDescriptor on which the Evaluator executes.

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/idle/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/idle/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * Contains the Driver idle handling and extension APIs
+ * Contains the Driver idle handling and extension APIs.
  */
 package org.apache.reef.runtime.common.driver.idle;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/NodeDescriptorEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/NodeDescriptorEvent.java
@@ -24,7 +24,7 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
 import org.apache.reef.util.Optional;
 
 /**
- * Event from Driver Runtime -> Driver Process
+ * Event from Driver Runtime -> Driver Process.
  * Description of a node in the cluster
  */
 @RuntimeAuthor

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceStatusEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceStatusEvent.java
@@ -25,7 +25,7 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
 import org.apache.reef.util.Optional;
 
 /**
- * Event from Driver Runtime -> Driver Process
+ * Event from Driver Runtime -> Driver Process.
  * Status of a resource in the cluster
  */
 @RuntimeAuthor

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceStatusHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceStatusHandler.java
@@ -44,7 +44,7 @@ public final class ResourceStatusHandler implements EventHandler<ResourceStatusE
   }
 
   /**
-   * This resource status message comes from the ResourceManager layer; telling me what it thinks
+   * This resource status message comes from the ResourceManager layer; telling me what it thinks.
    * about the state of the resource executing an Evaluator; This method simply passes the message
    * off to the referenced EvaluatorManager
    *

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/RuntimeStatusEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/RuntimeStatusEvent.java
@@ -27,7 +27,7 @@ import org.apache.reef.util.Optional;
 import java.util.List;
 
 /**
- * Event from Driver Runtime -> Driver Process
+ * Event from Driver Runtime -> Driver Process.
  * A status update from the Driver Runtime to the Driver Process
  */
 @RuntimeAuthor

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/RuntimeStatusEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/RuntimeStatusEventImpl.java
@@ -100,7 +100,7 @@ public final class RuntimeStatusEventImpl implements RuntimeStatusEvent {
     }
 
     /**
-     * Add an entry to containerAllocationList
+     * Add an entry to containerAllocationList.
      * @see RuntimeStatusEvent#getContainerAllocationList()
      */
     public Builder addContainerAllocation(final String containerAllocation) {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/DriverConnection.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/DriverConnection.java
@@ -19,7 +19,7 @@
 package org.apache.reef.runtime.common.evaluator;
 
 /**
- * Interface used for reconnecting to driver after driver restart
+ * Interface used for reconnecting to driver after driver restart.
  */
 public interface DriverConnection extends AutoCloseable {
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/ContextLifeCycle.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/ContextLifeCycle.java
@@ -76,7 +76,7 @@ final class ContextLifeCycle {
   }
 
   /**
-   * Deliver the driver message to the context message handler
+   * Deliver the driver message to the context message handler.
    *
    * @param message sent by the driver
    */

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/ContextManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/ContextManager.java
@@ -325,7 +325,7 @@ public final class ContextManager implements AutoCloseable {
   }
 
   /**
-   * THIS ASSUMES THAT IT IS CALLED ON A THREAD HOLDING THE LOCK ON THE HeartBeatManager
+   * THIS ASSUMES THAT IT IS CALLED ON A THREAD HOLDING THE LOCK ON THE HeartBeatManager.
    */
   private void handleTaskException(final TaskClientCodeException e) {
 
@@ -347,7 +347,7 @@ public final class ContextManager implements AutoCloseable {
   }
 
   /**
-   * THIS ASSUMES THAT IT IS CALLED ON A THREAD HOLDING THE LOCK ON THE HeartBeatManager
+   * THIS ASSUMES THAT IT IS CALLED ON A THREAD HOLDING THE LOCK ON THE HeartBeatManager.
    */
   private void handleContextException(final ContextClientCodeException e) {
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/defaults/DefaultContextStartHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/defaults/DefaultContextStartHandler.java
@@ -27,7 +27,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Default handler for ContextStart
+ * Default handler for ContextStart.
  */
 @EvaluatorSide
 public final class DefaultContextStartHandler implements EventHandler<ContextStart> {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/defaults/DefaultContextStopHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/defaults/DefaultContextStopHandler.java
@@ -27,7 +27,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Default event handler for ContextStop
+ * Default event handler for ContextStop.
  */
 @EvaluatorSide
 public final class DefaultContextStopHandler implements EventHandler<ContextStop> {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/parameters/RootServiceConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/parameters/RootServiceConfiguration.java
@@ -22,7 +22,7 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
- * The service configuration for the root context
+ * The service configuration for the root context.
  */
 @NamedParameter(doc = "The service configuration for the root context")
 public final class RootServiceConfiguration implements Name<String> {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/TaskRuntime.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/TaskRuntime.java
@@ -150,7 +150,7 @@ public final class TaskRuntime implements Runnable {
   }
 
   /**
-   * Called by heartbeat manager
+   * Called by heartbeat manager.
    *
    * @return current TaskStatusProto
    */

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/TaskStartImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/TaskStartImpl.java
@@ -25,7 +25,7 @@ import org.apache.reef.task.events.TaskStart;
 import javax.inject.Inject;
 
 /**
- * Injectable implementation of TaskStart
+ * Injectable implementation of TaskStart.
  */
 final class TaskStartImpl implements TaskStart {
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/TaskStopImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/TaskStopImpl.java
@@ -25,7 +25,7 @@ import org.apache.reef.task.events.TaskStop;
 import javax.inject.Inject;
 
 /**
- * Injectable implementation of TaskStop
+ * Injectable implementation of TaskStop.
  */
 final class TaskStopImpl implements TaskStop {
   private final String id;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/defaults/DefaultCloseHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/defaults/DefaultCloseHandler.java
@@ -25,7 +25,7 @@ import org.apache.reef.wake.EventHandler;
 import javax.inject.Inject;
 
 /**
- * Default implementation for EventHandler<CloseEvent>
+ * Default implementation for EventHandler<CloseEvent>.
  */
 @Private
 public final class DefaultCloseHandler implements EventHandler<CloseEvent> {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/defaults/DefaultDriverMessageHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/defaults/DefaultDriverMessageHandler.java
@@ -25,7 +25,7 @@ import org.apache.reef.wake.EventHandler;
 import javax.inject.Inject;
 
 /**
- * A default implementation of EventHandler<DriverMessage>
+ * A default implementation of EventHandler<DriverMessage>.
  */
 @Private
 public final class DefaultDriverMessageHandler implements EventHandler<DriverMessage> {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/defaults/DefaultSuspendHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/defaults/DefaultSuspendHandler.java
@@ -25,7 +25,7 @@ import org.apache.reef.wake.EventHandler;
 import javax.inject.Inject;
 
 /**
- * Default handler for SuspendEvent
+ * Default handler for SuspendEvent.
  */
 @Private
 public final class DefaultSuspendHandler implements EventHandler<SuspendEvent> {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskCallFailure.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskCallFailure.java
@@ -22,7 +22,7 @@ import org.apache.reef.annotations.audience.EvaluatorSide;
 import org.apache.reef.annotations.audience.Private;
 
 /**
- * Thrown when a Task.call() throws an exception
+ * Thrown when a Task.call() throws an exception.
  */
 @EvaluatorSide
 @Private

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskCloseHandlerFailure.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskCloseHandlerFailure.java
@@ -22,7 +22,7 @@ import org.apache.reef.annotations.audience.EvaluatorSide;
 import org.apache.reef.annotations.audience.Private;
 
 /**
- * Thrown when a Task Close Handler throws an exception
+ * Thrown when a Task Close Handler throws an exception.
  */
 @EvaluatorSide
 @Private

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskMessageHandlerFailure.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskMessageHandlerFailure.java
@@ -22,7 +22,7 @@ import org.apache.reef.annotations.audience.EvaluatorSide;
 import org.apache.reef.annotations.audience.Private;
 
 /**
- * Thrown when a Task Message Handler throws an exception
+ * Thrown when a Task Message Handler throws an exception.
  */
 @EvaluatorSide
 @Private

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskStartHandlerFailure.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskStartHandlerFailure.java
@@ -24,7 +24,7 @@ import org.apache.reef.task.events.TaskStart;
 import org.apache.reef.wake.EventHandler;
 
 /**
- * Thrown when a TastStart handler throws an exception
+ * Thrown when a TastStart handler throws an exception.
  */
 @EvaluatorSide
 @Private

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskStopHandlerFailure.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskStopHandlerFailure.java
@@ -24,7 +24,7 @@ import org.apache.reef.task.events.TaskStop;
 import org.apache.reef.wake.EventHandler;
 
 /**
- * Thrown when a TaskStop handler throws an exception
+ * Thrown when a TaskStop handler throws an exception.
  */
 @EvaluatorSide
 @Private

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskSuspendHandlerFailure.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskSuspendHandlerFailure.java
@@ -22,7 +22,7 @@ import org.apache.reef.annotations.audience.EvaluatorSide;
 import org.apache.reef.annotations.audience.Private;
 
 /**
- * Thrown when a Task Suspend Handler throws an exception
+ * Thrown when a Task Suspend Handler throws an exception.
  */
 @EvaluatorSide
 @Private

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/FileResource.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/FileResource.java
@@ -22,7 +22,7 @@ import org.apache.reef.annotations.audience.RuntimeAuthor;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
 /**
- * A File Resource with a FileType for use by Runtimes
+ * A File Resource with a FileType for use by Runtimes.
  */
 @RuntimeAuthor
 @DefaultImplementation(FileResourceImpl.class)

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/FileType.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/FileType.java
@@ -21,7 +21,7 @@ package org.apache.reef.runtime.common.files;
 import org.apache.reef.annotations.audience.RuntimeAuthor;
 
 /**
- * Type of a File Resource used by Runtimes
+ * Type of a File Resource used by Runtimes.
  */
 @RuntimeAuthor
 public enum FileType {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/REEFFileNames.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/REEFFileNames.java
@@ -67,7 +67,7 @@ public final class REEFFileNames {
   }
 
   /**
-   * reef/local/BRIDGE_DLL_NAME
+   * reef/local/BRIDGE_DLL_NAME.
    *
    * @return the File pointing to the DLL containing the DLL for the bridge.
    */
@@ -84,7 +84,7 @@ public final class REEFFileNames {
 
 
   /**
-   * The name of the REEF folder inside of the working directory of an Evaluator or Driver
+   * The name of the REEF folder inside of the working directory of an Evaluator or Driver.
    */
   public String getREEFFolderName() {
     return REEF_BASE_FOLDER;
@@ -143,7 +143,7 @@ public final class REEFFileNames {
 
 
   /**
-   * The name under which the driver configuration will be stored in REEF_BASE_FOLDER/LOCAL_FOLDER
+   * The name under which the driver configuration will be stored in REEF_BASE_FOLDER/LOCAL_FOLDER.
    */
   public String getDriverConfigurationName() {
     return DRIVER_CONFIGURATION_NAME;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/UnixJVMPathProvider.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/UnixJVMPathProvider.java
@@ -21,7 +21,7 @@ package org.apache.reef.runtime.common.files;
 import javax.inject.Inject;
 
 /**
- * Supplies the java binary's path for Unix systems based on JAVA_HOME
+ * Supplies the java binary's path for Unix systems based on JAVA_HOME.
  */
 public final class UnixJVMPathProvider implements RuntimePathProvider {
   @Inject

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/ProcessType.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/ProcessType.java
@@ -19,7 +19,7 @@
 package org.apache.reef.runtime.common.launch;
 
 /**
- * The type of a process to be launched by the Runtime
+ * The type of a process to be launched by the Runtime.
  */
 public enum ProcessType {
     JVM,

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/parameters/ClockConfigurationPath.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/parameters/ClockConfigurationPath.java
@@ -22,7 +22,7 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
- * The path to the clock configuration
+ * The path to the clock configuration.
  */
 @NamedParameter(doc = "The path to process configuration.", short_name = ClockConfigurationPath.SHORT_NAME)
 public final class ClockConfigurationPath implements Name<String> {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/BuilderUtils.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/BuilderUtils.java
@@ -19,11 +19,11 @@
 package org.apache.reef.util;
 
 /**
- * Utilities for creating Builders
+ * Utilities for creating Builders.
  */
 public final class BuilderUtils {
   /**
-   * Throws a runtime exception if the parameter is null
+   * Throws a runtime exception if the parameter is null.
    */
   public static <T> T notNull(final T parameter) {
     if (parameter == null) {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/CommandUtils.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/CommandUtils.java
@@ -25,7 +25,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * run given command and return the result as string
+ * run given command and return the result as string.
  */
 final public class CommandUtils {
   /**

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/DeadlockInfo.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/DeadlockInfo.java
@@ -55,7 +55,7 @@ final class DeadlockInfo {
   }
 
   /**
-   * Get a list of monitor locks that were acquired by this thread at this stack element
+   * Get a list of monitor locks that were acquired by this thread at this stack element.
    * @param threadInfo The thread that created the stack element
    * @param stackTraceElement The stack element
    * @return List of monitor locks that were acquired by this thread at this stack element or an empty list if none were acquired
@@ -75,7 +75,7 @@ final class DeadlockInfo {
   }
 
   /**
-   * Get a string identifying the lock that this thread is waiting on
+   * Get a string identifying the lock that this thread is waiting on.
    * @param threadInfo
    * @return A string identifying the lock that this thread is waiting on, or null if the thread is not waiting on a lock
    */

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/Exceptions.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/Exceptions.java
@@ -19,7 +19,7 @@
 package org.apache.reef.util;
 
 /**
- * Utility class to deal with Exceptions
+ * Utility class to deal with Exceptions.
  */
 public final class Exceptions {
   private Exceptions() {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/OSUtils.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/OSUtils.java
@@ -89,7 +89,7 @@ public final class OSUtils {
   }
 
   /**
-   * Formats the given variable for expansion by Windows (<code>%VARIABE%</code>) or Linux (<code>$VARIABLE</code>)
+   * Formats the given variable for expansion by Windows (<code>%VARIABE%</code>) or Linux (<code>$VARIABLE</code>).
    *
    * @param variableName
    * @return

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/REEFVersion.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/REEFVersion.java
@@ -26,7 +26,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Version information, retrieved from the pom (via a properties file reference)
+ * Version information, retrieved from the pom (via a properties file reference).
  */
 public final class REEFVersion {
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/ThreadLogger.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/ThreadLogger.java
@@ -38,7 +38,7 @@ public final class ThreadLogger {
   }
 
   /**
-   * Same as <code>logThreads(logger, level, prefix, "\n\t", "\n\t\t")</code>
+   * Same as <code>logThreads(logger, level, prefix, "\n\t", "\n\t\t")</code>.
    */
   public static void logThreads(final Logger logger, final Level level, final String prefix) {
     logThreads(logger, level, prefix, "\n\t", "\n\t\t");
@@ -80,14 +80,14 @@ public final class ThreadLogger {
   }
 
   /**
-   * Same as <code>getFormattedThreadList(prefix, "\n\t", "\n\t\t")</code>
+   * Same as <code>getFormattedThreadList(prefix, "\n\t", "\n\t\t")</code>.
    */
   public static String getFormattedThreadList(final String prefix) {
     return getFormattedThreadList(prefix, "\n\t", "\n\t\t");
   }
 
   /**
-   * Produces a String representation of threads that are deadlocked, including lock information
+   * Produces a String representation of threads that are deadlocked, including lock information.
    * @param prefix             The prefix of the string returned.
    * @param threadPrefix       Printed before each thread, e.g. "\n\t" to create an indented list.
    * @param stackElementPrefix Printed before each stack trace element, e.g. "\n\t\t" to create an indented list.
@@ -125,7 +125,7 @@ public final class ThreadLogger {
   }
 
   /**
-   * Same as <code>getFormattedDeadlockInfo(prefix, "\n\t", "\n\t\t")</code>
+   * Same as <code>getFormattedDeadlockInfo(prefix, "\n\t", "\n\t\t")</code>.
    */
   public static String getFormattedDeadlockInfo(final String prefix) {
     return getFormattedDeadlockInfo(prefix, "\n\t", "\n\t\t");

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/LogLevelName.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/LogLevelName.java
@@ -23,7 +23,7 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
- * Name of a log Level as a string such as "INFO", "FINE"
+ * Name of a log Level as a string such as "INFO", "FINE".
  */
 @NamedParameter(default_value = "FINE")
 public class LogLevelName implements Name<String> {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/LogParser.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/LogParser.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 
 /**
- * Parse logs for reporting
+ * Parse logs for reporting.
  */
 public class LogParser {
 
@@ -57,7 +57,7 @@ public class LogParser {
   }
 
   /**
-   * Get lines from a given file with a specified filter, trim the line by removing strings before removeBeforeToken and after removeAfterToken
+   * Get lines from a given file with a specified filter, trim the line by removing strings before removeBeforeToken and after removeAfterToken.
    * @param fileName
    * @param filter
    * @return
@@ -99,7 +99,7 @@ public class LogParser {
   }
 
   /**
-   * get lines from given file with specified filter
+   * get lines from given file with specified filter.
    * @param fileName
    * @param filter
    * @return
@@ -110,7 +110,7 @@ public class LogParser {
   }
 
   /**
-   * filter array list of lines and get the last portion of the line separated by the token, like ":::"
+   * filter array list of lines and get the last portion of the line separated by the token, like ":::".
    * @param original
    * @param filter
    * @return

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/LoggingScope.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/LoggingScope.java
@@ -20,7 +20,7 @@
 package org.apache.reef.util.logging;
 
 /**
- * Log time elapsed for a scope
+ * Log time elapsed for a scope.
  */
 public interface LoggingScope extends AutoCloseable {
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/LoggingScopeFactory.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/LoggingScopeFactory.java
@@ -29,7 +29,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Create Logging scope objects
+ * Create Logging scope objects.
  */
 public class LoggingScopeFactory {
 
@@ -68,7 +68,7 @@ public class LoggingScopeFactory {
   private final Level logLevel;
 
   /**
-   * User can inject a LoggingScopeFactory with injected log level as a string
+   * User can inject a LoggingScopeFactory with injected log level as a string.
    */
   @Inject
   private LoggingScopeFactory(@Parameter(LogLevelName.class) final String logLevelName) {
@@ -76,7 +76,7 @@ public class LoggingScopeFactory {
   }
 
   /**
-   * Get a new instance of LoggingScope with specified log level
+   * Get a new instance of LoggingScope with specified log level.
    * @param logLevel
    * @param msg
    * @return
@@ -86,7 +86,7 @@ public class LoggingScopeFactory {
   }
 
   /**
-   * Get a new instance of LoggingScope with injected LoggingScopeFactory instance
+   * Get a new instance of LoggingScope with injected LoggingScopeFactory instance.
    * @param msg
    * @return
    */
@@ -95,7 +95,7 @@ public class LoggingScopeFactory {
   }
 
   /**
-   * Get a new instance of LoggingScope with msg and params through new
+   * Get a new instance of LoggingScope with msg and params through new.
    * @param msg
    * @param params
    * @return
@@ -131,7 +131,7 @@ public class LoggingScopeFactory {
   }
 
   /**
-   * The method is to measure the time used to load global files and libraries
+   * The method is to measure the time used to load global files and libraries.
    * @return
    */
   public LoggingScope loadLib() {
@@ -156,7 +156,7 @@ public class LoggingScopeFactory {
   }
 
   /**
-   * The method is to measure the time used to submit a Evaluator request at java side
+   * The method is to measure the time used to submit a Evaluator request at java side.
    * @param evaluatorNumber
    * @return
    */
@@ -165,7 +165,7 @@ public class LoggingScopeFactory {
   }
 
   /**
-   * This is to measure the time on evaluatorAllocated handler
+   * This is to measure the time on evaluatorAllocated handler.
    * @param evaluatorId
    * @return
    */
@@ -174,7 +174,7 @@ public class LoggingScopeFactory {
   }
 
   /**
-   * This is to measure the time to launch an evaluator
+   * This is to measure the time to launch an evaluator.
    * @param evaluatorId
    * @return
    */
@@ -183,7 +183,7 @@ public class LoggingScopeFactory {
   }
 
   /**
-   * This is to measure the time in calling evaluatorCompleted handler
+   * This is to measure the time in calling evaluatorCompleted handler.
    * @param evaluatorId
    * @return
    */
@@ -192,7 +192,7 @@ public class LoggingScopeFactory {
   }
 
   /**
-   * This is to measure the time in calling evaluatorFailed handler
+   * This is to measure the time in calling evaluatorFailed handler.
    * @param evaluatorId
    * @return
    */
@@ -201,7 +201,7 @@ public class LoggingScopeFactory {
   }
 
   /**
-   * This is to measure the time in calling activeContext handler
+   * This is to measure the time in calling activeContext handler.
    * @param contextId
    * @return
    */
@@ -210,7 +210,7 @@ public class LoggingScopeFactory {
   }
 
   /**
-   * This is to measure the time in calling closedContext handler
+   * This is to measure the time in calling closedContext handler.
    * @param contextId
    * @return
    */
@@ -219,7 +219,7 @@ public class LoggingScopeFactory {
   }
 
   /**
-   * This is to measure the time in calling runningTaskHandler
+   * This is to measure the time in calling runningTaskHandler.
    * @param taskId
    * @return
    */
@@ -228,7 +228,7 @@ public class LoggingScopeFactory {
   }
 
   /**
-   * This is to measure the time in calling taskCompletedHandler
+   * This is to measure the time in calling taskCompletedHandler.
    * @param taskId
    * @return
    */
@@ -237,7 +237,7 @@ public class LoggingScopeFactory {
   }
 
   /**
-   * This is to measure the time in calling taskSuspendedHandler
+   * This is to measure the time in calling taskSuspendedHandler.
    * @param taskId
    * @return
    */
@@ -246,7 +246,7 @@ public class LoggingScopeFactory {
   }
 
   /**
-   * This is to measure the time in calling taskMessageReceivedHandler
+   * This is to measure the time in calling taskMessageReceivedHandler.
    * @param msg
    * @return
    */
@@ -255,7 +255,7 @@ public class LoggingScopeFactory {
   }
 
   /**
-   * This is to measure the time in calling contextMessageReceivedHandler
+   * This is to measure the time in calling contextMessageReceivedHandler.
    * @param msg
    * @return
    */
@@ -264,7 +264,7 @@ public class LoggingScopeFactory {
   }
 
   /**
-   * This is to measure the time in calling driverRestartHandler
+   * This is to measure the time in calling driverRestartHandler.
    * @param startTime
    * @return
    */
@@ -273,7 +273,7 @@ public class LoggingScopeFactory {
   }
 
   /**
-   * This is to measure the time in calling driverRestartCompletedHandler
+   * This is to measure the time in calling driverRestartCompletedHandler.
    * @param timeStamp
    * @return
    */
@@ -282,7 +282,7 @@ public class LoggingScopeFactory {
   }
 
   /**
-   * This is to measure the time in calling driverRestartRunningTaskHandler
+   * This is to measure the time in calling driverRestartRunningTaskHandler.
    * @param taskId
    * @return
    */
@@ -291,7 +291,7 @@ public class LoggingScopeFactory {
   }
 
   /**
-   * This is to measure the time in calling driverRestartActiveContextReceivedHandler
+   * This is to measure the time in calling driverRestartActiveContextReceivedHandler.
    * @param contextId
    * @return
    */
@@ -300,7 +300,7 @@ public class LoggingScopeFactory {
   }
 
   /**
-   * This is to measure the time in handling a http request
+   * This is to measure the time in handling a http request.
    * @param uri
    * @return
    */
@@ -309,7 +309,7 @@ public class LoggingScopeFactory {
   }
 
   /**
-   * This is to measure the time used to create HttpServer
+   * This is to measure the time used to create HttpServer.
    * @return
    */
   public LoggingScope httpServer() {
@@ -317,7 +317,7 @@ public class LoggingScopeFactory {
   }
 
   /**
-   * This is to measure the time to submit a driver
+   * This is to measure the time to submit a driver.
    * @param submitDriver
    * @return
    */
@@ -326,7 +326,7 @@ public class LoggingScopeFactory {
   }
 
   /**
-   * This is to measure the time to call Reef.Submit
+   * This is to measure the time to call Reef.Submit.
    * @return
    */
   public LoggingScope reefSubmit() {
@@ -334,7 +334,7 @@ public class LoggingScopeFactory {
   }
 
   /**
-   * This is to measure the time for a job submission
+   * This is to measure the time for a job submission.
    * @return
    */
   public LoggingScope localJobSubmission() {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/LoggingScopeImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/LoggingScopeImpl.java
@@ -26,7 +26,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Log time and duration for a scope
+ * Log time and duration for a scope.
  */
 public class LoggingScopeImpl implements LoggingScope {
   public static final String TOKEN = ":::";
@@ -91,7 +91,7 @@ public class LoggingScopeImpl implements LoggingScope {
   }
 
   /**
-   * log massage
+   * log massage.
    * @param msg
    */
   private void log(final String msg) {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/LoggingSetup.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/LoggingSetup.java
@@ -19,7 +19,7 @@
 package org.apache.reef.util.logging;
 
 /**
- * Configure Commons Logging
+ * Configure Commons Logging.
  */
 public final class LoggingSetup {
 

--- a/lang/java/reef-examples-clr/src/main/java/org/apache/reef/examples/helloCLR/HelloDriver.java
+++ b/lang/java/reef-examples-clr/src/main/java/org/apache/reef/examples/helloCLR/HelloDriver.java
@@ -46,7 +46,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * The Driver code for the Hello REEF Application
+ * The Driver code for the Hello REEF Application.
  */
 @Unit
 public final class HelloDriver {
@@ -167,7 +167,7 @@ public final class HelloDriver {
   }
 
   /**
-   * Handles AllocatedEvaluator: Submit an empty context and the HelloTask
+   * Handles AllocatedEvaluator: Submit an empty context and the HelloTask.
    */
   final class EvaluatorAllocatedHandler implements EventHandler<AllocatedEvaluator> {
     @Override

--- a/lang/java/reef-examples-hdinsight/src/main/java/org/apache/reef/examples/hello/HelloHDInsight.java
+++ b/lang/java/reef-examples-hdinsight/src/main/java/org/apache/reef/examples/hello/HelloHDInsight.java
@@ -24,7 +24,7 @@ import org.apache.reef.tang.exceptions.InjectionException;
 import java.io.IOException;
 
 /**
- * HelloREEF running on HDInsight
+ * HelloREEF running on HDInsight.
  */
 public class HelloHDInsight {
   public static void main(final String[] args) throws InjectionException, IOException {

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/data/loading/DataLoadingREEF.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/data/loading/DataLoadingREEF.java
@@ -43,7 +43,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Client for the data loading demo app
+ * Client for the data loading demo app.
  */
 @ClientSide
 public class DataLoadingREEF {
@@ -51,7 +51,7 @@ public class DataLoadingREEF {
   private static final Logger LOG = Logger.getLogger(DataLoadingREEF.class.getName());
 
   /**
-   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently
+   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently.
    */
   private static final int MAX_NUMBER_OF_EVALUATORS = 16;
 

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/BGDClient.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/BGDClient.java
@@ -39,7 +39,7 @@ import org.apache.reef.util.EnvironmentUtils;
 import javax.inject.Inject;
 
 /**
- * A client to submit BGD Jobs
+ * A client to submit BGD Jobs.
  */
 public class BGDClient {
   private final String input;

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/data/parser/SVMLightParser.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/data/parser/SVMLightParser.java
@@ -32,7 +32,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * A Parser for SVMLight records
+ * A Parser for SVMLight records.
  */
 public class SVMLightParser implements Parser<String> {
 

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/Lambda.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/Lambda.java
@@ -22,7 +22,7 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
- * The regularization constant
+ * The regularization constant.
  */
 @NamedParameter(doc = "The regularization constant", short_name = "lambda", default_value = "1e-4")
 public final class Lambda implements Name<Double> {

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/BroadcastDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/BroadcastDriver.java
@@ -134,7 +134,7 @@ public class BroadcastDriver {
   }
 
   /**
-   * Handles AllocatedEvaluator: Submits a context with an id
+   * Handles AllocatedEvaluator: Submits a context with an id.
    */
   final class EvaluatorAllocatedHandler implements EventHandler<AllocatedEvaluator> {
     @Override

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/BroadcastREEF.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/BroadcastREEF.java
@@ -85,7 +85,7 @@ public class BroadcastREEF {
   }
 
   /**
-   * copy the parameters from the command line required for the Client configuration
+   * copy the parameters from the command line required for the Client configuration.
    */
   private static void storeCommandLineArgs(
       final Configuration commandLineConf) throws InjectionException {

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/AbstractImmutableVector.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/AbstractImmutableVector.java
@@ -25,7 +25,7 @@ import java.util.Formatter;
 import java.util.Locale;
 
 /**
- * Base class for implementing ImmutableVector
+ * Base class for implementing ImmutableVector.
  */
 abstract class AbstractImmutableVector implements ImmutableVector {
 

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/DenseVector.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/DenseVector.java
@@ -23,7 +23,7 @@ import java.util.Arrays;
 import java.util.Random;
 
 /**
- * A dense {@link Vector} implementation backed by a double[]
+ * A dense {@link Vector} implementation backed by a double[].
  */
 public class DenseVector extends AbstractVector implements Serializable {
 
@@ -31,7 +31,7 @@ public class DenseVector extends AbstractVector implements Serializable {
   private final double[] values;
 
   /**
-   * Creates a dense vector of the given size
+   * Creates a dense vector of the given size.
    */
   public DenseVector(final int size) {
     this(new double[size]);
@@ -79,7 +79,7 @@ public class DenseVector extends AbstractVector implements Serializable {
   }
 
   /**
-   * Creates a random Vector of size 'size' where each element is individually
+   * Creates a random Vector of size 'size' where each element is individually.
    * drawn from Math.random()
    *
    * @return a random Vector of the given size where each element is
@@ -90,7 +90,7 @@ public class DenseVector extends AbstractVector implements Serializable {
   }
 
   /**
-   * Creates a random Vector of size 'size' where each element is individually
+   * Creates a random Vector of size 'size' where each element is individually.
    * drawn from Math.random()
    *
    * @param random the random number generator to use.

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/ImmutableVector.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/ImmutableVector.java
@@ -26,7 +26,7 @@ import org.apache.reef.io.Tuple;
  */
 public interface ImmutableVector {
   /**
-   * Access the value of the Vector at dimension i
+   * Access the value of the Vector at dimension i.
    *
    * @param i index
    * @return the value at index i
@@ -34,7 +34,7 @@ public interface ImmutableVector {
   double get(int i);
 
   /**
-   * The size (dimensionality) of the Vector
+   * The size (dimensionality) of the Vector.
    *
    * @return the size of the Vector.
    */
@@ -70,7 +70,7 @@ public interface ImmutableVector {
   double norm2Sqr();
 
   /**
-   * Computes the min of all entries in the Vector
+   * Computes the min of all entries in the Vector.
    *
    * @return the min of all entries in this Vector
    */

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/Vector.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/Vector.java
@@ -26,7 +26,7 @@ import java.io.Serializable;
 public interface Vector extends ImmutableVector, Serializable {
 
   /**
-   * Set dimension i of the Vector to value v
+   * Set dimension i of the Vector to value v.
    *
    * @param i the index
    * @param v value
@@ -62,7 +62,7 @@ public interface Vector extends ImmutableVector, Serializable {
   public void normalize();
 
   /**
-   * Create a new instance of the current type
+   * Create a new instance of the current type.
    * with elements being zero
    *
    * @return zero vector of current dimensionality

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/VectorCodec.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/VectorCodec.java
@@ -24,13 +24,13 @@ import javax.inject.Inject;
 import java.io.*;
 
 /**
- * Codec for the Vector type Uses Data*Stream
+ * Codec for the Vector type Uses Data*Stream.
  *
  * @author shravan
  */
 public class VectorCodec implements Codec<Vector> {
   /**
-   * This class is instantiated by TANG
+   * This class is instantiated by TANG.
    */
   @Inject
   public VectorCodec() {

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloDriver.java
@@ -32,7 +32,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * The Driver code for the Hello REEF Application
+ * The Driver code for the Hello REEF Application.
  */
 @Unit
 public final class HelloDriver {
@@ -68,7 +68,7 @@ public final class HelloDriver {
   }
 
   /**
-   * Handles AllocatedEvaluator: Submit the HelloTask
+   * Handles AllocatedEvaluator: Submit the HelloTask.
    */
   public final class EvaluatorAllocatedHandler implements EventHandler<AllocatedEvaluator> {
     @Override

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEF.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEF.java
@@ -37,7 +37,7 @@ public final class HelloREEF {
   private static final Logger LOG = Logger.getLogger(HelloREEF.class.getName());
 
   /**
-   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently
+   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently.
    */
   private static final int MAX_NUMBER_OF_EVALUATORS = 2;
 

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hellohttp/HelloREEFHttp.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hellohttp/HelloREEFHttp.java
@@ -39,7 +39,7 @@ import java.util.logging.Logger;
  */
 public final class HelloREEFHttp {
   /**
-   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently
+   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently.
    */
   private static final int MAX_NUMBER_OF_EVALUATORS = 3;
 
@@ -88,7 +88,7 @@ public final class HelloREEFHttp {
   }
 
   /**
-   * Run Hello Reef with merged configuration
+   * Run Hello Reef with merged configuration.
    *
    * @param runtimeConf
    * @param timeOut
@@ -103,7 +103,7 @@ public final class HelloREEFHttp {
   }
 
   /**
-   * main program
+   * main program.
    *
    * @param args
    * @throws InjectionException

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hellohttp/HelloREEFHttpYarn.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hellohttp/HelloREEFHttpYarn.java
@@ -29,7 +29,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * HelloREEFHttp for running on Yarn
+ * HelloREEFHttp for running on Yarn.
  */
 public class HelloREEFHttpYarn {
 

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hellohttp/HttpServerShellCmdtHandler.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hellohttp/HttpServerShellCmdtHandler.java
@@ -36,7 +36,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Http Event handler for Shell Command
+ * Http Event handler for Shell Command.
  */
 @Unit
 class HttpServerShellCmdtHandler implements HttpHandler {
@@ -50,17 +50,17 @@ class HttpServerShellCmdtHandler implements HttpHandler {
   private static final int WAIT_TIME = 50;
 
   /**
-   * ClientMessageHandler
+   * ClientMessageHandler.
    */
   private final InjectionFuture<HttpShellJobDriver.ClientMessageHandler> messageHandler;
 
   /**
-   * uri specification
+   * uri specification.
    */
   private String uriSpecification = "Command";
 
   /**
-   * output for command
+   * output for command.
    */
   private String cmdOutput = null;
 
@@ -73,7 +73,7 @@ class HttpServerShellCmdtHandler implements HttpHandler {
   }
 
   /**
-   * returns URI specification for the handler
+   * returns URI specification for the handler.
    *
    * @return
    */
@@ -83,7 +83,7 @@ class HttpServerShellCmdtHandler implements HttpHandler {
   }
 
   /**
-   * set URI specification
+   * set URI specification.
    *
    * @param s
    */
@@ -92,7 +92,7 @@ class HttpServerShellCmdtHandler implements HttpHandler {
   }
 
   /**
-   * it is called when receiving a http request
+   * it is called when receiving a http request.
    *
    * @param parsedHttpRequest
    * @param response
@@ -132,7 +132,7 @@ class HttpServerShellCmdtHandler implements HttpHandler {
   }
 
   /**
-   * called after shell command is completed
+   * called after shell command is completed.
    *
    * @param message
    */
@@ -157,7 +157,7 @@ class HttpServerShellCmdtHandler implements HttpHandler {
   }
 
   /**
-   * Handler for client to call back
+   * Handler for client to call back.
    */
   final class ClientCallBackHandler implements EventHandler<byte[]> {
     @Override

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hellohttp/HttpShellJobDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hellohttp/HttpShellJobDriver.java
@@ -48,7 +48,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * The Driver code for the Hello REEF Http Distributed Shell Application
+ * The Driver code for the Hello REEF Http Distributed Shell Application.
  */
 @Unit
 public final class HttpShellJobDriver {
@@ -60,7 +60,7 @@ public final class HttpShellJobDriver {
   public static final ObjectSerializableCodec<String> CODEC = new ObjectSerializableCodec<>();
   private static final Logger LOG = Logger.getLogger(HttpShellJobDriver.class.getName());
   /**
-   * Evaluator Requester
+   * Evaluator Requester.
    */
   private final EvaluatorRequestor evaluatorRequestor;
   /**
@@ -89,12 +89,12 @@ public final class HttpShellJobDriver {
    */
   private int expectCount = 0;
   /**
-   * Callback handler for http return message
+   * Callback handler for http return message.
    */
   private HttpServerShellCmdtHandler.ClientCallBackHandler httpCallbackHandler;
 
   /**
-   * Job Driver Constructor
+   * Job Driver Constructor.
    *
    * @param requestor
    * @param clientCallBackHandler

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/library/ShellTask.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/library/ShellTask.java
@@ -43,7 +43,7 @@ public class ShellTask implements Task {
   private final String command;
 
   /**
-   * Object Serializable Codec
+   * Object Serializable Codec.
    */
   private static final ObjectSerializableCodec<String> CODEC = new ObjectSerializableCodec<>();
 

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/pool/Launch.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/pool/Launch.java
@@ -44,11 +44,11 @@ import java.util.logging.Logger;
 public final class Launch {
 
   /**
-   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently
+   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently.
    */
   private static final int MAX_NUMBER_OF_EVALUATORS = 4;
   /**
-   * Standard Java logger
+   * Standard Java logger.
    */
   private static final Logger LOG = Logger.getLogger(Launch.class.getName());
 

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/Scheduler.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/Scheduler.java
@@ -106,7 +106,7 @@ final class Scheduler {
   }
 
   /**
-   * Clear the pending list
+   * Clear the pending list.
    */
   public synchronized SchedulerResponse clear() {
     final int count = taskQueue.size();

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerHttpHandler.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerHttpHandler.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Receive HttpRequest so that it can handle the command list
+ * Receive HttpRequest so that it can handle the command list.
  */
 final class SchedulerHttpHandler implements HttpHandler {
   final InjectionFuture<SchedulerDriver> schedulerDriver;

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerREEF.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerREEF.java
@@ -39,12 +39,12 @@ import java.io.IOException;
  */
 public final class SchedulerREEF {
   /**
-   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently
+   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently.
    */
   private static final int MAX_NUMBER_OF_EVALUATORS = 3;
 
   /**
-   * Command line parameter = true to reuse evaluators,
+   * Command line parameter = true to reuse evaluators,.
    * or false to allocate/close for each iteration
    */
   @NamedParameter(doc = "Whether or not to reuse evaluators",
@@ -100,7 +100,7 @@ public final class SchedulerREEF {
   }
 
   /**
-   * Main program
+   * Main program.
    * @param args
    * @throws InjectionException
    */

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerREEFYarn.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerREEFYarn.java
@@ -32,7 +32,7 @@ import static org.apache.reef.examples.scheduler.SchedulerREEF.runTaskScheduler;
  */
 public final class SchedulerREEFYarn {
   /**
-   * Launch the scheduler with YARN client configuration
+   * Launch the scheduler with YARN client configuration.
    * @param args
    * @throws InjectionException
    * @throws java.io.IOException

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerResponse.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerResponse.java
@@ -44,28 +44,28 @@ final class SchedulerResponse {
   private static final int SC_NOT_FOUND = 404;
 
   /**
-   * Create a response with OK status
+   * Create a response with OK status.
    */
   public static SchedulerResponse OK(final String message){
     return new SchedulerResponse (SC_OK, message);
   }
 
   /**
-   * Create a response with BAD_REQUEST status
+   * Create a response with BAD_REQUEST status.
    */
   public static SchedulerResponse BAD_REQUEST(final String message){
     return new SchedulerResponse (SC_BAD_REQUEST, message);
   }
 
   /**
-   * Create a response with FORBIDDEN status
+   * Create a response with FORBIDDEN status.
    */
   public static SchedulerResponse FORBIDDEN(final String message){
     return new SchedulerResponse (SC_FORBIDDEN, message);
   }
 
   /**
-   * Create a response with NOT FOUND status
+   * Create a response with NOT FOUND status.
    */
   public static SchedulerResponse NOT_FOUND(final String message){
     return new SchedulerResponse (SC_NOT_FOUND, message);

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/package-info.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * Task scheduler example based on reef-webserver
+ * Task scheduler example based on reef-webserver.
  */
 package org.apache.reef.examples.scheduler;

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/Launch.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/Launch.java
@@ -42,11 +42,11 @@ import java.util.logging.Logger;
 public final class Launch {
 
   /**
-   * Standard Java logger
+   * Standard Java logger.
    */
   private static final Logger LOG = Logger.getLogger(Launch.class.getName());
   /**
-   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently
+   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently.
    */
   private static final int MAX_NUMBER_OF_EVALUATORS = 4;
 

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/ObjectWritableCodec.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/ObjectWritableCodec.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
 public class ObjectWritableCodec<T extends Writable> implements Codec<T> {
 
   /**
-   * Standard Java logger
+   * Standard Java logger.
    */
   private static final Logger LOG = Logger.getLogger(ObjectWritableCodec.class.getName());
 

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/SuspendDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/SuspendDriver.java
@@ -59,7 +59,7 @@ public class SuspendDriver {
   private static final Logger LOG = Logger.getLogger(SuspendDriver.class.getName());
 
   /**
-   * Number of evaluators to request
+   * Number of evaluators to request.
    */
   private static final int NUM_EVALUATORS = 2;
 

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/EvaluatorRequestSerializer.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/EvaluatorRequestSerializer.java
@@ -24,7 +24,7 @@ import org.apache.reef.driver.evaluator.EvaluatorRequest;
 import java.io.*;
 
 /**
- * Serialize and deserialize EvaluatorRequest objects
+ * Serialize and deserialize EvaluatorRequest objects.
  * Currently only supports number & memory
  * Does not take care of Resource Descriptor
  */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/EvaluatorToPartitionMapper.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/EvaluatorToPartitionMapper.java
@@ -56,7 +56,7 @@ public class EvaluatorToPartitionMapper<V extends InputSplit> {
   private final BlockingQueue<NumberedSplit<V>> unallocatedSplits = new LinkedBlockingQueue<>();
 
   /**
-   * Initializes the locations of splits mapping
+   * Initializes the locations of splits mapping.
    *
    * @param splits
    */
@@ -88,7 +88,7 @@ public class EvaluatorToPartitionMapper<V extends InputSplit> {
   }
 
   /**
-   * Get an input split to be assigned to this
+   * Get an input split to be assigned to this.
    * evaluator
    * <p/>
    * Allocates one if its not already allocated

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/InputFormatExternalConstructor.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/InputFormatExternalConstructor.java
@@ -27,7 +27,7 @@ import javax.inject.Inject;
 
 
 /**
- * A Tang External Constructor to inject the required
+ * A Tang External Constructor to inject the required.
  * InputFormat
  */
 @DriverSide

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/InputSplitExternalConstructor.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/InputSplitExternalConstructor.java
@@ -29,7 +29,7 @@ import org.apache.reef.tang.annotations.Parameter;
 import javax.inject.Inject;
 
 /**
- * A Tang external constructor to inject an InputSplit
+ * A Tang external constructor to inject an InputSplit.
  * by deserializing the serialized input split assigned
  * to this evaluator
  */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/NumberedSplit.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/NumberedSplit.java
@@ -21,7 +21,7 @@ package org.apache.reef.io.data.loading.impl;
 import org.apache.hadoop.mapred.InputSplit;
 
 /**
- * A tuple of an object of type E and an integer index
+ * A tuple of an object of type E and an integer index.
  * Used inside {@link EvaluatorToPartitionMapper} to
  * mark the partitions associated with each {@link InputSplit}
  *

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/ConnectionFactory.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/ConnectionFactory.java
@@ -21,14 +21,14 @@ package org.apache.reef.io.network;
 import org.apache.reef.wake.Identifier;
 
 /**
- * Factory that creates a new connection
+ * Factory that creates a new connection.
  *
  * @param <T> type
  */
 public interface ConnectionFactory<T> {
 
   /**
-   * Creates a new connection
+   * Creates a new connection.
    *
    * @param destId a destination identifier
    * @return a connection

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/Message.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/Message.java
@@ -21,28 +21,28 @@ package org.apache.reef.io.network;
 import org.apache.reef.wake.Identifier;
 
 /**
- * Network message
+ * Network message.
  *
  * @param <T>
  */
 public interface Message<T> {
 
   /**
-   * Gets a source identifier
+   * Gets a source identifier.
    *
    * @return an identifier
    */
   Identifier getSrcId();
 
   /**
-   * Gets a destination identifier
+   * Gets a destination identifier.
    *
    * @return an identifier
    */
   Identifier getDestId();
 
   /**
-   * Gets data
+   * Gets data.
    *
    * @return an iterable of data objects
    */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/exception/NetworkRuntimeException.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/exception/NetworkRuntimeException.java
@@ -19,13 +19,13 @@
 package org.apache.reef.io.network.exception;
 
 /**
- * Network service resourcemanager exception
+ * Network service resourcemanager exception.
  */
 public class NetworkRuntimeException extends RuntimeException {
   private static final long serialVersionUID = 1L;
 
   /**
-   * Constructs a new network resourcemanager exception with the specified detail message and cause
+   * Constructs a new network resourcemanager exception with the specified detail message and cause.
    *
    * @param s the detailed message
    * @param e the cause
@@ -35,7 +35,7 @@ public class NetworkRuntimeException extends RuntimeException {
   }
 
   /**
-   * Constructs a new network resourcemanager exception with the specified detail message
+   * Constructs a new network resourcemanager exception with the specified detail message.
    *
    * @param s the detailed message
    */
@@ -44,7 +44,7 @@ public class NetworkRuntimeException extends RuntimeException {
   }
 
   /**
-   * Constructs a new network resourcemanager exception with the specified cause
+   * Constructs a new network resourcemanager exception with the specified cause.
    *
    * @param e the cause
    */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/exception/ParentDeadException.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/exception/ParentDeadException.java
@@ -19,7 +19,7 @@
 package org.apache.reef.io.network.exception;
 
 /**
- * This exception is thrown by a child task
+ * This exception is thrown by a child task.
  * when it is told that its Parent died
  */
 public class ParentDeadException extends Exception {

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/GroupChanges.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/GroupChanges.java
@@ -21,7 +21,7 @@ package org.apache.reef.io.network.group.api;
 import org.apache.reef.annotations.audience.TaskSide;
 
 /**
- * Represents the changes in Topology that happened in a communication group
+ * Represents the changes in Topology that happened in a communication group.
  * from the last time the user asked for topology changes
  */
 @TaskSide

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/CommunicationGroupDriver.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/CommunicationGroupDriver.java
@@ -35,7 +35,7 @@ import org.apache.reef.tang.annotations.Name;
 public interface CommunicationGroupDriver {
 
   /**
-   * Add the broadcast operator specified by the
+   * Add the broadcast operator specified by the.
    * 'spec' with name 'operatorName' into this
    * Communication Group
    *
@@ -46,7 +46,7 @@ public interface CommunicationGroupDriver {
   public CommunicationGroupDriver addBroadcast(Class<? extends Name<String>> operatorName, BroadcastOperatorSpec spec);
 
   /**
-   * Add the reduce operator specified by the
+   * Add the reduce operator specified by the.
    * 'spec' with name 'operatorName' into this
    * Communication Group
    *
@@ -57,7 +57,7 @@ public interface CommunicationGroupDriver {
   public CommunicationGroupDriver addReduce(Class<? extends Name<String>> operatorName, ReduceOperatorSpec spec);
 
   /**
-   * This signals to the service that no more
+   * This signals to the service that no more.
    * operator specs will be added to this communication
    * group and an attempt to do that will throw an
    * IllegalStateException

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/GroupCommDriver.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/GroupCommDriver.java
@@ -27,7 +27,7 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
 import org.apache.reef.tang.annotations.Name;
 
 /**
- * The driver side interface of Group Communication
+ * The driver side interface of Group Communication.
  * which is the entry point for the service
  */
 @DriverSide
@@ -36,7 +36,7 @@ import org.apache.reef.tang.annotations.Name;
 public interface GroupCommDriver {
 
   /**
-   * Create a new communication group with the specified name
+   * Create a new communication group with the specified name.
    * and the minimum number of tasks needed in this group before
    * communication can start
    *
@@ -47,7 +47,7 @@ public interface GroupCommDriver {
   CommunicationGroupDriver newCommunicationGroup(Class<? extends Name<String>> groupName, int numberOfTasks);
 
   /**
-   * Tests whether the activeContext is a context configured
+   * Tests whether the activeContext is a context configured.
    * using the Group Communication Service
    *
    * @param activeContext

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/GroupCommServiceDriver.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/GroupCommServiceDriver.java
@@ -34,7 +34,7 @@ import org.apache.reef.wake.EStage;
 public interface GroupCommServiceDriver extends GroupCommDriver {
 
   /**
-   * Not user facing but used the Group Communication Service class
+   * Not user facing but used the Group Communication Service class.
    *
    * @return The running task stage that will handle the RunningTask
    * events
@@ -42,7 +42,7 @@ public interface GroupCommServiceDriver extends GroupCommDriver {
   EStage<RunningTask> getGroupCommRunningTaskStage();
 
   /**
-   * Not user facing but used the Group Communication Service class
+   * Not user facing but used the Group Communication Service class.
    *
    * @return The running task stage that will handle the FailedTask
    * events
@@ -50,7 +50,7 @@ public interface GroupCommServiceDriver extends GroupCommDriver {
   EStage<FailedTask> getGroupCommFailedTaskStage();
 
   /**
-   * Not user facing but used the Group Communication Service class
+   * Not user facing but used the Group Communication Service class.
    *
    * @return The running task stage that will handle the FailedEvaluator
    * events

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/TaskNode.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/TaskNode.java
@@ -21,7 +21,7 @@ package org.apache.reef.io.network.group.api.driver;
 import org.apache.reef.io.network.group.impl.GroupCommunicationMessage;
 
 /**
- * A node in the Topology representing a Task on the driver
+ * A node in the Topology representing a Task on the driver.
  * Impl should maintain state relating to whether task is running/dead and
  * status of neighboring nodes and send ctrl msgs to the tasks indicating
  * topology changing events
@@ -63,20 +63,20 @@ public interface TaskNode {
   void onChildDead(String childId);
 
   /**
-   * Check if this node is ready for sending
+   * Check if this node is ready for sending.
    * TopologySetup
    */
   void checkAndSendTopologySetupMessage();
 
   /**
-   * Check if the neighbor node with id source
+   * Check if the neighbor node with id source.
    * is ready for sending TopologySetup
    * @param source
    */
   void checkAndSendTopologySetupMessageFor(String source);
 
   /**
-   * reset topology setup ensures that update topology is not sent to someone
+   * reset topology setup ensures that update topology is not sent to someone.
    * who is already updating topology which is usually when they are just
    * (re)starting
    *

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/TaskNodeStatus.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/TaskNodeStatus.java
@@ -41,7 +41,7 @@ public interface TaskNodeStatus {
   boolean isActive(String neighborId);
 
   /**
-   * Process the msg that was received and update
+   * Process the msg that was received and update.
    * state accordingly
    */
   void processAcknowledgement(GroupCommunicationMessage msg);
@@ -58,7 +58,7 @@ public interface TaskNodeStatus {
   public void expectAckFor(final Type msgType, final String srcId);
 
   /**
-   * Used when the task has failed to clear all
+   * Used when the task has failed to clear all.
    * the state that is associated with this task
    * Also should release the locks held for implementing
    * the convenience wait* methods
@@ -66,7 +66,7 @@ public interface TaskNodeStatus {
   void clearStateAndReleaseLocks();
 
   /**
-   * This should remove state concerning neighboring tasks
+   * This should remove state concerning neighboring tasks.
    * that have failed
    */
   void updateFailureOf(String taskId);
@@ -74,7 +74,7 @@ public interface TaskNodeStatus {
   void waitForTopologySetup();
 
   /**
-   * Called to denote that a UpdateTopology msg will
+   * Called to denote that a UpdateTopology msg will.
    * be sent
    */
   void updatingTopology ();

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/Topology.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/Topology.java
@@ -32,7 +32,7 @@ import org.apache.reef.tang.Configuration;
 public interface Topology {
 
   /**
-   * Get the version of the Task 'taskId'
+   * Get the version of the Task 'taskId'.
    * that belongs to this topology
    *
    * @param taskId
@@ -41,14 +41,14 @@ public interface Topology {
   int getNodeVersion(String taskId);
 
   /**
-   * Get the id of the root task
+   * Get the id of the root task.
    *
    * @return
    */
   String getRootId();
 
   /**
-   * Set task with id 'senderId' as
+   * Set task with id 'senderId' as.
    * the root of this topology
    *
    * @param senderId
@@ -56,7 +56,7 @@ public interface Topology {
   void setRootTask(String senderId);
 
   /**
-   * Add task with id 'taskId' to
+   * Add task with id 'taskId' to.
    * the topology
    *
    * @param taskId
@@ -64,7 +64,7 @@ public interface Topology {
   void addTask(String taskId);
 
   /**
-   * Remove task with id 'taskId' from
+   * Remove task with id 'taskId' from.
    * the topology
    *
    * @param taskId
@@ -72,7 +72,7 @@ public interface Topology {
   void removeTask(String taskId);
 
   /**
-   * Update state on receipt of RunningTask
+   * Update state on receipt of RunningTask.
    * event for task with id 'id'
    *
    * @param id
@@ -80,7 +80,7 @@ public interface Topology {
   void onRunningTask(String id);
 
   /**
-   * Update state on receipt of FailedTask
+   * Update state on receipt of FailedTask.
    * event for task with id 'id'
    *
    * @param id
@@ -88,7 +88,7 @@ public interface Topology {
   void onFailedTask(String id);
 
   /**
-   * Set operator specification of the operator
+   * Set operator specification of the operator.
    * that is the owner of this topology instance
    *
    * @param spec
@@ -96,7 +96,7 @@ public interface Topology {
   void setOperatorSpecification(OperatorSpec spec);
 
   /**
-   * Get the topology portion of the Configuration
+   * Get the topology portion of the Configuration.
    * for the task 'taskId' that belongs to this
    * topology
    *
@@ -106,7 +106,7 @@ public interface Topology {
   Configuration getTaskConfiguration(String taskId);
 
   /**
-   * Update state on receipt of a message
+   * Update state on receipt of a message.
    * from the tasks
    *
    * @param msg

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Broadcast.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Broadcast.java
@@ -45,7 +45,7 @@ public interface Broadcast {
   }
 
   /**
-   * Receivers or Non-roots
+   * Receivers or Non-roots.
    */
   @DefaultImplementation(BroadcastReceiver.class)
   static interface Receiver<T> extends GroupCommOperator {

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Gather.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Gather.java
@@ -43,7 +43,7 @@ public interface Gather {
   }
 
   /**
-   * Receiver or Root
+   * Receiver or Root.
    */
   static interface Receiver<T> extends GroupCommOperator {
 
@@ -55,7 +55,7 @@ public interface Gather {
     List<T> receive() throws InterruptedException, NetworkException;
 
     /**
-     * Receive the elements sent by the senders in specified order
+     * Receive the elements sent by the senders in specified order.
      *
      * @return elements sent by senders as a List in specified order
      */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Reduce.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Reduce.java
@@ -36,7 +36,7 @@ import java.util.List;
 public interface Reduce {
 
   /**
-   * Receiver or Root
+   * Receiver or Root.
    */
   @DefaultImplementation(ReduceReceiver.class)
   static interface Receiver<T> extends GroupCommOperator {
@@ -58,7 +58,7 @@ public interface Reduce {
     T reduce(List<? extends Identifier> order) throws InterruptedException, NetworkException;
 
     /**
-     * The reduce function to be applied on the set of received values
+     * The reduce function to be applied on the set of received values.
      *
      * @return {@link ReduceFunction}
      */
@@ -66,7 +66,7 @@ public interface Reduce {
   }
 
   /**
-   * Senders or non roots
+   * Senders or non roots.
    */
   @DefaultImplementation(ReduceSender.class)
   static interface Sender<T> extends GroupCommOperator {
@@ -85,7 +85,7 @@ public interface Reduce {
   }
 
   /**
-   * Interface for a Reduce Function takes in an {@link Iterable} returns an
+   * Interface for a Reduce Function takes in an {@link Iterable} returns an.
    * aggregate value computed from the {@link Iterable}
    */
   static interface ReduceFunction<T> {

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/ReduceScatter.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/ReduceScatter.java
@@ -59,7 +59,7 @@ public interface ReduceScatter<T> extends GroupCommOperator {
                 List<? extends Identifier> order) throws InterruptedException, NetworkException;
 
   /**
-   * get {@link org.apache.reef.io.network.group.api.operators.Reduce.ReduceFunction} configured
+   * get {@link org.apache.reef.io.network.group.api.operators.Reduce.ReduceFunction} configured.
    *
    * @return {@link org.apache.reef.io.network.group.api.operators.Reduce.ReduceFunction}
    */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/CommGroupNetworkHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/CommGroupNetworkHandler.java
@@ -25,7 +25,7 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.wake.EventHandler;
 
 /**
- * The EventHandler that receives the GroupCommunicationMsg
+ * The EventHandler that receives the GroupCommunicationMsg.
  * pertaining to a specific Communication Group
  */
 @DefaultImplementation(value = CommGroupNetworkHandlerImpl.class)

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/CommunicationGroupClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/CommunicationGroupClient.java
@@ -27,7 +27,7 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
 import org.apache.reef.tang.annotations.Name;
 
 /**
- * The Task side interface of a communication group
+ * The Task side interface of a communication group.
  * Lets one get the operators configured for this task
  * and use them for communication between tasks configured
  * in this communication group
@@ -42,7 +42,7 @@ public interface CommunicationGroupClient {
   Class<? extends Name<String>> getName();
 
   /**
-   * The broadcast sender configured on this communication group
+   * The broadcast sender configured on this communication group.
    * with the given oepratorName
    *
    * @param operatorName
@@ -51,7 +51,7 @@ public interface CommunicationGroupClient {
   Broadcast.Sender getBroadcastSender(Class<? extends Name<String>> operatorName);
 
   /**
-   * The broadcast receiver configured on this communication group
+   * The broadcast receiver configured on this communication group.
    * with the given oepratorName
    *
    * @param operatorName
@@ -60,7 +60,7 @@ public interface CommunicationGroupClient {
   Broadcast.Receiver getBroadcastReceiver(Class<? extends Name<String>> operatorName);
 
   /**
-   * The reduce receiver configured on this communication group
+   * The reduce receiver configured on this communication group.
    * with the given oepratorName
    *
    * @param operatorName
@@ -69,7 +69,7 @@ public interface CommunicationGroupClient {
   Reduce.Receiver getReduceReceiver(Class<? extends Name<String>> operatorName);
 
   /**
-   * The reduce sender configured on this communication group
+   * The reduce sender configured on this communication group.
    * with the given oepratorName
    *
    * @param operatorName

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/CommunicationGroupServiceClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/CommunicationGroupServiceClient.java
@@ -26,7 +26,7 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
 @DefaultImplementation(value = CommunicationGroupClientImpl.class)
 public interface CommunicationGroupServiceClient extends CommunicationGroupClient {
   /**
-   * Should not be used by user code
+   * Should not be used by user code.
    * Used for initialization of the
    * communication group
    */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/GroupCommClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/GroupCommClient.java
@@ -26,7 +26,7 @@ import org.apache.reef.tang.annotations.Name;
 
 
 /**
- * The task side interface for the Group Communication Service
+ * The task side interface for the Group Communication Service.
  */
 @TaskSide
 @Provided

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/GroupCommNetworkHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/GroupCommNetworkHandler.java
@@ -27,7 +27,7 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.wake.EventHandler;
 
 /**
- * The global EventHandler that receives the GroupCommunicationMsg
+ * The global EventHandler that receives the GroupCommunicationMsg.
  * and routes it to the relevant communication group
  */
 @TaskSide

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/GroupCommunicationMessageCodec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/GroupCommunicationMessageCodec.java
@@ -27,7 +27,7 @@ import javax.inject.Inject;
 import java.io.*;
 
 /**
- * Codec for {@link GroupCommMessage}
+ * Codec for {@link GroupCommMessage}.
  */
 public class GroupCommunicationMessageCodec implements StreamingCodec<GroupCommunicationMessage> {
 

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/BroadcastOperatorSpec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/BroadcastOperatorSpec.java
@@ -24,13 +24,13 @@ import org.apache.reef.io.serialization.Codec;
 
 
 /**
- * The specification for the broadcast operator
+ * The specification for the broadcast operator.
  */
 public class BroadcastOperatorSpec implements OperatorSpec {
   private final String senderId;
 
   /**
-   * Codec to be used to serialize data
+   * Codec to be used to serialize data.
    */
   private final Class<? extends Codec> dataCodecClass;
 

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/ReduceOperatorSpec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/ReduceOperatorSpec.java
@@ -24,19 +24,19 @@ import org.apache.reef.io.network.group.impl.utils.Utils;
 import org.apache.reef.io.serialization.Codec;
 
 /**
- * The specification for the Reduce operator
+ * The specification for the Reduce operator.
  */
 public class ReduceOperatorSpec implements OperatorSpec {
 
   private final String receiverId;
 
   /**
-   * Codec to be used to serialize data
+   * Codec to be used to serialize data.
    */
   private final Class<? extends Codec> dataCodecClass;
 
   /**
-   * The reduce function to be used for operations that do reduction
+   * The reduce function to be used for operations that do reduction.
    */
   public final Class<? extends ReduceFunction> redFuncClass;
 

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CtrlMsgSender.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CtrlMsgSender.java
@@ -30,7 +30,7 @@ import org.apache.reef.wake.IdentifierFactory;
 import java.util.logging.Logger;
 
 /**
- * Event handler that receives ctrl msgs and
+ * Event handler that receives ctrl msgs and.
  * dispatched them using network service
  */
 public class CtrlMsgSender implements EventHandler<GroupCommunicationMessage> {

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/FlatTopology.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/FlatTopology.java
@@ -54,7 +54,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.logging.Logger;
 
 /**
- * Implements a one level Tree Topology
+ * Implements a one level Tree Topology.
  */
 public class FlatTopology implements Topology {
 

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/GroupCommDriverImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/GroupCommDriverImpl.java
@@ -74,7 +74,7 @@ import java.util.logging.Logger;
 public class GroupCommDriverImpl implements GroupCommServiceDriver {
   private static final Logger LOG = Logger.getLogger(GroupCommDriverImpl.class.getName());
   /**
-   * TANG instance
+   * TANG instance.
    */
   private static final Tang tang = Tang.Factory.getTang();
 

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/GroupCommMessageHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/GroupCommMessageHandler.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import java.util.logging.Logger;
 
 /**
- * The network handler for the group communcation service on the driver side
+ * The network handler for the group communcation service on the driver side.
  */
 public class GroupCommMessageHandler implements EventHandler<GroupCommunicationMessage> {
 

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/GroupCommService.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/GroupCommService.java
@@ -39,7 +39,7 @@ import javax.inject.Inject;
 import java.util.logging.Logger;
 
 /**
- * The Group Communication Service
+ * The Group Communication Service.
  */
 @Unit
 public class GroupCommService {

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/IndexedMsg.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/IndexedMsg.java
@@ -23,7 +23,7 @@ import org.apache.reef.io.network.group.impl.utils.Utils;
 import org.apache.reef.tang.annotations.Name;
 
 /**
- * Helper class to wrap msg and the operator name in the msg
+ * Helper class to wrap msg and the operator name in the msg.
  */
 public class IndexedMsg {
   private final Class<? extends Name<String>> operName;

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/MsgKey.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/MsgKey.java
@@ -22,7 +22,7 @@ import org.apache.reef.io.network.group.impl.GroupCommunicationMessage;
 import org.apache.reef.io.network.proto.ReefNetworkGroupCommProtos;
 
 /**
- * The key object used in map to aggregate msgs from
+ * The key object used in map to aggregate msgs from.
  * all the operators before updating state on driver
  */
 public class MsgKey {

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TaskNodeImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TaskNodeImpl.java
@@ -95,7 +95,7 @@ public class TaskNodeImpl implements TaskNode {
   }
 
   /**
-   * * Methods pertaining to my status change ***
+   * * Methods pertaining to my status change ***.
    */
   @Override
   public void onFailedTask() {
@@ -158,7 +158,7 @@ public class TaskNodeImpl implements TaskNode {
   }
 
   /**
-   * * Methods pertaining to my status change ends ***
+   * * Methods pertaining to my status change ends ***.
    */
 
   @Override
@@ -235,7 +235,7 @@ public class TaskNodeImpl implements TaskNode {
   }
 
   /**
-   * * Methods pertaining to my neighbors status change ends ***
+   * * Methods pertaining to my neighbors status change ends ***.
    */
 
   @Override

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TaskNodeStatusImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TaskNodeStatusImpl.java
@@ -108,7 +108,7 @@ public class TaskNodeStatusImpl implements TaskNodeStatus {
   }
 
   /**
-   * This needs to happen in line rather than in a stage because we need to note
+   * This needs to happen in line rather than in a stage because we need to note.
    * the messages we send to the tasks before we start processing msgs from the
    * nodes.(Acks & Topology msgs)
    */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TreeTopology.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TreeTopology.java
@@ -56,7 +56,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.logging.Logger;
 
 /**
- * Implements a tree topology with the specified Fan Out
+ * Implements a tree topology with the specified Fan Out.
  */
 public class TreeTopology implements Topology {
 

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/OperatorTopologyImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/OperatorTopologyImpl.java
@@ -233,7 +233,7 @@ public class OperatorTopologyImpl implements OperatorTopology {
   }
 
   /**
-   * Only refreshes the effective topology with deletion msgs from
+   * Only refreshes the effective topology with deletion msgs from.
    * deletionDeltas queue
    *
    * @throws ParentDeadException
@@ -267,7 +267,7 @@ public class OperatorTopologyImpl implements OperatorTopology {
   }
 
   /**
-   * Blocking method that waits till the base topology is updated Unblocks when
+   * Blocking method that waits till the base topology is updated Unblocks when.
    * we receive a TopologySetup msg from driver
    * <p/>
    * Will also update the effective topology when the base topology is updated

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/ConcurrentCountingMap.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/ConcurrentCountingMap.java
@@ -26,7 +26,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Utility map class that wraps a CountingMap
+ * Utility map class that wraps a CountingMap.
  * in a ConcurrentMap
  * Equivalent to Map<K,Map<V,Integer>>
  */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/CountingMap.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/CountingMap.java
@@ -24,7 +24,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Utility class to provide a map that allows to
+ * Utility class to provide a map that allows to.
  * add multiple keys and automatically
  * incrementing the count on each add
  * decrementing the count on each remove

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/SetMap.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/SetMap.java
@@ -23,7 +23,7 @@ import org.apache.reef.io.network.group.impl.driver.MsgKey;
 import java.util.*;
 
 /**
- * Map from K to Set<V>
+ * Map from K to Set<V>.
  */
 public class SetMap<K, V> {
   private final Map<K, Set<V>> map = new HashMap<>();

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NSConnection.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NSConnection.java
@@ -33,7 +33,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * A connection from the network service
+ * A connection from the network service.
  */
 class NSConnection<T> implements Connection<T> {
 
@@ -49,7 +49,7 @@ class NSConnection<T> implements Connection<T> {
   private Link<NSMessage<T>> link;
 
   /**
-   * Constructs a connection
+   * Constructs a connection.
    *
    * @param srcId    a source identifier
    * @param destId   a destination identifier
@@ -95,7 +95,7 @@ class NSConnection<T> implements Connection<T> {
   }
 
   /**
-   * Writes an object to the connection
+   * Writes an object to the connection.
    *
    * @param obj an object of type T
    * @throws a network exception
@@ -106,7 +106,7 @@ class NSConnection<T> implements Connection<T> {
   }
 
   /**
-   * Closes the connection and unregisters it from the service
+   * Closes the connection and unregisters it from the service.
    */
   @Override
   public void close() throws NetworkException {
@@ -115,7 +115,7 @@ class NSConnection<T> implements Connection<T> {
 }
 
 /**
- * No-op link listener
+ * No-op link listener.
  *
  * @param <T>
  */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NSMessage.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NSMessage.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Network service message that implements the Message interface
+ * Network service message that implements the Message interface.
  *
  * @param <T> type
  */
@@ -35,7 +35,7 @@ public class NSMessage<T> implements Message<T> {
   private final List<T> data;
 
   /**
-   * Constructs a network service message
+   * Constructs a network service message.
    *
    * @param srcId  a source identifier
    * @param destId a destination identifier
@@ -49,7 +49,7 @@ public class NSMessage<T> implements Message<T> {
   }
 
   /**
-   * Constructs a network service message
+   * Constructs a network service message.
    *
    * @param srcId  a source identifier
    * @param destId a destination identifier
@@ -62,7 +62,7 @@ public class NSMessage<T> implements Message<T> {
   }
 
   /**
-   * Gets a source identifier
+   * Gets a source identifier.
    *
    * @return an identifier
    */
@@ -71,7 +71,7 @@ public class NSMessage<T> implements Message<T> {
   }
 
   /**
-   * Gets a destination identifier
+   * Gets a destination identifier.
    *
    * @return an identifier
    */
@@ -80,7 +80,7 @@ public class NSMessage<T> implements Message<T> {
   }
 
   /**
-   * Gets data
+   * Gets data.
    *
    * @return data
    */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NSMessageCodec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NSMessageCodec.java
@@ -32,7 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Network service message codec
+ * Network service message codec.
  *
  * @param <T> type
  */
@@ -43,7 +43,7 @@ public class NSMessageCodec<T> implements Codec<NSMessage<T>> {
   private final boolean isStreamingCodec;
 
   /**
-   * Constructs a network service message codec
+   * Constructs a network service message codec.
    *
    * @param codec   a codec
    * @param factory an identifier factory
@@ -55,7 +55,7 @@ public class NSMessageCodec<T> implements Codec<NSMessage<T>> {
   }
 
   /**
-   * Encodes a network service message to bytes
+   * Encodes a network service message to bytes.
    *
    * @param obj a message
    * @return bytes
@@ -91,7 +91,7 @@ public class NSMessageCodec<T> implements Codec<NSMessage<T>> {
   }
 
   /**
-   * Decodes a network service message from bytes
+   * Decodes a network service message from bytes.
    *
    * @param buf bytes
    * @return a message

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkService.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkService.java
@@ -50,7 +50,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Network service for Task
+ * Network service for Task.
  */
 public final class NetworkService<T> implements Stage, ConnectionFactory<T> {
 

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/StreamingCodec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/StreamingCodec.java
@@ -24,7 +24,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 
 /**
- * A codec that can make serialization more efficient when an object has to be
+ * A codec that can make serialization more efficient when an object has to be.
  * codec'ed through a chain of codecs
  */
 public interface StreamingCodec<T> extends Codec<T> {

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameAssignmentTuple.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameAssignmentTuple.java
@@ -24,7 +24,7 @@ import org.apache.reef.wake.Identifier;
 import java.net.InetSocketAddress;
 
 /**
- * An implementation of the NameAssignment interface
+ * An implementation of the NameAssignment interface.
  */
 public class NameAssignmentTuple implements NameAssignment {
 
@@ -32,7 +32,7 @@ public class NameAssignmentTuple implements NameAssignment {
   private final InetSocketAddress addr;
 
   /**
-   * Constructs a name assignment tuple
+   * Constructs a name assignment tuple.
    *
    * @param id   an identifier
    * @param addr an Internet socket address
@@ -43,7 +43,7 @@ public class NameAssignmentTuple implements NameAssignment {
   }
 
   /**
-   * Gets an identifier
+   * Gets an identifier.
    *
    * @return an identifier
    */
@@ -53,7 +53,7 @@ public class NameAssignmentTuple implements NameAssignment {
   }
 
   /**
-   * Gets an address
+   * Gets an address.
    *
    * @return an Internet socket address
    */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameCache.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameCache.java
@@ -28,14 +28,14 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
 /**
- * Naming cache implementation
+ * Naming cache implementation.
  */
 public class NameCache implements Cache<Identifier, InetSocketAddress> {
 
   private final Cache<Identifier, InetSocketAddress> cache;
 
   /**
-   * Constructs a naming cache
+   * Constructs a naming cache.
    *
    * @param timeout a cache entry timeout after write
    */
@@ -44,7 +44,7 @@ public class NameCache implements Cache<Identifier, InetSocketAddress> {
   }
 
   /**
-   * Gets an address for an identifier
+   * Gets an address for an identifier.
    *
    * @param key          an identifier
    * @param valueFetcher a callable to load a value for the corresponding identifier
@@ -58,7 +58,7 @@ public class NameCache implements Cache<Identifier, InetSocketAddress> {
   }
 
   /**
-   * Invalidates the entry for an identifier
+   * Invalidates the entry for an identifier.
    *
    * @param key an identifier
    */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameClient.java
@@ -45,7 +45,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Naming client
+ * Naming client.
  */
 public class NameClient implements Stage, Naming {
   private static final Logger LOG = Logger.getLogger(NameClient.class.getName());
@@ -66,7 +66,7 @@ public class NameClient implements Stage, Naming {
   }
 
   /**
-   * Constructs a naming client
+   * Constructs a naming client.
    *
    * @param serverAddr a server address
    * @param serverPort a server port number
@@ -102,7 +102,7 @@ public class NameClient implements Stage, Naming {
   }
 
   /**
-   * Constructs a naming client
+   * Constructs a naming client.
    *
    * @param serverAddr a server address
    * @param serverPort a server port number
@@ -123,7 +123,7 @@ public class NameClient implements Stage, Naming {
   }
 
   /**
-   * Constructs a naming client
+   * Constructs a naming client.
    *
    * @param serverAddr a server address
    * @param serverPort a server port number
@@ -159,7 +159,7 @@ public class NameClient implements Stage, Naming {
   }
 
   /**
-   * Registers an (identifier, address) mapping
+   * Registers an (identifier, address) mapping.
    *
    * @param id   an identifier
    * @param addr an Internet socket address
@@ -172,7 +172,7 @@ public class NameClient implements Stage, Naming {
   }
 
   /**
-   * Unregisters an identifier
+   * Unregisters an identifier.
    *
    * @param id an identifier
    */
@@ -182,7 +182,7 @@ public class NameClient implements Stage, Naming {
   }
 
   /**
-   * Finds an address for an identifier
+   * Finds an address for an identifier.
    *
    * @param id an identifier
    * @return an Internet socket address
@@ -193,7 +193,7 @@ public class NameClient implements Stage, Naming {
   }
 
   /**
-   * Retrieves an address for an identifier remotely
+   * Retrieves an address for an identifier remotely.
    *
    * @param id an identifier
    * @return an Internet socket address
@@ -204,7 +204,7 @@ public class NameClient implements Stage, Naming {
   }
 
   /**
-   * Closes resources
+   * Closes resources.
    */
   @Override
   public void close() throws Exception {
@@ -224,7 +224,7 @@ public class NameClient implements Stage, Naming {
 }
 
 /**
- * Naming client transport event handler
+ * Naming client transport event handler.
  */
 class NamingClientEventHandler implements EventHandler<TransportEvent> {
 
@@ -247,7 +247,7 @@ class NamingClientEventHandler implements EventHandler<TransportEvent> {
 }
 
 /**
- * Naming response message handler
+ * Naming response message handler.
  */
 class NamingResponseHandler implements EventHandler<NamingMessage> {
 

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameLookupClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameLookupClient.java
@@ -54,7 +54,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Naming lookup client
+ * Naming lookup client.
  */
 public class NameLookupClient implements Stage, NamingLookup {
 
@@ -69,7 +69,7 @@ public class NameLookupClient implements Stage, NamingLookup {
   private final int retryTimeout;
 
   /**
-   * Constructs a naming lookup client
+   * Constructs a naming lookup client.
    *
    * @param serverAddr a server address
    * @param serverPort a server port number
@@ -87,7 +87,7 @@ public class NameLookupClient implements Stage, NamingLookup {
   }
 
   /**
-   * Constructs a naming lookup client
+   * Constructs a naming lookup client.
    *
    * @param serverAddr a server address
    * @param serverPort a server port number
@@ -123,7 +123,7 @@ public class NameLookupClient implements Stage, NamingLookup {
   }
 
   /**
-   * Constructs a naming lookup client
+   * Constructs a naming lookup client.
    *
    * @param serverAddr a server address
    * @param serverPort a server port number
@@ -144,7 +144,7 @@ public class NameLookupClient implements Stage, NamingLookup {
   }
 
   /**
-   * Constructs a naming lookup client
+   * Constructs a naming lookup client.
    *
    * @param serverAddr a server address
    * @param serverPort a server port number
@@ -195,7 +195,7 @@ public class NameLookupClient implements Stage, NamingLookup {
 
 
   /**
-   * Finds an address for an identifier
+   * Finds an address for an identifier.
    *
    * @param id an identifier
    * @return an Internet socket address
@@ -233,7 +233,7 @@ public class NameLookupClient implements Stage, NamingLookup {
   }
 
   /**
-   * Retrieves an address for an identifier remotely
+   * Retrieves an address for an identifier remotely.
    *
    * @param id an identifier
    * @return an Internet socket address
@@ -273,7 +273,7 @@ public class NameLookupClient implements Stage, NamingLookup {
   }
 
   /**
-   * Closes resources
+   * Closes resources.
    */
   @Override
   public void close() throws Exception {
@@ -291,7 +291,7 @@ public class NameLookupClient implements Stage, NamingLookup {
 }
 
 /**
- * Naming lookup client transport event handler
+ * Naming lookup client transport event handler.
  */
 class NamingLookupClientHandler implements EventHandler<TransportEvent> {
 
@@ -311,7 +311,7 @@ class NamingLookupClientHandler implements EventHandler<TransportEvent> {
 }
 
 /**
- * Naming lookup response handler
+ * Naming lookup response handler.
  */
 class NamingLookupResponseHandler implements EventHandler<NamingLookupResponse> {
 

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameRegistryClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameRegistryClient.java
@@ -52,7 +52,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Naming registry client
+ * Naming registry client.
  */
 public class NameRegistryClient implements Stage, NamingRegistry {
 
@@ -65,7 +65,7 @@ public class NameRegistryClient implements Stage, NamingRegistry {
   private final long timeout;
 
   /**
-   * Constructs a naming registry client
+   * Constructs a naming registry client.
    *
    * @param serverAddr a name server address
    * @param serverPort a name server port
@@ -77,7 +77,7 @@ public class NameRegistryClient implements Stage, NamingRegistry {
   }
 
   /**
-   * Constructs a naming registry client
+   * Constructs a naming registry client.
    *
    * @param serverAddr a name server address
    * @param serverPort a name server port
@@ -132,7 +132,7 @@ public class NameRegistryClient implements Stage, NamingRegistry {
   }
 
   /**
-   * Registers an (identifier, address) mapping
+   * Registers an (identifier, address) mapping.
    *
    * @param id   an identifier
    * @param addr an Internet socket address
@@ -164,7 +164,7 @@ public class NameRegistryClient implements Stage, NamingRegistry {
   }
 
   /**
-   * Unregisters an identifier
+   * Unregisters an identifier.
    *
    * @param id an identifier
    */
@@ -176,7 +176,7 @@ public class NameRegistryClient implements Stage, NamingRegistry {
   }
 
   /**
-   * Closes resources
+   * Closes resources.
    */
   @Override
   public void close() throws Exception {
@@ -186,7 +186,7 @@ public class NameRegistryClient implements Stage, NamingRegistry {
 }
 
 /**
- * Naming registry client transport event handler
+ * Naming registry client transport event handler.
  */
 class NamingRegistryClientHandler implements EventHandler<TransportEvent> {
   private static final Logger LOG = Logger.getLogger(NamingRegistryClientHandler.class.getName());
@@ -207,7 +207,7 @@ class NamingRegistryClientHandler implements EventHandler<TransportEvent> {
 }
 
 /**
- * Naming register response handler
+ * Naming register response handler.
  */
 class NamingRegistryResponseHandler implements EventHandler<NamingRegisterResponse> {
 

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameServer.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameServer.java
@@ -27,18 +27,18 @@ import java.net.InetSocketAddress;
 import java.util.List;
 
 /**
- * Naming server interface
+ * Naming server interface.
  */
 public interface NameServer extends Stage {
 
   /**
-   * get port number
+   * get port number.
    * @return
    */
   public int getPort();
 
   /**
-   * Registers an (identifier, address) mapping locally
+   * Registers an (identifier, address) mapping locally.
    *
    * @param id   an identifier
    * @param addr an Internet socket address
@@ -46,14 +46,14 @@ public interface NameServer extends Stage {
   public void register(final Identifier id, final InetSocketAddress addr);
 
   /**
-   * Unregisters an identifier locally
+   * Unregisters an identifier locally.
    *
    * @param id an identifier
    */
   public void unregister(final Identifier id);
 
   /**
-   * Finds an address for an identifier locally
+   * Finds an address for an identifier locally.
    *
    * @param id an identifier
    * @return an Internet socket address
@@ -61,7 +61,7 @@ public interface NameServer extends Stage {
   public InetSocketAddress lookup(final Identifier id);
 
   /**
-   * Finds addresses for identifiers locally
+   * Finds addresses for identifiers locally.
    *
    * @param identifiers an Iterable of identifiers
    * @return a list of name assignments

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameServerConfiguration.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameServerConfiguration.java
@@ -25,20 +25,20 @@ import org.apache.reef.tang.formats.OptionalParameter;
 import org.apache.reef.wake.IdentifierFactory;
 
 /**
- * Configuration Module Builder for NameServer
+ * Configuration Module Builder for NameServer.
  */
 public final class NameServerConfiguration extends ConfigurationModuleBuilder {
 
   /**
-   * The port used by name server
+   * The port used by name server.
    */
   public static final OptionalParameter<Integer> NAME_SERVICE_PORT = new OptionalParameter<>();
   /**
-   * DNS hostname running the name service
+   * DNS hostname running the name service.
    */
   public static final OptionalParameter<String> NAME_SERVER_HOSTNAME = new OptionalParameter<>();
   /**
-   * Identifier factory for the name service
+   * Identifier factory for the name service.
    */
   public static final OptionalParameter<IdentifierFactory> NAME_SERVER_IDENTIFIER_FACTORY = new OptionalParameter<>();
 

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameServerImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameServerImpl.java
@@ -48,7 +48,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Naming server implementation
+ * Naming server implementation.
  */
 public class NameServerImpl implements NameServer {
 
@@ -117,7 +117,7 @@ public class NameServerImpl implements NameServer {
   }
 
   /**
-   * Constructs a name server
+   * Constructs a name server.
    *
    * @param port                  a listening port number
    * @param factory               an identifier factory
@@ -136,7 +136,7 @@ public class NameServerImpl implements NameServer {
 
 
   /**
-   * Constructs a name server
+   * Constructs a name server.
    *
    * @param port                  a listening port number
    * @param factory               an identifier factory
@@ -184,7 +184,7 @@ public class NameServerImpl implements NameServer {
     return handler;
   }
   /**
-   * Gets port
+   * Gets port.
    */
   @Override
   public int getPort() {
@@ -192,7 +192,7 @@ public class NameServerImpl implements NameServer {
   }
 
   /**
-   * Closes resources
+   * Closes resources.
    */
   @Override
   public void close() throws Exception {
@@ -200,7 +200,7 @@ public class NameServerImpl implements NameServer {
   }
 
   /**
-   * Registers an (identifier, address) mapping locally
+   * Registers an (identifier, address) mapping locally.
    *
    * @param id   an identifier
    * @param addr an Internet socket address
@@ -212,7 +212,7 @@ public class NameServerImpl implements NameServer {
   }
 
   /**
-   * Unregisters an identifier locally
+   * Unregisters an identifier locally.
    *
    * @param id an identifier
    */
@@ -223,7 +223,7 @@ public class NameServerImpl implements NameServer {
   }
 
   /**
-   * Finds an address for an identifier locally
+   * Finds an address for an identifier locally.
    *
    * @param id an identifier
    * @return an Internet socket address
@@ -235,7 +235,7 @@ public class NameServerImpl implements NameServer {
   }
 
   /**
-   * Finds addresses for identifiers locally
+   * Finds addresses for identifiers locally.
    *
    * @param identifiers an iterable of identifiers
    * @return a list of name assignments
@@ -260,7 +260,7 @@ public class NameServerImpl implements NameServer {
 }
 
 /**
- * Naming server transport event handler that invokes a specific naming message handler
+ * Naming server transport event handler that invokes a specific naming message handler.
  */
 class NamingServerHandler implements EventHandler<TransportEvent> {
 
@@ -282,7 +282,7 @@ class NamingServerHandler implements EventHandler<TransportEvent> {
 }
 
 /**
- * Naming lookup request handler
+ * Naming lookup request handler.
  */
 class NamingLookupRequestHandler implements EventHandler<NamingLookupRequest> {
 
@@ -306,7 +306,7 @@ class NamingLookupRequestHandler implements EventHandler<NamingLookupRequest> {
 }
 
 /**
- * Naming register request handler
+ * Naming register request handler.
  */
 class NamingRegisterRequestHandler implements EventHandler<NamingRegisterRequest> {
 
@@ -330,7 +330,7 @@ class NamingRegisterRequestHandler implements EventHandler<NamingRegisterRequest
 }
 
 /**
- * Naming unregister request handler
+ * Naming unregister request handler.
  */
 class NamingUnregisterRequestHandler implements EventHandler<NamingUnregisterRequest> {
 

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NamingCodecFactory.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NamingCodecFactory.java
@@ -27,12 +27,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Factory to create naming codecs
+ * Factory to create naming codecs.
  */
 class NamingCodecFactory {
 
   /**
-   * Creates a codec only for lookup
+   * Creates a codec only for lookup.
    *
    * @param factory an identifier factory
    * @return a codec
@@ -47,7 +47,7 @@ class NamingCodecFactory {
   }
 
   /**
-   * Creates a codec only for registration
+   * Creates a codec only for registration.
    *
    * @param factory an identifier factory
    * @return a codec
@@ -63,7 +63,7 @@ class NamingCodecFactory {
   }
 
   /**
-   * Creates a codec for both lookup and registration
+   * Creates a codec for both lookup and registration.
    *
    * @param factory an identifier factory
    * @return a codec

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/exception/NamingException.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/exception/NamingException.java
@@ -21,13 +21,13 @@ package org.apache.reef.io.network.naming.exception;
 import org.apache.reef.exception.evaluator.NetworkException;
 
 /**
- * Naming exception
+ * Naming exception.
  */
 public class NamingException extends NetworkException {
   private static final long serialVersionUID = 1L;
 
   /**
-   * Constructs a new resourcemanager naming exception with the specified detail message and cause
+   * Constructs a new resourcemanager naming exception with the specified detail message and cause.
    *
    * @param s the detailed message
    * @param e the cause
@@ -37,7 +37,7 @@ public class NamingException extends NetworkException {
   }
 
   /**
-   * Constructs a new resourcemanager naming exception with the specified detail message
+   * Constructs a new resourcemanager naming exception with the specified detail message.
    *
    * @param s the detailed message
    */
@@ -46,7 +46,7 @@ public class NamingException extends NetworkException {
   }
 
   /**
-   * Constructs a new resourcemanager naming exception with the specified cause
+   * Constructs a new resourcemanager naming exception with the specified cause.
    *
    * @param e the cause
    */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/exception/NamingRuntimeException.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/exception/NamingRuntimeException.java
@@ -21,13 +21,13 @@ package org.apache.reef.io.network.naming.exception;
 import org.apache.reef.io.network.exception.NetworkRuntimeException;
 
 /**
- * Naming resourcemanager exception
+ * Naming resourcemanager exception.
  */
 public class NamingRuntimeException extends NetworkRuntimeException {
   private static final long serialVersionUID = 1L;
 
   /**
-   * Constructs a new resourcemanager naming exception with the specified detail message and cause
+   * Constructs a new resourcemanager naming exception with the specified detail message and cause.
    *
    * @param s the detailed message
    * @param e the cause
@@ -37,7 +37,7 @@ public class NamingRuntimeException extends NetworkRuntimeException {
   }
 
   /**
-   * Constructs a new resourcemanager naming exception with the specified detail message
+   * Constructs a new resourcemanager naming exception with the specified detail message.
    *
    * @param s the detailed message
    */
@@ -46,7 +46,7 @@ public class NamingRuntimeException extends NetworkRuntimeException {
   }
 
   /**
-   * Constructs a new resourcemanager naming exception with the specified cause
+   * Constructs a new resourcemanager naming exception with the specified cause.
    *
    * @param e the cause
    */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/AvroUtils.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/AvroUtils.java
@@ -34,7 +34,7 @@ final class AvroUtils {
   }
 
   /**
-   * Serializes the given avro object to a byte[]
+   * Serializes the given avro object to a byte[].
    *
    * @param avroObject
    * @param theClass

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingLookupRequest.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingLookupRequest.java
@@ -21,13 +21,13 @@ package org.apache.reef.io.network.naming.serialization;
 import org.apache.reef.wake.Identifier;
 
 /**
- * Naming lookup request
+ * Naming lookup request.
  */
 public class NamingLookupRequest extends NamingMessage {
   private Iterable<Identifier> ids;
 
   /**
-   * Constructs a naming lookup request
+   * Constructs a naming lookup request.
    *
    * @param ids the iterable of identifiers
    */
@@ -36,7 +36,7 @@ public class NamingLookupRequest extends NamingMessage {
   }
 
   /**
-   * Gets identifiers
+   * Gets identifiers.
    *
    * @return an iterable of identifiers
    */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingLookupRequestCodec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingLookupRequestCodec.java
@@ -28,14 +28,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Naming lookup request codec
+ * Naming lookup request codec.
  */
 public final class NamingLookupRequestCodec implements Codec<NamingLookupRequest> {
 
   private final IdentifierFactory factory;
 
   /**
-   * Constructs a naming lookup request codec
+   * Constructs a naming lookup request codec.
    *
    * @param factory the identifier factory
    */
@@ -45,7 +45,7 @@ public final class NamingLookupRequestCodec implements Codec<NamingLookupRequest
   }
 
   /**
-   * Encodes the identifiers to bytes
+   * Encodes the identifiers to bytes.
    *
    * @param obj the naming lookup request
    * @return a byte array
@@ -60,7 +60,7 @@ public final class NamingLookupRequestCodec implements Codec<NamingLookupRequest
   }
 
   /**
-   * Decodes the bytes to a naming lookup request
+   * Decodes the bytes to a naming lookup request.
    *
    * @param buf the byte array
    * @return a naming lookup request

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingLookupResponse.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingLookupResponse.java
@@ -23,13 +23,13 @@ import org.apache.reef.io.naming.NameAssignment;
 import java.util.List;
 
 /**
- * Naming lookup response
+ * Naming lookup response.
  */
 public class NamingLookupResponse extends NamingMessage {
   private final List<NameAssignment> nas;
 
   /**
-   * Constructs a naming lookup response
+   * Constructs a naming lookup response.
    *
    * @param nas the list of name assignments
    */
@@ -38,7 +38,7 @@ public class NamingLookupResponse extends NamingMessage {
   }
 
   /**
-   * Gets name assignments
+   * Gets name assignments.
    *
    * @return a list of name assignments
    */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingLookupResponseCodec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingLookupResponseCodec.java
@@ -32,14 +32,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Naming lookup response codec
+ * Naming lookup response codec.
  */
 public final class NamingLookupResponseCodec implements Codec<NamingLookupResponse> {
 
   private final IdentifierFactory factory;
 
   /**
-   * Constructs a naming lookup response codec
+   * Constructs a naming lookup response codec.
    *
    * @param factory the identifier factory
    */
@@ -49,7 +49,7 @@ public final class NamingLookupResponseCodec implements Codec<NamingLookupRespon
   }
 
   /**
-   * Encodes name assignments to bytes
+   * Encodes name assignments to bytes.
    *
    * @param obj the naming lookup response
    * @return a byte array
@@ -70,7 +70,7 @@ public final class NamingLookupResponseCodec implements Codec<NamingLookupRespon
   }
 
   /**
-   * Decodes bytes to an iterable of name assignments
+   * Decodes bytes to an iterable of name assignments.
    *
    * @param buf the byte array
    * @return a naming lookup response

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingMessage.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingMessage.java
@@ -21,13 +21,13 @@ package org.apache.reef.io.network.naming.serialization;
 import org.apache.reef.wake.remote.transport.Link;
 
 /**
- * An abstract base class for naming messages
+ * An abstract base class for naming messages.
  */
 public abstract class NamingMessage {
   private transient Link<byte[]> link;
 
   /**
-   * Gets a link
+   * Gets a link.
    *
    * @return a link
    */
@@ -36,7 +36,7 @@ public abstract class NamingMessage {
   }
 
   /**
-   * Sets the link
+   * Sets the link.
    *
    * @param link the link
    */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingRegisterRequest.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingRegisterRequest.java
@@ -21,13 +21,13 @@ package org.apache.reef.io.network.naming.serialization;
 import org.apache.reef.io.naming.NameAssignment;
 
 /**
- * naming registration request
+ * naming registration request.
  */
 public class NamingRegisterRequest extends NamingMessage {
   private final NameAssignment na;
 
   /**
-   * Constructs a naming registration request
+   * Constructs a naming registration request.
    *
    * @param na the name assignment
    */
@@ -36,7 +36,7 @@ public class NamingRegisterRequest extends NamingMessage {
   }
 
   /**
-   * Gets a name assignment
+   * Gets a name assignment.
    *
    * @return a name assignment
    */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingRegisterRequestCodec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingRegisterRequestCodec.java
@@ -27,14 +27,14 @@ import org.apache.reef.wake.remote.Codec;
 import java.net.InetSocketAddress;
 
 /**
- * Naming registration request codec
+ * Naming registration request codec.
  */
 public class NamingRegisterRequestCodec implements Codec<NamingRegisterRequest> {
 
   private final IdentifierFactory factory;
 
   /**
-   * Constructs a naming registration request codec
+   * Constructs a naming registration request codec.
    *
    * @param factory the identifier factory
    */
@@ -43,7 +43,7 @@ public class NamingRegisterRequestCodec implements Codec<NamingRegisterRequest> 
   }
 
   /**
-   * Encodes the name assignment to bytes
+   * Encodes the name assignment to bytes.
    *
    * @param obj the naming registration request
    * @return a byte array
@@ -59,7 +59,7 @@ public class NamingRegisterRequestCodec implements Codec<NamingRegisterRequest> 
   }
 
   /**
-   * Decodes the bytes to a name assignment
+   * Decodes the bytes to a name assignment.
    *
    * @param buf the byte array
    * @return a naming registration request

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingRegisterResponse.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingRegisterResponse.java
@@ -19,13 +19,13 @@
 package org.apache.reef.io.network.naming.serialization;
 
 /**
- * naming registration response
+ * naming registration response.
  */
 public class NamingRegisterResponse extends NamingMessage {
   private final NamingRegisterRequest request;
 
   /**
-   * Constructs a naming register response
+   * Constructs a naming register response.
    *
    * @param request the naming register request
    */
@@ -34,7 +34,7 @@ public class NamingRegisterResponse extends NamingMessage {
   }
 
   /**
-   * Gets a naming register request
+   * Gets a naming register request.
    *
    * @return a naming register request
    */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingRegisterResponseCodec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingRegisterResponseCodec.java
@@ -21,13 +21,13 @@ package org.apache.reef.io.network.naming.serialization;
 import org.apache.reef.wake.remote.Codec;
 
 /**
- * naming registration response codec
+ * naming registration response codec.
  */
 public class NamingRegisterResponseCodec implements Codec<NamingRegisterResponse> {
   private final NamingRegisterRequestCodec codec;
 
   /**
-   * Constructs a naming register response codec
+   * Constructs a naming register response codec.
    *
    * @param codec the naming register request codec
    */
@@ -36,7 +36,7 @@ public class NamingRegisterResponseCodec implements Codec<NamingRegisterResponse
   }
 
   /**
-   * Encodes a naming register response to bytes
+   * Encodes a naming register response to bytes.
    *
    * @param obj the naming register response
    * @return bytes a byte array
@@ -47,7 +47,7 @@ public class NamingRegisterResponseCodec implements Codec<NamingRegisterResponse
   }
 
   /**
-   * Decodes a naming register response from the bytes
+   * Decodes a naming register response from the bytes.
    *
    * @param buf the byte array
    * @return a naming register response

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingUnregisterRequest.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingUnregisterRequest.java
@@ -21,13 +21,13 @@ package org.apache.reef.io.network.naming.serialization;
 import org.apache.reef.wake.Identifier;
 
 /**
- * Naming un-registration request
+ * Naming un-registration request.
  */
 public class NamingUnregisterRequest extends NamingMessage {
   private final Identifier id;
 
   /**
-   * Constructs a naming un-registration request
+   * Constructs a naming un-registration request.
    *
    * @param id the identifier
    */
@@ -36,7 +36,7 @@ public class NamingUnregisterRequest extends NamingMessage {
   }
 
   /**
-   * Gets an identifier
+   * Gets an identifier.
    *
    * @return an identifier
    */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingUnregisterRequestCodec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingUnregisterRequestCodec.java
@@ -26,14 +26,14 @@ import org.apache.reef.wake.remote.Codec;
 import javax.inject.Inject;
 
 /**
- * Naming un-registration request codec
+ * Naming un-registration request codec.
  */
 public final class NamingUnregisterRequestCodec implements Codec<NamingUnregisterRequest> {
 
   private final IdentifierFactory factory;
 
   /**
-   * Constructs a naming un-registration request codec
+   * Constructs a naming un-registration request codec.
    *
    * @param factory the identifier factory
    */
@@ -43,7 +43,7 @@ public final class NamingUnregisterRequestCodec implements Codec<NamingUnregiste
   }
 
   /**
-   * Encodes the naming un-registration request to bytes
+   * Encodes the naming un-registration request to bytes.
    *
    * @param obj the naming un-registration request
    * @return a byte array
@@ -57,7 +57,7 @@ public final class NamingUnregisterRequestCodec implements Codec<NamingUnregiste
   }
 
   /**
-   * Decodes the bytes to a naming un-registration request
+   * Decodes the bytes to a naming un-registration request.
    *
    * @param buf the byte array
    * @return a naming un-registration request

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/package-info.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * Contains naming serialization codecs
+ * Contains naming serialization codecs.
  */
 package org.apache.reef.io.network.naming.serialization;

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/util/StringIdentifier.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/util/StringIdentifier.java
@@ -22,14 +22,14 @@ import org.apache.reef.wake.ComparableIdentifier;
 import org.apache.reef.wake.Identifier;
 
 /**
- * String identifier
+ * String identifier.
  */
 public class StringIdentifier implements ComparableIdentifier {
 
   private final String str;
 
   /**
-   * Constructs a string identifier
+   * Constructs a string identifier.
    *
    * @param str a string
    */
@@ -38,7 +38,7 @@ public class StringIdentifier implements ComparableIdentifier {
   }
 
   /**
-   * Returns a hash code for the object
+   * Returns a hash code for the object.
    *
    * @return a hash code value for this object
    */
@@ -47,7 +47,7 @@ public class StringIdentifier implements ComparableIdentifier {
   }
 
   /**
-   * Checks that another object is equal to this object
+   * Checks that another object is equal to this object.
    *
    * @param o another object
    * @return true if the object is the same as the object argument; false, otherwise
@@ -57,7 +57,7 @@ public class StringIdentifier implements ComparableIdentifier {
   }
 
   /**
-   * Returns a string representation of the object
+   * Returns a string representation of the object.
    *
    * @return a string representation of the object
    */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/util/StringIdentifierFactory.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/util/StringIdentifierFactory.java
@@ -24,7 +24,7 @@ import org.apache.reef.wake.IdentifierFactory;
 import javax.inject.Inject;
 
 /**
- * Factory that creates StringIdentifier
+ * Factory that creates StringIdentifier.
  */
 public class StringIdentifierFactory implements IdentifierFactory {
 
@@ -33,7 +33,7 @@ public class StringIdentifierFactory implements IdentifierFactory {
   }
 
   /**
-   * Creates a StringIdentifier object
+   * Creates a StringIdentifier object.
    *
    * @param s a string
    * @return a string identifier

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/local/LocalScratchSpace.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/local/LocalScratchSpace.java
@@ -31,7 +31,7 @@ public class LocalScratchSpace implements ScratchSpace {
   private final String evaluatorName;
   private final Set<File> tempFiles = new ConcurrentSkipListSet<File>();
   /**
-   * Zero denotes "unlimited"
+   * Zero denotes "unlimited".
    */
   private long quota;
 

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/HDInsightJVMPathProvider.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/HDInsightJVMPathProvider.java
@@ -22,7 +22,7 @@ import com.google.inject.Inject;
 import org.apache.reef.runtime.common.files.RuntimePathProvider;
 
 /**
- * Supplies the java binary's path for HDInsight
+ * Supplies the java binary's path for HDInsight.
  */
 public final class HDInsightJVMPathProvider implements RuntimePathProvider {
   @Inject

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/cli/HDICLI.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/cli/HDICLI.java
@@ -34,7 +34,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Main class for the HDInsight REST commandline
+ * Main class for the HDInsight REST commandline.
  */
 public final class HDICLI {
   private static final Logger LOG = Logger.getLogger(HDICLI.class.getName());

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/cli/LogFileEntry.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/cli/LogFileEntry.java
@@ -36,7 +36,7 @@ final class LogFileEntry {
   }
 
   /**
-   * Writes the contents of the entry into the given outputWriter
+   * Writes the contents of the entry into the given outputWriter.
    *
    * @param outputWriter
    * @throws IOException

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/cli/TFileParser.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/cli/TFileParser.java
@@ -30,7 +30,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Parse TFile's content to key value pair
+ * Parse TFile's content to key value pair.
  */
 final class TFileParser {
   private static final Logger LOG = Logger.getLogger(TFileParser.class.getName());
@@ -59,7 +59,7 @@ final class TFileParser {
   }
 
   /**
-   * Parses the given file and stores the logs for each container in a file named after the container in the given
+   * Parses the given file and stores the logs for each container in a file named after the container in the given.
    * outputFolder
    *
    * @param inputPath

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/cli/package-info.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/cli/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * A command line interface for HDInsight
+ * A command line interface for HDInsight.
  */
 package org.apache.reef.runtime.hdinsight.cli;

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/HDInsightRuntimeConfiguration.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/HDInsightRuntimeConfiguration.java
@@ -64,7 +64,7 @@ public final class HDInsightRuntimeConfiguration extends ConfigurationModuleBuil
   public static final RequiredParameter<String> PASSWORD = new RequiredParameter<>();
 
   /**
-   * The environment variable that holds the path to the default configuration file
+   * The environment variable that holds the path to the default configuration file.
    */
   public static final String HDINSIGHT_CONFIGURATION_FILE_ENVIRONMENT_VARIABLE = "REEF_HDI_CONF";
 

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/UnsafeHDInsightRuntimeConfigurationStatic.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/UnsafeHDInsightRuntimeConfigurationStatic.java
@@ -34,7 +34,7 @@ import org.apache.reef.util.logging.LoggingSetup;
 import org.apache.reef.wake.remote.RemoteConfiguration;
 
 /**
- * The static part of the UnsafeHDInsightRuntimeConfiguration
+ * The static part of the UnsafeHDInsightRuntimeConfiguration.
  */
 public final class UnsafeHDInsightRuntimeConfigurationStatic extends ConfigurationModuleBuilder {
   static {

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/DriverConfigurationProvider.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/DriverConfigurationProvider.java
@@ -56,7 +56,7 @@ public final class DriverConfigurationProvider {
   }
 
   /**
-   * Assembles the driver configuration
+   * Assembles the driver configuration.
    *
    * @param jobFolder                The folder in which the local runtime will execute this job.
    * @param clientRemoteId           the remote identifier of the client. It is used by the Driver to establish a

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/PreparedDriverFolderLauncher.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/PreparedDriverFolderLauncher.java
@@ -60,7 +60,7 @@ public class PreparedDriverFolderLauncher {
   }
 
   /**
-   * Launches the driver prepared in driverFolder
+   * Launches the driver prepared in driverFolder.
    *
    * @param driverFolder
    * @param jobId

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/package-info.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * client-side event handlers for the local resourcemanager
+ * client-side event handlers for the local resourcemanager.
  */
 package org.apache.reef.runtime.local.client;

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/parameters/MaxNumberOfEvaluators.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/parameters/MaxNumberOfEvaluators.java
@@ -22,7 +22,7 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
- * The maximum number of evaluators to allow to run at once
+ * The maximum number of evaluators to allow to run at once.
  */
 @NamedParameter(default_value = "4", doc = "The maximum number of evaluators to allow to run at once", short_name = "maxEvaluators")
 public final class MaxNumberOfEvaluators implements Name<Integer> {

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
@@ -58,12 +58,12 @@ final class ContainerManager implements AutoCloseable {
   private final static Logger LOG = Logger.getLogger(ContainerManager.class.getName());
 
   /**
-   * Map from containerID -> Container
+   * Map from containerID -> Container.
    */
   private final Map<String, Container> containers = new HashMap<>();
 
   /**
-   * List of free, unallocated nodes by their Node ID
+   * List of free, unallocated nodes by their Node ID.
    */
   private final List<String> freeNodeList = new LinkedList<>();
 

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalDriverConfiguration.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalDriverConfiguration.java
@@ -51,7 +51,7 @@ public class LocalDriverConfiguration extends ConfigurationModuleBuilder {
   public static final OptionalParameter<Double> JVM_HEAP_SLACK = new OptionalParameter<>();
 
   /**
-   * The remote identifier to use for communications back to the client
+   * The remote identifier to use for communications back to the client.
    */
   public static final OptionalParameter<String> CLIENT_REMOTE_IDENTIFIER = new OptionalParameter<>();
 

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalResourceRequestHandler.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalResourceRequestHandler.java
@@ -26,7 +26,7 @@ import org.apache.reef.runtime.common.driver.api.ResourceRequestHandler;
 import javax.inject.Inject;
 
 /**
- * Takes resource requests and patches them through to the ResourceManager
+ * Takes resource requests and patches them through to the ResourceManager.
  */
 @Private
 @DriverSide

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ProcessContainer.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ProcessContainer.java
@@ -35,7 +35,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * A Container that runs an Evaluator in a Process
+ * A Container that runs an Evaluator in a Process.
  */
 @Private
 @TaskSide

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/package-info.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * The resource manager for the local resourcemanager
+ * The resource manager for the local resourcemanager.
  */
 package org.apache.reef.runtime.local.driver;

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/process/LoggingRunnableProcessObserver.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/process/LoggingRunnableProcessObserver.java
@@ -22,7 +22,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * A RunnableProcessObserver that logs the events/
+ * A RunnableProcessObserver that logs the events/.
  */
 public final class LoggingRunnableProcessObserver implements RunnableProcessObserver {
   private static final Logger LOG = Logger.getLogger(LoggingRunnableProcessObserver.class.getName());

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/process/ReefRunnableProcessObserver.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/process/ReefRunnableProcessObserver.java
@@ -33,7 +33,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * a RunnableProcessObserver that relies events to REEF's ResourceStatusHandler
+ * a RunnableProcessObserver that relies events to REEF's ResourceStatusHandler.
  */
 @ThreadSafe
 public final class ReefRunnableProcessObserver implements RunnableProcessObserver {
@@ -94,7 +94,7 @@ public final class ReefRunnableProcessObserver implements RunnableProcessObserve
   }
 
   /**
-   * Inform REEF of an unclean process exit
+   * Inform REEF of an unclean process exit.
    *
    * @param processId
    * @param exitCode

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/process/RunnableProcess.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/process/RunnableProcess.java
@@ -109,7 +109,7 @@ public final class RunnableProcess implements Runnable {
   }
 
   /**
-   * Checks whether a transition from State 'from' to state 'to' is legal
+   * Checks whether a transition from State 'from' to state 'to' is legal.
    *
    * @param from
    * @param to

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/client/MesosClientConfiguration.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/client/MesosClientConfiguration.java
@@ -34,7 +34,7 @@ import org.apache.reef.tang.formats.OptionalParameter;
 import org.apache.reef.tang.formats.RequiredParameter;
 
 /**
- * A ConfigurationModule for the Mesos resource manager
+ * A ConfigurationModule for the Mesos resource manager.
  */
 @Public
 @ClientSide
@@ -46,7 +46,7 @@ public class MesosClientConfiguration extends ConfigurationModuleBuilder {
   public static final OptionalParameter<String> ROOT_FOLDER = new OptionalParameter<>();
 
   /**
-   * The ip address of Mesos Master
+   * The ip address of Mesos Master.
    */
   public static final RequiredParameter<String> MASTER_IP = new RequiredParameter<>();
 

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosDriverConfiguration.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosDriverConfiguration.java
@@ -40,7 +40,7 @@ import org.apache.reef.wake.impl.SingleThreadStage;
 import org.apache.reef.wake.time.Clock;
 
 /**
- * Binds Driver's runtime event handlers
+ * Binds Driver's runtime event handlers.
  */
 public final class MesosDriverConfiguration extends ConfigurationModuleBuilder {
   /**
@@ -54,7 +54,7 @@ public final class MesosDriverConfiguration extends ConfigurationModuleBuilder {
   public static final OptionalParameter<Long> EVALUATOR_TIMEOUT = new OptionalParameter<>();
 
   /**
-   * The ip address of Mesos Master
+   * The ip address of Mesos Master.
    */
   public static final RequiredParameter<String> MESOS_MASTER_IP = new RequiredParameter<>();
 
@@ -69,7 +69,7 @@ public final class MesosDriverConfiguration extends ConfigurationModuleBuilder {
   public static final OptionalParameter<Double> JVM_HEAP_SLACK = new OptionalParameter<>();
 
   /**
-   * Capacity for runnning Mesos Scheduler Driver
+   * Capacity for runnning Mesos Scheduler Driver.
    */
   public static final RequiredParameter<Integer> SCHEDULER_DRIVER_CAPACITY = new RequiredParameter<>();
 

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/REEFScheduler.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/REEFScheduler.java
@@ -148,7 +148,7 @@ final class REEFScheduler implements Scheduler {
   }
 
   /**
-   * All offers in each batch of offers will be either be launched or declined
+   * All offers in each batch of offers will be either be launched or declined.
    */
   @Override
   public void resourceOffers(final SchedulerDriver driver, final List<Protos.Offer> offers) {

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/evaluator/EvaluatorControlHandler.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/evaluator/EvaluatorControlHandler.java
@@ -28,7 +28,7 @@ import org.apache.reef.wake.remote.RemoteMessage;
 import javax.inject.Inject;
 
 /**
- * Handles evaluator launch requests via MesosRemoteManager from MesosResourceLaunchHandler
+ * Handles evaluator launch requests via MesosRemoteManager from MesosResourceLaunchHandler.
  */
 @EvaluatorSide
 @Private

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/ClassPathBuilder.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/ClassPathBuilder.java
@@ -65,7 +65,7 @@ final class ClassPathBuilder {
   }
 
   /**
-   * Adds the given classPathEntry to the classpath suffix
+   * Adds the given classPathEntry to the classpath suffix.
    *
    * @param classPathEntry
    */
@@ -74,7 +74,7 @@ final class ClassPathBuilder {
   }
 
   /**
-   * Adds the given classPathEntry to the classpath prefix
+   * Adds the given classPathEntry to the classpath prefix.
    *
    * @param classPathEntry
    */

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/YarnClasspathProvider.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/YarnClasspathProvider.java
@@ -111,7 +111,7 @@ public final class YarnClasspathProvider implements RuntimeClasspathProvider {
   }
 
   /**
-   * Fetches the string[] under the given key, if it exists and contains entries (.length >0)
+   * Fetches the string[] under the given key, if it exists and contains entries (.length >0).
    *
    * @param configuration
    * @param key

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/uploader/JobFolder.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/uploader/JobFolder.java
@@ -57,7 +57,7 @@ public final class JobFolder {
   }
 
   /**
-   * Uploads the given file to the DFS
+   * Uploads the given file to the DFS.
    *
    * @param localFile
    * @return the Path representing the file on the DFS.
@@ -94,7 +94,7 @@ public final class JobFolder {
   }
 
   /**
-   * Creates a LocalResource instance for the JAR file referenced by the given Path
+   * Creates a LocalResource instance for the JAR file referenced by the given Path.
    */
   public LocalResource getLocalResourceForPath(final Path path) throws IOException {
     final LocalResource localResource = Records.newRecord(LocalResource.class);

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/Containers.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/Containers.java
@@ -55,7 +55,7 @@ final class Containers {
   }
 
   /**
-   * Registers the given container
+   * Registers the given container.
    *
    * @param container
    * @throws java.lang.RuntimeException if a container with the same ID had been registered before.

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/UploaderToJobfolder.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/UploaderToJobfolder.java
@@ -75,7 +75,7 @@ final class UploaderToJobFolder {
   }
 
   /**
-   * Creates a LocalResource instance for the JAR file referenced by the given Path
+   * Creates a LocalResource instance for the JAR file referenced by the given Path.
    *
    * @param path
    * @return

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
@@ -502,7 +502,7 @@ final class YarnContainerManager
   }
 
   /**
-   * Update the driver with my current status
+   * Update the driver with my current status.
    */
   private void updateRuntimeStatus() {
 

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/util/YarnTypes.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/util/YarnTypes.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Helper class that creates the various records in the YARN API
+ * Helper class that creates the various records in the YARN API.
  */
 @Private
 public final class YarnTypes {

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Configurations.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Configurations.java
@@ -19,7 +19,7 @@
 package org.apache.reef.tang;
 
 /**
- * Helper class for Configurations
+ * Helper class for Configurations.
  */
 public final class Configurations {
 

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/JavaClassHierarchy.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/JavaClassHierarchy.java
@@ -55,7 +55,7 @@ public interface JavaClassHierarchy extends ClassHierarchy {
   public <T> T parse(NamedParameterNode<T> name, String value) throws ParseException;
 
   /**
-   * Obtain a parsed instance of the default value of a named parameter
+   * Obtain a parsed instance of the default value of a named parameter.
    *
    * @param name The named parameter that should be checked for a default instance.
    * @return The default instance or null, unless T is a set type.  If T is a set,

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/JavaConfigurationBuilder.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/JavaConfigurationBuilder.java
@@ -51,7 +51,7 @@ public interface JavaConfigurationBuilder extends ConfigurationBuilder {
   public <T> JavaConfigurationBuilder bind(Class<T> iface, Class<?> impl) throws BindException;
 
   /**
-   * Binds the Class impl as the implementation of the interface iface
+   * Binds the Class impl as the implementation of the interface iface.
    *
    * @param <T>
    * @param iface

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/AvroConfigurationSerializer.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/AvroConfigurationSerializer.java
@@ -231,7 +231,7 @@ public final class AvroConfigurationSerializer implements ConfigurationSerialize
   }
 
   /**
-   * Converts a given AvroConfiguration to Configuration
+   * Converts a given AvroConfiguration to Configuration.
    *
    * @param avroConfiguration
    * @return a Configuration version of the given AvroConfiguration
@@ -243,7 +243,7 @@ public final class AvroConfigurationSerializer implements ConfigurationSerialize
   }
 
   /**
-   * Converts a given AvroConfiguration to Configuration
+   * Converts a given AvroConfiguration to Configuration.
    *
    * @param avroConfiguration
    * @param classHierarchy    the class hierarchy used for validation.

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationSerializer.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationSerializer.java
@@ -90,7 +90,7 @@ public interface ConfigurationSerializer {
   public Configuration fromTextFile(final File file) throws IOException, BindException;
 
   /**
-   * Loads a Configuration from a File created with toFile() with ClassHierarchy
+   * Loads a Configuration from a File created with toFile() with ClassHierarchy.
    *
    * @param file
    * @param classHierarchy
@@ -132,7 +132,7 @@ public interface ConfigurationSerializer {
   public Configuration fromByteArray(final byte[] theBytes, final ClassHierarchy classHierarchy) throws IOException, BindException;
 
   /**
-   * Decodes a String generated via toString()
+   * Decodes a String generated via toString().
    *
    * @param theString to be parsed
    * @return the Configuration stored in theString.
@@ -142,7 +142,7 @@ public interface ConfigurationSerializer {
   public Configuration fromString(final String theString) throws IOException, BindException;
 
   /**
-   * Decodes a String generated via toString()
+   * Decodes a String generated via toString().
    *
    * @param theString      to be parsed
    * @param classHierarchy used to validate the configuration against

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/protobuf/ProtocolBufferClassHierarchy.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/protobuf/ProtocolBufferClassHierarchy.java
@@ -203,7 +203,7 @@ public class ProtocolBufferClassHierarchy implements ClassHierarchy {
   }
 
   /**
-   * serialize a class hierarchy into a file
+   * serialize a class hierarchy into a file.
    *
    * @param file
    * @param classHierarchy

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/graphviz/GraphvizConfigVisitor.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/graphviz/GraphvizConfigVisitor.java
@@ -34,7 +34,7 @@ public final class GraphvizConfigVisitor
     extends AbstractClassHierarchyNodeVisitor implements EdgeVisitor<Node> {
 
   /**
-   * Legend for the configuration graph in Graphviz format
+   * Legend for the configuration graph in Graphviz format.
    */
   private static final String LEGEND =
       "  subgraph cluster_legend {\n"

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/graphviz/GraphvizInjectionPlanVisitor.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/graphviz/GraphvizInjectionPlanVisitor.java
@@ -32,7 +32,7 @@ import org.apache.reef.tang.util.walk.Walk;
 public final class GraphvizInjectionPlanVisitor
     extends AbstractInjectionPlanNodeVisitor implements EdgeVisitor<InjectionPlan<?>> {
   /**
-   * Legend for the configuration graph in Graphviz format
+   * Legend for the configuration graph in Graphviz format.
    */
   private static final String LEGEND =
       "  subgraph cluster_legend {\n"

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/package-info.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * Commonly used event handlers and task implementations in our tests
+ * Commonly used event handlers and task implementations in our tests.
  */
 package org.apache.reef.tests.library;

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/yarn/failure/FailureREEF.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/yarn/failure/FailureREEF.java
@@ -40,7 +40,7 @@ import java.util.logging.Logger;
 
 public final class FailureREEF {
   /**
-   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently
+   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently.
    */
   public static final int MAX_NUMBER_OF_EVALUATORS = 16;
 

--- a/lang/java/reef-utils/src/main/java/org/apache/reef/util/cache/Cache.java
+++ b/lang/java/reef-utils/src/main/java/org/apache/reef/util/cache/Cache.java
@@ -28,7 +28,7 @@ import java.util.concurrent.ExecutionException;
  */
 public interface Cache<K, V> {
   /**
-   * Returns a value for the key if cached; otherwise creates, caches and returns
+   * Returns a value for the key if cached; otherwise creates, caches and returns.
    * When it creates a value for a key, only one callable for the key is executed
    *
    * @param key          a key
@@ -39,7 +39,7 @@ public interface Cache<K, V> {
   public V get(K key, Callable<V> valueFetcher) throws ExecutionException;
 
   /**
-   * Invalidates a key from the cache
+   * Invalidates a key from the cache.
    *
    * @param key a key
    */

--- a/lang/java/reef-utils/src/main/java/org/apache/reef/util/cache/CacheImpl.java
+++ b/lang/java/reef-utils/src/main/java/org/apache/reef/util/cache/CacheImpl.java
@@ -54,7 +54,7 @@ public final class CacheImpl<K, V> implements Cache<K, V> {
   private long expireCheckedTime;
 
   /**
-   * Construct an expire-after-write cache
+   * Construct an expire-after-write cache.
    *
    * @param currentTime   class that returns the current time for timeout purposes
    * @param timeoutMillis a cache entry timeout after write

--- a/lang/java/reef-utils/src/main/java/org/apache/reef/util/cache/CurrentTime.java
+++ b/lang/java/reef-utils/src/main/java/org/apache/reef/util/cache/CurrentTime.java
@@ -19,7 +19,7 @@
 package org.apache.reef.util.cache;
 
 /**
- * Return the current time
+ * Return the current time.
  */
 public interface CurrentTime {
   long now();

--- a/lang/java/reef-utils/src/main/java/org/apache/reef/util/cache/SystemTime.java
+++ b/lang/java/reef-utils/src/main/java/org/apache/reef/util/cache/SystemTime.java
@@ -19,7 +19,7 @@
 package org.apache.reef.util.cache;
 
 /**
- * Return the system time
+ * Return the system time.
  */
 public final class SystemTime implements CurrentTime {
 

--- a/lang/java/reef-utils/src/main/java/org/apache/reef/util/cache/WrappedValue.java
+++ b/lang/java/reef-utils/src/main/java/org/apache/reef/util/cache/WrappedValue.java
@@ -60,7 +60,7 @@ final class WrappedValue<V> {
   }
 
   /**
-   * Must only be called once, by the thread that created this WrappedValue
+   * Must only be called once, by the thread that created this WrappedValue.
    * @return The value returned by valueFetcher
    */
   public synchronized V loadAndGet() throws ExecutionException {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/AbstractEStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/AbstractEStage.java
@@ -23,7 +23,7 @@ import org.apache.reef.wake.metrics.Meter;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * An {@link EStage} that implements metering
+ * An {@link EStage} that implements metering.
  *
  * @param <T> type
  */
@@ -34,12 +34,12 @@ public abstract class AbstractEStage<T> implements EStage<T> {
   protected final Meter inMeter;
 
   /**
-   * outputs share a single meter
+   * outputs share a single meter.
    */
   protected final Meter outMeter;
 
   /**
-   * Constructs an abstract estage
+   * Constructs an abstract estage.
    *
    * @parm stageName the stage name
    */
@@ -51,7 +51,7 @@ public abstract class AbstractEStage<T> implements EStage<T> {
   }
 
   /**
-   * Gets the input meter of this stage
+   * Gets the input meter of this stage.
    *
    * @return the input meter
    */
@@ -60,7 +60,7 @@ public abstract class AbstractEStage<T> implements EStage<T> {
   }
 
   /**
-   * Gets the output meter of this stage
+   * Gets the output meter of this stage.
    *
    * @return the output meter
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/EStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/EStage.java
@@ -19,7 +19,7 @@
 package org.apache.reef.wake;
 
 /**
- * Stage that executes an event handler
+ * Stage that executes an event handler.
  *
  * @param <T> type
  */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/EventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/EventHandler.java
@@ -19,14 +19,14 @@
 package org.apache.reef.wake;
 
 /**
- * Handler to process an event
+ * Handler to process an event.
  *
  * @param <T> type
  */
 public interface EventHandler<T> {
 
   /**
-   * Handles an event
+   * Handles an event.
    *
    * @param value an event
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/Identifiable.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/Identifiable.java
@@ -21,7 +21,7 @@ package org.apache.reef.wake;
 public interface Identifiable {
 
   /**
-   * Returns an identifier of this object
+   * Returns an identifier of this object.
    *
    * @return an identifier of this object
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/Identifier.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/Identifier.java
@@ -29,14 +29,14 @@ package org.apache.reef.wake;
 public interface Identifier {
 
   /**
-   * Returns a hash code for the object
+   * Returns a hash code for the object.
    *
    * @return a hash code value for this object
    */
   public int hashCode();
 
   /**
-   * Checks that another object is equal to this object
+   * Checks that another object is equal to this object.
    *
    * @param o another object
    * @return true if the object is the same as the object argument; false,

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/IdentifierFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/IdentifierFactory.java
@@ -21,7 +21,7 @@ package org.apache.reef.wake;
 public interface IdentifierFactory {
 
   /**
-   * Creates a RemoteIdentifier object
+   * Creates a RemoteIdentifier object.
    *
    * @param str a string
    * @return an identifier

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/Stage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/Stage.java
@@ -19,7 +19,7 @@
 package org.apache.reef.wake;
 
 /**
- * Stage is an execution unit for events and provides a way to reclaim its resources
+ * Stage is an execution unit for events and provides a way to reclaim its resources.
  */
 public interface Stage extends AutoCloseable {
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/StageConfiguration.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/StageConfiguration.java
@@ -25,7 +25,7 @@ import org.apache.reef.wake.rx.Observer;
 import java.util.concurrent.ExecutorService;
 
 /**
- * Configuration options for Wake Stage
+ * Configuration options for Wake Stage.
  */
 public final class StageConfiguration {
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/WakeConfiguration.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/WakeConfiguration.java
@@ -34,7 +34,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Wake parameter configuration
+ * Wake parameter configuration.
  */
 public final class WakeConfiguration {
   private final static Logger LOG = Logger.getLogger(WakeConfiguration.class.getName());

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/exception/WakeRuntimeException.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/exception/WakeRuntimeException.java
@@ -19,14 +19,14 @@
 package org.apache.reef.wake.exception;
 
 /**
- * Wake runtime exception
+ * Wake runtime exception.
  */
 public class WakeRuntimeException extends RuntimeException {
 
   private static final long serialVersionUID = 1L;
 
   /**
-   * Constructs a new runtime wake exception with the specified detail message and cause
+   * Constructs a new runtime wake exception with the specified detail message and cause.
    *
    * @param s the detailed message
    * @param e the cause
@@ -36,7 +36,7 @@ public class WakeRuntimeException extends RuntimeException {
   }
 
   /**
-   * Constructs a new runtime stage exception with the specified detail message
+   * Constructs a new runtime stage exception with the specified detail message.
    *
    * @param s the detailed message
    */
@@ -45,7 +45,7 @@ public class WakeRuntimeException extends RuntimeException {
   }
 
   /**
-   * Constructs a new runtime stage exception with the specified cause
+   * Constructs a new runtime stage exception with the specified cause.
    *
    * @param e the cause
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/DefaultIdentifierFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/DefaultIdentifierFactory.java
@@ -43,7 +43,7 @@ public class DefaultIdentifierFactory implements IdentifierFactory {
   private final Map<String, Class<? extends Identifier>> typeToClazzMap;
 
   /**
-   * Constructs a default remote identifier factory
+   * Constructs a default remote identifier factory.
    */
   @Inject
   public DefaultIdentifierFactory() {
@@ -52,7 +52,7 @@ public class DefaultIdentifierFactory implements IdentifierFactory {
   }
 
   /**
-   * Constructs a default remote identifier factory
+   * Constructs a default remote identifier factory.
    *
    * @param typeToClazzMap the map of type strings to classes of remote identifiers
    */
@@ -61,7 +61,7 @@ public class DefaultIdentifierFactory implements IdentifierFactory {
   }
 
   /**
-   * Creates a new remote identifier instance
+   * Creates a new remote identifier instance.
    *
    * @param str a string representation
    * @return a remote identifier

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/DefaultThreadFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/DefaultThreadFactory.java
@@ -22,7 +22,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * A default thread factory implementation that names created threads
+ * A default thread factory implementation that names created threads.
  */
 public final class DefaultThreadFactory implements ThreadFactory {
   private static final AtomicInteger poolNumber = new AtomicInteger(1);
@@ -32,7 +32,7 @@ public final class DefaultThreadFactory implements ThreadFactory {
   private Thread.UncaughtExceptionHandler uncaughtExceptionHandler;
 
   /**
-   * Constructs a default thread factory
+   * Constructs a default thread factory.
    *
    * @param prefix the name prefix of the created thread
    */
@@ -44,7 +44,7 @@ public final class DefaultThreadFactory implements ThreadFactory {
   }
 
   /**
-   * Constructs a default thread factory
+   * Constructs a default thread factory.
    *
    * @param prefix                   the name prefix of the created thread
    * @param uncaughtExceptionHandler the uncaught exception handler of the created thread
@@ -57,7 +57,7 @@ public final class DefaultThreadFactory implements ThreadFactory {
   }
 
   /**
-   * Sets a uncaught exception handler
+   * Sets a uncaught exception handler.
    *
    * @param uncaughtExceptionHandler the uncaught exception handler
    */
@@ -66,7 +66,7 @@ public final class DefaultThreadFactory implements ThreadFactory {
   }
 
   /**
-   * Creates a new thread
+   * Creates a new thread.
    *
    * @param r the runnable
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/LoggingEventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/LoggingEventHandler.java
@@ -25,7 +25,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * A logging event handler
+ * A logging event handler.
  *
  * @param <T> type
  */
@@ -37,7 +37,7 @@ public class LoggingEventHandler<T> implements EventHandler<T> {
   }
 
   /**
-   * Logs the event
+   * Logs the event.
    *
    * @param value an event
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/LoggingUtils.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/LoggingUtils.java
@@ -24,12 +24,12 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Utility for logging
+ * Utility for logging.
  */
 public class LoggingUtils {
 
   /**
-   * Sets the logging level
+   * Sets the logging level.
    *
    * @param level the logging level
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/LoggingVoidEventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/LoggingVoidEventHandler.java
@@ -25,7 +25,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * A logging void event handler
+ * A logging void event handler.
  */
 public class LoggingVoidEventHandler implements EventHandler<Void> {
   private static final Logger LOG = Logger.getLogger(LoggingVoidEventHandler.class.getName());
@@ -35,7 +35,7 @@ public class LoggingVoidEventHandler implements EventHandler<Void> {
   }
 
   /**
-   * Logs the event
+   * Logs the event.
    *
    * @param value an event
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/MultiEventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/MultiEventHandler.java
@@ -24,7 +24,7 @@ import org.apache.reef.wake.exception.WakeRuntimeException;
 import java.util.Map;
 
 /**
- * Event handler that dispatches an event to a specific handler based on an event class type
+ * Event handler that dispatches an event to a specific handler based on an event class type.
  *
  * @param <T> type
  */
@@ -33,7 +33,7 @@ public class MultiEventHandler<T> implements EventHandler<T> {
   private final Map<Class<? extends T>, EventHandler<? extends T>> map;
 
   /**
-   * Constructs a multi-event handler
+   * Constructs a multi-event handler.
    *
    * @param map a map of class types to event handlers
    */
@@ -42,7 +42,7 @@ public class MultiEventHandler<T> implements EventHandler<T> {
   }
 
   /**
-   * Invokes a specific handler for the event class type if it exists
+   * Invokes a specific handler for the event class type if it exists.
    *
    * @param an event
    * @throws WakeRuntimeException

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/PeriodicEvent.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/PeriodicEvent.java
@@ -19,7 +19,7 @@
 package org.apache.reef.wake.impl;
 
 /**
- * Periodic event for timers
+ * Periodic event for timers.
  */
 public class PeriodicEvent {
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/PubSubEventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/PubSubEventHandler.java
@@ -31,7 +31,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Event handler that provides publish/subscribe interfaces
+ * Event handler that provides publish/subscribe interfaces.
  *
  * @param <T> type
  */
@@ -42,14 +42,14 @@ public class PubSubEventHandler<T> implements EventHandler<T> {
   private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
   /**
-   * Constructs a pub-sub event handler
+   * Constructs a pub-sub event handler.
    */
   public PubSubEventHandler() {
     this.clazzToListOfHandlersMap = new HashMap<Class<? extends T>, List<EventHandler<? extends T>>>();
   }
 
   /**
-   * Constructs a pub-sub event handler with initial subscribed event handlers
+   * Constructs a pub-sub event handler with initial subscribed event handlers.
    *
    * @param map a map of event class types to lists of event handlers
    */
@@ -58,7 +58,7 @@ public class PubSubEventHandler<T> implements EventHandler<T> {
   }
 
   /**
-   * Subscribes an event handler for an event class type
+   * Subscribes an event handler for an event class type.
    *
    * @param clazz   an event class
    * @param handler an event handler
@@ -78,7 +78,7 @@ public class PubSubEventHandler<T> implements EventHandler<T> {
   }
 
   /**
-   * Invokes subscribed handlers for the event class type
+   * Invokes subscribed handlers for the event class type.
    *
    * @param event an event
    * @throws WakeRuntimeException

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/SingleThreadStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/SingleThreadStage.java
@@ -33,7 +33,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Single thread stage that runs the event handler
+ * Single thread stage that runs the event handler.
  *
  * @param <T> type
  */
@@ -45,7 +45,7 @@ public final class SingleThreadStage<T> extends AbstractEStage<T> {
   private final AtomicBoolean interrupted;
 
   /**
-   * Constructs a single thread stage
+   * Constructs a single thread stage.
    *
    * @param handler  the event handler to execute
    * @param capacity the queue capacity
@@ -57,7 +57,7 @@ public final class SingleThreadStage<T> extends AbstractEStage<T> {
   }
 
   /**
-   * Constructs a single thread stage
+   * Constructs a single thread stage.
    *
    * @param name     the stage name
    * @param handler  the event handler to execute
@@ -77,7 +77,7 @@ public final class SingleThreadStage<T> extends AbstractEStage<T> {
   }
 
   /**
-   * Puts the value to the queue, which will be processed by the handler later
+   * Puts the value to the queue, which will be processed by the handler later.
    * if the queue is full, IllegalStateException is thrown
    *
    * @param value the value
@@ -90,7 +90,7 @@ public final class SingleThreadStage<T> extends AbstractEStage<T> {
   }
 
   /**
-   * Closes the stage
+   * Closes the stage.
    *
    * @throws Exception
    */
@@ -104,7 +104,7 @@ public final class SingleThreadStage<T> extends AbstractEStage<T> {
 
 
   /**
-   * Takes events from the queue and provides them to the handler
+   * Takes events from the queue and provides them to the handler.
    */
   private class Producer<U> implements Runnable {
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/StageManager.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/StageManager.java
@@ -28,7 +28,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * A manager that manages all the stage
+ * A manager that manages all the stage.
  */
 public final class StageManager implements Stage {
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/SyncStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/SyncStage.java
@@ -30,7 +30,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Stage that synchronously executes an event handler
+ * Stage that synchronously executes an event handler.
  *
  * @param <T> type
  */
@@ -42,7 +42,7 @@ public final class SyncStage<T> extends AbstractEStage<T> {
   private final EventHandler<Throwable> errorHandler;
 
   /**
-   * Constructs a synchronous stage
+   * Constructs a synchronous stage.
    *
    * @param handler the event handler
    */
@@ -52,7 +52,7 @@ public final class SyncStage<T> extends AbstractEStage<T> {
   }
 
   /**
-   * Constructs a synchronous stage
+   * Constructs a synchronous stage.
    *
    * @param handler the event handler
    * @name name the stage name
@@ -64,7 +64,7 @@ public final class SyncStage<T> extends AbstractEStage<T> {
   }
 
   /**
-   * Constructs a synchronous stage
+   * Constructs a synchronous stage.
    *
    * @param handler      the event handler
    * @param errorHandler the error handler
@@ -81,7 +81,7 @@ public final class SyncStage<T> extends AbstractEStage<T> {
   }
 
   /**
-   * Invokes the handler for the event
+   * Invokes the handler for the event.
    *
    * @param value the event
    */
@@ -102,7 +102,7 @@ public final class SyncStage<T> extends AbstractEStage<T> {
   }
 
   /**
-   * Closes resources
+   * Closes resources.
    *
    * @throws Exception
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/ThreadPoolStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/ThreadPoolStage.java
@@ -35,7 +35,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Stage that executes an event handler with a thread pool
+ * Stage that executes an event handler with a thread pool.
  *
  * @param <T> type
  */
@@ -49,7 +49,7 @@ public final class ThreadPoolStage<T> extends AbstractEStage<T> {
   private final EventHandler<Throwable> errorHandler;
 
   /**
-   * Constructs a thread-pool stage
+   * Constructs a thread-pool stage.
    *
    * @param handler    the event handler to execute
    * @param numThreads the number of threads to use
@@ -62,7 +62,7 @@ public final class ThreadPoolStage<T> extends AbstractEStage<T> {
   }
 
   /**
-   * Constructs a thread-pool stage
+   * Constructs a thread-pool stage.
    *
    * @param name         the stage name
    * @param handler      the event handler to execute
@@ -86,7 +86,7 @@ public final class ThreadPoolStage<T> extends AbstractEStage<T> {
   }
 
   /**
-   * Constructs a thread-pool stage
+   * Constructs a thread-pool stage.
    *
    * @param name       the stage name
    * @param handler    the event handler to execute
@@ -101,7 +101,7 @@ public final class ThreadPoolStage<T> extends AbstractEStage<T> {
   }
 
   /**
-   * Constructs a thread-pool stage
+   * Constructs a thread-pool stage.
    *
    * @param handler  the event handler to execute
    * @param executor the external executor service provided
@@ -114,7 +114,7 @@ public final class ThreadPoolStage<T> extends AbstractEStage<T> {
 
 
   /**
-   * Constructs a thread-pool stage
+   * Constructs a thread-pool stage.
    *
    * @param handler      the event handler to execute
    * @param executor     the external executor service provided
@@ -128,7 +128,7 @@ public final class ThreadPoolStage<T> extends AbstractEStage<T> {
   }
 
   /**
-   * Constructs a thread-pool stage
+   * Constructs a thread-pool stage.
    *
    * @param name     the stage name
    * @param handler  the event handler to execute
@@ -143,7 +143,7 @@ public final class ThreadPoolStage<T> extends AbstractEStage<T> {
   }
 
   /**
-   * Constructs a thread-pool stage
+   * Constructs a thread-pool stage.
    *
    * @param name         the stage name
    * @param handler      the event handler to execute
@@ -165,7 +165,7 @@ public final class ThreadPoolStage<T> extends AbstractEStage<T> {
   }
 
   /**
-   * Handles the event using a thread in the thread pool
+   * Handles the event using a thread in the thread pool.
    *
    * @param value the event
    */
@@ -193,7 +193,7 @@ public final class ThreadPoolStage<T> extends AbstractEStage<T> {
   }
 
   /**
-   * Closes resources
+   * Closes resources.
    *
    * @return Exception
    */
@@ -212,7 +212,7 @@ public final class ThreadPoolStage<T> extends AbstractEStage<T> {
   }
 
   /**
-   * Gets the queue length of this stage
+   * Gets the queue length of this stage.
    *
    * @return the queue length
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/TimerStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/TimerStage.java
@@ -37,7 +37,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Stage that triggers an event handler periodically
+ * Stage that triggers an event handler periodically.
  */
 public final class TimerStage implements Stage {
   private static final Logger LOG = Logger.getLogger(TimerStage.class.getName());
@@ -48,7 +48,7 @@ public final class TimerStage implements Stage {
   private final long shutdownTimeout = WakeParameters.EXECUTOR_SHUTDOWN_TIMEOUT;
 
   /**
-   * Constructs a timer stage with no initial delay
+   * Constructs a timer stage with no initial delay.
    *
    * @param handler an event handler
    * @param period  a period in milli-seconds
@@ -60,7 +60,7 @@ public final class TimerStage implements Stage {
   }
 
   /**
-   * Constructs a timer stage with no initial delay
+   * Constructs a timer stage with no initial delay.
    *
    * @param handler an event handler
    * @param period  a period in milli-seconds
@@ -74,7 +74,7 @@ public final class TimerStage implements Stage {
   }
 
   /**
-   * Constructs a timer stage
+   * Constructs a timer stage.
    *
    * @param handler      an event handler
    * @param initialDelay an initial delay
@@ -88,7 +88,7 @@ public final class TimerStage implements Stage {
   }
 
   /**
-   * Constructs a timer stage
+   * Constructs a timer stage.
    *
    * @param name         the stage name
    * @param handler      an event handler
@@ -115,7 +115,7 @@ public final class TimerStage implements Stage {
 
 
   /**
-   * Closes resources
+   * Closes resources.
    *
    * @throws Exception
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/WakeUncaughtExceptionHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/WakeUncaughtExceptionHandler.java
@@ -21,7 +21,7 @@ package org.apache.reef.wake.impl;
 import org.apache.reef.wake.EventHandler;
 
 /**
- * Exception handler for uncaught exceptions
+ * Exception handler for uncaught exceptions.
  */
 public final class WakeUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
   private EventHandler<Throwable> errorHandler;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/EWMA.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/EWMA.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Exponentially weighted moving average
+ * Exponentially weighted moving average.
  */
 public class EWMA {
 
@@ -33,7 +33,7 @@ public class EWMA {
   private volatile double rate = 0.0;
 
   /**
-   * Constructs an EWMA object
+   * Constructs an EWMA object.
    *
    * @param alpha
    * @param interval
@@ -45,7 +45,7 @@ public class EWMA {
   }
 
   /**
-   * Updates the EWMA with a new value
+   * Updates the EWMA with a new value.
    *
    * @param n the new value
    */
@@ -54,7 +54,7 @@ public class EWMA {
   }
 
   /**
-   * Updates the rate
+   * Updates the rate.
    */
   public void tick() {
     final long count = uncounted.getAndSet(0);
@@ -68,7 +68,7 @@ public class EWMA {
   }
 
   /**
-   * Gets the rate
+   * Gets the rate.
    *
    * @param rateUnit the unit of the rate
    * @return the rate

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/EWMAParameters.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/EWMAParameters.java
@@ -21,7 +21,7 @@ package org.apache.reef.wake.metrics;
 import static java.lang.Math.exp;
 
 /**
- * Default EWMA parameters
+ * Default EWMA parameters.
  */
 public class EWMAParameters {
   public static final int INTERVAL = 5;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/Histogram.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/Histogram.java
@@ -19,26 +19,26 @@
 package org.apache.reef.wake.metrics;
 
 /**
- * Histogram
+ * Histogram.
  */
 public interface Histogram {
 
   /**
-   * Updates the value in this histogram
+   * Updates the value in this histogram.
    *
    * @param value the new value
    */
   public void update(long value);
 
   /**
-   * Returns the number of recorded values
+   * Returns the number of recorded values.
    *
    * @return the number of recorded values
    */
   public long getCount();
 
   /**
-   * Returns the value of the index
+   * Returns the value of the index.
    *
    * @param index the histogram bin index
    * @return the value of the index
@@ -47,7 +47,7 @@ public interface Histogram {
   public long getValue(int index);
 
   /**
-   * Returns the number of bins
+   * Returns the number of bins.
    *
    * @return the number of bins
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/Meter.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/Meter.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Meter that monitors mean throughput and ewma (1m, 5m, 15m) throughput
+ * Meter that monitors mean throughput and ewma (1m, 5m, 15m) throughput.
  */
 public class Meter {
 
@@ -39,7 +39,7 @@ public class Meter {
   private final String name;
 
   /**
-   * Constructs a meter
+   * Constructs a meter.
    *
    * @param name the name of the meter
    */
@@ -53,7 +53,7 @@ public class Meter {
   }
 
   /**
-   * Gets the name of the meter
+   * Gets the name of the meter.
    *
    * @return the meter name
    */
@@ -62,7 +62,7 @@ public class Meter {
   }
 
   /**
-   * Marks the number of events
+   * Marks the number of events.
    *
    * @param n the number of events
    */
@@ -75,7 +75,7 @@ public class Meter {
   }
 
   /**
-   * Gets the count
+   * Gets the count.
    *
    * @return the count
    */
@@ -84,7 +84,7 @@ public class Meter {
   }
 
   /**
-   * Gets the mean throughput
+   * Gets the mean throughput.
    *
    * @return the mean throughput
    */
@@ -98,7 +98,7 @@ public class Meter {
   }
 
   /**
-   * Gets the 1-minute EWMA throughput
+   * Gets the 1-minute EWMA throughput.
    *
    * @return the 1-minute EWMA throughput
    */
@@ -108,7 +108,7 @@ public class Meter {
   }
 
   /**
-   * Gets the 5-minute EWMA throughput
+   * Gets the 5-minute EWMA throughput.
    *
    * @return the 5-minute EWMA throughput
    */
@@ -118,7 +118,7 @@ public class Meter {
   }
 
   /**
-   * Gets the 15-minute EWMA throughput
+   * Gets the 15-minute EWMA throughput.
    *
    * @return the 15-minute EWMA throughput
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/UniformHistogram.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/UniformHistogram.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongArray;
 
 /**
- * An {@link Histogram} that implements uniform binning of numbers (>=0)
+ * An {@link Histogram} that implements uniform binning of numbers (>=0).
  */
 public class UniformHistogram implements Histogram {
   private final AtomicLong count;
@@ -31,7 +31,7 @@ public class UniformHistogram implements Histogram {
   private final int numBins;
 
   /**
-   * Constructs a histogram
+   * Constructs a histogram.
    *
    * @param binWidth the width of each bin
    * @param numBins  the number of bins
@@ -44,7 +44,7 @@ public class UniformHistogram implements Histogram {
   }
 
   /**
-   * Updates the value
+   * Updates the value.
    *
    * @param value
    */
@@ -58,7 +58,7 @@ public class UniformHistogram implements Histogram {
   }
 
   /**
-   * Returns the number of recorded values
+   * Returns the number of recorded values.
    *
    * @return the number of recorded values
    */
@@ -68,7 +68,7 @@ public class UniformHistogram implements Histogram {
   }
 
   /**
-   * Returns the value of the index
+   * Returns the value of the index.
    *
    * @param index the index
    * @return the value of the index
@@ -79,7 +79,7 @@ public class UniformHistogram implements Histogram {
   }
 
   /**
-   * Returns the number of bins
+   * Returns the number of bins.
    *
    * @return the number of bins
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/Decoder.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/Decoder.java
@@ -27,7 +27,7 @@ package org.apache.reef.wake.remote;
 public interface Decoder<T> {
 
   /**
-   * Decodes the given byte array into an object
+   * Decodes the given byte array into an object.
    *
    * @param buf
    * @return the decoded object

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/DefaultErrorHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/DefaultErrorHandler.java
@@ -23,7 +23,7 @@ import org.apache.reef.wake.EventHandler;
 import javax.inject.Inject;
 
 /**
- * The default RemoteConfiguration.ErrorHandler
+ * The default RemoteConfiguration.ErrorHandler.
  */
 final class DefaultErrorHandler implements EventHandler<Throwable> {
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/Encoder.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/Encoder.java
@@ -27,7 +27,7 @@ package org.apache.reef.wake.remote;
 public interface Encoder<T> {
 
   /**
-   * Encodes the given object into a Byte Array
+   * Encodes the given object into a Byte Array.
    *
    * @param obj
    * @return a byte[] representation of the object

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteIdentifier.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteIdentifier.java
@@ -21,7 +21,7 @@ package org.apache.reef.wake.remote;
 import org.apache.reef.wake.Identifier;
 
 /**
- * Wake remote identifier
+ * Wake remote identifier.
  */
 public interface RemoteIdentifier extends Identifier {
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteIdentifierFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteIdentifierFactory.java
@@ -24,7 +24,7 @@ import org.apache.reef.wake.IdentifierFactory;
 import org.apache.reef.wake.remote.impl.DefaultRemoteIdentifierFactoryImplementation;
 
 /**
- * Factory that creates a RemoteIdentifier
+ * Factory that creates a RemoteIdentifier.
  */
 @DefaultImplementation(DefaultRemoteIdentifierFactoryImplementation.class)
 public interface RemoteIdentifierFactory extends IdentifierFactory {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteMessage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteMessage.java
@@ -19,21 +19,21 @@
 package org.apache.reef.wake.remote;
 
 /**
- * Message received from a remote handler
+ * Message received from a remote handler.
  *
  * @param <T> type
  */
 public interface RemoteMessage<T> {
 
   /**
-   * Returns a remote identifier of the sender
+   * Returns a remote identifier of the sender.
    *
    * @return a remote identifier
    */
   public RemoteIdentifier getIdentifier();
 
   /**
-   * Returns an actual message
+   * Returns an actual message.
    *
    * @return a message
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/address/HostnameBasedLocalAddressProvider.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/address/HostnameBasedLocalAddressProvider.java
@@ -28,7 +28,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * A LocalAddressProvider that uses <code>Inet4Address.getLocalHost().getHostAddress()</code>
+ * A LocalAddressProvider that uses <code>Inet4Address.getLocalHost().getHostAddress()</code>.
  */
 public final class HostnameBasedLocalAddressProvider implements LocalAddressProvider {
   private static final Logger LOG = Logger.getLogger(HostnameBasedLocalAddressProvider.class.getName());

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/address/LegacyLocalAddressProvider.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/address/LegacyLocalAddressProvider.java
@@ -35,7 +35,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * An implementation of LocalAddressProvider using the (removed) code from NetUtils.getLocalAddress()
+ * An implementation of LocalAddressProvider using the (removed) code from NetUtils.getLocalAddress().
  */
 public final class LegacyLocalAddressProvider implements LocalAddressProvider {
   private static final Logger LOG = Logger.getLogger(LegacyLocalAddressProvider.class.getName());

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/exception/RemoteRuntimeException.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/exception/RemoteRuntimeException.java
@@ -19,13 +19,13 @@
 package org.apache.reef.wake.remote.exception;
 
 /**
- * Wake remote runtime exception
+ * Wake remote runtime exception.
  */
 public class RemoteRuntimeException extends RuntimeException {
   private static final long serialVersionUID = 1L;
 
   /**
-   * Constructs a new runtime remote exception with the specified detail message and cause
+   * Constructs a new runtime remote exception with the specified detail message and cause.
    *
    * @param s the detailed message
    * @param e the cause
@@ -35,7 +35,7 @@ public class RemoteRuntimeException extends RuntimeException {
   }
 
   /**
-   * Constructs a new runtime remote exception with the specified detail message
+   * Constructs a new runtime remote exception with the specified detail message.
    *
    * @param s the detailed message
    */
@@ -44,7 +44,7 @@ public class RemoteRuntimeException extends RuntimeException {
   }
 
   /**
-   * Constructs a new runtime remote exception with the specified cause
+   * Constructs a new runtime remote exception with the specified cause.
    *
    * @param e the cause
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/ByteCodec.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/ByteCodec.java
@@ -21,12 +21,12 @@ package org.apache.reef.wake.remote.impl;
 import org.apache.reef.wake.remote.Codec;
 
 /**
- * Codec that performs identity transformation on bytes
+ * Codec that performs identity transformation on bytes.
  */
 public class ByteCodec implements Codec<byte[]> {
 
   /**
-   * Returns the byte array argument
+   * Returns the byte array argument.
    *
    * @param obj bytes
    * @return the same bytes
@@ -37,7 +37,7 @@ public class ByteCodec implements Codec<byte[]> {
   }
 
   /**
-   * Returns the byte array argument
+   * Returns the byte array argument.
    *
    * @param buf bytes
    * @return the same bytes

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteManagerImplementation.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteManagerImplementation.java
@@ -41,7 +41,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Default remote manager implementation
+ * Default remote manager implementation.
  */
 public class DefaultRemoteManagerImplementation implements RemoteManager {
 
@@ -50,7 +50,7 @@ public class DefaultRemoteManagerImplementation implements RemoteManager {
   private static final AtomicInteger counter = new AtomicInteger(0);
 
   /**
-   * The timeout used for the execute running in close()
+   * The timeout used for the execute running in close().
    */
   private static final long CLOSE_EXECUTOR_TIMEOUT = 10000; //ms
   private final AtomicBoolean closed = new AtomicBoolean(false);
@@ -135,7 +135,7 @@ public class DefaultRemoteManagerImplementation implements RemoteManager {
   }
 
   /**
-   * Returns a proxy event handler for a remote identifier and a message type
+   * Returns a proxy event handler for a remote identifier and a message type.
    */
   @Override
   public <T> EventHandler<T> getHandler(
@@ -151,7 +151,7 @@ public class DefaultRemoteManagerImplementation implements RemoteManager {
   }
 
   /**
-   * Registers an event handler for a remote identifier and a message type and
+   * Registers an event handler for a remote identifier and a message type and.
    * returns a subscription
    */
   @Override
@@ -167,7 +167,7 @@ public class DefaultRemoteManagerImplementation implements RemoteManager {
   }
 
   /**
-   * Registers an event handler for a message type and returns a subscription
+   * Registers an event handler for a message type and returns a subscription.
    */
   @Override
   public <T, U extends T> AutoCloseable registerHandler(
@@ -180,7 +180,7 @@ public class DefaultRemoteManagerImplementation implements RemoteManager {
   }
 
   /**
-   * Registers an exception handler and returns a subscription
+   * Registers an exception handler and returns a subscription.
    */
   @Override
   public AutoCloseable registerErrorHandler(final EventHandler<Exception> theHandler) {
@@ -192,7 +192,7 @@ public class DefaultRemoteManagerImplementation implements RemoteManager {
   }
 
   /**
-   * Returns my identifier
+   * Returns my identifier.
    */
   @Override
   public RemoteIdentifier getMyIdentifier() {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteMessage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteMessage.java
@@ -22,7 +22,7 @@ import org.apache.reef.wake.remote.RemoteIdentifier;
 import org.apache.reef.wake.remote.RemoteMessage;
 
 /**
- * Default remote message implementation
+ * Default remote message implementation.
  *
  * @param <T> type
  */
@@ -32,7 +32,7 @@ class DefaultRemoteMessage<T> implements RemoteMessage<T> {
   private final T message;
 
   /**
-   * Constructs a default remote message
+   * Constructs a default remote message.
    *
    * @param id      the remote identifier
    * @param message the message
@@ -43,7 +43,7 @@ class DefaultRemoteMessage<T> implements RemoteMessage<T> {
   }
 
   /**
-   * Gets the identifier part of this remote message
+   * Gets the identifier part of this remote message.
    *
    * @return the identifier
    */
@@ -53,7 +53,7 @@ class DefaultRemoteMessage<T> implements RemoteMessage<T> {
   }
 
   /**
-   * Gets the message part of this remote message
+   * Gets the message part of this remote message.
    *
    * @return the message
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/HandlerContainer.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/HandlerContainer.java
@@ -32,7 +32,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Main logic to dispatch messages
+ * Main logic to dispatch messages.
  */
 final class HandlerContainer<T> implements EventHandler<RemoteEvent<byte[]>> {
 
@@ -94,7 +94,7 @@ final class HandlerContainer<T> implements EventHandler<RemoteEvent<byte[]>> {
   }
 
   /**
-   * Unsubscribes a handler
+   * Unsubscribes a handler.
    *
    * @param subscription
    * @throws org.apache.reef.wake.remote.exception.RemoteRuntimeException if the Subscription type is unknown
@@ -115,7 +115,7 @@ final class HandlerContainer<T> implements EventHandler<RemoteEvent<byte[]>> {
   }
 
   /**
-   * Dispatches a message
+   * Dispatches a message.
    *
    * @param value
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/MultiCodec.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/MultiCodec.java
@@ -26,7 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Codec using the WakeTuple protocol buffer
+ * Codec using the WakeTuple protocol buffer.
  * (class name and bytes)
  *
  * @param <T>
@@ -37,7 +37,7 @@ public class MultiCodec<T> implements Codec<T> {
   private final Decoder<T> decoder;
 
   /**
-   * Constructs a codec that encodes/decodes an object to/from bytes based on the class name
+   * Constructs a codec that encodes/decodes an object to/from bytes based on the class name.
    *
    * @param clazzToDecoderMap
    */
@@ -53,7 +53,7 @@ public class MultiCodec<T> implements Codec<T> {
   }
 
   /**
-   * Encodes an object to a byte array
+   * Encodes an object to a byte array.
    *
    * @param obj
    */
@@ -63,7 +63,7 @@ public class MultiCodec<T> implements Codec<T> {
   }
 
   /**
-   * Decodes byte array
+   * Decodes byte array.
    *
    * @param data class name and byte payload
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/MultiDecoder.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/MultiDecoder.java
@@ -26,7 +26,7 @@ import org.apache.reef.wake.remote.proto.WakeRemoteProtos.WakeTuplePBuf;
 import java.util.Map;
 
 /**
- * Decoder using the WakeTuple protocol buffer
+ * Decoder using the WakeTuple protocol buffer.
  * (class name and bytes)
  *
  * @param <T> type
@@ -35,7 +35,7 @@ public class MultiDecoder<T> implements Decoder<T> {
   private final Map<Class<? extends T>, Decoder<? extends T>> clazzToDecoderMap;
 
   /**
-   * Constructs a decoder that decodes bytes based on the class name
+   * Constructs a decoder that decodes bytes based on the class name.
    *
    * @param clazzToDecoderMap
    */
@@ -44,7 +44,7 @@ public class MultiDecoder<T> implements Decoder<T> {
   }
 
   /**
-   * Decodes byte array
+   * Decodes byte array.
    *
    * @param data class name and byte payload
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/MultiEncoder.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/MultiEncoder.java
@@ -26,7 +26,7 @@ import org.apache.reef.wake.remote.proto.WakeRemoteProtos.WakeTuplePBuf;
 import java.util.Map;
 
 /**
- * Encoder using the WakeTuple protocol buffer
+ * Encoder using the WakeTuple protocol buffer.
  * (class name and bytes)
  *
  * @param <T>
@@ -36,7 +36,7 @@ public class MultiEncoder<T> implements Encoder<T> {
   private final Map<Class<? extends T>, Encoder<? extends T>> clazzToEncoderMap;
 
   /**
-   * Constructs an encoder that encodes an object to bytes based on the class name
+   * Constructs an encoder that encodes an object to bytes based on the class name.
    *
    * @param clazzToDecoderMap
    */
@@ -45,7 +45,7 @@ public class MultiEncoder<T> implements Encoder<T> {
   }
 
   /**
-   * Encodes an object to a byte array
+   * Encodes an object to a byte array.
    *
    * @param obj
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/ObjectSerializableCodec.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/ObjectSerializableCodec.java
@@ -25,7 +25,7 @@ import javax.inject.Inject;
 import java.io.*;
 
 /**
- * Codec that uses Java serialization
+ * Codec that uses Java serialization.
  *
  * @param <T>
  */
@@ -36,7 +36,7 @@ public class ObjectSerializableCodec<T> implements Codec<T> {
   }
 
   /**
-   * Encodes the object to bytes
+   * Encodes the object to bytes.
    *
    * @param obj the object
    * @return bytes
@@ -54,7 +54,7 @@ public class ObjectSerializableCodec<T> implements Codec<T> {
   }
 
   /**
-   * Decodes an object from the bytes
+   * Decodes an object from the bytes.
    *
    * @param buf the bytes
    * @return an object

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/OrderedRemoteReceiverStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/OrderedRemoteReceiverStage.java
@@ -32,7 +32,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Receive incoming events and dispatch to correct handlers in order
+ * Receive incoming events and dispatch to correct handlers in order.
  */
 public class OrderedRemoteReceiverStage implements EStage<TransportEvent> {
 
@@ -47,7 +47,7 @@ public class OrderedRemoteReceiverStage implements EStage<TransportEvent> {
   private final ThreadPoolStage<OrderedEventStream> pullStage;
 
   /**
-   * Constructs a ordered remote receiver stage
+   * Constructs a ordered remote receiver stage.
    *
    * @param handler      the handler of remote events
    * @param errorHandler the exception handler

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/ProxyEventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/ProxyEventHandler.java
@@ -26,7 +26,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Proxy of the event handler that runs remotely
+ * Proxy of the event handler that runs remotely.
  *
  * @param <T> type
  */
@@ -40,7 +40,7 @@ public class ProxyEventHandler<T> implements EventHandler<T> {
   private final RemoteSeqNumGenerator seqGen;
 
   /**
-   * Constructs a proxy event handler
+   * Constructs a proxy event handler.
    *
    * @param myId           my identifier
    * @param remoteId       the remote identifier
@@ -62,7 +62,7 @@ public class ProxyEventHandler<T> implements EventHandler<T> {
   }
 
   /**
-   * Sends the event to the event handler running remotely
+   * Sends the event to the event handler running remotely.
    *
    * @param event the event
    */
@@ -75,7 +75,7 @@ public class ProxyEventHandler<T> implements EventHandler<T> {
   }
 
   /**
-   * Returns a string representation of the object
+   * Returns a string representation of the object.
    *
    * @return a string representation of the object
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEvent.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEvent.java
@@ -21,7 +21,7 @@ package org.apache.reef.wake.remote.impl;
 import java.net.SocketAddress;
 
 /**
- * Event that are exchanged across process boundaries
+ * Event that are exchanged across process boundaries.
  *
  * @param <T> type
  */
@@ -36,7 +36,7 @@ public class RemoteEvent<T> {
   private String sink;
 
   /**
-   * Constructs a remote event
+   * Constructs a remote event.
    *
    * @param localAddr  the local socket address
    * @param remoteAddr the remote socket address
@@ -55,7 +55,7 @@ public class RemoteEvent<T> {
   }
 
   /**
-   * Gets the local socket address
+   * Gets the local socket address.
    *
    * @return the local socket address
    */
@@ -64,7 +64,7 @@ public class RemoteEvent<T> {
   }
 
   /**
-   * Gets the remote socket address
+   * Gets the remote socket address.
    *
    * @return the remote socket address
    */
@@ -73,7 +73,7 @@ public class RemoteEvent<T> {
   }
 
   /**
-   * Gets the source
+   * Gets the source.
    *
    * @return the source
    */
@@ -82,7 +82,7 @@ public class RemoteEvent<T> {
   }
 
   /**
-   * Sets the source
+   * Sets the source.
    *
    * @param name the source name
    */
@@ -91,7 +91,7 @@ public class RemoteEvent<T> {
   }
 
   /**
-   * Gets the sink
+   * Gets the sink.
    *
    * @return the sink
    */
@@ -100,7 +100,7 @@ public class RemoteEvent<T> {
   }
 
   /**
-   * Sets the sink
+   * Sets the sink.
    *
    * @param name the sink name
    */
@@ -109,7 +109,7 @@ public class RemoteEvent<T> {
   }
 
   /**
-   * Gets the actual event
+   * Gets the actual event.
    *
    * @return the event
    */
@@ -118,7 +118,7 @@ public class RemoteEvent<T> {
   }
 
   /**
-   * Gets the sequence number
+   * Gets the sequence number.
    *
    * @return the sequence number
    */
@@ -127,7 +127,7 @@ public class RemoteEvent<T> {
   }
 
   /**
-   * Sets the local socket address
+   * Sets the local socket address.
    *
    * @param addr the local socket address
    */
@@ -136,7 +136,7 @@ public class RemoteEvent<T> {
   }
 
   /**
-   * Sets the remote socket address
+   * Sets the remote socket address.
    *
    * @param addr the remote socket address
    */
@@ -145,7 +145,7 @@ public class RemoteEvent<T> {
   }
 
   /**
-   * Returns a string representation of this object
+   * Returns a string representation of this object.
    *
    * @return a string representation of this object
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEventCodec.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEventCodec.java
@@ -21,7 +21,7 @@ package org.apache.reef.wake.remote.impl;
 import org.apache.reef.wake.remote.Codec;
 
 /**
- * Codec of the event sent remotely
+ * Codec of the event sent remotely.
  *
  * @param <T> type
  */
@@ -31,7 +31,7 @@ public class RemoteEventCodec<T> implements Codec<RemoteEvent<T>> {
   private final RemoteEventDecoder<T> decoder;
 
   /**
-   * Constructs a remote event codec
+   * Constructs a remote event codec.
    *
    * @param codec the codec for the event
    */
@@ -41,7 +41,7 @@ public class RemoteEventCodec<T> implements Codec<RemoteEvent<T>> {
   }
 
   /**
-   * Encodes the remote event object to bytes
+   * Encodes the remote event object to bytes.
    *
    * @param obj the remote event object
    * @returns bytes
@@ -52,7 +52,7 @@ public class RemoteEventCodec<T> implements Codec<RemoteEvent<T>> {
   }
 
   /**
-   * Decodes a remote event object from the bytes
+   * Decodes a remote event object from the bytes.
    *
    * @param data the byte array
    * @return a remote event object

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEventComparator.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEventComparator.java
@@ -21,7 +21,7 @@ package org.apache.reef.wake.remote.impl;
 import java.util.Comparator;
 
 /**
- * Comparator for the remote event
+ * Comparator for the remote event.
  */
 public class RemoteEventComparator<T> implements Comparator<RemoteEvent<T>> {
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEventDecoder.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEventDecoder.java
@@ -24,7 +24,7 @@ import org.apache.reef.wake.remote.exception.RemoteRuntimeException;
 import org.apache.reef.wake.remote.proto.WakeRemoteProtos.WakeMessagePBuf;
 
 /**
- * Remote event decoder using the WakeMessage protocol buffer
+ * Remote event decoder using the WakeMessage protocol buffer.
  *
  * @param <T> type
  */
@@ -33,7 +33,7 @@ public class RemoteEventDecoder<T> implements Decoder<RemoteEvent<T>> {
   private final Decoder<T> decoder;
 
   /**
-   * Constructs a remote event decoder
+   * Constructs a remote event decoder.
    *
    * @param decoder the decoder of the event
    */
@@ -42,7 +42,7 @@ public class RemoteEventDecoder<T> implements Decoder<RemoteEvent<T>> {
   }
 
   /**
-   * Decodes a remote event from the byte array data
+   * Decodes a remote event from the byte array data.
    *
    * @param data the byte array data
    * @return a remote event object

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEventEncoder.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEventEncoder.java
@@ -24,7 +24,7 @@ import org.apache.reef.wake.remote.exception.RemoteRuntimeException;
 import org.apache.reef.wake.remote.proto.WakeRemoteProtos.WakeMessagePBuf;
 
 /**
- * Remote event encoder using the WakeMessage protocol buffer
+ * Remote event encoder using the WakeMessage protocol buffer.
  *
  * @param <T> type
  */
@@ -33,7 +33,7 @@ public class RemoteEventEncoder<T> implements Encoder<RemoteEvent<T>> {
   private final Encoder<T> encoder;
 
   /**
-   * Constructs a remote event encoder
+   * Constructs a remote event encoder.
    *
    * @param encoder the encoder of the event
    */
@@ -42,7 +42,7 @@ public class RemoteEventEncoder<T> implements Encoder<RemoteEvent<T>> {
   }
 
   /**
-   * Encodes the remote event object to bytes
+   * Encodes the remote event object to bytes.
    *
    * @param obj the remote event
    * @return bytes

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteReceiverEventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteReceiverEventHandler.java
@@ -24,7 +24,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Remote receiver event handler
+ * Remote receiver event handler.
  */
 class RemoteReceiverEventHandler implements EventHandler<TransportEvent> {
 
@@ -34,7 +34,7 @@ class RemoteReceiverEventHandler implements EventHandler<TransportEvent> {
   private final EventHandler<RemoteEvent<byte[]>> handler;
 
   /**
-   * Constructs a remote receiver event handler
+   * Constructs a remote receiver event handler.
    *
    * @param handler the upstream handler
    */
@@ -44,7 +44,7 @@ class RemoteReceiverEventHandler implements EventHandler<TransportEvent> {
   }
 
   /**
-   * Handles the event received from a remote node
+   * Handles the event received from a remote node.
    *
    * @param e the event
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteReceiverStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteReceiverStage.java
@@ -33,7 +33,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Receive incoming events and dispatch to correct handlers
+ * Receive incoming events and dispatch to correct handlers.
  */
 public class RemoteReceiverStage implements EStage<TransportEvent> {
 
@@ -46,7 +46,7 @@ public class RemoteReceiverStage implements EStage<TransportEvent> {
   private final long shutdownTimeout = WakeParameters.REMOTE_EXECUTOR_SHUTDOWN_TIMEOUT;
 
   /**
-   * Constructs a remote receiver stage
+   * Constructs a remote receiver stage.
    *
    * @param handler      the handler of remote events
    * @param errorHandler the exception handler
@@ -64,7 +64,7 @@ public class RemoteReceiverStage implements EStage<TransportEvent> {
   }
 
   /**
-   * Handles the received event
+   * Handles the received event.
    *
    * @param value the event
    */
@@ -75,7 +75,7 @@ public class RemoteReceiverStage implements EStage<TransportEvent> {
   }
 
   /**
-   * Closes the stage
+   * Closes the stage.
    */
   @Override
   public void close() throws Exception {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteSenderEventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteSenderEventHandler.java
@@ -33,7 +33,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Remote sender event handler
+ * Remote sender event handler.
  *
  * @param <T> type
  */
@@ -48,7 +48,7 @@ class RemoteSenderEventHandler<T> implements EventHandler<RemoteEvent<T>> {
   private final ExecutorService executor;
 
   /**
-   * Constructs a remote sender event handler
+   * Constructs a remote sender event handler.
    *
    * @param encoder   the encoder
    * @param transport the transport to send events
@@ -82,7 +82,7 @@ class RemoteSenderEventHandler<T> implements EventHandler<RemoteEvent<T>> {
   }
 
   /**
-   * Handles the event to send to a remote node
+   * Handles the event to send to a remote node.
    *
    * @param value the event
    * @throws RemoteRuntimeException

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteSenderStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteSenderStage.java
@@ -47,7 +47,7 @@ public class RemoteSenderStage implements Stage {
   private final Transport transport;
 
   /**
-   * Constructs a remote sender stage
+   * Constructs a remote sender stage.
    *
    * @param encoder    the encoder of the event
    * @param transport  the transport to send events
@@ -61,7 +61,7 @@ public class RemoteSenderStage implements Stage {
   }
 
   /**
-   * Returns a new remote sender event handler
+   * Returns a new remote sender event handler.
    *
    * @return a remote sender event handler
    */
@@ -70,7 +70,7 @@ public class RemoteSenderStage implements Stage {
   }
 
   /**
-   * Closes the stage
+   * Closes the stage.
    */
   @Override
   public void close() throws Exception {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteSeqNumGenerator.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteSeqNumGenerator.java
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 
 /**
- * Generates the sequence number for remote messages per destination
+ * Generates the sequence number for remote messages per destination.
  */
 public class RemoteSeqNumGenerator {
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/SocketRemoteIdentifier.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/SocketRemoteIdentifier.java
@@ -24,14 +24,14 @@ import org.apache.reef.wake.remote.exception.RemoteRuntimeException;
 import java.net.InetSocketAddress;
 
 /**
- * Remote identifier based on a socket address
+ * Remote identifier based on a socket address.
  */
 public class SocketRemoteIdentifier implements RemoteIdentifier {
 
   private InetSocketAddress addr;
 
   /**
-   * Constructs a remote identifier
+   * Constructs a remote identifier.
    *
    * @param addr the socket address
    */
@@ -40,7 +40,7 @@ public class SocketRemoteIdentifier implements RemoteIdentifier {
   }
 
   /**
-   * Constructs a remote identifier
+   * Constructs a remote identifier.
    *
    * @param str the string representation
    * @throws RemoteRuntimeException
@@ -64,7 +64,7 @@ public class SocketRemoteIdentifier implements RemoteIdentifier {
   }
 
   /**
-   * Gets the socket address
+   * Gets the socket address.
    *
    * @return the socket address
    */
@@ -73,7 +73,7 @@ public class SocketRemoteIdentifier implements RemoteIdentifier {
   }
 
   /**
-   * Returns a hash code for the object
+   * Returns a hash code for the object.
    *
    * @return a hash code value for this object
    */
@@ -83,7 +83,7 @@ public class SocketRemoteIdentifier implements RemoteIdentifier {
   }
 
   /**
-   * Checks that another object is equal to this object
+   * Checks that another object is equal to this object.
    *
    * @param o another object
    * @return true if the object is the same as the object argument; false, otherwise
@@ -94,7 +94,7 @@ public class SocketRemoteIdentifier implements RemoteIdentifier {
   }
 
   /**
-   * Returns a string representation of the object
+   * Returns a string representation of the object.
    *
    * @return a string representation of the object
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/StringCodec.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/StringCodec.java
@@ -21,12 +21,12 @@ package org.apache.reef.wake.remote.impl;
 import org.apache.reef.wake.remote.Codec;
 
 /**
- * Codec that encodes/decodes a string
+ * Codec that encodes/decodes a string.
  */
 public class StringCodec implements Codec<String> {
 
   /**
-   * Returns a byte array representation of the string
+   * Returns a byte array representation of the string.
    *
    * @param obj the string
    * @return a byte array representation of the string
@@ -37,7 +37,7 @@ public class StringCodec implements Codec<String> {
   }
 
   /**
-   * Returns a string decoded from the byte array
+   * Returns a string decoded from the byte array.
    *
    * @param buf the byte array
    * @return a string

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/Subscription.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/Subscription.java
@@ -19,7 +19,7 @@
 package org.apache.reef.wake.remote.impl;
 
 /**
- * Subscription of a handler
+ * Subscription of a handler.
  *
  * @param <T> type
  */
@@ -29,7 +29,7 @@ public class Subscription<T> implements AutoCloseable {
   private final T token;
 
   /**
-   * Constructs a subscription
+   * Constructs a subscription.
    *
    * @param token            the token for finding the subscription
    * @param handlerContainer the container managing handlers
@@ -40,7 +40,7 @@ public class Subscription<T> implements AutoCloseable {
   }
 
   /**
-   * Gets the token of this subscription
+   * Gets the token of this subscription.
    *
    * @return the token of this subscription
    */
@@ -49,7 +49,7 @@ public class Subscription<T> implements AutoCloseable {
   }
 
   /**
-   * Unsubscribes this subscription
+   * Unsubscribes this subscription.
    *
    * @throws Exception
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/TransportEvent.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/TransportEvent.java
@@ -24,7 +24,7 @@ import java.net.SocketAddress;
 
 
 /**
- * Event sent from a remote node
+ * Event sent from a remote node.
  */
 public class TransportEvent {
   private final byte[] data;
@@ -33,7 +33,7 @@ public class TransportEvent {
   private final Link<byte[]> link;
 
   /**
-   * Constructs an object event
+   * Constructs an object event.
    *
    * @param data       the data
    * @param localAddr  the local socket address
@@ -47,7 +47,7 @@ public class TransportEvent {
   }
 
   /**
-   * Constructs the transport even object using link to
+   * Constructs the transport even object using link to.
    * initialize local and remote address if link not null
    *
    * @param data
@@ -66,7 +66,7 @@ public class TransportEvent {
   }
 
   /**
-   * Gets the data
+   * Gets the data.
    *
    * @return data
    */
@@ -75,7 +75,7 @@ public class TransportEvent {
   }
 
   /**
-   * Returns the link associated with the event
+   * Returns the link associated with the event.
    * which can be used to write back to the client
    * without creating a new link
    *
@@ -86,7 +86,7 @@ public class TransportEvent {
   }
 
   /**
-   * Gets the local socket address
+   * Gets the local socket address.
    *
    * @return the local socket address
    */
@@ -95,7 +95,7 @@ public class TransportEvent {
   }
 
   /**
-   * Gets the remote socket address
+   * Gets the remote socket address.
    *
    * @return the remote socket address
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/Tuple2.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/Tuple2.java
@@ -19,7 +19,7 @@
 package org.apache.reef.wake.remote.impl;
 
 /**
- * Tuple with two values
+ * Tuple with two values.
  *
  * @param <T1>
  * @param <T2>

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/RandomRangeIterator.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/RandomRangeIterator.java
@@ -24,7 +24,7 @@ import java.util.Iterator;
 import java.util.Random;
 
 /**
- * This class will give out random port numbers between tcpPortRangeBegin and tcpPortRangeBegin+tcpPortRangeCount
+ * This class will give out random port numbers between tcpPortRangeBegin and tcpPortRangeBegin+tcpPortRangeCount.
  * Max number of ports given is tryCount
  */
 @ThreadSafe
@@ -52,7 +52,7 @@ final class RandomRangeIterator implements Iterator<Integer> {
   }
 
   /**
-   * always throws
+   * always throws.
    * @throws UnsupportedOperationException always.
    */
   @Override

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/RangeTcpPortProvider.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/RangeTcpPortProvider.java
@@ -33,7 +33,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * A TcpPortProvider which gives out random ports in a range
+ * A TcpPortProvider which gives out random ports in a range.
  */
 public final class RangeTcpPortProvider implements TcpPortProvider {
   private final int portRangeBegin;
@@ -52,7 +52,7 @@ public final class RangeTcpPortProvider implements TcpPortProvider {
   }
 
   /**
-   * Returns an iterator over a set of tcp ports
+   * Returns an iterator over a set of tcp ports.
    *
    * @return an Iterator.
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/TcpPortProvider.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/TcpPortProvider.java
@@ -29,7 +29,7 @@ import java.util.Iterator;
 @DefaultImplementation(RangeTcpPortProvider.class)
 public interface TcpPortProvider extends Iterable<Integer> {
   /**
-   * Returns an iterator over a set of tcp ports
+   * Returns an iterator over a set of tcp ports.
    *
    * @return an Iterator.
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/parameters/TcpPortRangeBegin.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/parameters/TcpPortRangeBegin.java
@@ -22,7 +22,7 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
- * First tcp port number to try
+ * First tcp port number to try.
  */
 @NamedParameter(doc = "First tcp port number to try", default_value = TcpPortRangeBegin.default_value)
 public class TcpPortRangeBegin implements Name<Integer> {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/parameters/TcpPortRangeCount.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/parameters/TcpPortRangeCount.java
@@ -22,7 +22,7 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
- * Number of tcp ports in the range
+ * Number of tcp ports in the range.
  */
 @NamedParameter(doc = "Number of tcp ports in the range", default_value = TcpPortRangeCount.default_value)
 public class TcpPortRangeCount implements Name<Integer> {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/parameters/TcpPortRangeTryCount.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/parameters/TcpPortRangeTryCount.java
@@ -22,7 +22,7 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
- * Max number tries for port numbers
+ * Max number tries for port numbers.
  */
 @NamedParameter(doc = "Max number tries for port numbers", default_value = TcpPortRangeTryCount.default_value)
 public class TcpPortRangeTryCount implements Name<Integer> {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/LinkListener.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/LinkListener.java
@@ -21,14 +21,14 @@ package org.apache.reef.wake.remote.transport;
 import java.net.SocketAddress;
 
 /**
- * Link listener
+ * Link listener.
  *
  * @param <T> type
  */
 public interface LinkListener<T> {
 
   /**
-   * Called when the sent message is successfully transferred
+   * Called when the sent message is successfully transferred.
    *
    * @param message the sent message
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/Transport.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/Transport.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import java.net.SocketAddress;
 
 /**
- * Transport for sending and receiving data
+ * Transport for sending and receiving data.
  */
 public interface Transport extends Stage {
 
@@ -35,7 +35,7 @@ public interface Transport extends Stage {
    */
 
   /**
-   * Returns a link for the remote address if cached; otherwise opens, caches and returns
+   * Returns a link for the remote address if cached; otherwise opens, caches and returns.
    * When it opens a link for the remote address, only one attempt for the address is made at a given time
    *
    * @param remoteAddr the remote socket address
@@ -47,7 +47,7 @@ public interface Transport extends Stage {
   public <T> Link<T> open(SocketAddress remoteAddr, Encoder<? super T> encoder, LinkListener<? super T> listener) throws IOException;
 
   /**
-   * Returns a link for the remote address if already cached; otherwise, returns null
+   * Returns a link for the remote address if already cached; otherwise, returns null.
    *
    * @param remoteAddr the remote address
    * @return a link if already cached; otherwise, null
@@ -55,21 +55,21 @@ public interface Transport extends Stage {
   public <T> Link<T> get(SocketAddress remoteAddr);
 
   /**
-   * Gets a server listening port of this transport
+   * Gets a server listening port of this transport.
    *
    * @return a listening port number
    */
   public int getListeningPort();
 
   /**
-   * Gets a server local socket address of this transport
+   * Gets a server local socket address of this transport.
    *
    * @return a server local socket address
    */
   public SocketAddress getLocalAddress();
 
   /**
-   * Registers the exception handler
+   * Registers the exception handler.
    *
    * @param handler the exception handler
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/TransportFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/TransportFactory.java
@@ -26,13 +26,13 @@ import org.apache.reef.wake.remote.ports.TcpPortProvider;
 import org.apache.reef.wake.remote.transport.netty.MessagingTransportFactory;
 
 /**
- * Factory that creates a transport
+ * Factory that creates a transport.
  */
 @DefaultImplementation(MessagingTransportFactory.class)
 public interface TransportFactory {
 
   /**
-   * Creates a transport
+   * Creates a transport.
    *
    * @param port          a listening port
    * @param clientHandler a transport client-side handler
@@ -46,7 +46,7 @@ public interface TransportFactory {
                           EventHandler<Exception> exHandler);
 
   /**
-   * Creates a transport
+   * Creates a transport.
    *
    * @param hostAddress     a host address
    * @param port            a listening port
@@ -63,7 +63,7 @@ public interface TransportFactory {
                                final int retryTimeout);
 
   /**
-   * Creates a transport
+   * Creates a transport.
    *
    * @param hostAddress     a host address
    * @param port            a listening port

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/exception/TransportRuntimeException.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/exception/TransportRuntimeException.java
@@ -19,13 +19,13 @@
 package org.apache.reef.wake.remote.transport.exception;
 
 /**
- * Transport runtime exception
+ * Transport runtime exception.
  */
 public class TransportRuntimeException extends RuntimeException {
   private static final long serialVersionUID = 1L;
 
   /**
-   * Constructs a new runtime transport exception with the specified detail message and cause
+   * Constructs a new runtime transport exception with the specified detail message and cause.
    *
    * @param s the detailed message
    * @param e the cause
@@ -35,7 +35,7 @@ public class TransportRuntimeException extends RuntimeException {
   }
 
   /**
-   * Constructs a new runtime transport exception with the specified detail message
+   * Constructs a new runtime transport exception with the specified detail message.
    *
    * @param s the detailed message
    */
@@ -44,7 +44,7 @@ public class TransportRuntimeException extends RuntimeException {
   }
 
   /**
-   * Constructs a new runtime transport exception with the specified cause
+   * Constructs a new runtime transport exception with the specified cause.
    *
    * @param e the cause
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/ByteEncoder.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/ByteEncoder.java
@@ -21,7 +21,7 @@ package org.apache.reef.wake.remote.transport.netty;
 import org.apache.reef.wake.remote.Encoder;
 
 /**
- * Wrapping encoder for byte[]
+ * Wrapping encoder for byte[].
  */
 public class ByteEncoder implements Encoder<byte[]> {
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/ChunkedReadWriteHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/ChunkedReadWriteHandler.java
@@ -135,7 +135,7 @@ public class ChunkedReadWriteHandler extends ChunkedWriteHandler {
   }
 
   /**
-   * Converts the int size into a byte[]
+   * Converts the int size into a byte[].
    *
    * @return the bit representation of size
    */
@@ -149,14 +149,14 @@ public class ChunkedReadWriteHandler extends ChunkedWriteHandler {
   }
 
   /**
-   * Get expected size encoded as the first 4 bytes of data
+   * Get expected size encoded as the first 4 bytes of data.
    */
   private int getSize(final byte[] data) {
     return getSize(data, 0);
   }
 
   /**
-   * Get expected size encoded as offset + 4 bytes of data
+   * Get expected size encoded as offset + 4 bytes of data.
    */
   private int getSize(final byte[] data, final int offset) {
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/LoggingLinkListener.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/LoggingLinkListener.java
@@ -25,7 +25,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Link listener that logs whether the message is sent successfully
+ * Link listener that logs whether the message is sent successfully.
  *
  * @param <T> type
  */
@@ -34,7 +34,7 @@ public class LoggingLinkListener<T> implements LinkListener<T> {
   private static final Logger LOG = Logger.getLogger(LoggingLinkListener.class.getName());
 
   /**
-   * Called when the sent message is transferred successfully
+   * Called when the sent message is transferred successfully.
    */
   @Override
   public void onSuccess(T message) {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/MessagingTransportFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/MessagingTransportFactory.java
@@ -36,7 +36,7 @@ import org.apache.reef.wake.remote.transport.TransportFactory;
 import javax.inject.Inject;
 
 /**
- * Factory that creates a messaging transport
+ * Factory that creates a messaging transport.
  */
 public class MessagingTransportFactory implements TransportFactory {
 
@@ -60,7 +60,7 @@ public class MessagingTransportFactory implements TransportFactory {
   }
 
   /**
-   * Creates a transport
+   * Creates a transport.
    *
    * @param port          a listening port
    * @param clientHandler a transport client side handler

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyChannelHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyChannelHandler.java
@@ -37,7 +37,7 @@ class NettyChannelHandler extends ChannelInboundHandlerAdapter {
   private final NettyEventListener listener;
 
   /**
-   * Constructs a Netty channel handler
+   * Constructs a Netty channel handler.
    *
    * @param tag          tag string
    * @param channelGroup the channel group
@@ -69,7 +69,7 @@ class NettyChannelHandler extends ChannelInboundHandlerAdapter {
   }
 
   /**
-   * Handles the channel active event
+   * Handles the channel active event.
    *
    * @param ctx the context object for this handler
    * @throws Exception
@@ -82,7 +82,7 @@ class NettyChannelHandler extends ChannelInboundHandlerAdapter {
   }
 
   /**
-   * Handles the channel inactive event
+   * Handles the channel inactive event.
    *
    * @param ctx the context object for this handler
    * @throws Exception
@@ -94,7 +94,7 @@ class NettyChannelHandler extends ChannelInboundHandlerAdapter {
   }
 
   /**
-   * Handles the exception event
+   * Handles the exception event.
    *
    * @param ctx   the context object for this handler
    * @param cause the cause

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyChannelHandlerFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyChannelHandlerFactory.java
@@ -22,12 +22,12 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 
 
 /**
- * Factory that creates a Netty channel handler
+ * Factory that creates a Netty channel handler.
  */
 interface NettyChannelHandlerFactory {
 
   /**
-   * Creates a channel inbound handler
+   * Creates a channel inbound handler.
    *
    * @return a channel inbound handler adapter
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyChannelInitializer.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyChannelInitializer.java
@@ -26,7 +26,7 @@ import io.netty.handler.codec.bytes.ByteArrayDecoder;
 import io.netty.handler.codec.bytes.ByteArrayEncoder;
 
 /**
- * Netty channel initializer for Transport
+ * Netty channel initializer for Transport.
  * <p/>
  * MAXFRAMELENGTH : the buffer size of the frame decoder
  */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyDefaultChannelHandlerFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyDefaultChannelHandlerFactory.java
@@ -22,7 +22,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.group.ChannelGroup;
 
 /**
- * Default Netty channel handler factory
+ * Default Netty channel handler factory.
  */
 final class NettyDefaultChannelHandlerFactory implements NettyChannelHandlerFactory {
 
@@ -38,7 +38,7 @@ final class NettyDefaultChannelHandlerFactory implements NettyChannelHandlerFact
   }
 
   /**
-   * Creates a Netty channel handler
+   * Creates a Netty channel handler.
    *
    * @return a simple channel upstream handler.
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyEventListener.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyEventListener.java
@@ -21,12 +21,12 @@ package org.apache.reef.wake.remote.transport.netty;
 import io.netty.channel.ChannelHandlerContext;
 
 /**
- * Netty event listener
+ * Netty event listener.
  */
 interface NettyEventListener {
 
   /**
-   * Handles the message
+   * Handles the message.
    *
    * @param ctx the channel handler context
    * @param msg the message
@@ -34,7 +34,7 @@ interface NettyEventListener {
   void channelRead(ChannelHandlerContext ctx, Object msg);
 
   /**
-   * Handles the exception event
+   * Handles the exception event.
    *
    * @param ctx   the channel handler context
    * @param cause the cause
@@ -42,14 +42,14 @@ interface NettyEventListener {
   void exceptionCaught(ChannelHandlerContext ctx, Throwable cause);
 
   /**
-   * Handles the channel active event
+   * Handles the channel active event.
    *
    * @param ctx the channel handler context
    */
   void channelActive(ChannelHandlerContext ctx);
 
   /**
-   * Handles the channel inactive event
+   * Handles the channel inactive event.
    *
    * @param ctx the channel handler context
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyLink.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyLink.java
@@ -45,7 +45,7 @@ public class NettyLink<T> implements Link<T> {
   private final LinkListener<? super T> listener;
 
   /**
-   * Constructs a link
+   * Constructs a link.
    *
    * @param channel the channel
    * @param encoder the encoder
@@ -55,7 +55,7 @@ public class NettyLink<T> implements Link<T> {
   }
 
   /**
-   * Constructs a link
+   * Constructs a link.
    *
    * @param channel  the channel
    * @param encoder  the encoder
@@ -70,7 +70,7 @@ public class NettyLink<T> implements Link<T> {
 
 
   /**
-   * Writes the message to this link
+   * Writes the message to this link.
    *
    * @param message the message
    */
@@ -88,7 +88,7 @@ public class NettyLink<T> implements Link<T> {
   }
 
   /**
-   * Gets a local address of the link
+   * Gets a local address of the link.
    *
    * @return a local socket address
    */
@@ -98,7 +98,7 @@ public class NettyLink<T> implements Link<T> {
   }
 
   /**
-   * Gets a remote address of the link
+   * Gets a remote address of the link.
    *
    * @return a remote socket address
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyMessagingTransport.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyMessagingTransport.java
@@ -61,7 +61,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Messaging transport implementation with Netty
+ * Messaging transport implementation with Netty.
  */
 public class NettyMessagingTransport implements Transport {
 
@@ -100,7 +100,7 @@ public class NettyMessagingTransport implements Transport {
 
 
   /**
-   * Constructs a messaging transport
+   * Constructs a messaging transport.
    *
    * @param hostAddress   the server host address
    * @param port          the server listening port; when it is 0, randomly assign a port number
@@ -125,7 +125,7 @@ public class NettyMessagingTransport implements Transport {
         retryTimeout, tcpPortProvider, LocalAddressProviderFactory.getInstance());
   }
   /**
-   * Constructs a messaging transport
+   * Constructs a messaging transport.
    *
    * @param hostAddress   the server host address
    * @param port          the server listening port; when it is 0, randomly assign a port number
@@ -220,7 +220,7 @@ public class NettyMessagingTransport implements Transport {
   }
 
   /**
-   * Constructs a messaging transport
+   * Constructs a messaging transport.
    *
    * @param hostAddress   the server host address
    * @param port          the server listening port; when it is 0, randomly assign a port number
@@ -241,7 +241,7 @@ public class NettyMessagingTransport implements Transport {
   }
 
   /**
-   * Closes all channels and releases all resources
+   * Closes all channels and releases all resources.
    */
   @Override
   public void close() throws Exception {
@@ -259,7 +259,7 @@ public class NettyMessagingTransport implements Transport {
   }
 
   /**
-   * Returns a link for the remote address if cached; otherwise opens, caches and returns
+   * Returns a link for the remote address if cached; otherwise opens, caches and returns.
    * When it opens a link for the remote address, only one attempt for the address is made at a given time
    *
    * @param remoteAddr the remote socket address
@@ -358,7 +358,7 @@ public class NettyMessagingTransport implements Transport {
   }
 
   /**
-   * Returns a link for the remote address if already cached; otherwise, returns null
+   * Returns a link for the remote address if already cached; otherwise, returns null.
    *
    * @param remoteAddr the remote address
    * @return a link if already cached; otherwise, null
@@ -369,7 +369,7 @@ public class NettyMessagingTransport implements Transport {
   }
 
   /**
-   * Gets a server local socket address of this transport
+   * Gets a server local socket address of this transport.
    *
    * @return a server local socket address
    */
@@ -379,7 +379,7 @@ public class NettyMessagingTransport implements Transport {
   }
 
   /**
-   * Gets a server listening port of this transport
+   * Gets a server listening port of this transport.
    *
    * @return a listening port number
    */
@@ -389,7 +389,7 @@ public class NettyMessagingTransport implements Transport {
   }
 
   /**
-   * Registers the exception event handler
+   * Registers the exception event handler.
    *
    * @param handler the exception event handler
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/AbstractRxStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/AbstractRxStage.java
@@ -23,7 +23,7 @@ import org.apache.reef.wake.metrics.Meter;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * An {@link RxStage} that implements metering
+ * An {@link RxStage} that implements metering.
  *
  * @param <T> type
  */
@@ -35,7 +35,7 @@ public abstract class AbstractRxStage<T> implements RxStage<T> {
   protected final Meter outMeter;
 
   /**
-   * Constructs an abstact rxstage
+   * Constructs an abstact rxstage.
    *
    * @param stageName the stage name
    */
@@ -67,7 +67,7 @@ public abstract class AbstractRxStage<T> implements RxStage<T> {
   }
 
   /**
-   * Gets the input meter of this stage
+   * Gets the input meter of this stage.
    *
    * @return the input meter
    */
@@ -76,7 +76,7 @@ public abstract class AbstractRxStage<T> implements RxStage<T> {
   }
 
   /**
-   * Gets the output meter of this stage
+   * Gets the output meter of this stage.
    *
    * @return the output meter
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/DynamicObservable.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/DynamicObservable.java
@@ -27,7 +27,7 @@ package org.apache.reef.wake.rx;
 public interface DynamicObservable<T> extends Observable {
 
   /**
-   * Subscribes the observer to this observable object
+   * Subscribes the observer to this observable object.
    *
    * @param o the observer
    * @return a subscription handle

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/Observable.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/Observable.java
@@ -19,7 +19,7 @@
 package org.apache.reef.wake.rx;
 
 /**
- * Defines a provider for push-based notification
+ * Defines a provider for push-based notification.
  */
 public interface Observable {
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/RxStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/RxStage.java
@@ -21,7 +21,7 @@ package org.apache.reef.wake.rx;
 import org.apache.reef.wake.Stage;
 
 /**
- * Stage that executes the observer
+ * Stage that executes the observer.
  *
  * @param <T> type
  */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/RxSyncStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/RxSyncStage.java
@@ -28,7 +28,7 @@ import org.apache.reef.wake.rx.Observer;
 import javax.inject.Inject;
 
 /**
- * Stage that executes the observer synchronously
+ * Stage that executes the observer synchronously.
  *
  * @param <T> type
  */
@@ -37,7 +37,7 @@ public final class RxSyncStage<T> extends AbstractRxStage<T> {
   private final Observer<T> observer;
 
   /**
-   * Constructs a Rx synchronous stage
+   * Constructs a Rx synchronous stage.
    *
    * @param observer the observer
    */
@@ -47,7 +47,7 @@ public final class RxSyncStage<T> extends AbstractRxStage<T> {
   }
 
   /**
-   * Constructs a Rx synchronous stage
+   * Constructs a Rx synchronous stage.
    *
    * @param name     the stage name
    * @param observer the observer
@@ -61,7 +61,7 @@ public final class RxSyncStage<T> extends AbstractRxStage<T> {
   }
 
   /**
-   * Provides the observer with the new value
+   * Provides the observer with the new value.
    *
    * @param value the new value
    */
@@ -93,7 +93,7 @@ public final class RxSyncStage<T> extends AbstractRxStage<T> {
   }
 
   /**
-   * Closes the stage
+   * Closes the stage.
    *
    * @throws Exception
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/RxThreadPoolStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/RxThreadPoolStage.java
@@ -59,7 +59,7 @@ public final class RxThreadPoolStage<T> extends AbstractRxStage<T> {
   private DefaultThreadFactory tf;
 
   /**
-   * Constructs a Rx thread pool stage
+   * Constructs a Rx thread pool stage.
    *
    * @param observer   the observer to execute
    * @param numThreads the number of threads
@@ -71,7 +71,7 @@ public final class RxThreadPoolStage<T> extends AbstractRxStage<T> {
   }
 
   /**
-   * Constructs a Rx thread pool stage
+   * Constructs a Rx thread pool stage.
    *
    * @param name       the stage name
    * @param observer   the observer to execute
@@ -92,7 +92,7 @@ public final class RxThreadPoolStage<T> extends AbstractRxStage<T> {
   }
 
   /**
-   * Provides the observer with the new value
+   * Provides the observer with the new value.
    *
    * @param value the new value
    */
@@ -165,7 +165,7 @@ public final class RxThreadPoolStage<T> extends AbstractRxStage<T> {
   }
 
   /**
-   * Closes the stage
+   * Closes the stage.
    *
    * @return Exception
    */
@@ -188,7 +188,7 @@ public final class RxThreadPoolStage<T> extends AbstractRxStage<T> {
   }
 
   /**
-   * Gets the queue length of this stage
+   * Gets the queue length of this stage.
    *
    * @return the queue length
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/SimpleSubject.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/SimpleSubject.java
@@ -33,7 +33,7 @@ public class SimpleSubject<T> implements Subject<T, T> {
   private final Observer<T> observer;
 
   /**
-   * Constructs a simple subject
+   * Constructs a simple subject.
    *
    * @param observer the observer
    */
@@ -43,7 +43,7 @@ public class SimpleSubject<T> implements Subject<T, T> {
   }
 
   /**
-   * Provides the observer with the new value
+   * Provides the observer with the new value.
    *
    * @param value the new value
    */
@@ -53,7 +53,7 @@ public class SimpleSubject<T> implements Subject<T, T> {
   }
 
   /**
-   * Provides the observer with the error
+   * Provides the observer with the error.
    *
    * @param error the error
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/Clock.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/Clock.java
@@ -42,7 +42,7 @@ import java.util.Set;
 public interface Clock extends Runnable, AutoCloseable {
 
   /**
-   * Schedule a TimerEvent at the given future offset
+   * Schedule a TimerEvent at the given future offset.
    *
    * @param handler to be called
    * @param offset  into the future
@@ -71,35 +71,35 @@ public interface Clock extends Runnable, AutoCloseable {
   public boolean isIdle();
 
   /**
-   * Bind this to an event handler to statically subscribe to the StartTime Event
+   * Bind this to an event handler to statically subscribe to the StartTime Event.
    */
   @NamedParameter(default_class = MissingStartHandlerHandler.class, doc = "Will be called upon the start event")
   public class StartHandler implements Name<Set<EventHandler<StartTime>>> {
   }
 
   /**
-   * Bind this to an event handler to statically subscribe to the StopTime Event
+   * Bind this to an event handler to statically subscribe to the StopTime Event.
    */
   @NamedParameter(default_class = LoggingEventHandler.class, doc = "Will be called upon the stop event")
   public class StopHandler implements Name<Set<EventHandler<StopTime>>> {
   }
 
   /**
-   * Bind this to an event handler to statically subscribe to the RuntimeStart Event
+   * Bind this to an event handler to statically subscribe to the RuntimeStart Event.
    */
   @NamedParameter(default_class = LoggingEventHandler.class, doc = "Will be called upon the runtime start event")
   public class RuntimeStartHandler implements Name<Set<EventHandler<RuntimeStart>>> {
   }
 
   /**
-   * Bind this to an event handler to statically subscribe to the RuntimeStart Event
+   * Bind this to an event handler to statically subscribe to the RuntimeStart Event.
    */
   @NamedParameter(default_class = LoggingEventHandler.class, doc = "Will be called upon the runtime stop event")
   public class RuntimeStopHandler implements Name<Set<EventHandler<RuntimeStop>>> {
   }
 
   /**
-   * Bind this to an event handler to statically subscribe to the IdleClock Event
+   * Bind this to an event handler to statically subscribe to the IdleClock Event.
    */
   @NamedParameter(default_class = LoggingEventHandler.class, doc = "Will be called upon the Idle event")
   public class IdleHandler implements Name<Set<EventHandler<IdleClock>>> {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/Time.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/Time.java
@@ -19,7 +19,7 @@
 package org.apache.reef.wake.time;
 
 /**
- * Time object
+ * Time object.
  */
 public abstract class Time implements Comparable<Time> {
 

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/AvroEvaluatorInfoSerializer.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/AvroEvaluatorInfoSerializer.java
@@ -84,7 +84,7 @@ public class AvroEvaluatorInfoSerializer implements EvaluatorInfoSerializer {
   }
 
   /**
-   * Convert AvroEvaluatorsInfo object to JSON string
+   * Convert AvroEvaluatorsInfo object to JSON string.
    */
   @Override
   public String toString(final AvroEvaluatorsInfo avroEvaluatorsInfo) {

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/AvroHttpSerializer.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/AvroHttpSerializer.java
@@ -87,7 +87,7 @@ public class AvroHttpSerializer {
   }
 
   /**
-   * Conver AvroHttpRequest to a file
+   * Conver AvroHttpRequest to a file.
    * @param avroHttpRequest
    * @param file
    * @throws IOException
@@ -102,7 +102,7 @@ public class AvroHttpSerializer {
   }
 
   /**
-   * Convert a file to AvroHttpRequest
+   * Convert a file to AvroHttpRequest.
    * @param file
    * @return
    * @throws IOException

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/DriverInfoSerializer.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/DriverInfoSerializer.java
@@ -23,12 +23,12 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
 import java.util.List;
 
 /**
- * Interface for DriverInfoSerializer
+ * Interface for DriverInfoSerializer.
  */
 @DefaultImplementation(AvroDriverInfoSerializer.class)
 public interface DriverInfoSerializer {
   /**
-   * Build AvroDriverInfo object from raw data
+   * Build AvroDriverInfo object from raw data.
    *
    * @param id
    * @param startTime
@@ -37,7 +37,7 @@ public interface DriverInfoSerializer {
   public AvroDriverInfo toAvro(final String id, final String startTime, final List<AvroReefServiceInfo> services);
 
   /**
-   * Convert AvroDriverInfo object to JSon string
+   * Convert AvroDriverInfo object to JSon string.
    *
    * @param avroDriverInfo
    * @return

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/EvaluatorInfoSerializer.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/EvaluatorInfoSerializer.java
@@ -28,7 +28,7 @@ import java.util.Map;
 public interface EvaluatorInfoSerializer {
 
   /**
-   * Build AvroEvaluatorsInfo object from raw data
+   * Build AvroEvaluatorsInfo object from raw data.
    */
   AvroEvaluatorsInfo toAvro(
       final List<String> ids, final Map<String, EvaluatorDescriptor> evaluators);

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/EvaluatorListSerializer.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/EvaluatorListSerializer.java
@@ -24,12 +24,12 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
 import java.util.Map;
 
 /**
- * interface for EvaluatorListSerializer
+ * interface for EvaluatorListSerializer.
  */
 @DefaultImplementation(AvroEvaluatorListSerializer.class)
 public interface EvaluatorListSerializer {
   /**
-   * Build AvroEvaluatorList object
+   * Build AvroEvaluatorList object.
    *
    * @param evaluatorMap
    * @param totalEvaluators
@@ -39,7 +39,7 @@ public interface EvaluatorListSerializer {
   public AvroEvaluatorList toAvro(final Map<String, EvaluatorDescriptor> evaluatorMap, final int totalEvaluators, final String startTime);
 
   /**
-   * Convert AvroEvaluatorList to JSon string
+   * Convert AvroEvaluatorList to JSon string.
    *
    * @param avroEvaluatorList
    * @return

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpEventHandlers.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpEventHandlers.java
@@ -24,7 +24,7 @@ import org.apache.reef.tang.annotations.NamedParameter;
 import java.util.Set;
 
 /**
- * HttpEventHandlers
+ * HttpEventHandlers.
  */
 @NamedParameter(doc = "Http Event Handlers")
 public class HttpEventHandlers implements Name<Set<HttpHandler>> {

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpHandler.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpHandler.java
@@ -23,7 +23,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 /**
- * HttpHandler interface
+ * HttpHandler interface.
  */
 public interface HttpHandler {
   /**
@@ -41,7 +41,7 @@ public interface HttpHandler {
   public void setUriSpecification(final String s);
 
   /**
-   * Will be called when request comes
+   * Will be called when request comes.
    *
    * @param parsedHttpRequest
    * @param response

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpHandlerConfiguration.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpHandlerConfiguration.java
@@ -24,17 +24,17 @@ import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
 import org.apache.reef.tang.formats.OptionalParameter;
 
 /**
- * Configuration Module Builder for Http Handler
+ * Configuration Module Builder for Http Handler.
  */
 public final class HttpHandlerConfiguration extends ConfigurationModuleBuilder {
 
   /**
-   * Specify optional parameter for HttpEventHandlers
+   * Specify optional parameter for HttpEventHandlers.
    */
   public static final OptionalParameter<HttpHandler> HTTP_HANDLERS = new OptionalParameter<>();
 
   /**
-   * HttpHandlerConfiguration merged with HttpRuntimeConfiguration
+   * HttpHandlerConfiguration merged with HttpRuntimeConfiguration.
    */
   public static final ConfigurationModule CONF = new HttpHandlerConfiguration().merge(HttpRuntimeConfiguration.CONF)
       .bindSetEntry(HttpEventHandlers.class, HTTP_HANDLERS)

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpRuntimeConfiguration.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpRuntimeConfiguration.java
@@ -23,11 +23,11 @@ import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
 import org.apache.reef.wake.time.Clock;
 
 /**
- * Configuration Module Builder for HttpRuntime
+ * Configuration Module Builder for HttpRuntime.
  */
 public final class HttpRuntimeConfiguration extends ConfigurationModuleBuilder {
   /**
-   * HttpRuntimeConfiguration
+   * HttpRuntimeConfiguration.
    */
   public static final ConfigurationModule CONF = new HttpRuntimeConfiguration()
       .bindSetEntry(Clock.RuntimeStartHandler.class, HttpRuntimeStartHandler.class)

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpRuntimeStartHandler.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpRuntimeStartHandler.java
@@ -26,7 +26,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * RuntimeStartHandler for Http server
+ * RuntimeStartHandler for Http server.
  */
 final class HttpRuntimeStartHandler implements EventHandler<RuntimeStart> {
   /**
@@ -35,7 +35,7 @@ final class HttpRuntimeStartHandler implements EventHandler<RuntimeStart> {
   private static final Logger LOG = Logger.getLogger(HttpRuntimeStartHandler.class.getName());
 
   /**
-   * HttpServer
+   * HttpServer.
    */
   private final HttpServer httpServer;
 
@@ -50,7 +50,7 @@ final class HttpRuntimeStartHandler implements EventHandler<RuntimeStart> {
   }
 
   /**
-   * Override EventHandler<RuntimeStart>
+   * Override EventHandler<RuntimeStart>.
    *
    * @param runtimeStart
    */

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpRuntimeStopHandler.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpRuntimeStopHandler.java
@@ -26,7 +26,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Http Runtime Stop Handler
+ * Http Runtime Stop Handler.
  */
 final class HttpRuntimeStopHandler implements EventHandler<RuntimeStop> {
   /**
@@ -35,7 +35,7 @@ final class HttpRuntimeStopHandler implements EventHandler<RuntimeStop> {
   private static final Logger LOG = Logger.getLogger(HttpRuntimeStopHandler.class.getName());
 
   /**
-   * HttpServer
+   * HttpServer.
    */
   private final HttpServer httpServer;
 
@@ -50,7 +50,7 @@ final class HttpRuntimeStopHandler implements EventHandler<RuntimeStop> {
   }
 
   /**
-   * Override EventHandler<RuntimeStop>
+   * Override EventHandler<RuntimeStop>.
    *
    * @param runtimeStop
    */

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpServer.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpServer.java
@@ -21,33 +21,33 @@ package org.apache.reef.webserver;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
 /**
- * HttpServer interface
+ * HttpServer interface.
  */
 public interface HttpServer {
 
   /**
-   * start the server
+   * start the server.
    *
    * @throws Exception
    */
   public void start() throws Exception;
 
   /**
-   * stop the server
+   * stop the server.
    *
    * @throws Exception
    */
   public void stop() throws Exception;
 
   /**
-   * get port number of the server
+   * get port number of the server.
    *
    * @return
    */
   public int getPort();
 
   /**
-   * Add a httpHandler to the server
+   * Add a httpHandler to the server.
    *
    * @param httpHandler
    */

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpServerImpl.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpServerImpl.java
@@ -38,7 +38,7 @@ public final class HttpServerImpl implements HttpServer {
   private static final Logger LOG = Logger.getLogger(HttpServerImpl.class.getName());
 
   /**
-   *  JettyHandler injected in the constructor
+   *  JettyHandler injected in the constructor.
    */
   private JettyHandler jettyHandler;
 
@@ -48,17 +48,17 @@ public final class HttpServerImpl implements HttpServer {
   private final Server server;
 
   /**
-   * port number used in Jetty Server
+   * port number used in Jetty Server.
    */
   private final int port;
 
   /**
-   * Logging scope factory
+   * Logging scope factory.
    */
   private final LoggingScopeFactory loggingScopeFactory;
 
   /**
-   * Constructor of HttpServer that wraps Jetty Server
+   * Constructor of HttpServer that wraps Jetty Server.
    *
    * @param jettyHandler
    * @param portNumber
@@ -104,7 +104,7 @@ public final class HttpServerImpl implements HttpServer {
   }
 
   /**
-   * get a random port number in min and max range
+   * get a random port number in min and max range.
    *
    * @return
    */
@@ -137,7 +137,7 @@ public final class HttpServerImpl implements HttpServer {
   }
 
   /**
-   * Add a HttpHandler to Jetty Handler
+   * Add a HttpHandler to Jetty Handler.
    *
    * @param httpHandler
    */

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpServerReefEventHandler.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpServerReefEventHandler.java
@@ -58,7 +58,7 @@ public final class HttpServerReefEventHandler implements HttpHandler {
   private final LoggingScopeFactory loggingScopeFactory;
 
   /**
-   * Log level string prefix in the log lines
+   * Log level string prefix in the log lines.
    */
   private final String logLevelPrefix;
 
@@ -184,7 +184,7 @@ public final class HttpServerReefEventHandler implements HttpHandler {
   }
 
   /**
-   * handle HTTP queries
+   * handle HTTP queries.
    * Example of a query: http://localhost:8080/reef/Evaluators/?id=Node-2-1403225213803&id=Node-1-1403225213712
    */
   private void handleQueries(
@@ -286,7 +286,7 @@ public final class HttpServerReefEventHandler implements HttpHandler {
   }
 
   /**
-   * Get all evaluator ids and send it back to response so that can be displayed on web
+   * Get all evaluator ids and send it back to response so that can be displayed on web.
    *
    * @param response
    * @throws IOException
@@ -366,7 +366,7 @@ public final class HttpServerReefEventHandler implements HttpHandler {
   }
 
   /**
-   * Write lines in ArrayList to the response writer
+   * Write lines in ArrayList to the response writer.
    * @param response
    * @param lines
    * @param header

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpTrackingURLProvider.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpTrackingURLProvider.java
@@ -27,7 +27,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Http TrackingURLProvider
+ * Http TrackingURLProvider.
  */
 public final class HttpTrackingURLProvider implements TrackingURLProvider {
   /**
@@ -36,12 +36,12 @@ public final class HttpTrackingURLProvider implements TrackingURLProvider {
   private static final Logger LOG = Logger.getLogger(HttpTrackingURLProvider.class.getName());
 
   /**
-   * HttpServer
+   * HttpServer.
    */
   private final HttpServer httpServer;
 
   /**
-   * Constructor of HttpTrackingURLProvider
+   * Constructor of HttpTrackingURLProvider.
    *
    * @param httpServer
    */
@@ -51,7 +51,7 @@ public final class HttpTrackingURLProvider implements TrackingURLProvider {
   }
 
   /**
-   * get tracking URI
+   * get tracking URI.
    *
    * @return
    */

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/JettyHandler.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/JettyHandler.java
@@ -35,12 +35,12 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Jetty Event Handler
+ * Jetty Event Handler.
  */
 class JettyHandler extends AbstractHandler {
   private static final Logger LOG = Logger.getLogger(JettyHandler.class.getName());
   /**
-   * a map that contains eventHandler's specification and the reference
+   * a map that contains eventHandler's specification and the reference.
    */
   private final Map<String, HttpHandler> eventHandlers = new HashMap<>();
 
@@ -61,7 +61,7 @@ class JettyHandler extends AbstractHandler {
   }
 
   /**
-   * handle http request
+   * handle http request.
    *
    * @param target
    * @param request
@@ -97,7 +97,7 @@ class JettyHandler extends AbstractHandler {
   }
 
   /**
-   * Validate request and get http handler for the request
+   * Validate request and get http handler for the request.
    *
    * @param request
    * @param response
@@ -130,7 +130,7 @@ class JettyHandler extends AbstractHandler {
   }
 
   /**
-   * process write message and status on the response
+   * process write message and status on the response.
    *
    * @param response
    * @param message

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/MaxPortNumber.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/MaxPortNumber.java
@@ -22,7 +22,7 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
- * max port number range when generating a port number for the Http Server
+ * max port number range when generating a port number for the Http Server.
  */
 @NamedParameter(doc = "Max port number for Jetty Server", default_value = "49151")
 public class MaxPortNumber implements Name<Integer> {

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/MaxRetryAttempts.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/MaxRetryAttempts.java
@@ -22,7 +22,7 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
- * Max retry times when generating a port number for the Http Server
+ * Max retry times when generating a port number for the Http Server.
  */
 @NamedParameter(doc = "Maximum retry attempts for port number of Jetty Server", default_value = "100")
 public class MaxRetryAttempts implements Name<Integer> {

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/MinPortNumber.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/MinPortNumber.java
@@ -22,7 +22,7 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
- * minimum port number range when generating a port number for the Http Server
+ * minimum port number range when generating a port number for the Http Server.
  */
 @NamedParameter(doc = "Minimum port number for Jetty Server", default_value = "1024")
 public class MinPortNumber implements Name<Integer> {

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/ParsedHttpRequest.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/ParsedHttpRequest.java
@@ -25,7 +25,7 @@ import java.net.URLDecoder;
 import java.util.*;
 
 /**
- * Parsed HttpServletRequest
+ * Parsed HttpServletRequest.
  */
 public final class ParsedHttpRequest {
   private final String pathInfo;
@@ -42,7 +42,7 @@ public final class ParsedHttpRequest {
   private final Map<String, List<String>> queryPairs = new LinkedHashMap<>();
 
   /**
-   * parse HttpServletRequest
+   * parse HttpServletRequest.
    *
    * @param request
    * @throws IOException
@@ -94,7 +94,7 @@ public final class ParsedHttpRequest {
   }
 
   /**
-   * get http header as a list of HeaderEntry
+   * get http header as a list of HeaderEntry.
    * @return
    */
   public List<HeaderEntry> getHeaderEntryList() {
@@ -114,7 +114,7 @@ public final class ParsedHttpRequest {
   }
 
   /**
-   * get target to match specification like "Reef"
+   * get target to match specification like "Reef".
    *
    * @return specification
    */
@@ -132,7 +132,7 @@ public final class ParsedHttpRequest {
   }
 
   /**
-   * get target target entity like "Evaluators"
+   * get target target entity like "Evaluators".
    *
    * @return
    */
@@ -141,7 +141,7 @@ public final class ParsedHttpRequest {
   }
 
   /**
-   * get http request method like "Get"
+   * get http request method like "Get".
    *
    * @return
    */
@@ -150,7 +150,7 @@ public final class ParsedHttpRequest {
   }
 
   /**
-   * get input Stream
+   * get input Stream.
    *
    * @return
    */
@@ -159,7 +159,7 @@ public final class ParsedHttpRequest {
   }
 
   /**
-   * get request headers
+   * get request headers.
    *
    * @return
    */
@@ -168,7 +168,7 @@ public final class ParsedHttpRequest {
   }
 
   /**
-   * get parsed queries
+   * get parsed queries.
    *
    * @return
    */
@@ -177,7 +177,7 @@ public final class ParsedHttpRequest {
   }
 
   /**
-   * get URL like //http://localhost:8080/Reef/Evaluators/
+   * get URL like //http://localhost:8080/Reef/Evaluators/.
    *
    * @return
    */
@@ -186,7 +186,7 @@ public final class ParsedHttpRequest {
   }
 
   /**
-   * get path infor, like /Reef/Evaluators/
+   * get path infor, like /Reef/Evaluators/.
    *
    * @return
    */
@@ -195,7 +195,7 @@ public final class ParsedHttpRequest {
   }
 
   /**
-   * get URI, like /Reef/Evaluators/
+   * get URI, like /Reef/Evaluators/.
    *
    * @return
    */
@@ -204,7 +204,7 @@ public final class ParsedHttpRequest {
   }
 
   /**
-   * get version of the request for Rest API
+   * get version of the request for Rest API.
    *
    * @return
    */

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/ReefEventStateManager.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/ReefEventStateManager.java
@@ -38,7 +38,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Reef Event Manager that manages Reef states
+ * Reef Event Manager that manages Reef states.
  */
 @Unit
 public final class ReefEventStateManager {
@@ -48,12 +48,12 @@ public final class ReefEventStateManager {
   private static final Logger LOG = Logger.getLogger(ReefEventStateManager.class.getName());
 
   /**
-   * date format
+   * date format.
    */
   private static final Format format = new SimpleDateFormat("yyyy MM dd HH:mm:ss");
 
   /**
-   * Map of evaluators
+   * Map of evaluators.
    */
   private final Map<String, EvaluatorDescriptor> evaluators = new HashMap<>();
 
@@ -65,27 +65,27 @@ public final class ReefEventStateManager {
   private final List<AvroReefServiceInfo> serviceInfoList = new ArrayList<AvroReefServiceInfo>();
 
   /**
-   * Remote manager in driver the carries information such as driver endpoint identifier
+   * Remote manager in driver the carries information such as driver endpoint identifier.
    */
   private final RemoteManager remoteManager;
 
   /**
-   * Driver Status Manager that controls the driver status
+   * Driver Status Manager that controls the driver status.
    */
   private final DriverStatusManager driverStatusManager;
 
   /**
-   * Evaluator start time
+   * Evaluator start time.
    */
   private StartTime startTime;
 
   /**
-   * Evaluator stop time
+   * Evaluator stop time.
    */
   private StopTime stopTime;
 
   /**
-   * ReefEventStateManager that keeps the states of Reef components
+   * ReefEventStateManager that keeps the states of Reef components.
    */
   @Inject
   public ReefEventStateManager(final RemoteManager remoteManager, final DriverStatusManager driverStatusManager) {
@@ -94,7 +94,7 @@ public final class ReefEventStateManager {
   }
 
   /**
-   * get start time
+   * get start time.
    *
    * @return
    */
@@ -106,7 +106,7 @@ public final class ReefEventStateManager {
   }
 
   /**
-   * get stop time
+   * get stop time.
    *
    * @return
    */
@@ -118,7 +118,7 @@ public final class ReefEventStateManager {
   }
 
   /**
-   * convert time from long to formatted string
+   * convert time from long to formatted string.
    *
    * @param time
    * @return
@@ -129,7 +129,7 @@ public final class ReefEventStateManager {
   }
 
   /**
-   * get evaluator map
+   * get evaluator map.
    *
    * @return
    */
@@ -138,7 +138,7 @@ public final class ReefEventStateManager {
   }
 
   /**
-   * get driver endpoint identifier
+   * get driver endpoint identifier.
    */
   public String getDriverEndpointIdentifier() {
     return remoteManager.getMyIdentifier();
@@ -156,7 +156,7 @@ public final class ReefEventStateManager {
   }
 
   /**
-   * get a map of contexts
+   * get a map of contexts.
    *
    * @return
    */
@@ -165,7 +165,7 @@ public final class ReefEventStateManager {
   }
 
   /**
-   * pus a entry to evaluators
+   * pus a entry to evaluators.
    *
    * @param key
    * @param value
@@ -175,7 +175,7 @@ public final class ReefEventStateManager {
   }
 
   /**
-   * get a value from evaluators by key
+   * get a value from evaluators by key.
    *
    * @param key
    * @return
@@ -185,7 +185,7 @@ public final class ReefEventStateManager {
   }
 
   /**
-   * getEvaluatorDescriptor
+   * getEvaluatorDescriptor.
    *
    * @param evaluatorId
    * @return
@@ -195,7 +195,7 @@ public final class ReefEventStateManager {
   }
 
   /**
-   * get Evaluator NodeDescriptor
+   * get Evaluator NodeDescriptor.
    *
    * @param evaluatorId
    * @return
@@ -212,7 +212,7 @@ public final class ReefEventStateManager {
   }
 
   /**
-   * Job Driver is ready and the clock is set up
+   * Job Driver is ready and the clock is set up.
    */
   public final class StartStateHandler implements EventHandler<StartTime> {
     @Override
@@ -236,7 +236,7 @@ public final class ReefEventStateManager {
   }
 
   /**
-   * Receive notification that an Evaluator had been allocated
+   * Receive notification that an Evaluator had been allocated.
    */
   public final class AllocatedEvaluatorStateHandler implements EventHandler<AllocatedEvaluator> {
     @Override
@@ -248,7 +248,7 @@ public final class ReefEventStateManager {
   }
 
   /**
-   * Receive event when task is running
+   * Receive event when task is running.
    */
   public final class TaskRunningStateHandler implements EventHandler<RunningTask> {
     @Override
@@ -258,7 +258,7 @@ public final class ReefEventStateManager {
   }
 
   /**
-   * Receive event during driver restart that a task is running in previous evaluator
+   * Receive event during driver restart that a task is running in previous evaluator.
    */
   public final class DriverRestartTaskRunningStateHandler implements EventHandler<RunningTask> {
     @Override


### PR DESCRIPTION
We would like to use snapshot number starting from 00-99, this would allow the NuGet version numbers to increase sequentially. As current script use integer for the snapshot number, the leading 0 got lost. This PR
*Update the build script to form a two digits of snapshot number
*Update the snapshot number to 02 for next push

JIRA: REEF-352(https://issues.apache.org/jira/browse/REEF-352) 

This closes #      

Author: Julia Wang  Email: jwang98052@yahoo.com