### PR TITLE
[REEF-344] Cleaned up LibLoader

### DIFF
--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/LibLoader.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/LibLoader.java
@@ -73,39 +73,39 @@ public final class LibLoader {
   /**
    * Loads the Bridge DLL.
    * <p>
-   * If the file is found in the reef/local folder, it is used. Else, we load teh one in reef/global. If that isn't
+   * If the file is found in the reef/local folder, it is used. Else, we load the one in reef/global. If that isn't
    * present, this method throws an IOException
    *
    * @throws FileNotFoundException if neither file is available.
    * @throws Throwable             if the DLL is found, but System.load() throws an exception.
    */
   private void loadBridgeDLL() throws FileNotFoundException {
-    if (reefFileNames.getBridgeDLLInLocalFolderFile().exists()) {
-      loadBridgeDLLFromFile(reefFileNames.getBridgeDLLInLocalFolderFile());
-      LOG.log(Level.INFO, "Loaded the bridge DLL from the local folder.");
-    } else if (reefFileNames.getBridgeDLLInGlobalFolderFile().exists()) {
-      loadBridgeDLLFromFile(reefFileNames.getBridgeDLLInGlobalFolderFile());
-      LOG.log(Level.INFO, "Loaded the bridge DLL from " + reefFileNames.getBridgeDLLInGlobalFolderFile());
-    } else {
-      throw new FileNotFoundException("Couldn't find the bridge DLL in the local or global folder.");
-    }
+    final File bridgeDLLFile = this.getBridgeDllFile();
+    LOG.log(Level.FINEST, "Attempting to load the bridge DLL from {0}", bridgeDLLFile);
+    System.load(bridgeDLLFile.getAbsolutePath());
+    LOG.log(Level.INFO, "Loaded the bridge DLL from {0}", bridgeDLLFile);
   }
 
   /**
-   * Attempts to load the bridge DLL from the given file.
+   * Returns the File holding the bridge DLL.
+   * <p>
+   * This method prefers the one in reef/local. If that isn't found, the one in reef/global is used. If neither exists,
+   * a FileNotFoundException is thrown.
    *
-   * @param bridgeDLLFile
-   * @throws Throwable whenever System.load() applied to that file name throws.
+   * @throws FileNotFoundException if neither file is available.
    */
-  private static void loadBridgeDLLFromFile(final File bridgeDLLFile) {
-    try {
-      LOG.log(Level.FINEST, "Attempting to load the bridge DLL from {0}", bridgeDLLFile);
-      System.load(bridgeDLLFile.getAbsolutePath());
-      LOG.log(Level.FINEST, "Successfully loaded the bridge DLL from {0}", bridgeDLLFile);
-    } catch (final Throwable t) {
-      LOG.log(Level.WARNING, "Unable to load " + bridgeDLLFile, t);
-      throw t;
+  private File getBridgeDllFile() throws FileNotFoundException {
+    final File bridgeDllInLocal = reefFileNames.getBridgeDLLInLocalFolderFile();
+    if (bridgeDllInLocal.exists()) {
+      return bridgeDllInLocal;
+    } else {
+      final File bridgeDllInGlobal = reefFileNames.getBridgeDLLInGlobalFolderFile();
+      if (bridgeDllInGlobal.exists()) {
+        return bridgeDllInGlobal;
+      }
     }
+    // If we got here, neither file exists.
+    throw new FileNotFoundException("Couldn't find the bridge DLL in the local or global folder.");
   }
 
   /**

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/LibLoader.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/LibLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -19,13 +19,15 @@
 
 package org.apache.reef.javabridge;
 
-import org.apache.commons.compress.utils.IOUtils;
 import org.apache.reef.runtime.common.files.REEFFileNames;
 import org.apache.reef.util.logging.LoggingScope;
 import org.apache.reef.util.logging.LoggingScopeFactory;
 
 import javax.inject.Inject;
-import java.io.*;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FilenameFilter;
+import java.io.IOException;
 import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -33,13 +35,11 @@ import java.util.logging.Logger;
 /**
  * Loading CLR libraries.
  */
-public class LibLoader {
+public final class LibLoader {
 
   private static final Logger LOG = Logger.getLogger(LibLoader.class.getName());
 
-  private static final String LIB_BIN = "/";
   private static final String DLL_EXTENSION = ".dll";
-  private static final String USER_DIR = "user.dir";
 
   private final LoggingScopeFactory loggingScopeFactory;
 
@@ -62,84 +62,50 @@ public class LibLoader {
       this.loadBridgeDLL();
 
       // Load all DLLs in local
-      this.loadAllManagedDLLs(this.reefFileNames.getLocalFolder());
+      loadAllManagedDLLs(this.reefFileNames.getLocalFolder());
 
       // Load all DLLs in global
-      this.loadAllManagedDLLs(this.reefFileNames.getGlobalFolder());
+      loadAllManagedDLLs(this.reefFileNames.getGlobalFolder());
     }
     LOG.log(Level.INFO, "Done loading DLLs for Driver at time {0}." + new Date().toString());
   }
 
   /**
-   * Loads the Bridge DLL. First, it attempts to load from the reef/local folder. Second attempt is reef/global, last
-   * attempt is loading it from the JAR.
+   * Loads the Bridge DLL.
+   * <p>
+   * If the file is found in the reef/local folder, it is used. Else, we load teh one in reef/global. If that isn't
+   * present, this method throws an IOException
    *
-   * @throws IOException If all attempts fail.
+   * @throws FileNotFoundException if neither file is available.
+   * @throws Throwable             if the DLL is found, but System.load() throws an exception.
    */
-  private void loadBridgeDLL() throws IOException {
-    try {
-      loadBridgeDLLFromLocal();
-    } catch (final Throwable t) {
-      LOG.log(Level.INFO, "Unable to load bridge DLL from local folder. Attempting global folder next.", t);
-      try {
-        loadBridgeDLLFromGlobal();
-      } catch (final Throwable t2) {
-        LOG.log(Level.WARNING, "Unable to load bridge DLL from global folder. Attempting jar next.", t2);
-        loadBridgeDLLFromJAR();
-      }
+  private void loadBridgeDLL() throws FileNotFoundException {
+    if (reefFileNames.getBridgeDLLInLocalFolderFile().exists()) {
+      loadBridgeDLLFromFile(reefFileNames.getBridgeDLLInLocalFolderFile());
+      LOG.log(Level.INFO, "Loaded the bridge DLL from the local folder.");
+    } else if (reefFileNames.getBridgeDLLInGlobalFolderFile().exists()) {
+      loadBridgeDLLFromFile(reefFileNames.getBridgeDLLInGlobalFolderFile());
+      LOG.log(Level.INFO, "Loaded the bridge DLL from " + reefFileNames.getBridgeDLLInGlobalFolderFile());
+    } else {
+      throw new FileNotFoundException("Couldn't find the bridge DLL in the local or global folder.");
     }
-  }
-
-
-  /**
-   * Attempts to load the bridge DLL from the global folder.
-   */
-  private void loadBridgeDLLFromGlobal() throws FileNotFoundException {
-    LOG.log(Level.INFO, "Attempting to load the bridge DLL from the global folder.");
-    loadBridgeDLLFromFile(reefFileNames.getBridgeDLLInGlobalFolderFile());
-  }
-
-  /**
-   * Attempts to load the bridge DLL from the local folder.
-   */
-  private void loadBridgeDLLFromLocal() throws FileNotFoundException {
-    LOG.log(Level.INFO, "Attempting to load the bridge DLL from the local folder.");
-    loadBridgeDLLFromFile(reefFileNames.getBridgeDLLInLocalFolderFile());
   }
 
   /**
    * Attempts to load the bridge DLL from the given file.
    *
    * @param bridgeDLLFile
+   * @throws Throwable whenever System.load() applied to that file name throws.
    */
-  private static void loadBridgeDLLFromFile(final File bridgeDLLFile) throws FileNotFoundException {
-    if (!bridgeDLLFile.exists()) {
-      throw new FileNotFoundException("Unable to load Bridge DLL from " + bridgeDLLFile.getAbsolutePath() + " because the file can't be found.");
-    }
+  private static void loadBridgeDLLFromFile(final File bridgeDLLFile) {
     try {
-      LOG.log(Level.INFO, "Attempting to load the bridge DLL from {0}", bridgeDLLFile);
+      LOG.log(Level.FINEST, "Attempting to load the bridge DLL from {0}", bridgeDLLFile);
       System.load(bridgeDLLFile.getAbsolutePath());
-      LOG.log(Level.INFO, "Successfully loaded the bridge DLL from {0}", bridgeDLLFile);
+      LOG.log(Level.FINEST, "Successfully loaded the bridge DLL from {0}", bridgeDLLFile);
     } catch (final Throwable t) {
-      LOG.log(Level.WARNING, "Unable to load " + bridgeDLLFile.getAbsolutePath(), t);
+      LOG.log(Level.WARNING, "Unable to load " + bridgeDLLFile, t);
       throw t;
     }
-  }
-
-  /**
-   * Attempts to load the bridge DLL from the JAR file.
-   *
-   * @throws IOException
-   * @deprecated We should use the files instead.
-   */
-  @Deprecated
-  private void loadBridgeDLLFromJAR() throws IOException {
-    final String tempLoadDir = System.getProperty(USER_DIR) + this.reefFileNames.getLoadDir();
-    new File(tempLoadDir).mkdir();
-    LOG.log(Level.INFO, "loadBridgeDLL() - tempLoadDir created: {0} ", tempLoadDir);
-    final String bridgeMixedDLLName = this.reefFileNames.getBridgeDLLName();
-    LOG.log(Level.INFO, "loadBridgeDLL() - BridgeMixedDLLName: {0}", bridgeMixedDLLName);
-    loadFromReefJar(bridgeMixedDLLName, false);
   }
 
   /**
@@ -147,7 +113,7 @@ public class LibLoader {
    *
    * @param folder
    */
-  private void loadAllManagedDLLs(final File folder) {
+  private static void loadAllManagedDLLs(final File folder) {
     LOG.log(Level.INFO, "Loading all managed DLLs from {0}", folder.getAbsolutePath());
     final File[] files = folder.listFiles(new FilenameFilter() {
       public boolean accept(File dir, String name) {
@@ -165,7 +131,7 @@ public class LibLoader {
    *
    * @param dllFile
    */
-  private void loadManagedDLL(final File dllFile) {
+  private static void loadManagedDLL(final File dllFile) {
     final String absolutePath = dllFile.getAbsolutePath();
     try {
       LOG.log(Level.FINE, "Loading Managed DLL {0} ", absolutePath);
@@ -173,65 +139,6 @@ public class LibLoader {
     } catch (final Exception e) {
       LOG.log(Level.SEVERE, "Unable to load managed DLL {0}", absolutePath);
       throw e;
-    }
-  }
-
-  /**
-   * Get file from jar file and copy it to temp dir and loads the library to memory.
-   *
-   * @deprecated This is replaced by loading it from the folders directly.
-   */
-  @Deprecated
-  private void loadFromReefJar(String name, final boolean managed) throws IOException {
-    LOG.log(Level.SEVERE, "Consider upgrading your REEF client. Loading DLLs from the JAR is deprecated.");
-    if (!name.endsWith(".dll")) {
-      name = name + DLL_EXTENSION;
-    }
-    try {
-      File fileOut = null;
-      // get input file from jar
-      final String path = this.reefFileNames.getReefDriverAppDllDir() + name;
-      LOG.log(Level.INFO, "Source file path: " + path);
-      final java.net.URL url = NativeInterop.class.getClass().getResource(path);
-      if (url != null) {
-        LOG.log(Level.INFO, "Source file: " + url.getPath());
-      }
-      try (final InputStream in = NativeInterop.class.getResourceAsStream(path)) {
-        //copy to /reef/CLRLoadingDirectory
-        final String tempLoadDir = System.getProperty(USER_DIR) + this.reefFileNames.getLoadDir();
-        fileOut = new File(tempLoadDir + LIB_BIN + name);
-        LOG.log(Level.INFO, "Destination file: " + fileOut.toString());
-        if (null == in) {
-          LOG.log(Level.WARNING, "Cannot find " + path);
-          return;
-        }
-        try (final OutputStream out = new FileOutputStream(fileOut)) {
-          IOUtils.copy(in, out);
-        }
-      }
-      loadAssembly(fileOut, managed);
-    } catch (final FileNotFoundException e) {
-      LOG.log(Level.SEVERE, "File not find exception: ", name);
-      throw e;
-    } catch (IOException e) {
-      LOG.log(Level.SEVERE, "File copy error: ", name);
-      throw e;
-    }
-  }
-
-  /**
-   * load assembly.
-   *
-   * @param fileOut
-   * @param managed
-   */
-  private void loadAssembly(final File fileOut, final boolean managed) {
-    if (managed) {
-      NativeInterop.loadClrAssembly(fileOut.toString());
-      LOG.log(Level.INFO, "Loading DLL managed done");
-    } else {
-      System.load(fileOut.toString());
-      LOG.log(Level.INFO, "Loading DLL not managed done");
     }
   }
 }

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/package-info.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * The Java-side of the CLR/Java bridge.
+ */
+package org.apache.reef.javabridge;


### PR DESCRIPTION
After this change, LibLoader will only load the Bridge DLL from the `reef/local` or `reef/global` folder. Preference is given to `reef/local`.

If the DLL is found but can't be loaded, the bridge will now crash. This is to avoid situations in which users believe they load the version in `reef/local` while the system in fact silently switches to `reef/global`.

Loading the DLL from the REEF JAR is no longer supported after this change.

JIRA:
  [REEF-344](https://issues.apache.org/jira/browse/REEF-344)