### PR TITLE
[REEF-315] Replace JavaDoc comment style for the license headers

### DIFF
--- a/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/Optional.java
+++ b/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/Optional.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/Provided.java
+++ b/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/Provided.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/Unstable.java
+++ b/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/Unstable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/audience/ClientSide.java
+++ b/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/audience/ClientSide.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/audience/DriverSide.java
+++ b/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/audience/DriverSide.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/audience/EvaluatorSide.java
+++ b/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/audience/EvaluatorSide.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/audience/Private.java
+++ b/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/audience/Private.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/audience/Public.java
+++ b/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/audience/Public.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/audience/RuntimeAuthor.java
+++ b/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/audience/RuntimeAuthor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/audience/TaskSide.java
+++ b/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/audience/TaskSide.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/audience/package-info.java
+++ b/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/audience/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/package-info.java
+++ b/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/semantics/Idempotent.java
+++ b/lang/java/reef-annotations/src/main/java/org/apache/reef/annotations/semantics/Idempotent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/Constants.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/Constants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/package-info.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/AllocatedEvaluatorBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/AllocatedEvaluatorBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/CompletedEvaluatorBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/CompletedEvaluatorBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ContextMessageBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ContextMessageBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/EvaluatorRequestorBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/EvaluatorRequestorBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/FailedEvaluatorBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/FailedEvaluatorBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/HttpServerEventBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/HttpServerEventBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/InteropLogger.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/InteropLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/InteropReturnInfo.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/InteropReturnInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/JavaBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/JavaBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/LibLoader.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/LibLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/NativeBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/NativeBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/NativeInterop.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/NativeInterop.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/TaskMessageBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/TaskMessageBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/Utilities.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/Utilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobClient.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/Launch.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/Launch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/LaunchHeadless.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/LaunchHeadless.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/package-info.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/util/logging/CLRBufferedLogHandler.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/util/logging/CLRBufferedLogHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/util/logging/CLRLoggingConfig.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/util/logging/CLRLoggingConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/util/logging/package-info.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/util/logging/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/CheckpointID.java
+++ b/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/CheckpointID.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/CheckpointNamingService.java
+++ b/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/CheckpointNamingService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/CheckpointService.java
+++ b/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/CheckpointService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/RandomNameCNS.java
+++ b/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/RandomNameCNS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/SimpleNamingService.java
+++ b/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/SimpleNamingService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/fs/FSCheckPointServiceConfiguration.java
+++ b/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/fs/FSCheckPointServiceConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/fs/FSCheckpointID.java
+++ b/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/fs/FSCheckpointID.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/fs/FSCheckpointService.java
+++ b/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/fs/FSCheckpointService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/ClientConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/ClientConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/CompletedJob.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/CompletedJob.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverLauncher.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverLauncher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverServiceConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverServiceConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/FailedJob.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/FailedJob.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/FailedRuntime.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/FailedRuntime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/JobMessage.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/JobMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/LauncherStatus.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/LauncherStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/REEF.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/REEF.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/RunningJob.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/RunningJob.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/parameters/JobCompletedHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/parameters/JobCompletedHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/parameters/JobFailedHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/parameters/JobFailedHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/parameters/JobMessageHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/parameters/JobMessageHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/parameters/JobRunningHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/parameters/JobRunningHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/parameters/ResourceManagerErrorHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/parameters/ResourceManagerErrorHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/parameters/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/parameters/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/common/AbstractFailure.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/common/AbstractFailure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/common/Failure.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/common/Failure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/ContextAndTaskSubmittable.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/ContextAndTaskSubmittable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/ContextSubmittable.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/ContextSubmittable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/FlexiblePreemptionEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/FlexiblePreemptionEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/PreemptionEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/PreemptionEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/PreemptionHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/PreemptionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/StrictPreemptionEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/StrictPreemptionEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/TaskSubmittable.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/TaskSubmittable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/catalog/NodeDescriptor.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/catalog/NodeDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/catalog/RackDescriptor.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/catalog/RackDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/catalog/ResourceCatalog.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/catalog/ResourceCatalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/client/JobMessageObserver.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/client/JobMessageObserver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/client/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/client/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/ActiveContext.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/ActiveContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/ClosedContext.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/ClosedContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/ContextBase.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/ContextBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/ContextConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/ContextConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/ContextMessage.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/ContextMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/FailedContext.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/FailedContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/ServiceConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/ServiceConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/AllocatedEvaluator.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/AllocatedEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/CompletedEvaluator.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/CompletedEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorDescriptor.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequest.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequestor.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequestor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorType.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/FailedEvaluator.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/FailedEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ClientCloseHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ClientCloseHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ClientCloseWithMessageHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ClientCloseWithMessageHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ClientMessageHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ClientMessageHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ContextActiveHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ContextActiveHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ContextClosedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ContextClosedHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ContextFailedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ContextFailedHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ContextMessageHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ContextMessageHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverIdentifier.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverIdleSources.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverIdleSources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverJobSubmissionDirectory.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverJobSubmissionDirectory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverLocalFiles.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverLocalFiles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverLocalLibraries.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverLocalLibraries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverMemory.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverMemory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverRestartCompletedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverRestartCompletedHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverRestartContextActiveHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverRestartContextActiveHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverRestartHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverRestartHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverRestartTaskRunningHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverRestartTaskRunningHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverStartHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverStartHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/EvaluatorAllocatedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/EvaluatorAllocatedHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/EvaluatorCompletedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/EvaluatorCompletedHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/EvaluatorDispatcherThreads.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/EvaluatorDispatcherThreads.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/EvaluatorFailedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/EvaluatorFailedHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/JobGlobalFiles.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/JobGlobalFiles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/JobGlobalLibraries.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/JobGlobalLibraries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceContextActiveHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceContextActiveHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceContextClosedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceContextClosedHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceContextFailedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceContextFailedHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceContextMessageHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceContextMessageHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceDriverRestartCompletedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceDriverRestartCompletedHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceDriverRestartContextActiveHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceDriverRestartContextActiveHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceDriverRestartTaskRunningHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceDriverRestartTaskRunningHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceEvaluatorAllocatedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceEvaluatorAllocatedHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceEvaluatorCompletedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceEvaluatorCompletedHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceEvaluatorFailedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceEvaluatorFailedHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceTaskCompletedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceTaskCompletedHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceTaskFailedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceTaskFailedHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceTaskMessageHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceTaskMessageHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceTaskRunningHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceTaskRunningHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceTaskSuspendedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceTaskSuspendedHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/TaskCompletedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/TaskCompletedHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/TaskFailedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/TaskFailedHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/TaskMessageHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/TaskMessageHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/TaskRunningHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/TaskRunningHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/TaskSuspendedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/TaskSuspendedHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/CompletedTask.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/CompletedTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/FailedTask.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/FailedTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/RunningTask.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/RunningTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/SuspendedTask.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/SuspendedTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/TaskConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/TaskConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/TaskConfigurationOptions.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/TaskConfigurationOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/TaskMessage.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/TaskMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/ContextMessage.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/ContextMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/ContextMessageHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/ContextMessageHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/ContextMessageSource.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/ContextMessageSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/events/ContextStart.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/events/ContextStart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/events/ContextStop.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/events/ContextStop.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/parameters/ContextIdentifier.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/parameters/ContextIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/parameters/ContextMessageHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/parameters/ContextMessageHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/parameters/ContextMessageSources.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/parameters/ContextMessageSources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/parameters/ContextStartHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/parameters/ContextStartHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/parameters/ContextStopHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/parameters/ContextStopHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/parameters/Services.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/parameters/Services.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/exception/DriverException.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/exception/DriverException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/exception/EvaluatorException.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/exception/EvaluatorException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/exception/EvaluatorKilledByResourceManagerException.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/exception/EvaluatorKilledByResourceManagerException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/exception/EvaluatorTimeoutException.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/exception/EvaluatorTimeoutException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/exception/evaluator/NetworkException.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/exception/evaluator/NetworkException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/exception/evaluator/ServiceException.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/exception/evaluator/ServiceException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/exception/evaluator/ServiceRuntimeException.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/exception/evaluator/ServiceRuntimeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/exception/evaluator/StorageException.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/exception/evaluator/StorageException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/exception/evaluator/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/exception/evaluator/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/exception/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/exception/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/Accumulable.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/Accumulable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/Accumulator.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/Accumulator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/ExternalMap.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/ExternalMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/Message.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/Message.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/PartitionSpec.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/PartitionSpec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/Spool.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/Spool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/SystemTempFileCreator.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/SystemTempFileCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/TempFileCreator.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/TempFileCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/Tuple.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/Tuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/WorkingDirectoryTempFileCreator.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/WorkingDirectoryTempFileCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/naming/Identifiable.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/naming/Identifiable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/naming/NameAssignment.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/naming/NameAssignment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/naming/Naming.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/naming/Naming.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/naming/NamingLookup.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/naming/NamingLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/naming/NamingRegistry.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/naming/NamingRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/serialization/Codec.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/serialization/Codec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/serialization/Deserializer.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/serialization/Deserializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/serialization/SerializableCodec.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/serialization/SerializableCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/serialization/Serializer.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/serialization/Serializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/DriverRestartCompleted.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/DriverRestartCompleted.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/Launcher.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/Launcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/ClientWireUp.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/ClientWireUp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/CompletedJobImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/CompletedJobImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/JobStatusMessageHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/JobStatusMessageHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/JobSubmissionHelper.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/JobSubmissionHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/RunningJobImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/RunningJobImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/RunningJobs.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/RunningJobs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/RunningJobsImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/RunningJobsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/RuntimeErrorProtoHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/RuntimeErrorProtoHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/ClientRuntimeParameters.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/ClientRuntimeParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/JobSubmissionEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/JobSubmissionEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/JobSubmissionEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/JobSubmissionEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/JobSubmissionHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/JobSubmissionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/defaults/DefaultCompletedJobHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/defaults/DefaultCompletedJobHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/defaults/DefaultFailedJobHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/defaults/DefaultFailedJobHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/defaults/DefaultJobMessageHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/defaults/DefaultJobMessageHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/defaults/DefaultRunningJobHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/defaults/DefaultRunningJobHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/defaults/DefaultRuntimeErrorHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/defaults/DefaultRuntimeErrorHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/defaults/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/defaults/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/parameters/ClientPresent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/parameters/ClientPresent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverExceptionHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverExceptionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeConfigurationOptions.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeConfigurationOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeStartHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeStartHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeStopHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeStopHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverSingleton.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverSingleton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverSingletons.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverSingletons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverStartHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverStartHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverStatus.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverStatusManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverStatusManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/EvaluatorRequestorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/EvaluatorRequestorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/AbstractDriverRuntimeConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/AbstractDriverRuntimeConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/DefaultResourceManagerLifeCycle.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/DefaultResourceManagerLifeCycle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceLaunchEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceLaunchEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceLaunchHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceLaunchHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceManagerLifeCycle.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceManagerLifeCycle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceReleaseEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceReleaseEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceReleaseEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceReleaseEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceReleaseHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceReleaseHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/RuntimeParameters.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/RuntimeParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/catalog/NodeDescriptorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/catalog/NodeDescriptorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/catalog/RackDescriptorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/catalog/RackDescriptorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/catalog/ResourceCatalogImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/catalog/ResourceCatalogImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/client/ClientConnection.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/client/ClientConnection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/client/ClientManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/client/ClientManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/client/JobMessageObserverImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/client/JobMessageObserverImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/client/LoggingJobStatusHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/client/LoggingJobStatusHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/client/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/client/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/ClosedContextImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/ClosedContextImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/ContextControlHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/ContextControlHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/ContextFactory.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/ContextFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/ContextMessageImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/ContextMessageImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/ContextRepresenters.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/ContextRepresenters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/EvaluatorContext.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/EvaluatorContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/FailedContextImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/FailedContextImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultClientCloseHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultClientCloseHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultClientCloseWithMessageHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultClientCloseWithMessageHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultClientMessageHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultClientMessageHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultContextActiveHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultContextActiveHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultContextClosureHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultContextClosureHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultContextFailureHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultContextFailureHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultContextMessageHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultContextMessageHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultDriverRestartCompletedHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultDriverRestartCompletedHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultDriverRestartContextActiveHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultDriverRestartContextActiveHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultDriverRestartTaskRunningHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultDriverRestartTaskRunningHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultEvaluatorAllocationHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultEvaluatorAllocationHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultEvaluatorCompletionHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultEvaluatorCompletionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultEvaluatorFailureHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultEvaluatorFailureHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultTaskCompletionHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultTaskCompletionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultTaskFailureHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultTaskFailureHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultTaskMessageHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultTaskMessageHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultTaskRunningHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultTaskRunningHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultTaskSuspensionHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultTaskSuspensionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/CompletedEvaluatorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/CompletedEvaluatorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorControlHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorControlHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorDescriptorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorDescriptorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorHeartBeatSanityChecker.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorHeartBeatSanityChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorHeartbeatHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorHeartbeatHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManagerFactory.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManagerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorMessageDispatcher.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorMessageDispatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorResourceManagerErrorHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorResourceManagerErrorHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorState.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorStatusManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorStatusManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/Evaluators.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/Evaluators.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/FailedEvaluatorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/FailedEvaluatorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/idle/ClockIdlenessSource.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/idle/ClockIdlenessSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/idle/DriverIdleManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/idle/DriverIdleManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/idle/DriverIdlenessSource.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/idle/DriverIdlenessSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/idle/EventHandlerIdlenessSource.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/idle/EventHandlerIdlenessSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/idle/IdleMessage.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/idle/IdleMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/idle/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/idle/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/NodeDescriptorEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/NodeDescriptorEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/NodeDescriptorEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/NodeDescriptorEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/NodeDescriptorHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/NodeDescriptorHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceAllocationEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceAllocationEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceAllocationEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceAllocationEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceAllocationHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceAllocationHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceManagerErrorHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceManagerErrorHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceManagerStatus.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceManagerStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceStatusEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceStatusEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceStatusEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceStatusEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceStatusHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceStatusHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/RuntimeStatusEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/RuntimeStatusEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/RuntimeStatusEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/RuntimeStatusEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/CompletedTaskImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/CompletedTaskImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/RunningTaskImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/RunningTaskImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/SuspendedTaskImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/SuspendedTaskImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/TaskMessageImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/TaskMessageImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/TaskRepresenter.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/TaskRepresenter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/DefaultDriverConnection.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/DefaultDriverConnection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/DriverConnection.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/DriverConnection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/EvaluatorConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/EvaluatorConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/EvaluatorRuntime.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/EvaluatorRuntime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/HeartBeatManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/HeartBeatManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/PIDStoreStartHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/PIDStoreStartHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/ContextClientCodeException.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/ContextClientCodeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/ContextLifeCycle.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/ContextLifeCycle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/ContextManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/ContextManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/ContextRuntime.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/ContextRuntime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/ContextStartImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/ContextStartImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/ContextStopImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/ContextStopImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/RootContextLauncher.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/RootContextLauncher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/defaults/DefaultContextMessageHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/defaults/DefaultContextMessageHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/defaults/DefaultContextMessageSource.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/defaults/DefaultContextMessageSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/defaults/DefaultContextStartHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/defaults/DefaultContextStartHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/defaults/DefaultContextStopHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/defaults/DefaultContextStopHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/defaults/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/defaults/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/parameters/ApplicationIdentifier.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/parameters/ApplicationIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/parameters/DriverRemoteIdentifier.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/parameters/DriverRemoteIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/parameters/EvaluatorIdentifier.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/parameters/EvaluatorIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/parameters/HeartbeatPeriod.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/parameters/HeartbeatPeriod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/parameters/InitialTaskConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/parameters/InitialTaskConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/parameters/RootContextConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/parameters/RootContextConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/parameters/RootServiceConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/parameters/RootServiceConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/CloseEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/CloseEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/DriverMessageImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/DriverMessageImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/SuspendEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/SuspendEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/TaskClientCodeException.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/TaskClientCodeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/TaskLifeCycleHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/TaskLifeCycleHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/TaskRuntime.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/TaskRuntime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/TaskStartImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/TaskStartImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/TaskStatus.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/TaskStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/TaskStopImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/TaskStopImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/defaults/DefaultCloseHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/defaults/DefaultCloseHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/defaults/DefaultDriverMessageHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/defaults/DefaultDriverMessageHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/defaults/DefaultSuspendHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/defaults/DefaultSuspendHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/defaults/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/defaults/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskCallFailure.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskCallFailure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskCloseHandlerFailure.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskCloseHandlerFailure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskMessageHandlerFailure.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskMessageHandlerFailure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskStartHandlerFailure.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskStartHandlerFailure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskStopHandlerFailure.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskStopHandlerFailure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskSuspendHandlerFailure.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskSuspendHandlerFailure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/ClasspathProvider.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/ClasspathProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/FileResource.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/FileResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/FileResourceImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/FileResourceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/FileType.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/FileType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/JobJarMaker.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/JobJarMaker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/REEFFileNames.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/REEFFileNames.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/RuntimeClasspathProvider.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/RuntimeClasspathProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/CLRLaunchCommandBuilder.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/CLRLaunchCommandBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/JavaLaunchCommandBuilder.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/JavaLaunchCommandBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/LaunchCommandBuilder.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/LaunchCommandBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/LauncherSingletons.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/LauncherSingletons.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/ProcessType.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/ProcessType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/ProfilingStopHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/ProfilingStopHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/REEFErrorHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/REEFErrorHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/REEFMessageCodec.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/REEFMessageCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/REEFUncaughtExceptionHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/REEFUncaughtExceptionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/parameters/ClockConfigurationPath.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/parameters/ClockConfigurationPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/parameters/ErrorHandlerRID.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/parameters/ErrorHandlerRID.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/parameters/LaunchID.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/parameters/LaunchID.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/parameters/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/parameters/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/parameters/DeleteTempFiles.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/parameters/DeleteTempFiles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/parameters/JVMHeapSlack.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/parameters/JVMHeapSlack.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/BroadCastEventHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/BroadCastEventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/DefaultExceptionCodec.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/DefaultExceptionCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/DispatchingEStage.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/DispatchingEStage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/ExceptionCodec.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/ExceptionCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/RemoteManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/RemoteManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/task/HeartBeatTriggerManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/task/HeartBeatTriggerManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/task/Task.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/task/Task.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/task/TaskMessage.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/task/TaskMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/task/TaskMessageSource.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/task/TaskMessageSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/task/events/CloseEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/task/events/CloseEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/task/events/DriverMessage.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/task/events/DriverMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/task/events/SuspendEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/task/events/SuspendEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/task/events/TaskStart.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/task/events/TaskStart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/task/events/TaskStop.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/task/events/TaskStop.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/Builder.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/Builder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/BuilderUtils.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/BuilderUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/CommandUtils.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/CommandUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/DeadlockInfo.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/DeadlockInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/EnvironmentUtils.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/EnvironmentUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/ExceptionHandlingEventHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/ExceptionHandlingEventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/Exceptions.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/Exceptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/JARFileMaker.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/JARFileMaker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/MemoryUtils.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/MemoryUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/OSUtils.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/OSUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/ObjectInstantiationLogger.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/ObjectInstantiationLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/REEFVersion.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/REEFVersion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/SetOnce.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/SetOnce.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/SingletonAsserter.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/SingletonAsserter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/ThreadLogger.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/ThreadLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/Config.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/Config.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/LogLevelName.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/LogLevelName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/LogParser.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/LogParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/LoggingScope.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/LoggingScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/LoggingScopeFactory.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/LoggingScopeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/LoggingScopeImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/LoggingScopeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/LoggingSetup.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/LoggingSetup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/ThreadLogFormatter.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/ThreadLogFormatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/main/proto/client_runtime.proto
+++ b/lang/java/reef-common/src/main/proto/client_runtime.proto
@@ -1,19 +1,22 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 option java_package = "org.apache.reef.proto";
 option java_outer_classname = "ClientRuntimeProtocol";
 option java_generic_services = true;

--- a/lang/java/reef-common/src/main/proto/evaluator_runtime.proto
+++ b/lang/java/reef-common/src/main/proto/evaluator_runtime.proto
@@ -1,19 +1,21 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 option java_package = "org.apache.reef.proto";
 option java_outer_classname = "EvaluatorRuntimeProtocol";

--- a/lang/java/reef-common/src/main/proto/reef_protocol.proto
+++ b/lang/java/reef-common/src/main/proto/reef_protocol.proto
@@ -1,19 +1,22 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import "client_runtime.proto";
 
 import "evaluator_runtime.proto";

--- a/lang/java/reef-common/src/main/proto/reef_service_protos.proto
+++ b/lang/java/reef-common/src/main/proto/reef_service_protos.proto
@@ -1,19 +1,21 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 option java_package = "org.apache.reef.proto";
 

--- a/lang/java/reef-common/src/test/java/org/apache/reef/runtime/common/driver/EvaluatorRequestorImplTest.java
+++ b/lang/java/reef-common/src/test/java/org/apache/reef/runtime/common/driver/EvaluatorRequestorImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/test/java/org/apache/reef/runtime/common/driver/catalog/CatalogTest.java
+++ b/lang/java/reef-common/src/test/java/org/apache/reef/runtime/common/driver/catalog/CatalogTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/test/java/org/apache/reef/util/DeadlockInfoTest.java
+++ b/lang/java/reef-common/src/test/java/org/apache/reef/util/DeadlockInfoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/test/java/org/apache/reef/util/LoggingScopeTest.java
+++ b/lang/java/reef-common/src/test/java/org/apache/reef/util/LoggingScopeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-common/src/test/java/org/apache/reef/util/SingletonAsserterTest.java
+++ b/lang/java/reef-common/src/test/java/org/apache/reef/util/SingletonAsserterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples-clr/src/main/java/org/apache/reef/examples/helloCLR/HelloCLR.java
+++ b/lang/java/reef-examples-clr/src/main/java/org/apache/reef/examples/helloCLR/HelloCLR.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples-clr/src/main/java/org/apache/reef/examples/helloCLR/HelloDriver.java
+++ b/lang/java/reef-examples-clr/src/main/java/org/apache/reef/examples/helloCLR/HelloDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples-clr/src/main/java/org/apache/reef/examples/helloCLR/package-info.java
+++ b/lang/java/reef-examples-clr/src/main/java/org/apache/reef/examples/helloCLR/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples-hdinsight/src/main/java/org/apache/reef/examples/hello/HelloHDInsight.java
+++ b/lang/java/reef-examples-hdinsight/src/main/java/org/apache/reef/examples/hello/HelloHDInsight.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/data/loading/DataLoadingREEF.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/data/loading/DataLoadingREEF.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/data/loading/LineCounter.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/data/loading/LineCounter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/data/loading/LineCountingTask.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/data/loading/LineCountingTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/BGDClient.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/BGDClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/BGDDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/BGDDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/BGDLocal.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/BGDLocal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/BGDYarn.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/BGDYarn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/ControlMessages.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/ControlMessages.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/ExampleList.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/ExampleList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/LineSearchReduceFunction.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/LineSearchReduceFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/LossAndGradientReduceFunction.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/LossAndGradientReduceFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/MasterTask.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/MasterTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/SlaveTask.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/SlaveTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/data/Example.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/data/Example.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/data/SparseExample.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/data/SparseExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/data/parser/Parser.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/data/parser/Parser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/data/parser/SVMLightParser.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/data/parser/SVMLightParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/loss/LogisticLossFunction.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/loss/LogisticLossFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/loss/LossFunction.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/loss/LossFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/loss/SquaredErrorLossFunction.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/loss/SquaredErrorLossFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/loss/WeightedLogisticLossFunction.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/loss/WeightedLogisticLossFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/operatornames/ControlMessageBroadcaster.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/operatornames/ControlMessageBroadcaster.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/operatornames/DescentDirectionBroadcaster.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/operatornames/DescentDirectionBroadcaster.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/operatornames/LineSearchEvaluationsReducer.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/operatornames/LineSearchEvaluationsReducer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/operatornames/LossAndGradientReducer.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/operatornames/LossAndGradientReducer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/operatornames/MinEtaBroadcaster.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/operatornames/MinEtaBroadcaster.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/operatornames/ModelAndDescentDirectionBroadcaster.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/operatornames/ModelAndDescentDirectionBroadcaster.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/operatornames/ModelBroadcaster.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/operatornames/ModelBroadcaster.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/operatornames/package-info.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/operatornames/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/AllCommunicationGroup.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/AllCommunicationGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/BGDControlParameters.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/BGDControlParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/BGDLossType.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/BGDLossType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/EnableRampup.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/EnableRampup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/Eps.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/Eps.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/Eta.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/Eta.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/EvaluatorMemory.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/EvaluatorMemory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/InputDir.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/InputDir.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/Iterations.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/Iterations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/Lambda.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/Lambda.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/LossFunctionType.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/LossFunctionType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/MinParts.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/MinParts.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/ModelDimensions.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/ModelDimensions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/NumSplits.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/NumSplits.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/NumberOfReceivers.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/NumberOfReceivers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/ProbabilityOfFailure.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/ProbabilityOfFailure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/ProbabilityOfSuccesfulIteration.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/ProbabilityOfSuccesfulIteration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/Timeout.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/Timeout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/utils/StepSizes.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/utils/StepSizes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/utils/SubConfiguration.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/utils/SubConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/BroadcastDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/BroadcastDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/BroadcastREEF.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/BroadcastREEF.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/ControlMessages.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/ControlMessages.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/MasterTask.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/MasterTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/ModelReceiveAckReduceFunction.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/ModelReceiveAckReduceFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/SlaveTask.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/SlaveTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/parameters/AllCommunicationGroup.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/parameters/AllCommunicationGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/parameters/ControlMessageBroadcaster.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/parameters/ControlMessageBroadcaster.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/parameters/Dimensions.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/parameters/Dimensions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/parameters/FailureProbability.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/parameters/FailureProbability.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/parameters/ModelBroadcaster.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/parameters/ModelBroadcaster.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/parameters/ModelReceiveAckReducer.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/parameters/ModelReceiveAckReducer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/parameters/NumberOfReceivers.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/parameters/NumberOfReceivers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/AbstractImmutableVector.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/AbstractImmutableVector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/AbstractVector.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/AbstractVector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/DenseVector.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/DenseVector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/ImmutableVector.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/ImmutableVector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/SparseVector.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/SparseVector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/Vector.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/Vector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/VectorCodec.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/VectorCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/Window.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/Window.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/timer/Timer.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/timer/Timer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEF.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEF.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEFMesos.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEFMesos.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEFNoClient.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEFNoClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloReefYarn.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloReefYarn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloTask.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/package-info.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hellohttp/HelloREEFHttp.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hellohttp/HelloREEFHttp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hellohttp/HelloREEFHttpYarn.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hellohttp/HelloREEFHttpYarn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hellohttp/HttpServerShellCmdtHandler.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hellohttp/HttpServerShellCmdtHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hellohttp/HttpShellJobDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hellohttp/HttpShellJobDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/library/Command.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/library/Command.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/library/ShellTask.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/library/ShellTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/pool/JobDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/pool/JobDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/pool/Launch.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/pool/Launch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/pool/SleepTask.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/pool/SleepTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/pool/package-info.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/pool/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/Scheduler.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/Scheduler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerHttpHandler.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerHttpHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerREEF.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerREEF.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerREEFYarn.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerREEFYarn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerResponse.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/TaskEntity.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/TaskEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/package-info.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/Control.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/Control.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/Launch.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/Launch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/ObjectWritableCodec.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/ObjectWritableCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/SuspendClient.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/SuspendClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/SuspendClientControl.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/SuspendClientControl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/SuspendDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/SuspendDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/SuspendTestTask.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/SuspendTestTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/package-info.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/utils/wake/BlockingEventHandler.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/utils/wake/BlockingEventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/utils/wake/LoggingEventHandler.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/utils/wake/LoggingEventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/test/java/org/apache/reef/examples/hello/HelloHttpTest.java
+++ b/lang/java/reef-examples/src/test/java/org/apache/reef/examples/hello/HelloHttpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-examples/src/test/java/org/apache/reef/examples/suspend/ObjectWritableCodecTest.java
+++ b/lang/java/reef-examples/src/test/java/org/apache/reef/examples/suspend/ObjectWritableCodecTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/avro/nameservice.avsc
+++ b/lang/java/reef-io/src/main/avro/nameservice.avsc
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/api/DataLoader.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/api/DataLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/api/DataLoadingDriverConfiguration.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/api/DataLoadingDriverConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/api/DataLoadingRequestBuilder.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/api/DataLoadingRequestBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/api/DataLoadingService.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/api/DataLoadingService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/api/DataSet.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/api/DataSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/api/ResourceRequestHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/api/ResourceRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/EvaluatorRequestSerializer.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/EvaluatorRequestSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/EvaluatorToPartitionMapper.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/EvaluatorToPartitionMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/InMemoryInputFormatDataSet.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/InMemoryInputFormatDataSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/InputFormatDataSet.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/InputFormatDataSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/InputFormatExternalConstructor.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/InputFormatExternalConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/InputFormatLoadingService.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/InputFormatLoadingService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/InputSplitExternalConstructor.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/InputSplitExternalConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/JobConfExternalConstructor.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/JobConfExternalConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/NumberedSplit.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/NumberedSplit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/WritableSerializer.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/WritableSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/Connection.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/Connection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/ConnectionFactory.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/ConnectionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/Message.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/Message.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/exception/NetworkRuntimeException.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/exception/NetworkRuntimeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/exception/ParentDeadException.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/exception/ParentDeadException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/exception/package-info.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/exception/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/GroupChanges.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/GroupChanges.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/config/OperatorSpec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/config/OperatorSpec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/CommunicationGroupDriver.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/CommunicationGroupDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/GroupCommDriver.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/GroupCommDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/GroupCommServiceDriver.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/GroupCommServiceDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/TaskNode.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/TaskNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/TaskNodeStatus.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/TaskNodeStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/Topology.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/Topology.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/AbstractGroupCommOperator.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/AbstractGroupCommOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/AllGather.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/AllGather.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/AllReduce.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/AllReduce.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Broadcast.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Broadcast.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Gather.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Gather.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/GroupCommOperator.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/GroupCommOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Reduce.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Reduce.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/ReduceScatter.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/ReduceScatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Scatter.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Scatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/package-info.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/CommGroupNetworkHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/CommGroupNetworkHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/CommunicationGroupClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/CommunicationGroupClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/CommunicationGroupServiceClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/CommunicationGroupServiceClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/GroupCommClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/GroupCommClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/GroupCommNetworkHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/GroupCommNetworkHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/NodeStruct.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/NodeStruct.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/OperatorTopology.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/OperatorTopology.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/OperatorTopologyStruct.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/OperatorTopologyStruct.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/GroupChangesCodec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/GroupChangesCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/GroupChangesImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/GroupChangesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/GroupCommunicationMessage.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/GroupCommunicationMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/GroupCommunicationMessageCodec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/GroupCommunicationMessageCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/BroadcastOperatorSpec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/BroadcastOperatorSpec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/ReduceOperatorSpec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/ReduceOperatorSpec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/CommunicationGroupName.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/CommunicationGroupName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/DataCodec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/DataCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/OperatorName.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/OperatorName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/ReduceFunctionParam.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/ReduceFunctionParam.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/SerializedGroupConfigs.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/SerializedGroupConfigs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/SerializedOperConfigs.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/SerializedOperConfigs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/TaskVersion.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/TaskVersion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/TreeTopologyFanOut.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/TreeTopologyFanOut.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CommunicationGroupDriverImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CommunicationGroupDriverImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CtrlMsgSender.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CtrlMsgSender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/ExceptionHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/ExceptionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/FlatTopology.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/FlatTopology.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/GroupCommMessageHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/GroupCommMessageHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/GroupCommService.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/GroupCommService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/IndexedMsg.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/IndexedMsg.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/MsgKey.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/MsgKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TaskNodeImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TaskNodeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TaskNodeStatusImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TaskNodeStatusImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TaskState.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TaskState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TopologyFailedEvaluatorHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TopologyFailedEvaluatorHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TopologyFailedTaskHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TopologyFailedTaskHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TopologyMessageHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TopologyMessageHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TopologyRunningTaskHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TopologyRunningTaskHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TopologyUpdateWaitHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TopologyUpdateWaitHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TreeTopology.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TreeTopology.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/package-info.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/operators/BroadcastReceiver.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/operators/BroadcastReceiver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/operators/BroadcastSender.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/operators/BroadcastSender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/operators/ReduceReceiver.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/operators/ReduceReceiver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/operators/ReduceSender.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/operators/ReduceSender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/operators/Sender.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/operators/Sender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/ChildNodeStruct.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/ChildNodeStruct.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/CommGroupNetworkHandlerImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/CommGroupNetworkHandlerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/CommunicationGroupClientImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/CommunicationGroupClientImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/GroupCommClientImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/GroupCommClientImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/GroupCommNetworkHandlerImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/GroupCommNetworkHandlerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/InitHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/InitHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/NodeStructImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/NodeStructImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/OperatorTopologyImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/OperatorTopologyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/OperatorTopologyStructImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/OperatorTopologyStructImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/ParentNodeStruct.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/ParentNodeStruct.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/BroadcastingEventHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/BroadcastingEventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/ConcurrentCountingMap.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/ConcurrentCountingMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/CountingMap.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/CountingMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/CountingSemaphore.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/CountingSemaphore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/ResettingCountDownLatch.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/ResettingCountDownLatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/SetMap.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/SetMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/Utils.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/package-info.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/BindNSToTask.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/BindNSToTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NSConnection.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NSConnection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NSMessage.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NSMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NSMessageCodec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NSMessageCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NameServiceCloseHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NameServiceCloseHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkServiceClosingHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkServiceClosingHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkServiceParameters.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkServiceParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/StreamingCodec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/StreamingCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/UnbindNSFromTask.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/UnbindNSFromTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/package-info.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameAssignmentTuple.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameAssignmentTuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameCache.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameServer.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameServerConfiguration.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameServerConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameServerParameters.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameServerParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NamingCodecFactory.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NamingCodecFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/exception/NamingException.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/exception/NamingException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/exception/NamingRuntimeException.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/exception/NamingRuntimeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/exception/package-info.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/exception/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/package-info.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/AvroUtils.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/AvroUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingLookupRequest.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingLookupRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingLookupRequestCodec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingLookupRequestCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingLookupResponse.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingLookupResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingLookupResponseCodec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingLookupResponseCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingMessage.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingRegisterRequest.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingRegisterRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingRegisterRequestCodec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingRegisterRequestCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingRegisterResponse.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingRegisterResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingRegisterResponseCodec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingRegisterResponseCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingUnregisterRequest.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingUnregisterRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingUnregisterRequestCodec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/NamingUnregisterRequestCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/package-info.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/serialization/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/package-info.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/util/ListCodec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/util/ListCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/util/Pair.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/util/Pair.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/util/StringCodec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/util/StringCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/util/StringIdentifier.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/util/StringIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/util/StringIdentifierFactory.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/util/StringIdentifierFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/util/Utils.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/util/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/util/package-info.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/util/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/FramingInputStream.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/FramingInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/FramingOutputStream.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/FramingOutputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/FramingTupleDeserializer.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/FramingTupleDeserializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/FramingTupleSerializer.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/FramingTupleSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/MergingIterator.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/MergingIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/ScratchSpace.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/ScratchSpace.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/StorageService.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/StorageService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/local/CodecFileAccumulable.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/local/CodecFileAccumulable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/local/CodecFileAccumulator.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/local/CodecFileAccumulator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/local/CodecFileIterable.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/local/CodecFileIterable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/local/CodecFileIterator.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/local/CodecFileIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/local/LocalScratchSpace.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/local/LocalScratchSpace.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/local/LocalStorageService.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/local/LocalStorageService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/local/SerializerFileSpool.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/local/SerializerFileSpool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/ram/CodecRamMap.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/ram/CodecRamMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/ram/RamMap.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/ram/RamMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/ram/RamSpool.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/ram/RamSpool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/ram/RamStorageService.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/ram/RamStorageService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/ram/SortingRamSpool.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/ram/SortingRamSpool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/util/GetAllIterable.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/util/GetAllIterable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/util/IntegerCodec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/util/IntegerCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/util/IntegerDeserializer.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/util/IntegerDeserializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/util/IntegerSerializer.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/util/IntegerSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/util/StringDeserializer.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/util/StringDeserializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/util/StringSerializer.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/util/StringSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/util/TupleKeyComparator.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/util/TupleKeyComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/proto/group_comm_protocol.proto
+++ b/lang/java/reef-io/src/main/proto/group_comm_protocol.proto
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/main/proto/ns_protocol.proto
+++ b/lang/java/reef-io/src/main/proto/ns_protocol.proto
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/test/java/org/apache/reef/io/network/group/GroupCommunicationMessageCodecTest.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/io/network/group/GroupCommunicationMessageCodecTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/test/java/org/apache/reef/io/network/util/TestUtils.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/io/network/util/TestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/test/java/org/apache/reef/services/network/TestEvent.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/services/network/TestEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/test/java/org/apache/reef/services/network/util/LoggingUtils.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/services/network/util/LoggingUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/test/java/org/apache/reef/services/network/util/Monitor.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/services/network/util/Monitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/test/java/org/apache/reef/services/network/util/StringCodec.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/services/network/util/StringCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/test/java/org/apache/reef/services/network/util/TimeoutHandler.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/services/network/util/TimeoutHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/test/java/org/apache/reef/services/network/util/package-info.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/services/network/util/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/test/java/org/apache/reef/services/storage/ExternalMapTest.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/services/storage/ExternalMapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/test/java/org/apache/reef/services/storage/FramingTest.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/services/storage/FramingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/test/java/org/apache/reef/services/storage/MergingIteratorTest.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/services/storage/MergingIteratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/test/java/org/apache/reef/services/storage/SortingSpoolTest.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/services/storage/SortingSpoolTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/test/java/org/apache/reef/services/storage/SpoolFileTest.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/services/storage/SpoolFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-io/src/test/java/org/apache/reef/services/storage/TupleSerializerTest.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/services/storage/TupleSerializerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-poison/src/main/java/org/apache/reef/poison/PoisonException.java
+++ b/lang/java/reef-poison/src/main/java/org/apache/reef/poison/PoisonException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-poison/src/main/java/org/apache/reef/poison/PoisonedAlarmHandler.java
+++ b/lang/java/reef-poison/src/main/java/org/apache/reef/poison/PoisonedAlarmHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-poison/src/main/java/org/apache/reef/poison/PoisonedConfiguration.java
+++ b/lang/java/reef-poison/src/main/java/org/apache/reef/poison/PoisonedConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-poison/src/main/java/org/apache/reef/poison/context/PoisonedContextStartHandler.java
+++ b/lang/java/reef-poison/src/main/java/org/apache/reef/poison/context/PoisonedContextStartHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-poison/src/main/java/org/apache/reef/poison/context/PoissonPoisonedContextStartHandler.java
+++ b/lang/java/reef-poison/src/main/java/org/apache/reef/poison/context/PoissonPoisonedContextStartHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-poison/src/main/java/org/apache/reef/poison/context/package-info.java
+++ b/lang/java/reef-poison/src/main/java/org/apache/reef/poison/context/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-poison/src/main/java/org/apache/reef/poison/package-info.java
+++ b/lang/java/reef-poison/src/main/java/org/apache/reef/poison/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-poison/src/main/java/org/apache/reef/poison/params/CrashProbability.java
+++ b/lang/java/reef-poison/src/main/java/org/apache/reef/poison/params/CrashProbability.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-poison/src/main/java/org/apache/reef/poison/params/CrashTimeout.java
+++ b/lang/java/reef-poison/src/main/java/org/apache/reef/poison/params/CrashTimeout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-poison/src/main/java/org/apache/reef/poison/task/PoisonedTaskStartHandler.java
+++ b/lang/java/reef-poison/src/main/java/org/apache/reef/poison/task/PoisonedTaskStartHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-poison/src/main/java/org/apache/reef/poison/task/PoissonPoisonedTaskStartHandler.java
+++ b/lang/java/reef-poison/src/main/java/org/apache/reef/poison/task/PoissonPoisonedTaskStartHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-poison/src/main/java/org/apache/reef/poison/task/package-info.java
+++ b/lang/java/reef-poison/src/main/java/org/apache/reef/poison/task/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/HDInsightClasspathProvider.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/HDInsightClasspathProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/cli/HDICLI.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/cli/HDICLI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/cli/LogFetcher.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/cli/LogFetcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/cli/LogFileEntry.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/cli/LogFileEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/cli/TFileParser.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/cli/TFileParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/cli/package-info.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/cli/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/AzureUploader.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/AzureUploader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/HDInsightDriverConfiguration.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/HDInsightDriverConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/HDInsightJobSubmissionHandler.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/HDInsightJobSubmissionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/HDInsightRuntimeConfiguration.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/HDInsightRuntimeConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/UnsafeHDInsightRuntimeConfiguration.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/UnsafeHDInsightRuntimeConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/UnsafeHDInsightRuntimeConfigurationStatic.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/UnsafeHDInsightRuntimeConfigurationStatic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/package-info.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/sslhacks/DefaultClientConstructor.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/sslhacks/DefaultClientConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/sslhacks/UnsafeClientConstructor.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/sslhacks/UnsafeClientConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/sslhacks/UnsafeHostNameVerifier.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/sslhacks/UnsafeHostNameVerifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/sslhacks/UnsafeTrustManager.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/sslhacks/UnsafeTrustManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/AmContainerSpec.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/AmContainerSpec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/ApplicationID.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/ApplicationID.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/ApplicationResponse.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/ApplicationResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/ApplicationState.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/ApplicationState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/ApplicationSubmission.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/ApplicationSubmission.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/Commands.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/Commands.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/Constants.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/Constants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/Credentials.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/Credentials.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/HDInsightInstance.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/HDInsightInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/ListApplicationResponse.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/ListApplicationResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/LocalResource.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/LocalResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/LocalResourcesEntry.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/LocalResourcesEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/Resource.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/Resource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/StringEntry.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/StringEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/package-info.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/yarnrest/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/package-info.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/parameters/AzureStorageAccountContainerName.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/parameters/AzureStorageAccountContainerName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/parameters/AzureStorageAccountKey.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/parameters/AzureStorageAccountKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/parameters/AzureStorageAccountName.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/parameters/AzureStorageAccountName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/parameters/AzureStorageBaseFolder.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/parameters/AzureStorageBaseFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/parameters/HDInsightInstanceURL.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/parameters/HDInsightInstanceURL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/parameters/HDInsightPassword.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/parameters/HDInsightPassword.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/parameters/HDInsightUsername.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/parameters/HDInsightUsername.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-hdinsight/src/test/java/org/apache/reef/runtime/hdinsight/TestHDInsightRESTJsonSerialization.java
+++ b/lang/java/reef-runtime-hdinsight/src/test/java/org/apache/reef/runtime/hdinsight/TestHDInsightRESTJsonSerialization.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/LocalClasspathProvider.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/LocalClasspathProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/DriverConfigurationProvider.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/DriverConfigurationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/DriverFiles.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/DriverFiles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/ExecutorServiceConstructor.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/ExecutorServiceConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/FileSet.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/FileSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/LocalJobSubmissionHandler.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/LocalJobSubmissionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/PreparedDriverFolderLauncher.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/PreparedDriverFolderLauncher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/package-info.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/parameters/DefaultMemorySize.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/parameters/DefaultMemorySize.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/parameters/DefaultNumberOfCores.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/parameters/DefaultNumberOfCores.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/parameters/MaxNumberOfEvaluators.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/parameters/MaxNumberOfEvaluators.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/parameters/RootFolder.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/parameters/RootFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/parameters/package-info.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/parameters/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/Container.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/Container.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/IDMaker.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/IDMaker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalDriverConfiguration.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalDriverConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalResourceLaunchHandler.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalResourceLaunchHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalResourceReleaseHandler.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalResourceReleaseHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalResourceRequestHandler.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalResourceRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ProcessContainer.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ProcessContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ResourceManager.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ResourceManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ResourceRequest.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ResourceRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ResourceRequestQueue.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ResourceRequestQueue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/package-info.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/process/LoggingRunnableProcessObserver.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/process/LoggingRunnableProcessObserver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/process/ReefRunnableProcessObserver.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/process/ReefRunnableProcessObserver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/process/RunnableProcess.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/process/RunnableProcess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/process/RunnableProcessObserver.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/process/RunnableProcessObserver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/process/package-info.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/process/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/test/java/org/apache/reef/runtime/local/driver/ResourceRequestQueueTest.java
+++ b/lang/java/reef-runtime-local/src/test/java/org/apache/reef/runtime/local/driver/ResourceRequestQueueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-local/src/test/java/org/apache/reef/runtime/local/driver/ResourceRequestTest.java
+++ b/lang/java/reef-runtime-local/src/test/java/org/apache/reef/runtime/local/driver/ResourceRequestTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-mesos/src/main/avro/EvaluatorControl.avsc
+++ b/lang/java/reef-runtime-mesos/src/main/avro/EvaluatorControl.avsc
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/MesosClasspathProvider.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/MesosClasspathProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/client/MesosJobSubmissionHandler.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/client/MesosJobSubmissionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/client/parameters/MasterIp.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/client/parameters/MasterIp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/client/parameters/RootFolder.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/client/parameters/RootFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosDriverConfiguration.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosDriverConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosResourceLaunchHandler.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosResourceLaunchHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosResourceReleaseHandler.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosResourceReleaseHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosResourceRequestHandler.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosResourceRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosRuntimeStartHandler.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosRuntimeStartHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosRuntimeStopHandler.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosRuntimeStopHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosSchedulerDriverExecutor.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosSchedulerDriverExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/REEFEventHandlers.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/REEFEventHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/REEFExecutor.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/REEFExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/REEFExecutors.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/REEFExecutors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/REEFScheduler.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/REEFScheduler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/parameters/MesosMasterIp.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/parameters/MesosMasterIp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/evaluator/EvaluatorControlHandler.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/evaluator/EvaluatorControlHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/evaluator/REEFExecutor.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/evaluator/REEFExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/evaluator/parameters/MesosExecutorId.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/evaluator/parameters/MesosExecutorId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/util/HDFSConfigurationConstructor.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/util/HDFSConfigurationConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/util/MesosErrorHandler.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/util/MesosErrorHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/util/MesosRemoteManagerCodec.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/util/MesosRemoteManagerCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/ClassPathBuilder.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/ClassPathBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/YarnClasspathProvider.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/YarnClasspathProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/YarnJobSubmissionHandler.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/YarnJobSubmissionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/YarnSubmissionHelper.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/YarnSubmissionHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/parameters/JobPriority.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/parameters/JobPriority.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/parameters/JobQueue.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/parameters/JobQueue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/uploader/JobFolder.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/uploader/JobFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/uploader/JobUploader.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/uploader/JobUploader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/ApplicationMasterRegistration.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/ApplicationMasterRegistration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/ContainerRequestCounter.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/ContainerRequestCounter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/Containers.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/Containers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/DefaultTrackingURLProvider.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/DefaultTrackingURLProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/EvaluatorSetupHelper.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/EvaluatorSetupHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/GlobalJarUploader.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/GlobalJarUploader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/REEFEventHandlers.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/REEFEventHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/TrackingURLProvider.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/TrackingURLProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/UploaderToJobfolder.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/UploaderToJobfolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YARNResourceLaunchHandler.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YARNResourceLaunchHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YARNResourceReleaseHandler.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YARNResourceReleaseHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YARNRuntimeStartHandler.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YARNRuntimeStartHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YARNRuntimeStopHandler.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YARNRuntimeStopHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerRequestHandler.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerRequestHandlerImpl.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerRequestHandlerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverConfiguration.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnResourceRequestHandler.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnResourceRequestHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/package-info.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/parameters/JobSubmissionDirectory.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/parameters/JobSubmissionDirectory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/parameters/YarnHeartbeatPeriod.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/parameters/YarnHeartbeatPeriod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/util/YarnConfigurationConstructor.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/util/YarnConfigurationConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/util/YarnTypes.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/util/YarnTypes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-runtime-yarn/src/main/test/java/org/apache/reef/runtime/yarn/driver/YarnResourceRequestHandlerTest.java
+++ b/lang/java/reef-runtime-yarn/src/main/test/java/org/apache/reef/runtime/yarn/driver/YarnResourceRequestHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang-test-jarA/src/main/java/org/apache/reef/tang/examples/A.java
+++ b/lang/java/reef-tang/tang-test-jarA/src/main/java/org/apache/reef/tang/examples/A.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang-test-jarAB/src/main/java/org/apache/reef/tang/examples/A.java
+++ b/lang/java/reef-tang/tang-test-jarAB/src/main/java/org/apache/reef/tang/examples/A.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang-test-jarAB/src/main/java/org/apache/reef/tang/examples/B.java
+++ b/lang/java/reef-tang/tang-test-jarAB/src/main/java/org/apache/reef/tang/examples/B.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang-test-jarB/src/main/java/org/apache/reef/tang/examples/B.java
+++ b/lang/java/reef-tang/tang-test-jarB/src/main/java/org/apache/reef/tang/examples/B.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/avro/configuration.avsc
+++ b/lang/java/reef-tang/tang/src/main/avro/configuration.avsc
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Aspect.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Aspect.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/BindLocation.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/BindLocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/ClassHierarchy.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/ClassHierarchy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Configuration.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Configuration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/ConfigurationBuilder.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/ConfigurationBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Configurations.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Configurations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/ExternalConstructor.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/ExternalConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/InjectionFuture.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/InjectionFuture.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Injector.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Injector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/JavaClassHierarchy.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/JavaClassHierarchy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/JavaConfigurationBuilder.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/JavaConfigurationBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Tang.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Tang.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/annotations/DefaultImplementation.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/annotations/DefaultImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/annotations/Name.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/annotations/Name.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/annotations/NamedParameter.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/annotations/NamedParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/annotations/Parameter.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/annotations/Parameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/annotations/Unit.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/annotations/Unit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/annotations/package-info.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/annotations/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/examples/PrintTypeHierarchy.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/examples/PrintTypeHierarchy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/examples/Timer.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/examples/Timer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/examples/TimerV1.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/examples/TimerV1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/examples/package-info.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/examples/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/examples/timer/Timer.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/examples/timer/Timer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/examples/timer/TimerImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/examples/timer/TimerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/examples/timer/TimerMock.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/examples/timer/TimerMock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/examples/timer/package-info.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/examples/timer/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/exceptions/BindException.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/exceptions/BindException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/exceptions/ClassHierarchyException.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/exceptions/ClassHierarchyException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/exceptions/InjectionException.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/exceptions/InjectionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/exceptions/NameResolutionException.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/exceptions/NameResolutionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/exceptions/ParseException.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/exceptions/ParseException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/exceptions/package-info.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/exceptions/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/AvroConfigurationSerializer.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/AvroConfigurationSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/CommandLine.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/CommandLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationFile.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationModule.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationModuleBuilder.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationModuleBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationSerializer.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/Impl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/Impl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/OptionalImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/OptionalImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/OptionalParameter.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/OptionalParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/Param.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/Param.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ParameterParser.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ParameterParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/Provides.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/Provides.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/RequiredImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/RequiredImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/RequiredParameter.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/RequiredParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/package-info.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/ConfigurationBuilderImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/ConfigurationBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/ConfigurationImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/ConfigurationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/Constructor.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/Constructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/InjectionFuturePlan.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/InjectionFuturePlan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/InjectionPlan.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/InjectionPlan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/ListInjectionPlan.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/ListInjectionPlan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/SetInjectionPlan.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/SetInjectionPlan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/StackBindLocation.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/StackBindLocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/Subplan.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/Subplan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/TangImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/TangImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/ClassHierarchyImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/ClassHierarchyImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/InjectorImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/InjectorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/JavaConfigurationBuilderImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/JavaConfigurationBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/JavaInstance.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/JavaInstance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/JavaNodeFactory.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/JavaNodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/package-info.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/package-info.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/protobuf/ProtocolBufferClassHierarchy.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/protobuf/ProtocolBufferClassHierarchy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/protobuf/ProtocolBufferInjectionPlan.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/protobuf/ProtocolBufferInjectionPlan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/protobuf/package-info.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/protobuf/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/types/AbstractNode.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/types/AbstractNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/types/ClassNodeImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/types/ClassNodeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/types/ConstructorArgImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/types/ConstructorArgImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/types/ConstructorDefImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/types/ConstructorDefImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/types/NamedParameterNodeImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/types/NamedParameterNodeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/types/PackageNodeImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/types/PackageNodeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/types/package-info.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/types/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/package-info.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types/ClassNode.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types/ClassNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types/ConstructorArg.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types/ConstructorArg.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types/ConstructorDef.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types/ConstructorDef.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types/NamedParameterNode.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types/NamedParameterNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types/Node.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types/Node.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types/PackageNode.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types/PackageNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types/Traversable.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types/Traversable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types/package-info.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/AbstractMonotonicMultiMap.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/AbstractMonotonicMultiMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/MonotonicHashMap.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/MonotonicHashMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/MonotonicHashSet.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/MonotonicHashSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/MonotonicMultiHashMap.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/MonotonicMultiHashMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/MonotonicMultiMap.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/MonotonicMultiMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/MonotonicSet.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/MonotonicSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/MonotonicTreeMap.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/MonotonicTreeMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/ReflectionUtilities.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/ReflectionUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/Tint.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/Tint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/TracingMonotonicMap.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/TracingMonotonicMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/TracingMonotonicTreeMap.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/TracingMonotonicTreeMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/ValidateConfiguration.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/ValidateConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/package-info.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/AbstractClassHierarchyNodeVisitor.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/AbstractClassHierarchyNodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/AbstractInjectionPlanNodeVisitor.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/AbstractInjectionPlanNodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/EdgeVisitor.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/EdgeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/NodeVisitor.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/NodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/Walk.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/Walk.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/graphviz/GraphvizConfigVisitor.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/graphviz/GraphvizConfigVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/graphviz/GraphvizInjectionPlanVisitor.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/graphviz/GraphvizInjectionPlanVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/graphviz/package-info.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/graphviz/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/package-info.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/main/proto/class_hierarchy.proto
+++ b/lang/java/reef-tang/tang/src/main/proto/class_hierarchy.proto
@@ -1,19 +1,22 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 option java_package = "org.apache.reef.tang.proto";
 option java_outer_classname = "ClassHierarchyProto";
 //option java_generic_services = true;

--- a/lang/java/reef-tang/tang/src/main/proto/injection_plan.proto
+++ b/lang/java/reef-tang/tang/src/main/proto/injection_plan.proto
@@ -1,19 +1,22 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 option java_package = "org.apache.reef.tang.proto";
 option java_outer_classname = "InjectionPlanProto";
 //option java_generic_services = true;

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/ClassHierarchyDeserializationTest.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/ClassHierarchyDeserializationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestBindSingleton.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestBindSingleton.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestClassLoaders.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestClassLoaders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestConfFileParser.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestConfFileParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestExternalConstructor.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestExternalConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestImplicitConversions.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestImplicitConversions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestInjectionFuture.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestInjectionFuture.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestListInjection.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestListInjection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestNamedParameterRoundTrip.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestNamedParameterRoundTrip.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestSetInjection.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestSetInjection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestTang.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestTang.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestTweetExample.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestTweetExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/formats/AvroConfigurationSerializerAvroRoundtripTest.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/formats/AvroConfigurationSerializerAvroRoundtripTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/formats/AvroConfigurationSerializerByteArrayRoundtripTest.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/formats/AvroConfigurationSerializerByteArrayRoundtripTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/formats/AvroConfigurationSerializerFileRoundtripTest.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/formats/AvroConfigurationSerializerFileRoundtripTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/formats/AvroConfigurationSerializerStringRoundtripTest.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/formats/AvroConfigurationSerializerStringRoundtripTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/formats/AvroConfigurationSerializerTextFileRoundtripTest.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/formats/AvroConfigurationSerializerTextFileRoundtripTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/formats/ConfigurationFileTest.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/formats/ConfigurationFileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/formats/NamedParameters.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/formats/NamedParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/formats/TestCommandLine.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/formats/TestCommandLine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/formats/TestConfigurationModule.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/formats/TestConfigurationModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/implementation/TestClassHierarchy.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/implementation/TestClassHierarchy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/implementation/java/TestConfigurationBuilder.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/implementation/java/TestConfigurationBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/implementation/java/TestParameterParser.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/implementation/java/TestParameterParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/implementation/protobuf/TestClassHierarchyRoundTrip.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/implementation/protobuf/TestClassHierarchyRoundTrip.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/AnInterface.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/AnInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/AnInterfaceImplementation.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/AnInterfaceImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/CyclicDependency.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/CyclicDependency.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/CyclicDependencyClassOne.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/CyclicDependencyClassOne.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/CyclicDependencyClassTwo.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/CyclicDependencyClassTwo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/Handler.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/Handler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/InjectableClass.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/InjectableClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/ListInterface.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/ListInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/ListInterfaceImplOne.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/ListInterfaceImplOne.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/ListInterfaceImplTwo.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/ListInterfaceImplTwo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/ListOfBaseTypes.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/ListOfBaseTypes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/ListOfImplementations.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/ListOfImplementations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/ObjectTreeTest.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/ObjectTreeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/RootImplementation.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/RootImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/RootImplementationWithoutList.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/RootImplementationWithoutList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/RootInterface.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/RootInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/RoundTripTest.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/RoundTripTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/SetInterface.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/SetInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/SetInterfaceImplOne.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/SetInterfaceImplOne.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/SetInterfaceImplTwo.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/SetInterfaceImplTwo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/SetOfBaseTypes.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/SetOfBaseTypes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/SetOfImplementations.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/SetOfImplementations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/TestConfiguration.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/TestConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/TestConfigurationWithoutList.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/TestConfigurationWithoutList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/UnitClass.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/UnitClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/package-info.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/test/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/TestDriverLauncher.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/TestDriverLauncher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/driver/DriverTestStartHandler.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/driver/DriverTestStartHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/driver/package-info.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/driver/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/evaluatorreuse/EvaluatorReuseTestDriver.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/evaluatorreuse/EvaluatorReuseTestDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/evaluatorreuse/package-info.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/evaluatorreuse/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/driver/DriverFailOnFail.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/driver/DriverFailOnFail.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/driver/FailClient.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/driver/FailClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/driver/FailDriver.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/driver/FailDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/driver/FailDriverDelayedMsg.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/driver/FailDriverDelayedMsg.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/driver/NoopTask.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/driver/NoopTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/task/Client.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/task/Client.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/task/Driver.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/task/Driver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/task/FailTask.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/task/FailTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/task/FailTaskCall.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/task/FailTaskCall.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/task/FailTaskClose.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/task/FailTaskClose.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/task/FailTaskMsg.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/task/FailTaskMsg.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/task/FailTaskStart.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/task/FailTaskStart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/task/FailTaskStop.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/task/FailTaskStop.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/task/FailTaskSuspend.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/task/FailTaskSuspend.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/driver/ExpectedTaskFailureHandler.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/driver/ExpectedTaskFailureHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/driver/OnDriverStartedAllocateOne.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/driver/OnDriverStartedAllocateOne.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/exceptions/ClientSideFailure.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/exceptions/ClientSideFailure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/exceptions/DriverSideFailure.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/exceptions/DriverSideFailure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/exceptions/ExpectedTaskException.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/exceptions/ExpectedTaskException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/exceptions/SimulatedDriverFailure.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/exceptions/SimulatedDriverFailure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/exceptions/SimulatedTaskFailure.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/exceptions/SimulatedTaskFailure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/exceptions/TaskSideFailure.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/exceptions/TaskSideFailure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/exceptions/UnexpectedTaskReturnValue.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/exceptions/UnexpectedTaskReturnValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/package-info.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/tasks/EchoTask.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/tasks/EchoTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/tasks/NoopTask.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/tasks/NoopTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/messaging/driver/DriverMessaging.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/messaging/driver/DriverMessaging.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/messaging/driver/DriverMessagingDriver.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/messaging/driver/DriverMessagingDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/messaging/task/TaskMessagingDriver.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/messaging/task/TaskMessagingDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/messaging/task/TaskMessagingTask.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/messaging/task/TaskMessagingTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/statepassing/Counter.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/statepassing/Counter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/statepassing/StatePassingDriver.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/statepassing/StatePassingDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/statepassing/StatePassingTask.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/statepassing/StatePassingTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/yarn/failure/FailureDriver.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/yarn/failure/FailureDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/yarn/failure/FailureREEF.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/yarn/failure/FailureREEF.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/FailureTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/FailureTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/LocalTestEnvironment.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/LocalTestEnvironment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/MesosTestEnvironment.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/MesosTestEnvironment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/ProbabilisticTests.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/ProbabilisticTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/TestEnvironment.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/TestEnvironment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/TestEnvironmentBase.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/TestEnvironmentBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/TestEnvironmentFactory.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/TestEnvironmentFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/TestUtils.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/TestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/YarnTestEnvironment.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/YarnTestEnvironment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/close_eval/CloseEvaluatorDriver.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/close_eval/CloseEvaluatorDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/close_eval/CloseEvaluatorTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/close_eval/CloseEvaluatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/driver/DriverTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/driver/DriverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorexit/EvaluatorExitTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorexit/EvaluatorExitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorexit/EvaluatorExitTestDriver.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorexit/EvaluatorExitTestDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorexit/EvaluatorExitTestTask.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorexit/EvaluatorExitTestTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorexit/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorexit/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorfailure/EvaluatorFailureDuringAlarmDriver.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorfailure/EvaluatorFailureDuringAlarmDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorfailure/EvaluatorFailureTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorfailure/EvaluatorFailureTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorfailure/ExpectedException.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorfailure/ExpectedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorfailure/FailureSchedulingContextStartHandler.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorfailure/FailureSchedulingContextStartHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorfailure/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorfailure/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorreuse/EvaluatorReuseTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorreuse/EvaluatorReuseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorsize/EvaluatorSizeTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorsize/EvaluatorSizeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorsize/EvaluatorSizeTestConfiguration.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorsize/EvaluatorSizeTestConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorsize/EvaluatorSizeTestDriver.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorsize/EvaluatorSizeTestDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorsize/MemorySizeTask.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorsize/MemorySizeTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorsize/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorsize/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/examples/ExamplesTestSuite.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/examples/ExamplesTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/examples/TestHelloREEF.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/examples/TestHelloREEF.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/examples/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/examples/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/fail/DriverFailOnFailTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/fail/DriverFailOnFailTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/fail/FailDriverDelayedMsgTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/fail/FailDriverDelayedMsgTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/fail/FailDriverTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/fail/FailDriverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/fail/FailTaskTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/fail/FailTaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/fail/FailTestSuite.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/fail/FailTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/files/FileResourceTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/files/FileResourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/files/FileResourceTestDriver.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/files/FileResourceTestDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/files/FileResourceTestDriverConfiguration.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/files/FileResourceTestDriverConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/files/FileResourceTestTask.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/files/FileResourceTestTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/files/FileResourceTestTaskConfiguration.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/files/FileResourceTestTaskConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/files/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/files/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/messaging/driver/DriverMessagingTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/messaging/driver/DriverMessagingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/messaging/driver/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/messaging/driver/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/messaging/task/TaskMessagingTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/messaging/task/TaskMessagingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/messaging/task/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/messaging/task/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/multipleEventHandlerInstances/ActiveContextHandler.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/multipleEventHandlerInstances/ActiveContextHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/multipleEventHandlerInstances/AllocatedEvaluatorHandler.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/multipleEventHandlerInstances/AllocatedEvaluatorHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/multipleEventHandlerInstances/Client.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/multipleEventHandlerInstances/Client.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/multipleEventHandlerInstances/ClosedContextHandler.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/multipleEventHandlerInstances/ClosedContextHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/multipleEventHandlerInstances/CompletedEvaluatorHandler.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/multipleEventHandlerInstances/CompletedEvaluatorHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/multipleEventHandlerInstances/CompletedTaskHandler.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/multipleEventHandlerInstances/CompletedTaskHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/multipleEventHandlerInstances/EmptyTask.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/multipleEventHandlerInstances/EmptyTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/multipleEventHandlerInstances/RunningTaskHandler.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/multipleEventHandlerInstances/RunningTaskHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/multipleEventHandlerInstances/StartHandler.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/multipleEventHandlerInstances/StartHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/roguethread/RogueThreadDriver.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/roguethread/RogueThreadDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/roguethread/RogueThreadTask.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/roguethread/RogueThreadTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/roguethread/RogueThreadTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/roguethread/RogueThreadTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/roguethread/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/roguethread/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/statepassing/StatePassingTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/statepassing/StatePassingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/statepassing/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/statepassing/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/subcontexts/ContextStartHandler1.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/subcontexts/ContextStartHandler1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/subcontexts/ContextStartHandler2.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/subcontexts/ContextStartHandler2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/subcontexts/ContextStopHandler1.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/subcontexts/ContextStopHandler1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/subcontexts/ContextStopHandler2.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/subcontexts/ContextStopHandler2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/subcontexts/SubContextDriver.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/subcontexts/SubContextDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/subcontexts/SubContextTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/subcontexts/SubContextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/subcontexts/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/subcontexts/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/taskcounting/TaskCountingDriver.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/taskcounting/TaskCountingDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/taskcounting/TaskCountingTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/taskcounting/TaskCountingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/taskcounting/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/taskcounting/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/taskresubmit/TaskResubmitDriver.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/taskresubmit/TaskResubmitDriver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/taskresubmit/TaskResubmitTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/taskresubmit/TaskResubmitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/taskresubmit/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/taskresubmit/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-utils-hadoop/src/main/java/org/apache/reef/util/HadoopEnvironment.java
+++ b/lang/java/reef-utils-hadoop/src/main/java/org/apache/reef/util/HadoopEnvironment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-utils-hadoop/src/main/java/org/apache/reef/util/logging/DFSHandler.java
+++ b/lang/java/reef-utils-hadoop/src/main/java/org/apache/reef/util/logging/DFSHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-utils/src/main/java/org/apache/reef/util/Optional.java
+++ b/lang/java/reef-utils/src/main/java/org/apache/reef/util/Optional.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-utils/src/main/java/org/apache/reef/util/cache/Cache.java
+++ b/lang/java/reef-utils/src/main/java/org/apache/reef/util/cache/Cache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-utils/src/main/java/org/apache/reef/util/cache/CacheImpl.java
+++ b/lang/java/reef-utils/src/main/java/org/apache/reef/util/cache/CacheImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-utils/src/main/java/org/apache/reef/util/cache/CurrentTime.java
+++ b/lang/java/reef-utils/src/main/java/org/apache/reef/util/cache/CurrentTime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-utils/src/main/java/org/apache/reef/util/cache/SystemTime.java
+++ b/lang/java/reef-utils/src/main/java/org/apache/reef/util/cache/SystemTime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-utils/src/main/java/org/apache/reef/util/cache/WrappedValue.java
+++ b/lang/java/reef-utils/src/main/java/org/apache/reef/util/cache/WrappedValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-utils/src/main/java/org/apache/reef/util/package-info.java
+++ b/lang/java/reef-utils/src/main/java/org/apache/reef/util/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-utils/src/test/java/org/apache/reef/util/OptionalTest.java
+++ b/lang/java/reef-utils/src/test/java/org/apache/reef/util/OptionalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-utils/src/test/java/org/apache/reef/util/cache/CacheImplConcurrentTest.java
+++ b/lang/java/reef-utils/src/test/java/org/apache/reef/util/cache/CacheImplConcurrentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-utils/src/test/java/org/apache/reef/util/cache/CacheImplTest.java
+++ b/lang/java/reef-utils/src/test/java/org/apache/reef/util/cache/CacheImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-utils/src/test/java/org/apache/reef/util/cache/ImmediateInteger.java
+++ b/lang/java/reef-utils/src/test/java/org/apache/reef/util/cache/ImmediateInteger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-utils/src/test/java/org/apache/reef/util/cache/SleepingInteger.java
+++ b/lang/java/reef-utils/src/test/java/org/apache/reef/util/cache/SleepingInteger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-utils/src/test/java/org/apache/reef/util/cache/WrappedValueTest.java
+++ b/lang/java/reef-utils/src/test/java/org/apache/reef/util/cache/WrappedValueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/AbstractEStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/AbstractEStage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/ComparableIdentifier.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/ComparableIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/EStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/EStage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/EventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/EventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/Identifiable.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/Identifiable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/Identifier.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/Identifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/IdentifierFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/IdentifierFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/IdentifierParser.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/IdentifierParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/Stage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/Stage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/StageConfiguration.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/StageConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/WakeConfiguration.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/WakeConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/WakeParameters.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/WakeParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/accumulate/CombinerStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/accumulate/CombinerStage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/BlockingJoin.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/BlockingJoin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/EventPrinter.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/EventPrinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/NonBlockingJoin.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/NonBlockingJoin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/TupleEvent.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/TupleEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/TupleSource.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/TupleSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/p2p/EventSource.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/p2p/EventSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/p2p/Pull2Push.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/p2p/Pull2Push.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/p2p/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/p2p/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/exception/WakeRuntimeException.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/exception/WakeRuntimeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/exception/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/exception/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/BlockingEventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/BlockingEventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/BlockingSignalEventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/BlockingSignalEventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/DefaultIdentifierFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/DefaultIdentifierFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/DefaultThreadFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/DefaultThreadFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/ForkPoolStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/ForkPoolStage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/IndependentIterationsThreadPoolStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/IndependentIterationsThreadPoolStage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/LoggingEventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/LoggingEventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/LoggingUtils.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/LoggingUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/LoggingVoidEventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/LoggingVoidEventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/MergingEventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/MergingEventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/MissingStartHandlerHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/MissingStartHandlerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/MultiEventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/MultiEventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/OpaqueLocalIdentifier.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/OpaqueLocalIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/PeriodicEvent.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/PeriodicEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/PubSubEventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/PubSubEventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/SingleThreadStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/SingleThreadStage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/StageManager.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/StageManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/SyncStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/SyncStage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/ThreadPoolStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/ThreadPoolStage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/TimerStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/TimerStage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/WakeSharedPool.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/WakeSharedPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/WakeUncaughtExceptionHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/WakeUncaughtExceptionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/EWMA.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/EWMA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/EWMAParameters.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/EWMAParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/Histogram.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/Histogram.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/Meter.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/Meter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/UniformHistogram.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/UniformHistogram.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/Vertex.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/Vertex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/WakeProfiler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/WakeProfiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/Codec.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/Codec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/Decoder.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/Decoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/DefaultErrorHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/DefaultErrorHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/Encoder.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/Encoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteConfiguration.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteIdentifier.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteIdentifierFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteIdentifierFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteManager.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteMessage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/exception/RemoteRuntimeException.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/exception/RemoteRuntimeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/exception/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/exception/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/ByteCodec.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/ByteCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/ConnectFutureTask.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/ConnectFutureTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteIdentifierFactoryImplementation.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteIdentifierFactoryImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteMessage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultTransportEStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultTransportEStage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/HandlerContainer.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/HandlerContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/MultiCodec.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/MultiCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/MultiDecoder.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/MultiDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/MultiEncoder.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/MultiEncoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/ObjectSerializableCodec.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/ObjectSerializableCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/OrderedRemoteReceiverStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/OrderedRemoteReceiverStage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/ProxyEventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/ProxyEventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEvent.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEventCodec.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEventCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEventComparator.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEventComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEventDecoder.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEventDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEventEncoder.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEventEncoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteReceiverEventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteReceiverEventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteReceiverStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteReceiverStage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteSenderEventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteSenderEventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteSenderStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteSenderStage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteSeqNumGenerator.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteSeqNumGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/SocketRemoteIdentifier.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/SocketRemoteIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/StringCodec.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/StringCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/Subscription.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/Subscription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/TransportEvent.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/TransportEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/Tuple2.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/Tuple2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/RandomRangeIterator.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/RandomRangeIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/RangeTcpPortProvider.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/RangeTcpPortProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/parameters/TcpPortRangeBegin.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/parameters/TcpPortRangeBegin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/parameters/TcpPortRangeCount.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/parameters/TcpPortRangeCount.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/parameters/TcpPortRangeTryCount.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/parameters/TcpPortRangeTryCount.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/Link.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/Link.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/LinkListener.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/LinkListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/Transport.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/Transport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/TransportFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/TransportFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/exception/TransportRuntimeException.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/exception/TransportRuntimeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/exception/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/exception/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/AbstractNettyEventListener.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/AbstractNettyEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/ByteEncoder.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/ByteEncoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/ChunkedReadWriteHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/ChunkedReadWriteHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/LinkReference.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/LinkReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/LoggingLinkListener.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/LoggingLinkListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyChannelHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyChannelHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyChannelHandlerFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyChannelHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyChannelInitializer.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyChannelInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyClientEventListener.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyClientEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyDefaultChannelHandlerFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyDefaultChannelHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyEventListener.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyLink.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyLink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyMessagingTransport.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyMessagingTransport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyServerEventListener.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyServerEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/AbstractObserver.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/AbstractObserver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/AbstractRxStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/AbstractRxStage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/DynamicObservable.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/DynamicObservable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/Observable.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/Observable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/Observer.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/Observer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/RxStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/RxStage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/StaticObservable.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/StaticObservable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/Subject.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/Subject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/exception/ObserverCompletedException.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/exception/ObserverCompletedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/exception/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/exception/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/RxSyncStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/RxSyncStage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/RxThreadPoolStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/RxThreadPoolStage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/SimpleSubject.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/SimpleSubject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/TimeoutSubject.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/TimeoutSubject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/storage/FileHandlePool.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/storage/FileHandlePool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/storage/FileIdentifier.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/storage/FileIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/storage/ReadRequest.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/storage/ReadRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/storage/ReadResponse.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/storage/ReadResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/storage/SequentialFileReader.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/storage/SequentialFileReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/storage/StorageIdentifier.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/storage/StorageIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/Clock.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/Clock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/Time.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/Time.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/event/Alarm.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/event/Alarm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/event/StartTime.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/event/StartTime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/event/StopTime.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/event/StopTime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/event/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/event/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/LogicalTimer.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/LogicalTimer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RealTimer.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RealTimer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RuntimeClock.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RuntimeClock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/Timer.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/Timer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/ClientAlarm.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/ClientAlarm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/IdleClock.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/IdleClock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/RuntimeAlarm.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/RuntimeAlarm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/RuntimeStart.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/RuntimeStart.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/RuntimeStop.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/RuntimeStop.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/main/proto/RemoteProtocol.proto
+++ b/lang/java/reef-wake/wake/src/main/proto/RemoteProtocol.proto
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/BlockingEventHandlerTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/BlockingEventHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/BlockingSignalEventHandlerTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/BlockingSignalEventHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/ForkPoolStageTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/ForkPoolStageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/IndependentIterationsThreadPoolStageTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/IndependentIterationsThreadPoolStageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/MergingEventHandlerTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/MergingEventHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/MetricsTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/MetricsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/PubSubThreadPoolStageTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/PubSubThreadPoolStageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/StageManagerTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/StageManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/SyncStageTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/SyncStageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/ThreadPoolStageTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/ThreadPoolStageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/TimerStageTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/TimerStageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/SkipListTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/SkipListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestBlockingJoin.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestBlockingJoin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestCombiner.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestCombiner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestJoin.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestJoin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestTupleSource.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestTupleSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/package-info.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/StartEvent.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/StartEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestEvent.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestEvent1.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestEvent1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestEvent2.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestEvent2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestEventCodec.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestEventCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestRemoteIdentifier.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestRemoteIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/package-info.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/RxTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/RxTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/RxThreadPoolStageTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/RxThreadPoolStageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/TimeoutSubjectTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/TimeoutSubjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/package-info.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/ClockTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/ClockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/package-info.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/util/Monitor.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/util/Monitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/util/PassThroughEncoder.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/util/PassThroughEncoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/util/TimeoutHandler.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/util/TimeoutHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/util/package-info.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/util/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/proto/TestEvent1.proto
+++ b/lang/java/reef-wake/wake/src/test/proto/TestEvent1.proto
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-wake/wake/src/test/proto/TestProtocol.proto
+++ b/lang/java/reef-wake/wake/src/test/proto/TestProtocol.proto
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/avro/DriverInfo.avsc
+++ b/lang/java/reef-webserver/src/main/avro/DriverInfo.avsc
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/avro/EvaluatorInfo.avsc
+++ b/lang/java/reef-webserver/src/main/avro/EvaluatorInfo.avsc
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/avro/EvaluatorList.avsc
+++ b/lang/java/reef-webserver/src/main/avro/EvaluatorList.avsc
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/avro/webRequest.avsc
+++ b/lang/java/reef-webserver/src/main/avro/webRequest.avsc
@@ -1,4 +1,4 @@
-/**
+/*
 * Licensed to the Apache Software Foundation (ASF) under one
 * or more contributor license agreements.  See the NOTICE file
 * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/AvroDriverInfoSerializer.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/AvroDriverInfoSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/AvroEvaluatorInfoSerializer.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/AvroEvaluatorInfoSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/AvroEvaluatorListSerializer.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/AvroEvaluatorListSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/AvroHttpSerializer.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/AvroHttpSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/DriverInfoSerializer.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/DriverInfoSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/EvaluatorInfoSerializer.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/EvaluatorInfoSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/EvaluatorListSerializer.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/EvaluatorListSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpEventHandlers.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpEventHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpHandler.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpHandlerConfiguration.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpHandlerConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpRuntimeConfiguration.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpRuntimeConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpRuntimeStartHandler.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpRuntimeStartHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpRuntimeStopHandler.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpRuntimeStopHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpServer.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpServerImpl.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpServerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpServerReefEventHandler.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpServerReefEventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpTrackingURLProvider.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpTrackingURLProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/JettyHandler.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/JettyHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/MaxPortNumber.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/MaxPortNumber.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/MaxRetryAttempts.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/MaxRetryAttempts.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/MinPortNumber.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/MinPortNumber.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/ParsedHttpRequest.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/ParsedHttpRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/PortNumber.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/PortNumber.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/ReefEventStateManager.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/ReefEventStateManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestAvroHttpSerializer.java
+++ b/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestAvroHttpSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestAvroSerializerForHttp.java
+++ b/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestAvroSerializerForHttp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestHttpConfiguration.java
+++ b/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestHttpConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestHttpServer.java
+++ b/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestHttpServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestJettyHandler.java
+++ b/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestJettyHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestParsedHttpRequest.java
+++ b/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestParsedHttpRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestReefEventHandler.java
+++ b/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestReefEventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestReefEventStateManager.java
+++ b/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestReefEventStateManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestRuntimeStartHandler.java
+++ b/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestRuntimeStartHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestTrackingUri.java
+++ b/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestTrackingUri.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information


### PR DESCRIPTION
This addressed the issue by
  * Replacing /** beginnings of license comments at the beginning of the file with /*

JIRA: [REEF-315](https://issues.apache.org/jira/browse/REEF-315)