### PR TITLE
[REEF-307] Make CRLF line terminator consistent in .Net code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,25 @@
 # Commit text files using LF endings
 *.java text eol=lf whitespace=trailing-space,space-before-tab,tab-in-indent,blank-at-eof
+*.sh text eol=lf
+*.js text eol=lf
+site.xml text eol=lf
+*.apt text eol=lf
+DISCLAIMER text eol=lf
+HEADER text eol=lf
+LICENSE text eol=lf
+NOTICE text eol=lf
+*.md text eol=lf
+pom.xml text eol=lf
+*.h text eol=crlf
+*.cpp text eol=crlf
+*.rc text eol=crlf
+*.vcproj text eol=crlf
+*.csproj text eol=crlf
+*.bat text eol=crlf
+*.cs text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+*.psm1 eol=crlf
+*.png binary
+*.jpg binary
 * text=auto


### PR DESCRIPTION
In releasing 0.11.0 version, we noticed clrf line terminators in script files like DISCLAIMER, HEADER, LICENSE, NOTICE, .md file, and pom.xml file if they are check-out and then check-in through windows machine. This change is to enforce those files terminated with lf, and .Net files such as .cpp. .cs, .csproj, terminated with crlf. Default is still auto to avoid messing up.

To verify it, after checkout the code, you might need to
git rm --cached -r .
git reset --hard

JIRA: REEF-307(https://issues.apache.org/jira/browse/REEF-307)

This closes #

Author: Julia Wang  Email: jwang98052@yahoo.com