### PR TITLE
[REEF-343] Remove `More than 7 parameters` Checkstyle check for constructors

### DIFF
--- a/lang/java/reef-common/src/main/resources/checkstyle.xml
+++ b/lang/java/reef-common/src/main/resources/checkstyle.xml
@@ -121,8 +121,10 @@
             <property name="max" value="120"/>
         </module>
         <module name="MethodLength"/>
-        <module name="ParameterNumber"/>
-
+        <module name="ParameterNumber">
+            <property name="max" value="7"/>
+            <property name="tokens" value="METHOD_DEF"/>
+        </module>
 
         <!-- Checks for whitespace                               -->
         <!-- See http://checkstyle.sf.net/config_whitespace.html -->


### PR DESCRIPTION
This addressed the issue by
  * Configuring ParameterNumber module to check only methods

JIRA: [REEF-343](https://issues.apache.org/jira/browse/REEF-343)