### PR TITLE
[REEF-220] Refactor DriverBridgeConfiguration

### DIFF
--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverBridgeConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverBridgeConfiguration.cs
@@ -37,6 +37,7 @@ using Org.Apache.REEF.Wake.Time.Event;
 
 namespace Org.Apache.REEF.Driver.Bridge
 {
+    [Obsolete(message:"Obsolete since 0.12, will be removed in 0,.13. Use DriverConfiguration instead.", error:false)]
     public class DriverBridgeConfiguration : ConfigurationModuleBuilder
     {
         /// <summary>
@@ -45,12 +46,6 @@ namespace Org.Apache.REEF.Driver.Bridge
         [SuppressMessage("Microsoft.Security", "CA2104:Do not declare read only mutable reference types", Justification = "not applicable")]
         [Obsolete("Use OnDriverStart instead. Please see Jira REEF-336. Obsoleted v0.12 and will be removed v0.13", false)]
         public static readonly OptionalImpl<IStartHandler> OnDriverStarted = new OptionalImpl<IStartHandler>();
-
-        /// <summary>
-        /// The event handler called on driver start
-        /// </summary>
-        [SuppressMessage("Microsoft.Security", "CA2104:Do not declare read only mutable reference types", Justification = "not applicable")]
-        public static readonly OptionalImpl<IObserver<DateTime>> OnDriverStart = new OptionalImpl<IObserver<DateTime>>();
 
         /// <summary>
         ///  The event handler invoked when driver restarts
@@ -213,7 +208,6 @@ namespace Org.Apache.REEF.Driver.Bridge
                 .BindImplementation(GenericType<IStartHandler>.Class, OnDriverStarted)
                 .BindNamedParameter(GenericType<DriverBridgeConfigurationOptions.DriverRestartHandler>.Class, OnDriverRestarted)
                 .BindImplementation(GenericType<IDriverConnection>.Class, OnDriverReconnect)
-                .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.DriverStartHandlers>.Class, OnDriverStart)
                 .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.EvaluatorRequestHandlers>.Class, OnEvaluatorRequested)
                 .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.AllocatedEvaluatorHandlers>.Class, OnEvaluatorAllocated)
                 .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.ActiveContextHandlers>.Class, OnContextActive)

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverBridgeConfigurationOptions.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverBridgeConfigurationOptions.cs
@@ -36,19 +36,25 @@ namespace Org.Apache.REEF.Driver.Bridge
     /// <summary>
     /// Hosts all named parameters for Drivers, including bridge handlers.
     /// </summary>
-    public class DriverBridgeConfigurationOptions
+    public sealed class DriverBridgeConfigurationOptions
     {
         // Level.Verbose (since enum is not suppoted for TANG, we use a string here)
         private const string _verboseLevel = "Verbose";
 
-        // There is not supposed to be a default for Start handler but we need to provide one because all the existing apps would break;
-        [NamedParameter(documentation: "Called when driver is started, after CLR bridge is set up.", defaultClasses: new[] { typeof(DefaultDriverStartHandler) })]
-        public class DriverStartHandlers : Name<ISet<IObserver<DateTime>>>
+        // TODO: Remove the default value in 0.13 when the DriverStartedHandler becomes mandatory
+        [NamedParameter(documentation:"The start point for application logic. Event fired after the Driver is done initializing.", defaultClasses: new []{typeof(DefaultDriverStartedHandler)})]
+        public class DriverStartedHandlers : Name<ISet<IObserver<IDriverStarted>>>
         {
         }
 
+        [Obsolete(message:"Since 0.12, Removed in 0.13. Use DriverRestartedHandler instead.")]
         [NamedParameter(documentation: "Called when driver is restarted, after CLR bridge is set up.", defaultClasses: new[] { typeof(DefaultDriverRestartHandler) })]
         public class DriverRestartHandler : Name<IObserver<StartTime>>
+        {
+        }
+
+        [NamedParameter(documentation: "Called when driver is restarted, after CLR bridge is set up.", defaultClasses: new[] { typeof(DefaultDriverRestartedHandler) })]
+        public class DriverRestartedHandler : Name<IObserver<IDriverRestarted>>
         {
         }
 
@@ -146,15 +152,5 @@ namespace Org.Apache.REEF.Driver.Bridge
         public class TraceLevel : Name<string>
         {
         }
-
-        //[NamedParameter(documentation: "Job message handler.", defaultClasses: new[] { typeof(DefaultClientMessageHandler) })]
-        //public class ClientMessageHandlers : Name<ISet<IObserver<byte[]>>>
-        //{
-        //}
-
-        //[NamedParameter(documentation: "Client close handler.", defaultClasses: new[] { typeof(DefaultClientCloseHandler) })]
-        //public class ClientCloseHandlers : Name<ISet<IObserver<byte[]>>>
-        //{
-        //}
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverRestartHandlerWrapper.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverRestartHandlerWrapper.cs
@@ -1,0 +1,60 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System;
+using Org.Apache.REEF.Driver.Bridge.Events;
+using Org.Apache.REEF.Wake.Time.Event;
+
+namespace Org.Apache.REEF.Driver.Bridge
+{
+    /// <summary>
+    /// Wrapper of the new Observers of DriverRestarted with and into an Observer of StartTime.
+    /// </summary>
+    /// <remarks>
+    /// Rationale: This way, we don't have to change the C++ code in the same change as the API.
+    /// </remarks>
+    internal sealed class DriverRestartHandlerWrapper : IObserver<StartTime>
+    {
+        private readonly IObserver<IDriverRestarted> _driverRestartedObserver;
+        private readonly IObserver<StartTime> _startTimeObserver;
+
+        internal DriverRestartHandlerWrapper(IObserver<StartTime> startTimeObserver,
+            IObserver<IDriverRestarted> driverRestartedObserver)
+        {
+            _startTimeObserver = startTimeObserver;
+            _driverRestartedObserver = driverRestartedObserver;
+        }
+
+        public void OnNext(StartTime startTime)
+        {
+            _driverRestartedObserver.OnNext(new DriverRestarted(new DateTime(startTime.TimeStamp)));
+            _startTimeObserver.OnNext(startTime);
+        }
+
+        public void OnError(Exception error)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void OnCompleted()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/DriverRestarted.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/DriverRestarted.cs
@@ -1,0 +1,37 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+using System;
+
+namespace Org.Apache.REEF.Driver.Bridge.Events
+{
+    internal sealed class DriverRestarted : IDriverRestarted
+    {
+        private readonly DateTime _startTime;
+
+        internal DriverRestarted(DateTime startTime)
+        {
+            _startTime = startTime;
+        }
+
+        public DateTime StartTime
+        {
+            get { return _startTime; }
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/DriverStarted.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/DriverStarted.cs
@@ -1,0 +1,41 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System;
+
+namespace Org.Apache.REEF.Driver.Bridge.Events
+{
+    /// <summary>
+    /// Implementation of IDriverStarted.
+    /// </summary>
+    internal sealed class DriverStarted : IDriverStarted
+    {
+        private readonly DateTime _startTime;
+
+        internal DriverStarted(DateTime startTime)
+        {
+            _startTime = startTime;
+        }
+
+        public DateTime StartTime
+        {
+            get { return _startTime; }
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Driver/Defaults/DefaultDriverRestartedHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Defaults/DefaultDriverRestartedHandler.cs
@@ -1,0 +1,48 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System;
+using Org.Apache.REEF.Tang.Annotations;
+
+namespace Org.Apache.REEF.Driver.Defaults
+{
+    internal sealed class DefaultDriverRestartedHandler : IObserver<IDriverRestarted>
+    {
+        [Inject]
+        private DefaultDriverRestartedHandler()
+        {
+        }
+
+        public void OnNext(IDriverRestarted value)
+        {
+            // We throw immediately, as there is no sane default for Driver restart behavior.
+            throw new Exception("Driver restart handler was called, but not implemented.");
+        }
+
+        public void OnError(Exception error)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void OnCompleted()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Driver/Defaults/DefaultDriverStartedHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Defaults/DefaultDriverStartedHandler.cs
@@ -1,0 +1,52 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Utilities.Logging;
+
+namespace Org.Apache.REEF.Driver.Defaults
+{
+    // This class should be removed in 0.13, when the DriverStartedHandler becomes mandatory.
+    [Obsolete("This class will be removed in 0.13.", false)]
+    internal sealed class DefaultDriverStartedHandler : IObserver<IDriverStarted>
+    {
+        private static readonly Logger LOGGER = Logger.GetLogger(typeof(DefaultDriverStartedHandler));
+
+        [Inject]
+        private DefaultDriverStartedHandler()
+        {
+        }
+
+        public void OnNext(IDriverStarted value)
+        {
+            LOGGER.Log(Level.Info, "Driver started at {0}", value.StartTime);
+        }
+
+        public void OnError(Exception error)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void OnCompleted()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Driver/DriverConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/DriverConfiguration.cs
@@ -1,0 +1,210 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System;
+using System.Diagnostics;
+using Org.Apache.REEF.Common.Context;
+using Org.Apache.REEF.Common.Evaluator;
+using Org.Apache.REEF.Driver.Bridge;
+using Org.Apache.REEF.Driver.Context;
+using Org.Apache.REEF.Driver.Evaluator;
+using Org.Apache.REEF.Driver.Task;
+using Org.Apache.REEF.Tang.Formats;
+using Org.Apache.REEF.Tang.Util;
+using Org.Apache.REEF.Wake.Time.Event;
+
+namespace Org.Apache.REEF.Driver
+{
+    /// <summary>
+    /// Fill this out to configure a Driver.
+    /// </summary>
+    public sealed class DriverConfiguration : ConfigurationModuleBuilder
+    {
+        /// <summary>
+        /// The event handler called after the Driver started.
+        /// </summary>
+        public static readonly RequiredImpl<IObserver<IDriverStarted>> OnDriverStarted =
+            new RequiredImpl<IObserver<IDriverStarted>>();
+
+        /// <summary>
+        /// The event handler invoked when driver restarts
+        /// </summary>
+        public static readonly OptionalImpl<IObserver<StartTime>> OnDriverRestarted =
+            new OptionalImpl<IObserver<StartTime>>();
+
+        /// <summary>
+        /// Event handler for allocated evaluators. Defaults to returning the evaluator if not bound.
+        /// </summary>
+        public static readonly OptionalImpl<IObserver<IAllocatedEvaluator>> OnEvaluatorAllocated =
+            new OptionalImpl<IObserver<IAllocatedEvaluator>>();
+
+        /// <summary>
+        /// Event handler for completed evaluators. Defaults to logging if not bound.
+        /// </summary>
+        public static readonly OptionalImpl<IObserver<ICompletedEvaluator>> OnEvaluatorCompleted =
+            new OptionalImpl<IObserver<ICompletedEvaluator>>();
+
+        /// <summary>
+        /// Event handler for failed evaluators. Defaults to job failure if not bound.
+        /// </summary>
+        public static readonly OptionalImpl<IObserver<IFailedEvaluator>> OnEvaluatorFailed =
+            new OptionalImpl<IObserver<IFailedEvaluator>>();
+
+        /// <summary>
+        /// Event handler for for HTTP calls to the Driver's HTTP server.
+        /// </summary>
+        public static readonly OptionalImpl<IHttpHandler> OnHttpEvent = new OptionalImpl<IHttpHandler>();
+
+        /// <summary>
+        /// Event handler for task messages. Defaults to logging if not bound.
+        /// </summary>
+        public static readonly OptionalImpl<IObserver<ITaskMessage>> OnTaskMessage =
+            new OptionalImpl<IObserver<ITaskMessage>>();
+
+        /// <summary>
+        /// Event handler for completed tasks. Defaults to closing the context the task ran on if not bound.
+        /// </summary>
+        public static readonly OptionalImpl<IObserver<ICompletedTask>> OnTaskCompleted =
+            new OptionalImpl<IObserver<ICompletedTask>>();
+
+        /// <summary>
+        /// Event handler for failed tasks. Defaults to job failure if not bound.
+        /// </summary>
+        public static readonly OptionalImpl<IObserver<IFailedTask>> OnTaskFailed =
+            new OptionalImpl<IObserver<IFailedTask>>();
+
+        ///// <summary>
+        ///// Event handler for running tasks. Defaults to logging if not bound.
+        ///// </summary>
+        public static readonly OptionalImpl<IObserver<IRunningTask>> OnTaskRunning =
+            new OptionalImpl<IObserver<IRunningTask>>();
+
+        ///// <summary>
+        ///// Event handler for running task received during driver restart. Defaults to logging if not bound.
+        ///// </summary>
+        public static readonly OptionalImpl<IObserver<IRunningTask>> OnDriverRestartTaskRunning =
+            new OptionalImpl<IObserver<IRunningTask>>();
+
+        /// <summary>
+        /// Event handler for suspended tasks. Defaults to job failure if not bound.
+        /// </summary>
+        /// <remarks>
+        /// Rationale: many jobs don't support task suspension. Hence, this parameter should be optional. The only sane default is
+        /// to crash the job, then.
+        /// </remarks>
+        public static readonly OptionalImpl<IObserver<ISuspendedTask>> OnTaskSuspended =
+            new OptionalImpl<IObserver<ISuspendedTask>>();
+
+        /// <summary>
+        /// Event handler for active context. Defaults to closing the context if not bound.
+        /// </summary>
+        public static readonly OptionalImpl<IObserver<IActiveContext>> OnContextActive =
+            new OptionalImpl<IObserver<IActiveContext>>();
+
+        /// <summary>
+        /// Event handler for active context received during driver restart. Defaults to closing the context if not bound.
+        /// </summary>
+        public static readonly OptionalImpl<IObserver<IActiveContext>> OnDirverRestartContextActive =
+            new OptionalImpl<IObserver<IActiveContext>>();
+
+        /// <summary>
+        /// Event handler for closed context. Defaults to logging if not bound.
+        /// </summary>
+        public static readonly OptionalImpl<IObserver<IClosedContext>> OnContextClosed =
+            new OptionalImpl<IObserver<IClosedContext>>();
+
+        /// <summary>
+        /// Event handler for closed context. Defaults to job failure if not bound.
+        /// </summary>
+        public static readonly OptionalImpl<IObserver<IFailedContext>> OnContextFailed =
+            new OptionalImpl<IObserver<IFailedContext>>();
+
+        /// <summary>
+        /// Event handler for context messages. Defaults to logging if not bound.
+        /// </summary>
+        public static readonly OptionalImpl<IObserver<IContextMessage>> OnContextMessage =
+            new OptionalImpl<IObserver<IContextMessage>>();
+
+        /// <summary>
+        /// Additional set of string arguments that can be pssed to handlers through client
+        /// </summary>
+        public static readonly OptionalParameter<string> CommandLineArguments = new OptionalParameter<string>();
+
+        /// <summary>
+        /// The trace level of the TraceListner
+        /// </summary>
+        public static readonly OptionalParameter<string> CustomTraceLevel = new OptionalParameter<string>();
+
+        /// <summary>
+        /// Additional set of trace listners provided by client
+        /// </summary>
+        public static readonly OptionalParameter<TraceListener> CustomTraceListeners =
+            new OptionalParameter<TraceListener>();
+
+        /// <summary>
+        /// The implemenation for (attempting to) re-establish connection to driver
+        /// </summary>
+        public static readonly OptionalImpl<IDriverConnection> OnDriverReconnect = new OptionalImpl<IDriverConnection>();
+
+        public static ConfigurationModule ConfigurationModule
+        {
+            get
+            {
+                return new DriverConfiguration()
+                    .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.DriverStartedHandlers>.Class,
+                        OnDriverStarted)
+                    .BindNamedParameter(GenericType<DriverBridgeConfigurationOptions.DriverRestartHandler>.Class,
+                        OnDriverRestarted)
+                    .BindImplementation(GenericType<IDriverConnection>.Class, OnDriverReconnect)
+                    .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.AllocatedEvaluatorHandlers>.Class,
+                        OnEvaluatorAllocated)
+                    .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.ActiveContextHandlers>.Class,
+                        OnContextActive)
+                    .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.TaskMessageHandlers>.Class, OnTaskMessage)
+                    .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.FailedTaskHandlers>.Class, OnTaskFailed)
+                    .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.RunningTaskHandlers>.Class, OnTaskRunning)
+                    .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.SuspendedTaskHandlers>.Class,
+                        OnTaskSuspended)
+                    .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.FailedEvaluatorHandlers>.Class,
+                        OnEvaluatorFailed)
+                    .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.CompletedEvaluatorHandlers>.Class,
+                        OnEvaluatorCompleted)
+                    .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.CompletedTaskHandlers>.Class,
+                        OnTaskCompleted)
+                    .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.ClosedContextHandlers>.Class,
+                        OnContextClosed)
+                    .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.FailedContextHandlers>.Class,
+                        OnContextFailed)
+                    .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.ContextMessageHandlers>.Class,
+                        OnContextMessage)
+                    .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.ArgumentSets>.Class, CommandLineArguments)
+                    .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.HttpEventHandlers>.Class, OnHttpEvent)
+                    .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.TraceListenersSet>.Class,
+                        CustomTraceListeners)
+                    .BindSetEntry(
+                        GenericType<DriverBridgeConfigurationOptions.DriverRestartActiveContextHandlers>.Class,
+                        OnDirverRestartContextActive)
+                    .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.DriverRestartRunningTaskHandlers>.Class,
+                        OnDriverRestartTaskRunning)
+                    .BindNamedParameter(GenericType<DriverBridgeConfigurationOptions.TraceLevel>.Class, CustomTraceLevel)
+                    .Build();
+            }
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Driver/IDriverRestarted.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/IDriverRestarted.cs
@@ -1,0 +1,28 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Org.Apache.REEF.Driver
+{
+    /// <summary>
+    /// Event fired on Driver restarts instead of IDriverStarted.
+    /// </summary>
+    public interface IDriverRestarted : IDriverStarted
+    {
+         
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Driver/IDriverStarted.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/IDriverStarted.cs
@@ -18,37 +18,14 @@
  */
 
 using System;
-using Org.Apache.REEF.Tang.Annotations;
-using Org.Apache.REEF.Utilities.Logging;
-using Org.Apache.REEF.Wake.Time.Event;
 
-namespace Org.Apache.REEF.Driver.Defaults
+namespace Org.Apache.REEF.Driver
 {
     /// <summary>
-    ///  Default event handler for driver start: Logging it.
+    /// Event fired when the Driver started.
     /// </summary>
-    public class DefaultDriverStartHandler : IObserver<DateTime>
+    public interface IDriverStarted
     {
-        private static readonly Logger LOGGER = Logger.GetLogger(typeof(DefaultDriverStartHandler));
-
-        [Inject]
-        public DefaultDriverStartHandler()
-        {
-        }
-
-        public void OnNext(DateTime startTime)
-        {
-            LOGGER.Log(Level.Info, "Driver started at" + startTime);
-        }
-
-        public void OnError(Exception error)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void OnCompleted()
-        {
-            throw new NotImplementedException();
-        }
+        DateTime StartTime { get; }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/Org.Apache.REEF.Driver.csproj
+++ b/lang/cs/Org.Apache.REEF.Driver/Org.Apache.REEF.Driver.csproj
@@ -62,12 +62,15 @@ under the License.
     <Compile Include="Bridge\DriverBridge.cs" />
     <Compile Include="Bridge\DriverBridgeConfiguration.cs" />
     <Compile Include="Bridge\DriverBridgeConfigurationOptions.cs" />
+    <Compile Include="Bridge\DriverRestartHandlerWrapper.cs" />
     <Compile Include="Bridge\Events\ActiveContext.cs" />
     <Compile Include="Bridge\Events\AllocatedEvaluator.cs" />
     <Compile Include="Bridge\Events\ClosedContext.cs" />
     <Compile Include="Bridge\Events\CompletedEvaluator.cs" />
     <Compile Include="Bridge\Events\CompletedTask.cs" />
     <Compile Include="Bridge\Events\ContextMessage.cs" />
+    <Compile Include="Bridge\Events\DriverRestarted.cs" />
+    <Compile Include="Bridge\Events\DriverStarted.cs" />
     <Compile Include="Bridge\Events\EvaluatorRequstor.cs" />
     <Compile Include="Bridge\Events\FailedContext.cs" />
     <Compile Include="Bridge\Events\FailedEvaluator.cs" />
@@ -104,9 +107,10 @@ under the License.
     <Compile Include="Defaults\DefaultContextMessageHandler.cs" />
     <Compile Include="Defaults\DefaultCustomTraceListener.cs" />
     <Compile Include="Defaults\DefaultDriverRestartContextActiveHandler.cs" />
+    <Compile Include="Defaults\DefaultDriverRestartedHandler.cs" />
     <Compile Include="Defaults\DefaultDriverRestartHandler.cs" />
     <Compile Include="Defaults\DefaultDriverRestartTaskRunningHandler.cs" />
-    <Compile Include="Defaults\DefaultDriverStartHandler.cs" />
+    <Compile Include="Defaults\DefaultDriverStartedHandler.cs" />
     <Compile Include="Defaults\DefaultEvaluatorAllocationHandler.cs" />
     <Compile Include="Defaults\DefaultEvaluatorCompletionHandler.cs" />
     <Compile Include="Defaults\DefaultEvaluatorFailureHandler.cs" />
@@ -119,6 +123,7 @@ under the License.
     <Compile Include="Defaults\DefaultTaskRunningHandler.cs" />
     <Compile Include="Defaults\DefaultTaskSuspensionHandler.cs" />
     <Compile Include="DriverConfigGenerator.cs" />
+    <Compile Include="DriverConfiguration.cs" />
     <Compile Include="DriverConfigurationSettings.cs" />
     <Compile Include="DriverSubmissionSettings.cs" />
     <Compile Include="Evaluator\EvaluatorDescriptorImpl.cs" />
@@ -132,6 +137,8 @@ under the License.
     <Compile Include="Evaluator\IFailedEvaluator.cs" />
     <Compile Include="FailedJob.cs" />
     <Compile Include="IDriver.cs" />
+    <Compile Include="IDriverRestarted.cs" />
+    <Compile Include="IDriverStarted.cs" />
     <Compile Include="IStartHandler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Task\ICompletedTask.cs" />

--- a/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloDriver.cs
@@ -36,7 +36,7 @@ namespace Org.Apache.REEF.Examples.HelloREEF
     /// <summary>
     /// The Driver for HelloREEF: It requests a single Evaluator and then submits the HelloTask to it.
     /// </summary>
-    public sealed class HelloDriver : IObserver<IAllocatedEvaluator>, IObserver<DateTime>
+    public sealed class HelloDriver : IObserver<IAllocatedEvaluator>, IObserver<IDriverStarted>
     {
         private static readonly Logger _Logger = Logger.GetLogger(typeof(HelloDriver));
 
@@ -70,10 +70,10 @@ namespace Org.Apache.REEF.Examples.HelloREEF
         /// <summary>
         /// Called to start the user mode driver
         /// </summary>
-        /// <param name="startTime"></param>
-        public void OnNext(DateTime startTime)
+        /// <param name="driverStarted"></param>
+        public void OnNext(IDriverStarted driverStarted)
         {
-            _Logger.Log(Level.Info, string.Format("HelloDriver started at {0}", startTime));
+            _Logger.Log(Level.Info, string.Format("HelloDriver started at {0}", driverStarted.StartTime));
             _evaluatorRequestor.Submit(new EvaluatorRequest(number: 1, megaBytes: 64));
         }
 

--- a/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEF.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEF.cs
@@ -21,8 +21,7 @@ using System;
 using Org.Apache.REEF.Client.API;
 using Org.Apache.REEF.Client.Local;
 using Org.Apache.REEF.Client.YARN;
-using Org.Apache.REEF.Common.Io;
-using Org.Apache.REEF.Driver.Bridge;
+using Org.Apache.REEF.Driver;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
@@ -53,14 +52,14 @@ namespace Org.Apache.REEF.Examples.HelloREEF
         private void Run()
         {
             // The driver configuration contains all the needed bindings.
-            var helloDriverConfiguration = DriverBridgeConfiguration.ConfigurationModule
-                .Set(DriverBridgeConfiguration.OnEvaluatorAllocated, GenericType<HelloDriver>.Class)
-                .Set(DriverBridgeConfiguration.OnDriverStart, GenericType<HelloDriver>.Class)
+            var helloDriverConfiguration = DriverConfiguration.ConfigurationModule
+                .Set(DriverConfiguration.OnEvaluatorAllocated, GenericType<HelloDriver>.Class)
+                .Set(DriverConfiguration.OnDriverStarted, GenericType<HelloDriver>.Class)
                 .Build();
             // The JobSubmission contains the Driver configuration as well as the files needed on the Driver.
             var helloJobSubmission = _jobSubmissionBuilderFactory.GetJobSubmissionBuilder()
                 .AddDriverConfiguration(helloDriverConfiguration)
-                .AddGlobalAssemblyForType(typeof (HelloDriver))
+                .AddGlobalAssemblyForType(typeof(HelloDriver))
                 .SetJobIdentifier("HelloREEF")
                 .Build();
 


### PR DESCRIPTION
This change addresses several items listed on [REEF-220]:

[REEF-356]:
  * Added `DriverConfiguration`
  * Removed deprecated event hanlders from that
  * Fixed the docs on HttpHandler [REEF-355]
  * Deprecated `DriverBridgeConfiguration`
  * Used `DriverConfiguration` in `HelloREEF`

[REEF-354]:
  * Introduced `IDriverStarted` and `IDriverRestarted`events to replace `DateTime` and `StartTime`

JIRAs:
  * [REEF-220](https://issues.apache.org/jira/browse/REEF-220)
  * [REEF-354](https://issues.apache.org/jira/browse/REEF-354)
  * [REEF-355](https://issues.apache.org/jira/browse/REEF-355)
  * [REEF-356](https://issues.apache.org/jira/browse/REEF-356)
