### PR TITLE
[REEF-363] Add a `talks` section to our website.

### DIFF
--- a/website/src/site/markdown/talks.md
+++ b/website/src/site/markdown/talks.md
@@ -1,0 +1,42 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Talks
+On this page, we collect slides and videos of talks given by members of the REEF community.
+
+**REEF.NET for Java developers** ([Slides](http://1drv.ms/1QQy3lN))
+
+This deck was used as part of a discussion during the 2015 Seoul REEF hackathon.
+  
+**SIGMOD 2015** ([Slides](http://1drv.ms/1Gxpf30))
+
+REEF was presented in the industrial track of SIGMOD 2015. 
+
+**Workshop on Software Engineering for Machine Learning** ([Slides](http://1drv.ms/1GxpaMJ))
+  
+Markus gave a talk at the 2014 Workshop on Software Engineering for Machine Learning at NIPS held in Montreal,
+Canada. It uses REEF as an example for potential pitfalls and learnings when making machine learning software.
+
+**GraphLab conference 2014** ([Slides](http://1drv.ms/1e7pIOX), [Video](http://www.youtube.com/watch?v=xPhsYioU80I))
+
+This was presented to the GraphLab conference. Some special focus is given to Machine Learning tasks.
+
+**Hadoop Summit 2014** ([Slides](http://1drv.ms/1e7pIOX), [Video](http://www.youtube.com/watch?v=5dWgF_9dnRE))
+
+This is the first talk introducing Apache REEF, as opposed to Microsoft REEF.

--- a/website/src/site/site.xml
+++ b/website/src/site/site.xml
@@ -23,7 +23,7 @@ under the License.
     <skin>
         <groupId>org.apache.maven.skins</groupId>
         <artifactId>maven-fluido-skin</artifactId>
-        <version>1.3.1</version>
+        <version>1.4</version>
 
     </skin>
     <custom>
@@ -74,17 +74,17 @@ under the License.
             <item name="FAQ" href="faq.html"/>
             <item name="License" href="license.html"/>
             <item name="Downloads" href="downloads.html"/>
-            <item name="0.10.0-incubating API" href="apidocs/0.10.0-incubating/index.html"/>
-            <item name="0.11.0-incubating API" href="apidocs/0.11.0-incubating/index.html"/>
-
         </menu>
 
         <menu name="Documentation">
             <item name="Introduction to REEF" href="introduction.html"/>
             <item name="REEF Tutorial" href="https://cwiki.apache.org/confluence/display/REEF/Tutorials"/>
+            <item name="Talks" href="talks.html"/>
             <item name="Glossary" href="glossary.html"/>
             <item name="Tang" href="tang.html"/>
             <item name="Wake" href="wake.html"/>
+            <item name="0.10.0-incubating API" href="apidocs/0.10.0-incubating/index.html"/>
+            <item name="0.11.0-incubating API" href="apidocs/0.11.0-incubating/index.html"/>
         </menu>
         <menu name="Contribution">
             <item name="Contributing" href="https://cwiki.apache.org/confluence/display/REEF/Contributing"/>


### PR DESCRIPTION
This change adds a `talks` section to our website. It contains links to slides and videos of talks given on Apache REEF.

This change also moves the API docs into the `Documentation` menu and updates the underlying skin to its current version (1.4).

JIRA:
  [REEF-363](https://issues.apache.org/jira/browse/REEF-363)