### PR TITLE
[REEF-367]: Allow clean multiple calls to Wake Clock close

### DIFF
--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RuntimeClock.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RuntimeClock.java
@@ -112,6 +112,10 @@ public final class RuntimeClock implements Clock {
   public final void close() {
     LOG.entering(RuntimeClock.class.getCanonicalName(), "close");
     synchronized (this.schedule) {
+      if (this.closed) {
+        LOG.log(Level.INFO, "Clock is already closed");
+        return;
+      }
       this.schedule.clear();
       this.schedule.add(new StopTime(findAcceptableStopTime()));
       this.schedule.notifyAll();

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/ClockTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/ClockTest.java
@@ -114,6 +114,30 @@ public class ClockTest {
   }
 
   @Test
+  public void testMultipleCloseCalls() throws Exception {
+    LoggingUtils.setLoggingLevel(Level.FINE);
+
+    final int numThreads = 3;
+    final RuntimeClock clock = buildClock();
+    new Thread(clock).start();
+    ThreadPoolStage<Alarm> stage = new ThreadPoolStage<>(new EventHandler<Alarm>() {
+      @Override
+      public void onNext(Alarm value) {
+        clock.close();
+      }
+    }, numThreads);
+
+    try {
+      for (int i = 0; i < numThreads; ++i)
+        stage.onNext(null);
+      Thread.sleep(1000);
+    } finally {
+      stage.close();
+      clock.close();
+    }
+  }
+
+  @Test
   public void testSimultaneousAlarms() throws Exception {
     LoggingUtils.setLoggingLevel(Level.FINE);
 

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/ClockTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/ClockTest.java
@@ -120,9 +120,9 @@ public class ClockTest {
     final int numThreads = 3;
     final RuntimeClock clock = buildClock();
     new Thread(clock).start();
-    ThreadPoolStage<Alarm> stage = new ThreadPoolStage<>(new EventHandler<Alarm>() {
+    final ThreadPoolStage<Alarm> stage = new ThreadPoolStage<>(new EventHandler<Alarm>() {
       @Override
-      public void onNext(Alarm value) {
+      public void onNext(final Alarm value) {
         clock.close();
       }
     }, numThreads);


### PR DESCRIPTION
  This adds a condition to check if the clock is already closed
  and a test that invokes close calls from multiple threads.

JIRA:
  [REEF-367] https://issues.apache.org/jira/browse/REEF-367