### PR TITLE
[REEF-62]: Tighten state transition checks in EvaluatorStatusManager

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorStatusManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorStatusManager.java
@@ -43,8 +43,30 @@ final class EvaluatorStatusManager {
   }
 
   private static boolean isLegal(final EvaluatorState from, final EvaluatorState to) {
-    // TODO
-    return true;
+    switch(from) {
+      case ALLOCATED: {
+        if (to == EvaluatorState.SUBMITTED || to == EvaluatorState.FAILED || to == EvaluatorState.KILLED) {
+          return true;
+        }
+        break;
+      }
+      case SUBMITTED: {
+        if (to == EvaluatorState.RUNNING || to == EvaluatorState.FAILED ||
+            to == EvaluatorState.DONE || to == EvaluatorState.KILLED) {
+          return true;
+        }
+        break;
+      }
+      case RUNNING: {
+        if (to == EvaluatorState.DONE || to == EvaluatorState.FAILED || to == EvaluatorState.KILLED) {
+          return true;
+        }
+        break;
+      }
+    }
+
+    LOG.warning("Illegal evaluator state transition from " + from + " to " + to + ".");
+    return false;
   }
 
   synchronized void setRunning() {
@@ -101,6 +123,5 @@ final class EvaluatorStatusManager {
       throw new IllegalStateException("Illegal state transition from '" + this.state + "' to '" + state + "'");
     }
     this.state = state;
-
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorStatusManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorStatusManager.java
@@ -43,30 +43,34 @@ final class EvaluatorStatusManager {
   }
 
   private static boolean isLegal(final EvaluatorState from, final EvaluatorState to) {
+    if (from == to) {
+      return true;
+    }
+
+    if (!isDoneOrFailedOrKilled(from) && isDoneOrFailedOrKilled(to)) {
+      return true;
+    }
+
     switch(from) {
       case ALLOCATED: {
-        if (to == EvaluatorState.SUBMITTED || to == EvaluatorState.FAILED || to == EvaluatorState.KILLED) {
-          return true;
-        }
-        break;
+        return to == EvaluatorState.SUBMITTED;
       }
       case SUBMITTED: {
-        if (to == EvaluatorState.RUNNING || to == EvaluatorState.FAILED ||
-            to == EvaluatorState.DONE || to == EvaluatorState.KILLED) {
-          return true;
-        }
-        break;
+        return to == EvaluatorState.RUNNING;
       }
       case RUNNING: {
-        if (to == EvaluatorState.DONE || to == EvaluatorState.FAILED || to == EvaluatorState.KILLED) {
-          return true;
-        }
-        break;
+        return isDoneOrFailedOrKilled(to);
       }
     }
 
     LOG.warning("Illegal evaluator state transition from " + from + " to " + to + ".");
     return false;
+  }
+
+  private static boolean isDoneOrFailedOrKilled(final EvaluatorState state) {
+    return (state == EvaluatorState.DONE ||
+            state == EvaluatorState.FAILED ||
+            state == EvaluatorState.KILLED);
   }
 
   synchronized void setRunning() {
@@ -94,9 +98,7 @@ final class EvaluatorStatusManager {
   }
 
   synchronized boolean isDoneOrFailedOrKilled() {
-    return (this.state == EvaluatorState.DONE ||
-        this.state == EvaluatorState.FAILED ||
-        this.state == EvaluatorState.KILLED);
+    return isDoneOrFailedOrKilled(this.state);
   }
 
   synchronized boolean isAllocatedOrSubmittedOrRunning() {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorStatusManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorStatusManager.java
@@ -47,19 +47,32 @@ final class EvaluatorStatusManager {
       return true;
     }
 
-    if (!isDoneOrFailedOrKilled(from) && isDoneOrFailedOrKilled(to)) {
-      return true;
-    }
-
     switch(from) {
       case ALLOCATED: {
-        return to == EvaluatorState.SUBMITTED;
+        switch(to) {
+          case SUBMITTED:
+          case DONE:
+          case FAILED:
+          case KILLED:
+            return true;
+        }
       }
       case SUBMITTED: {
-        return to == EvaluatorState.RUNNING;
+        switch(to) {
+          case RUNNING:
+          case DONE:
+          case FAILED:
+          case KILLED:
+            return true;
+        }
       }
       case RUNNING: {
-        return isDoneOrFailedOrKilled(to);
+        switch(to) {
+          case DONE:
+          case FAILED:
+          case KILLED:
+            return true;
+        }
       }
     }
 


### PR DESCRIPTION
This addressed the issue by
  * Checking that the transition of evaluator status is legal.
  * Logging a warning when the transition is illegal.

JIRA: [REEF-62](https://issues.apache.org/jira/browse/REEF-62)