### PR TITLE
[REEF-368]: Avoid holding Wake schedule lock while calling event hand…

### DIFF
--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RuntimeClock.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RuntimeClock.java
@@ -197,12 +197,13 @@ public final class RuntimeClock implements Clock {
       while (true) {
         LOG.log(Level.FINEST, "Entering clock main loop iteration.");
         try {
+          if (this.isIdle()) {
+            // Handle an idle clock event, without locking this.schedule
+            this.handlers.onNext(new IdleClock(timer.getCurrent()));
+          }
+
           Time time = null;
           synchronized (this.schedule) {
-            if (this.isIdle()) {
-              this.handlers.onNext(new IdleClock(timer.getCurrent()));
-            }
-
             while (this.schedule.isEmpty()) {
               this.schedule.wait();
             }


### PR DESCRIPTION
…lers

  This removes the call to handle an idle event to before the schedule lock
  is taken.

  This should avoid the deadlock situation seen in REEF-294, where a separate
  thread holds a lock needed by the idle event handler, and then waits for
  the schedule lock. Now the idle event handler call will not be holding the
  schedule lock.

JIRA:
  [REEF-368] https://issues.apache.org/jira/browse/REEF-368