### PR TITLE
[REEF-380] Move named parameters out of `AbstractDriverRuntimeConfiguration`

### DIFF
--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/LocalClient.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/LocalClient.java
@@ -20,7 +20,7 @@ package org.apache.reef.bridge.client;
 
 import org.apache.reef.client.parameters.DriverConfigurationProviders;
 import org.apache.reef.io.TcpPortConfigurationProvider;
-import org.apache.reef.runtime.common.driver.api.AbstractDriverRuntimeConfiguration;
+import org.apache.reef.runtime.common.driver.parameters.ClientRemoteIdentifier;
 import org.apache.reef.runtime.common.files.REEFFileNames;
 import org.apache.reef.runtime.local.client.DriverConfigurationProvider;
 import org.apache.reef.runtime.local.client.LocalRuntimeConfiguration;
@@ -43,7 +43,7 @@ import java.util.Set;
  */
 public class LocalClient {
 
-  private static final String CLIENT_REMOTE_ID = AbstractDriverRuntimeConfiguration.ClientRemoteIdentifier.NONE;
+  private static final String CLIENT_REMOTE_ID = ClientRemoteIdentifier.NONE;
   private final AvroConfigurationSerializer configurationSerializer;
   private final PreparedDriverFolderLauncher launcher;
   private final REEFFileNames fileNames;

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/YarnJobSubmissionClient.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/YarnJobSubmissionClient.java
@@ -23,7 +23,7 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.reef.client.parameters.DriverConfigurationProviders;
 import org.apache.reef.io.TcpPortConfigurationProvider;
-import org.apache.reef.runtime.common.driver.api.AbstractDriverRuntimeConfiguration;
+import org.apache.reef.runtime.common.driver.parameters.ClientRemoteIdentifier;
 import org.apache.reef.runtime.common.files.ClasspathProvider;
 import org.apache.reef.runtime.common.files.REEFFileNames;
 import org.apache.reef.runtime.yarn.client.YarnClientConfiguration;
@@ -78,7 +78,7 @@ public final class YarnJobSubmissionClient {
         YarnDriverConfiguration.CONF
             .set(YarnDriverConfiguration.JOB_SUBMISSION_DIRECTORY, jobSubmissionFolder)
             .set(YarnDriverConfiguration.JOB_IDENTIFIER, jobId)
-            .set(YarnDriverConfiguration.CLIENT_REMOTE_IDENTIFIER, AbstractDriverRuntimeConfiguration.ClientRemoteIdentifier.NONE)
+            .set(YarnDriverConfiguration.CLIENT_REMOTE_IDENTIFIER, ClientRemoteIdentifier.NONE)
             .set(YarnDriverConfiguration.JVM_HEAP_SLACK, 0.0)
             .build());
 
@@ -150,7 +150,7 @@ public final class YarnJobSubmissionClient {
           .setDriverMemory(driverMemory)
           .setPriority(priority)
           .setQueue(queue)
-          .submit(AbstractDriverRuntimeConfiguration.ClientRemoteIdentifier.NONE);
+          .submit(ClientRemoteIdentifier.NONE);
     }
   }
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverStatusManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverStatusManager.java
@@ -20,8 +20,8 @@ package org.apache.reef.runtime.common.driver;
 
 import com.google.protobuf.ByteString;
 import org.apache.reef.proto.ReefServiceProtos;
-import org.apache.reef.runtime.common.driver.api.AbstractDriverRuntimeConfiguration;
 import org.apache.reef.runtime.common.driver.client.ClientConnection;
+import org.apache.reef.runtime.common.driver.parameters.JobIdentifier;
 import org.apache.reef.runtime.common.utils.ExceptionCodec;
 import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.util.Optional;
@@ -57,7 +57,7 @@ public final class DriverStatusManager {
   @Inject
   DriverStatusManager(final Clock clock,
                       final ClientConnection clientConnection,
-                      final @Parameter(AbstractDriverRuntimeConfiguration.JobIdentifier.class) String jobIdentifier,
+                      final @Parameter(JobIdentifier.class) String jobIdentifier,
                       final ExceptionCodec exceptionCodec) {
     LOG.entering(DriverStatusManager.class.getCanonicalName(), "<init>");
     this.clock = clock;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/AbstractDriverRuntimeConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/AbstractDriverRuntimeConfiguration.java
@@ -18,12 +18,13 @@
  */
 package org.apache.reef.runtime.common.driver.api;
 
-import org.apache.reef.runtime.common.launch.parameters.ErrorHandlerRID;
+import org.apache.reef.runtime.common.driver.parameters.ClientRemoteIdentifier;
+import org.apache.reef.runtime.common.driver.parameters.DriverProcessMemory;
+import org.apache.reef.runtime.common.driver.parameters.EvaluatorTimeout;
+import org.apache.reef.runtime.common.driver.parameters.JobIdentifier;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.JavaConfigurationBuilder;
 import org.apache.reef.tang.Tang;
-import org.apache.reef.tang.annotations.Name;
-import org.apache.reef.tang.annotations.NamedParameter;
 import org.apache.reef.tang.exceptions.BindException;
 import org.apache.reef.util.Builder;
 
@@ -98,27 +99,4 @@ public abstract class AbstractDriverRuntimeConfiguration implements Builder<Conf
     }
   }
 
-  @NamedParameter(doc = "The job identifier.")
-  public final static class JobIdentifier implements Name<String> {
-  }
-
-  @NamedParameter(doc = "The client remote identifier.", default_value = ClientRemoteIdentifier.NONE)
-  public final static class ClientRemoteIdentifier implements Name<String> {
-    /**
-     * Indicates that there is no Client.
-     */
-    public static final String NONE = ErrorHandlerRID.NONE;
-  }
-
-  @NamedParameter(doc = "The evaluator timeout (how long to wait before deciding an evaluator is dead.", default_value = "60000")
-  public final static class EvaluatorTimeout implements Name<Long> {
-  }
-
-  /**
-   * This parameter denotes that the driver process should actually be
-   * started in a separate process with the given amount of JVM memory.
-   */
-  @NamedParameter(doc = "The driver process memory.", default_value = "512")
-  public final static class DriverProcessMemory implements Name<Integer> {
-  }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/client/ClientConnection.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/client/ClientConnection.java
@@ -21,7 +21,8 @@ package org.apache.reef.runtime.common.driver.client;
 import com.google.protobuf.ByteString;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.proto.ReefServiceProtos;
-import org.apache.reef.runtime.common.driver.api.AbstractDriverRuntimeConfiguration;
+import org.apache.reef.runtime.common.driver.parameters.ClientRemoteIdentifier;
+import org.apache.reef.runtime.common.driver.parameters.JobIdentifier;
 import org.apache.reef.runtime.common.utils.RemoteManager;
 import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.wake.EventHandler;
@@ -44,10 +45,10 @@ public final class ClientConnection {
   @Inject
   public ClientConnection(
       final RemoteManager remoteManager,
-      final @Parameter(AbstractDriverRuntimeConfiguration.ClientRemoteIdentifier.class) String clientRID,
-      final @Parameter(AbstractDriverRuntimeConfiguration.JobIdentifier.class) String jobIdentifier) {
+      final @Parameter(ClientRemoteIdentifier.class) String clientRID,
+      final @Parameter(JobIdentifier.class) String jobIdentifier) {
     this.jobIdentifier = jobIdentifier;
-    if (clientRID.equals(AbstractDriverRuntimeConfiguration.ClientRemoteIdentifier.NONE)) {
+    if (clientRID.equals(ClientRemoteIdentifier.NONE)) {
       LOG.log(Level.FINE, "Instantiated 'ClientConnection' without an actual connection to the client.");
       this.jobStatusHandler = new LoggingJobStatusHandler();
     } else {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/client/ClientManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/client/ClientManager.java
@@ -25,7 +25,7 @@ import org.apache.reef.driver.parameters.ClientCloseWithMessageHandlers;
 import org.apache.reef.driver.parameters.ClientMessageHandlers;
 import org.apache.reef.proto.ClientRuntimeProtocol;
 import org.apache.reef.runtime.common.driver.DriverStatusManager;
-import org.apache.reef.runtime.common.driver.api.AbstractDriverRuntimeConfiguration;
+import org.apache.reef.runtime.common.driver.parameters.ClientRemoteIdentifier;
 import org.apache.reef.runtime.common.utils.BroadCastEventHandler;
 import org.apache.reef.runtime.common.utils.RemoteManager;
 import org.apache.reef.tang.InjectionFuture;
@@ -66,7 +66,7 @@ public final class ClientManager implements EventHandler<ClientRuntimeProtocol.J
   ClientManager(final @Parameter(ClientCloseHandlers.class) InjectionFuture<Set<EventHandler<Void>>> clientCloseHandlers,
                 final @Parameter(ClientCloseWithMessageHandlers.class) InjectionFuture<Set<EventHandler<byte[]>>> clientCloseWithMessageHandlers,
                 final @Parameter(ClientMessageHandlers.class) InjectionFuture<Set<EventHandler<byte[]>>> clientMessageHandlers,
-                final @Parameter(AbstractDriverRuntimeConfiguration.ClientRemoteIdentifier.class) String clientRID,
+                final @Parameter(ClientRemoteIdentifier.class) String clientRID,
                 final RemoteManager remoteManager,
                 final DriverStatusManager driverStatusManager) {
     this.driverStatusManager = driverStatusManager;
@@ -74,7 +74,7 @@ public final class ClientManager implements EventHandler<ClientRuntimeProtocol.J
     this.clientCloseWithMessageHandlers = clientCloseWithMessageHandlers;
     this.clientMessageHandlers = clientMessageHandlers;
 
-    if (!clientRID.equals(AbstractDriverRuntimeConfiguration.ClientRemoteIdentifier.NONE)) {
+    if (!clientRID.equals(ClientRemoteIdentifier.NONE)) {
       remoteManager.registerHandler(clientRID, ClientRuntimeProtocol.JobControlProto.class, this);
     } else {
       LOG.log(Level.FINE, "Not registering a handler for JobControlProto, as there is no client.");

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/parameters/ClientRemoteIdentifier.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/parameters/ClientRemoteIdentifier.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runtime.common.driver.parameters;
+
+import org.apache.reef.runtime.common.launch.parameters.ErrorHandlerRID;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+/**
+ * The client remote identifier.
+ */
+@NamedParameter(doc = "The client remote identifier.", default_value = ClientRemoteIdentifier.NONE)
+public final class ClientRemoteIdentifier implements Name<String> {
+  /**
+   * Indicates that there is no Client.
+   */
+  public static final String NONE = ErrorHandlerRID.NONE;
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/parameters/DriverProcessMemory.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/parameters/DriverProcessMemory.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runtime.common.driver.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+/**
+ * The driver process memory.
+ */
+@NamedParameter(doc = "The driver process memory.", default_value = "512")
+public final class DriverProcessMemory implements Name<Integer> {
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/parameters/EvaluatorTimeout.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/parameters/EvaluatorTimeout.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runtime.common.driver.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+/**
+ * The evaluator timeout (how long to wait before deciding an evaluator is dead.
+ */
+@NamedParameter(doc = "The evaluator timeout (how long to wait before deciding an evaluator is dead.", default_value = "60000")
+public final class EvaluatorTimeout implements Name<Long> {
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/parameters/JobIdentifier.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/parameters/JobIdentifier.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runtime.common.driver.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+/**
+ * The job identifier.
+ */
+@NamedParameter(doc = "The job identifier.")
+public final class JobIdentifier implements Name<String> {
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/parameters/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/parameters/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Parameters for the driver.
+ */
+package org.apache.reef.runtime.common.driver.parameters;

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/HDInsightDriverConfiguration.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/HDInsightDriverConfiguration.java
@@ -23,10 +23,11 @@ import org.apache.reef.annotations.audience.ClientSide;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.io.TempFileCreator;
 import org.apache.reef.io.WorkingDirectoryTempFileCreator;
-import org.apache.reef.runtime.common.driver.api.AbstractDriverRuntimeConfiguration;
 import org.apache.reef.runtime.common.driver.api.ResourceLaunchHandler;
 import org.apache.reef.runtime.common.driver.api.ResourceReleaseHandler;
 import org.apache.reef.runtime.common.driver.api.ResourceRequestHandler;
+import org.apache.reef.runtime.common.driver.parameters.EvaluatorTimeout;
+import org.apache.reef.runtime.common.driver.parameters.JobIdentifier;
 import org.apache.reef.runtime.common.files.RuntimePathProvider;
 import org.apache.reef.runtime.common.files.RuntimeClasspathProvider;
 import org.apache.reef.runtime.common.parameters.JVMHeapSlack;
@@ -59,12 +60,12 @@ public final class HDInsightDriverConfiguration extends ConfigurationModuleBuild
   public static final OptionalParameter<Integer> YARN_HEARTBEAT_INTERVAL = new OptionalParameter<>();
 
   /**
-   * @see AbstractDriverRuntimeConfiguration.JobIdentifier.class
+   * @see JobIdentifier.class
    */
   public static final RequiredParameter<String> JOB_IDENTIFIER = new RequiredParameter<>();
 
   /**
-   * @see AbstractDriverRuntimeConfiguration.EvaluatorTimeout
+   * @see EvaluatorTimeout
    */
   public static final OptionalParameter<Long> EVALUATOR_TIMEOUT = new OptionalParameter<>();
 
@@ -89,8 +90,8 @@ public final class HDInsightDriverConfiguration extends ConfigurationModuleBuild
       .bindNamedParameter(YarnHeartbeatPeriod.class, YARN_HEARTBEAT_INTERVAL)
 
           // Bind the fields bound in AbstractDriverRuntimeConfiguration
-      .bindNamedParameter(AbstractDriverRuntimeConfiguration.JobIdentifier.class, JOB_IDENTIFIER)
-      .bindNamedParameter(AbstractDriverRuntimeConfiguration.EvaluatorTimeout.class, EVALUATOR_TIMEOUT)
+      .bindNamedParameter(JobIdentifier.class, JOB_IDENTIFIER)
+      .bindNamedParameter(EvaluatorTimeout.class, EVALUATOR_TIMEOUT)
       .bindNamedParameter(JVMHeapSlack.class, JVM_HEAP_SLACK)
       .bindImplementation(RuntimeClasspathProvider.class, HDInsightClasspathProvider.class)
       .bindImplementation(RuntimePathProvider.class, HDInsightJVMPathProvider.class)

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalDriverConfiguration.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalDriverConfiguration.java
@@ -18,10 +18,11 @@
  */
 package org.apache.reef.runtime.local.driver;
 
-import org.apache.reef.runtime.common.driver.api.AbstractDriverRuntimeConfiguration;
 import org.apache.reef.runtime.common.driver.api.ResourceLaunchHandler;
 import org.apache.reef.runtime.common.driver.api.ResourceReleaseHandler;
 import org.apache.reef.runtime.common.driver.api.ResourceRequestHandler;
+import org.apache.reef.runtime.common.driver.parameters.ClientRemoteIdentifier;
+import org.apache.reef.runtime.common.driver.parameters.JobIdentifier;
 import org.apache.reef.runtime.common.files.RuntimeClasspathProvider;
 import org.apache.reef.runtime.common.parameters.JVMHeapSlack;
 import org.apache.reef.runtime.local.LocalClasspathProvider;
@@ -64,8 +65,8 @@ public class LocalDriverConfiguration extends ConfigurationModuleBuilder {
       .bindImplementation(ResourceLaunchHandler.class, LocalResourceLaunchHandler.class)
       .bindImplementation(ResourceRequestHandler.class, LocalResourceRequestHandler.class)
       .bindImplementation(ResourceReleaseHandler.class, LocalResourceReleaseHandler.class)
-      .bindNamedParameter(AbstractDriverRuntimeConfiguration.ClientRemoteIdentifier.class, CLIENT_REMOTE_IDENTIFIER)
-      .bindNamedParameter(AbstractDriverRuntimeConfiguration.JobIdentifier.class, JOB_IDENTIFIER)
+      .bindNamedParameter(ClientRemoteIdentifier.class, CLIENT_REMOTE_IDENTIFIER)
+      .bindNamedParameter(JobIdentifier.class, JOB_IDENTIFIER)
       .bindNamedParameter(MaxNumberOfEvaluators.class, MAX_NUMBER_OF_EVALUATORS)
       .bindNamedParameter(RootFolder.class, ROOT_FOLDER)
       .bindNamedParameter(JVMHeapSlack.class, JVM_HEAP_SLACK)

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosDriverConfiguration.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosDriverConfiguration.java
@@ -21,10 +21,12 @@ package org.apache.reef.runtime.mesos.driver;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.reef.io.TempFileCreator;
 import org.apache.reef.io.WorkingDirectoryTempFileCreator;
-import org.apache.reef.runtime.common.driver.api.AbstractDriverRuntimeConfiguration;
 import org.apache.reef.runtime.common.driver.api.ResourceLaunchHandler;
 import org.apache.reef.runtime.common.driver.api.ResourceReleaseHandler;
 import org.apache.reef.runtime.common.driver.api.ResourceRequestHandler;
+import org.apache.reef.runtime.common.driver.parameters.ClientRemoteIdentifier;
+import org.apache.reef.runtime.common.driver.parameters.EvaluatorTimeout;
+import org.apache.reef.runtime.common.driver.parameters.JobIdentifier;
 import org.apache.reef.runtime.common.files.RuntimeClasspathProvider;
 import org.apache.reef.runtime.common.parameters.JVMHeapSlack;
 import org.apache.reef.runtime.mesos.MesosClasspathProvider;
@@ -44,12 +46,12 @@ import org.apache.reef.wake.time.Clock;
  */
 public final class MesosDriverConfiguration extends ConfigurationModuleBuilder {
   /**
-   * @see AbstractDriverRuntimeConfiguration.JobIdentifier.class
+   * @see JobIdentifier.class
    */
   public static final RequiredParameter<String> JOB_IDENTIFIER = new RequiredParameter<>();
 
   /**
-   * @see AbstractDriverRuntimeConfiguration.EvaluatorTimeout
+   * @see EvaluatorTimeout
    */
   public static final OptionalParameter<Long> EVALUATOR_TIMEOUT = new OptionalParameter<>();
 
@@ -90,9 +92,9 @@ public final class MesosDriverConfiguration extends ConfigurationModuleBuilder {
       .bindImplementation(EStage.class, SingleThreadStage.class)
 
           // Bind the fields bound in AbstractDriverRuntimeConfiguration
-      .bindNamedParameter(AbstractDriverRuntimeConfiguration.JobIdentifier.class, JOB_IDENTIFIER)
-      .bindNamedParameter(AbstractDriverRuntimeConfiguration.EvaluatorTimeout.class, EVALUATOR_TIMEOUT)
-      .bindNamedParameter(AbstractDriverRuntimeConfiguration.ClientRemoteIdentifier.class, CLIENT_REMOTE_IDENTIFIER)
+      .bindNamedParameter(JobIdentifier.class, JOB_IDENTIFIER)
+      .bindNamedParameter(EvaluatorTimeout.class, EVALUATOR_TIMEOUT)
+      .bindNamedParameter(ClientRemoteIdentifier.class, CLIENT_REMOTE_IDENTIFIER)
       .bindNamedParameter(JVMHeapSlack.class, JVM_HEAP_SLACK)
       .build();
 }

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/REEFScheduler.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/REEFScheduler.java
@@ -22,10 +22,10 @@ import com.google.protobuf.ByteString;
 import org.apache.mesos.MesosSchedulerDriver;
 import org.apache.reef.proto.ReefServiceProtos;
 import org.apache.reef.proto.ReefServiceProtos.State;
-import org.apache.reef.runtime.common.driver.api.AbstractDriverRuntimeConfiguration;
 import org.apache.reef.runtime.common.driver.api.ResourceReleaseEvent;
 import org.apache.reef.runtime.common.driver.api.ResourceRequestEvent;
 import org.apache.reef.runtime.common.driver.api.ResourceRequestEventImpl;
+import org.apache.reef.runtime.common.driver.parameters.JobIdentifier;
 import org.apache.reef.runtime.common.driver.resourcemanager.NodeDescriptorEventImpl;
 import org.apache.reef.runtime.common.driver.resourcemanager.ResourceAllocationEvent;
 import org.apache.reef.runtime.common.driver.resourcemanager.ResourceAllocationEventImpl;
@@ -118,7 +118,7 @@ final class REEFScheduler implements Scheduler {
                 final REEFFileNames fileNames,
                 final EStage<SchedulerDriver> schedulerDriverEStage,
                 final ClasspathProvider classpath,
-                final @Parameter(AbstractDriverRuntimeConfiguration.JobIdentifier.class) String jobIdentifier,
+                final @Parameter(JobIdentifier.class) String jobIdentifier,
                 final @Parameter(MesosMasterIp.class) String masterIp) {
     this.mesosRemoteManager = mesosRemoteManager;
     this.reefEventHandlers = reefEventHandlers;

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverConfiguration.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverConfiguration.java
@@ -21,10 +21,12 @@ package org.apache.reef.runtime.yarn.driver;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.reef.io.TempFileCreator;
 import org.apache.reef.io.WorkingDirectoryTempFileCreator;
-import org.apache.reef.runtime.common.driver.api.AbstractDriverRuntimeConfiguration;
 import org.apache.reef.runtime.common.driver.api.ResourceLaunchHandler;
 import org.apache.reef.runtime.common.driver.api.ResourceReleaseHandler;
 import org.apache.reef.runtime.common.driver.api.ResourceRequestHandler;
+import org.apache.reef.runtime.common.driver.parameters.ClientRemoteIdentifier;
+import org.apache.reef.runtime.common.driver.parameters.EvaluatorTimeout;
+import org.apache.reef.runtime.common.driver.parameters.JobIdentifier;
 import org.apache.reef.runtime.common.files.RuntimeClasspathProvider;
 import org.apache.reef.runtime.common.parameters.JVMHeapSlack;
 import org.apache.reef.runtime.yarn.YarnClasspathProvider;
@@ -51,12 +53,12 @@ public class YarnDriverConfiguration extends ConfigurationModuleBuilder {
   public static final OptionalParameter<Integer> YARN_HEARTBEAT_INTERVAL = new OptionalParameter<>();
 
   /**
-   * @see AbstractDriverRuntimeConfiguration.JobIdentifier.class
+   * @see JobIdentifier.class
    */
   public static final RequiredParameter<String> JOB_IDENTIFIER = new RequiredParameter<>();
 
   /**
-   * @see AbstractDriverRuntimeConfiguration.EvaluatorTimeout
+   * @see EvaluatorTimeout
    */
   public static final OptionalParameter<Long> EVALUATOR_TIMEOUT = new OptionalParameter<>();
 
@@ -86,9 +88,9 @@ public class YarnDriverConfiguration extends ConfigurationModuleBuilder {
       .bindNamedParameter(YarnHeartbeatPeriod.class, YARN_HEARTBEAT_INTERVAL)
 
           // Bind the fields bound in AbstractDriverRuntimeConfiguration
-      .bindNamedParameter(AbstractDriverRuntimeConfiguration.JobIdentifier.class, JOB_IDENTIFIER)
-      .bindNamedParameter(AbstractDriverRuntimeConfiguration.EvaluatorTimeout.class, EVALUATOR_TIMEOUT)
-      .bindNamedParameter(AbstractDriverRuntimeConfiguration.ClientRemoteIdentifier.class, CLIENT_REMOTE_IDENTIFIER)
+      .bindNamedParameter(JobIdentifier.class, JOB_IDENTIFIER)
+      .bindNamedParameter(EvaluatorTimeout.class, EVALUATOR_TIMEOUT)
+      .bindNamedParameter(ClientRemoteIdentifier.class, CLIENT_REMOTE_IDENTIFIER)
       .bindNamedParameter(JVMHeapSlack.class, JVM_HEAP_SLACK)
       .bindImplementation(RuntimeClasspathProvider.class, YarnClasspathProvider.class)
       .build();

--- a/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestHttpConfiguration.java
+++ b/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestHttpConfiguration.java
@@ -21,7 +21,7 @@ package org.apache.reef.webserver;
 import org.apache.reef.client.DriverServiceConfiguration;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.evaluator.EvaluatorDescriptor;
-import org.apache.reef.runtime.common.driver.api.AbstractDriverRuntimeConfiguration;
+import org.apache.reef.runtime.common.driver.parameters.JobIdentifier;
 import org.apache.reef.runtime.common.launch.REEFMessageCodec;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Configurations;
@@ -71,7 +71,7 @@ public class TestHttpConfiguration {
         .bindImplementation(ActiveContext.class, MockActiveContext.class)
         .bindNamedParameter(RemoteConfiguration.ManagerName.class, "REEF_TEST_REMOTE_MANAGER")
         .bindNamedParameter(RemoteConfiguration.MessageCodec.class, REEFMessageCodec.class)
-        .bindNamedParameter(AbstractDriverRuntimeConfiguration.JobIdentifier.class, "my job")
+        .bindNamedParameter(JobIdentifier.class, "my job")
         .build();
 
     final Configuration configuration = Configurations.merge(

--- a/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestHttpServer.java
+++ b/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestHttpServer.java
@@ -18,7 +18,7 @@
  */
 package org.apache.reef.webserver;
 
-import org.apache.reef.runtime.common.driver.api.AbstractDriverRuntimeConfiguration;
+import org.apache.reef.runtime.common.driver.parameters.JobIdentifier;
 import org.apache.reef.runtime.common.launch.REEFMessageCodec;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Configurations;
@@ -147,7 +147,7 @@ public class TestHttpServer {
     final Configuration reefConfiguration = Tang.Factory.getTang().newConfigurationBuilder()
         .bindNamedParameter(RemoteConfiguration.ManagerName.class, "REEF_TEST_REMOTE_MANAGER")
         .bindNamedParameter(RemoteConfiguration.MessageCodec.class, REEFMessageCodec.class)
-        .bindNamedParameter(AbstractDriverRuntimeConfiguration.JobIdentifier.class, "my job")
+        .bindNamedParameter(JobIdentifier.class, "my job")
         .build();
 
     final Configuration finalConfig =

--- a/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestJettyHandler.java
+++ b/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestJettyHandler.java
@@ -18,7 +18,7 @@
  */
 package org.apache.reef.webserver;
 
-import org.apache.reef.runtime.common.driver.api.AbstractDriverRuntimeConfiguration;
+import org.apache.reef.runtime.common.driver.parameters.JobIdentifier;
 import org.apache.reef.runtime.common.launch.REEFMessageCodec;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Configurations;
@@ -66,7 +66,7 @@ public class TestJettyHandler {
     final Configuration remoteConfiguration = tang.newConfigurationBuilder()
         .bindNamedParameter(RemoteConfiguration.ManagerName.class, "REEF_TEST_REMOTE_MANAGER")
         .bindNamedParameter(RemoteConfiguration.MessageCodec.class, REEFMessageCodec.class)
-        .bindNamedParameter(AbstractDriverRuntimeConfiguration.JobIdentifier.class, "my job")
+        .bindNamedParameter(JobIdentifier.class, "my job")
         .build();
 
     final Configuration finalConfig =

--- a/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestReefEventHandler.java
+++ b/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestReefEventHandler.java
@@ -18,7 +18,7 @@
  */
 package org.apache.reef.webserver;
 
-import org.apache.reef.runtime.common.driver.api.AbstractDriverRuntimeConfiguration;
+import org.apache.reef.runtime.common.driver.parameters.JobIdentifier;
 import org.apache.reef.runtime.common.launch.REEFMessageCodec;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Configurations;
@@ -64,7 +64,7 @@ public class TestReefEventHandler {
     final Configuration remoteConfiguration = tang.newConfigurationBuilder()
         .bindNamedParameter(RemoteConfiguration.ManagerName.class, "REEF_TEST_REMOTE_MANAGER")
         .bindNamedParameter(RemoteConfiguration.MessageCodec.class, REEFMessageCodec.class)
-        .bindNamedParameter(AbstractDriverRuntimeConfiguration.JobIdentifier.class, "my job")
+        .bindNamedParameter(JobIdentifier.class, "my job")
         .build();
 
     final Configuration finalConfig =

--- a/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestReefEventStateManager.java
+++ b/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestReefEventStateManager.java
@@ -20,12 +20,11 @@ package org.apache.reef.webserver;
 
 import org.apache.reef.driver.catalog.NodeDescriptor;
 import org.apache.reef.driver.catalog.RackDescriptor;
-import org.apache.reef.driver.evaluator.CLRProcess;
 import org.apache.reef.driver.evaluator.CLRProcessFactory;
 import org.apache.reef.driver.evaluator.EvaluatorDescriptor;
 import org.apache.reef.driver.evaluator.EvaluatorProcess;
 import org.apache.reef.driver.evaluator.EvaluatorProcessFactory;
-import org.apache.reef.runtime.common.driver.api.AbstractDriverRuntimeConfiguration;
+import org.apache.reef.runtime.common.driver.parameters.JobIdentifier;
 import org.apache.reef.runtime.common.launch.REEFMessageCodec;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Injector;
@@ -57,7 +56,7 @@ public class TestReefEventStateManager {
         .bindImplementation(EvaluatorProcessFactory.class, CLRProcessFactory.class)
         .bindNamedParameter(RemoteConfiguration.ManagerName.class, "REEF_TEST_REMOTE_MANAGER")
         .bindNamedParameter(RemoteConfiguration.MessageCodec.class, REEFMessageCodec.class)
-        .bindNamedParameter(AbstractDriverRuntimeConfiguration.JobIdentifier.class, "my job")
+        .bindNamedParameter(JobIdentifier.class, "my job")
         .build();
 
     injector = tang.newInjector(configuration);

--- a/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestRuntimeStartHandler.java
+++ b/lang/java/reef-webserver/src/test/java/org/apache/reef/webserver/TestRuntimeStartHandler.java
@@ -18,7 +18,7 @@
  */
 package org.apache.reef.webserver;
 
-import org.apache.reef.runtime.common.driver.api.AbstractDriverRuntimeConfiguration;
+import org.apache.reef.runtime.common.driver.parameters.JobIdentifier;
 import org.apache.reef.runtime.common.launch.REEFMessageCodec;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Configurations;
@@ -54,7 +54,7 @@ public class TestRuntimeStartHandler {
     final Configuration remoteConfiguration = Tang.Factory.getTang().newConfigurationBuilder()
         .bindNamedParameter(RemoteConfiguration.ManagerName.class, "REEF_TEST_REMOTE_MANAGER")
         .bindNamedParameter(RemoteConfiguration.MessageCodec.class, REEFMessageCodec.class)
-        .bindNamedParameter(AbstractDriverRuntimeConfiguration.JobIdentifier.class, "my job")
+        .bindNamedParameter(JobIdentifier.class, "my job")
         .build();
     this.configuation = Configurations.merge(clockConfiguraiton, remoteConfiguration);
   }


### PR DESCRIPTION
This change moves all the named parameters found in the deprecated class

```
org.apache.reef.runtime.common.driver.api.AbstractDriverRuntimeConfiguration
```

into the new package

```
org.apache.reef.runtime.common.driver.parameters
```

JIRA: [REEF-380](https://issues.apache.org/jira/browse/REEF-380)