### PR TITLE
[REEF-384]  Avoid Null pointer exception in AvroConfigurationSerializer

### DIFF
--- a/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestClassHierarchy.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestClassHierarchy.cs
@@ -189,10 +189,11 @@ namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
         }
 
         [TestMethod]
-        public void TestResolveDependencies() 
+        public void TestResolveDependencies()
         {
-            ns.GetNode(typeof(SimpleConstructors).AssemblyQualifiedName);
-            Assert.IsNotNull(ns.GetNode(typeof(string).AssemblyQualifiedName));
+            ns = TangFactory.GetTang().GetClassHierarchy(new string[] { FileNames.Examples });
+            var node = ns.GetNode(typeof(SimpleConstructors).AssemblyQualifiedName);
+            Assert.AreEqual(node.GetFullName(), ReflectionUtilities.GetAssemblyQualifiedName(typeof(SimpleConstructors)));
         }
 
         [TestMethod]

--- a/lang/cs/Org.Apache.REEF.Tang/Formats/AvroConfigurationSerializer.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Formats/AvroConfigurationSerializer.cs
@@ -313,13 +313,18 @@ namespace Org.Apache.REEF.Tang.Formats
 
         private IConfiguration AddFromAvro(IConfigurationBuilder cb, AvroConfiguration avroConfiguration)
         {
+            if (avroConfiguration == null)
+            {
+                return null;
+            }
+
             IList<KeyValuePair<string, string>> settings = new List<KeyValuePair<string, string>>();
 
             foreach (ConfigurationEntry e in avroConfiguration.Bindings)
             {
                 settings.Add(new KeyValuePair<string, string>(e.key, e.value));
             }
-            ConfigurationFile.ProcessConfigData(cb, settings);   //TODO
+            ConfigurationFile.ProcessConfigData(cb, settings); //TODO
             return cb.Build();
         }
     }


### PR DESCRIPTION
This PR added null checking in AvroConfigurationSerializer.FromAvro() and added tests cases for it.
It also fixed a Tang test case

JIRA: REEF-384(https://issues.apache.org/jira/browse/REEF-384)

This closes #

Author: Julia Wang  Email: jwang98052@yahoo.com