### PR TITLE
[REEF-390]  Allow serialized configuration pass to Evaluator as a string

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Services/ServiceConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Services/ServiceConfiguration.cs
@@ -72,17 +72,6 @@ namespace Org.Apache.REEF.Common.Services
             }
         }
 
-        public static string WrapServiceConfigAsString(IConfiguration serviceConfiguration)
-        {
-            AvroConfigurationSerializer serializer = new AvroConfigurationSerializer();
-            var wrappedConfig = TangFactory.GetTang().NewConfigurationBuilder()
-                .BindNamedParameter<ServicesConfigurationOptions.ServiceConfigString, string>(
-                    GenericType<ServicesConfigurationOptions.ServiceConfigString>.Class,
-                    serializer.ToString(serviceConfiguration))
-                .Build();
-            return serializer.ToString(wrappedConfig);
-        }
-
         public IConfiguration TangConfig { get; private set; }
     }
 

--- a/lang/cs/Org.Apache.REEF.Common/Services/ServicesConfigurationOptions.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Services/ServicesConfigurationOptions.cs
@@ -27,5 +27,10 @@ namespace Org.Apache.REEF.Common.Services
         public class Services : Name<string>
         {
         }
+
+        [NamedParameter]
+        public class ServiceConfigString : Name<string>
+        {
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/AllocatedEvaluator.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/AllocatedEvaluator.cs
@@ -109,7 +109,7 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
             LOGGER.Log(Level.Info, "AllocatedEvaluator::SubmitContextAndService");
 
             string context = _serializer.ToString(contextConfiguration);
-            string service = ServiceConfiguration.WrapServiceConfigAsString(serviceConfiguration);
+            string service = _serializer.ToString(WrapServiceConfigAsString(serviceConfiguration));
 
             LOGGER.Log(Level.Verbose, "serialized contextConfiguration: " + context);
             LOGGER.Log(Level.Verbose, "serialized serviceConfiguration: " + service);
@@ -124,7 +124,7 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
             //TODO: Change this to service configuration when REEF-289(https://issues.apache.org/jira/browse/REEF-289) is fixed.
             taskConfiguration = MergeWithConfigurationProviders(taskConfiguration);
             string context = _serializer.ToString(contextConfiguration);
-            string service = ServiceConfiguration.WrapServiceConfigAsString(serviceConfiguration);
+            string service = _serializer.ToString(WrapServiceConfigAsString(serviceConfiguration));
             string task = _serializer.ToString(taskConfiguration);
 
             LOGGER.Log(Level.Verbose, "serialized contextConfiguration: " + context);
@@ -203,6 +203,22 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
                 }
             }
             return config;
+        }
+
+        /// <summary>
+        /// This is to wrap entire service configuration in to a serialized string
+        /// At evaluator side, we will unwrap it to get the original Service Configuration string
+        /// It is to avoid issues that some C# class Node are dropped in the deserialized ClassHierarchy by Goold ProtoBuffer deserializer
+        /// </summary>
+        /// <param name="serviceConfiguration"></param>
+        /// <returns></returns>
+        private IConfiguration WrapServiceConfigAsString(IConfiguration serviceConfiguration)
+        {
+            return TangFactory.GetTang().NewConfigurationBuilder()
+                .BindNamedParameter<ServicesConfigurationOptions.ServiceConfigString, string>(
+                    GenericType<ServicesConfigurationOptions.ServiceConfigString>.Class,
+                    new AvroConfigurationSerializer().ToString(serviceConfiguration))
+                .Build();
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/AllocatedEvaluator.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/AllocatedEvaluator.cs
@@ -23,12 +23,15 @@ using System.Globalization;
 using System.Runtime.Serialization;
 using Org.Apache.REEF.Common.Catalog;
 using Org.Apache.REEF.Common.Evaluator;
+using Org.Apache.REEF.Common.Services;
 using Org.Apache.REEF.Driver.Bridge.Clr2java;
 using Org.Apache.REEF.Driver.Context;
 using Org.Apache.REEF.Driver.Evaluator;
 using Org.Apache.REEF.Tang.Formats;
 using Org.Apache.REEF.Tang.Implementations.Configuration;
+using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
+using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Logging;
 
 namespace Org.Apache.REEF.Driver.Bridge.Events
@@ -104,9 +107,9 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
         public void SubmitContextAndService(IConfiguration contextConfiguration, IConfiguration serviceConfiguration)
         {
             LOGGER.Log(Level.Info, "AllocatedEvaluator::SubmitContextAndService");
-            
+
             string context = _serializer.ToString(contextConfiguration);
-            string service = _serializer.ToString(serviceConfiguration);
+            string service = ServiceConfiguration.WrapServiceConfigAsString(serviceConfiguration);
 
             LOGGER.Log(Level.Verbose, "serialized contextConfiguration: " + context);
             LOGGER.Log(Level.Verbose, "serialized serviceConfiguration: " + service);
@@ -121,7 +124,7 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
             //TODO: Change this to service configuration when REEF-289(https://issues.apache.org/jira/browse/REEF-289) is fixed.
             taskConfiguration = MergeWithConfigurationProviders(taskConfiguration);
             string context = _serializer.ToString(contextConfiguration);
-            string service = _serializer.ToString(serviceConfiguration);
+            string service = ServiceConfiguration.WrapServiceConfigAsString(serviceConfiguration);
             string task = _serializer.ToString(taskConfiguration);
 
             LOGGER.Log(Level.Verbose, "serialized contextConfiguration: " + context);

--- a/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommuDriverTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommuDriverTests.cs
@@ -1,0 +1,67 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Org.Apache.REEF.Common.Services;
+using Org.Apache.REEF.Network.Group.Config;
+using Org.Apache.REEF.Tang.Exceptions;
+using Org.Apache.REEF.Tang.Formats;
+using Org.Apache.REEF.Tang.Implementations.Configuration;
+using Org.Apache.REEF.Tang.Implementations.Tang;
+using Org.Apache.REEF.Tang.Interface;
+using Org.Apache.REEF.Tang.Util;
+using Org.Apache.REEF.Wake.Remote.Impl;
+
+namespace Org.Apache.REEF.Network.Tests.GroupCommunication
+{
+    [TestClass]
+    public class GroupCommuDriverTests
+    {
+        [TestMethod]
+        public void TestServiceConfiguration()
+        {
+            string groupName = "group1";
+            string broadcastOperatorName = "broadcast";
+            string reduceOperatorName = "reduce";
+            string masterTaskId = "task0";
+            string driverId = "Driver Id";
+            int numTasks = 3;
+            int fanOut = 2;
+
+            var serializer = new AvroConfigurationSerializer();
+
+            var groupCommunicationDriver = GroupCommunicationTests.GetInstanceOfGroupCommDriver(driverId, masterTaskId,
+                groupName, fanOut,
+                numTasks);
+
+            //driver side to prepar for service config
+            IConfiguration codecConfig = CodecConfiguration<int>.Conf
+                .Set(CodecConfiguration<int>.Codec, GenericType<IntCodec>.Class)
+                .Build();
+            var driverServiceConfig = groupCommunicationDriver.GetServiceConfiguration();
+            var serviceConfig = Configurations.Merge(driverServiceConfig, codecConfig);
+            string serviceConfigString = ServiceConfiguration.WrapServiceConfigAsString(serviceConfig);
+
+            //the configuration string is received at Evaluator side
+            var serviceConfig2 = new ServiceConfiguration(serviceConfigString);
+
+            Assert.AreEqual(serializer.ToString(serviceConfig), serializer.ToString(serviceConfig2.TangConfig));
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommuDriverTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommuDriverTests.cs
@@ -51,12 +51,19 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
                 numTasks);
 
             //driver side to prepar for service config
-            IConfiguration codecConfig = CodecConfiguration<int>.Conf
+            var codecConfig = CodecConfiguration<int>.Conf
                 .Set(CodecConfiguration<int>.Codec, GenericType<IntCodec>.Class)
                 .Build();
             var driverServiceConfig = groupCommunicationDriver.GetServiceConfiguration();
             var serviceConfig = Configurations.Merge(driverServiceConfig, codecConfig);
-            string serviceConfigString = ServiceConfiguration.WrapServiceConfigAsString(serviceConfig);
+
+            //wrap it before serializing
+            var wrappedSeriveConfig = TangFactory.GetTang().NewConfigurationBuilder()
+                .BindNamedParameter<ServicesConfigurationOptions.ServiceConfigString, string>(
+                    GenericType<ServicesConfigurationOptions.ServiceConfigString>.Class,
+                    new AvroConfigurationSerializer().ToString(serviceConfig))
+                .Build();
+            var serviceConfigString = serializer.ToString(wrappedSeriveConfig);
 
             //the configuration string is received at Evaluator side
             var serviceConfig2 = new ServiceConfiguration(serviceConfigString);

--- a/lang/cs/Org.Apache.REEF.Network.Tests/Org.Apache.REEF.Network.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/Org.Apache.REEF.Network.Tests.csproj
@@ -50,6 +50,7 @@ under the License.
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BlockingCollectionExtensionTests.cs" />
+    <Compile Include="GroupCommunication\GroupCommuDriverTests.cs" />
     <Compile Include="GroupCommunication\GroupCommunicationTests.cs" />
     <Compile Include="GroupCommunication\GroupCommunicationTreeTopologyTests.cs" />
     <Compile Include="NamingService\NameServerTests.cs" />

--- a/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/GroupCommDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/GroupCommDriver.cs
@@ -32,6 +32,7 @@ using Org.Apache.REEF.Network.Naming;
 using Org.Apache.REEF.Network.NetworkService;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Formats;
+using Org.Apache.REEF.Tang.Implementations.Configuration;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
@@ -170,10 +171,10 @@ namespace Org.Apache.REEF.Network.Group.Driver.Impl
                     GenericType<ICodec<GroupCommunicationMessage>>.Class,
                     GenericType<GroupCommunicationMessageCodec>.Class)
                 .BindNamedParameter<NamingConfigurationOptions.NameServerAddress, string>(
-                    GenericType<NamingConfigurationOptions.NameServerAddress>.Class, 
+                    GenericType<NamingConfigurationOptions.NameServerAddress>.Class,
                     _nameServerAddr)
                 .BindNamedParameter<NamingConfigurationOptions.NameServerPort, int>(
-                    GenericType<NamingConfigurationOptions.NameServerPort>.Class, 
+                    GenericType<NamingConfigurationOptions.NameServerPort>.Class,
                     _nameServerPort.ToString(CultureInfo.InvariantCulture))
                 .BindImplementation(GenericType<INameClient>.Class,
                     GenericType<NameClient>.Class)


### PR DESCRIPTION
Currently, some of the Nodes were dropped by proto buffer libary when Java deserializes a class hierarchy created in C#, resulting in Java driver not able to deserialize service configurations passed from C# which use those classes. A typical example is nested generic types for ICodec which client would like to pass to the evaluator as part of the service config.

This PR:
*Add a new API GetServiceConfiguration to allow the client to pass additional service configuration
   IConfiguration GetServiceConfiguration(params IConfiguration[] clientConfigurations);
*Inside this method, serialize the clientConfigurations as a string and bind it with service config
*Updated ServiceConfiguration to inject the named parameter to get the string config and deserialze it, and then merge it with the service config
*Test cases are added for the hcange

JIRA: REEF-390(https://issues.apache.org/jira/browse/REEF-390)

This closes #

Author: Julia Wang  Email: jwang98052@yahoo.com