### PR TITLE
[REEF-261]: Make the GroupCommunicationOperator layer memory efficient by introducing StreamingCodec

### DIFF
--- a/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/StreamingCodecTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/StreamingCodecTests.cs
@@ -1,0 +1,190 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Org.Apache.REEF.Network.Group.Config;
+using Org.Apache.REEF.Network.StreamingCodec;
+using Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs;
+using Org.Apache.REEF.Tang.Implementations.InjectionPlan;
+using Org.Apache.REEF.Tang.Implementations.Tang;
+using Org.Apache.REEF.Tang.Interface;
+using Org.Apache.REEF.Tang.Util;
+using Org.Apache.REEF.Wake.Remote;
+using Org.Apache.REEF.Wake.Remote.Impl;
+
+namespace Org.Apache.REEF.Network.Tests.GroupCommunication
+{
+    /// <summary>
+    /// Defines streaming codec tests
+    /// </summary>
+    [TestClass]
+    public class StreamingCodecTests
+    {
+        [TestMethod]
+        public async Task TestCommonStreamingCodecs()
+        {
+            IInjector injector = TangFactory.GetTang().NewInjector();
+            IStreamingCodec<int> intCodec = injector.GetInstance<IntStreamingCodec>();
+            IStreamingCodec<double> doubleCodec = injector.GetInstance<DoubleStreamingCodec>();
+            IStreamingCodec<float> floatCodec = injector.GetInstance<FloatStreamingCodec>();
+
+            IStreamingCodec<int[]> intArrCodec = injector.GetInstance<IntArrayStreamingCodec>();
+            IStreamingCodec<double[]> doubleArrCodec = injector.GetInstance<DoubleArrayStreamingCodec>();
+            IStreamingCodec<float[]> floatArrCodec = injector.GetInstance<FloatArrayStreamingCodec>();
+
+            CancellationToken token = new CancellationToken();
+
+            int obj = 5;
+            int[] intArr = {1, 2};
+            double[] doubleArr = { 1, 2 };
+            float[] floatArr = { 1, 2 };
+
+            var stream = new MemoryStream();
+            IDataWriter writer = new StreamDataWriter(stream);
+            intCodec.Write(obj, writer);
+            await intCodec.WriteAsync(obj + 1, writer, token);
+            doubleCodec.Write(obj + 2, writer);
+            await doubleCodec.WriteAsync(obj + 3, writer, token);
+            floatCodec.Write(obj + 4, writer);
+            await floatCodec.WriteAsync(obj + 5, writer, token);
+            intArrCodec.Write(intArr, writer);
+            await intArrCodec.WriteAsync(intArr, writer, token);
+            doubleArrCodec.Write(doubleArr, writer);
+            await doubleArrCodec.WriteAsync(doubleArr, writer, token);
+            floatArrCodec.Write(floatArr, writer);
+            await floatArrCodec.WriteAsync(floatArr, writer, token);
+
+            stream.Position = 0;
+            IDataReader reader = new StreamDataReader(stream);
+            int res1 = intCodec.Read(reader);
+            int res2 = await intCodec.ReadAsync(reader, token);
+            double res3 = doubleCodec.Read(reader);
+            double res4 = await doubleCodec.ReadAsync(reader, token);
+            float res5 = floatCodec.Read(reader);
+            float res6 = await floatCodec.ReadAsync(reader, token);
+            int[] resArr1 = intArrCodec.Read(reader);
+            int[] resArr2 = await intArrCodec.ReadAsync(reader, token);
+            double[] resArr3 = doubleArrCodec.Read(reader);
+            double[] resArr4 = await doubleArrCodec.ReadAsync(reader, token);
+            float[] resArr5 = floatArrCodec.Read(reader);
+            float[] resArr6 = await floatArrCodec.ReadAsync(reader, token);
+            
+            Assert.AreEqual(obj, res1);
+            Assert.AreEqual(obj + 1, res2);
+            Assert.AreEqual(obj + 2, res3);
+            Assert.AreEqual(obj + 3, res4);
+            Assert.AreEqual(obj + 4, res5);
+            Assert.AreEqual(obj + 5, res6);
+
+            for (int i = 0; i < intArr.Length; i++)
+            {
+                Assert.AreEqual(intArr[i], resArr1[i]);
+                Assert.AreEqual(intArr[i], resArr2[i]);
+            }
+
+            for (int i = 0; i < doubleArr.Length; i++)
+            {
+                Assert.AreEqual(doubleArr[i], resArr3[i]);
+                Assert.AreEqual(doubleArr[i], resArr4[i]);
+            }
+
+            for (int i = 0; i < floatArr.Length; i++)
+            {
+                Assert.AreEqual(floatArr[i], resArr5[i]);
+                Assert.AreEqual(floatArr[i], resArr6[i]);
+            }
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void TestIntArrayStreamingCodecsNullException()
+        {
+            IInjector injector = TangFactory.GetTang().NewInjector();
+            IStreamingCodec<int[]> intArrCodec = injector.GetInstance<IntArrayStreamingCodec>();
+            var stream = new MemoryStream();
+            IDataWriter writer = new StreamDataWriter(stream);
+            intArrCodec.Write(null, writer);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void TestFloatArrayStreamingCodecsNullException()
+        {
+            IInjector injector = TangFactory.GetTang().NewInjector();
+            IStreamingCodec<float[]> floatArrCodec = injector.GetInstance<FloatArrayStreamingCodec>();
+            var stream = new MemoryStream();
+            IDataWriter writer = new StreamDataWriter(stream);
+            floatArrCodec.Write(null, writer);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void TestDoubleArrayStreamingCodecsNullException()
+        {
+            IInjector injector = TangFactory.GetTang().NewInjector();
+            IStreamingCodec<double[]> doubleArrCodec = injector.GetInstance<DoubleArrayStreamingCodec>();
+            var stream = new MemoryStream();
+            IDataWriter writer = new StreamDataWriter(stream);
+            doubleArrCodec.Write(null, writer);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void TestNullStreamException()
+        {
+            IDataWriter writer = new StreamDataWriter(null);
+            writer.WriteFloat(2.0f);
+        }
+
+        [TestMethod]
+        public async Task TestCodecToStreamingCodec()
+        {
+            var config = TangFactory.GetTang().NewConfigurationBuilder()
+                .BindImplementation(GenericType<ICodec<int>>.Class, GenericType<IntCodec>.Class)
+                .BindImplementation(GenericType<IStreamingCodec<int>>.Class,
+                    GenericType<CodecToStreamingCodec<int>>.Class)
+                .Build();
+
+            IStreamingCodec<int> streamingCodec =
+                TangFactory.GetTang().NewInjector(config).GetInstance<IStreamingCodec<int>>();
+           
+            CancellationToken token = new CancellationToken();
+
+            int obj = 5;
+            var stream = new MemoryStream();
+            IDataWriter writer = new StreamDataWriter(stream);
+            streamingCodec.Write(obj, writer);
+            await streamingCodec.WriteAsync(obj + 1, writer, token);
+
+            stream.Position = 0;
+            IDataReader reader = new StreamDataReader(stream);
+            int res1 = streamingCodec.Read(reader);
+            int res2 = await streamingCodec.ReadAsync(reader, token);
+            Assert.AreEqual(obj, res1);
+            Assert.AreEqual(obj + 1, res2);
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/StreamingCodecTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/StreamingCodecTests.cs
@@ -18,17 +18,12 @@
  */
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Org.Apache.REEF.Network.Group.Config;
 using Org.Apache.REEF.Network.StreamingCodec;
 using Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs;
-using Org.Apache.REEF.Tang.Implementations.InjectionPlan;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;

--- a/lang/cs/Org.Apache.REEF.Network.Tests/Org.Apache.REEF.Network.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/Org.Apache.REEF.Network.Tests.csproj
@@ -53,6 +53,7 @@ under the License.
     <Compile Include="GroupCommunication\GroupCommuDriverTests.cs" />
     <Compile Include="GroupCommunication\GroupCommunicationTests.cs" />
     <Compile Include="GroupCommunication\GroupCommunicationTreeTopologyTests.cs" />
+    <Compile Include="GroupCommunication\StreamingCodecTests.cs" />
     <Compile Include="NamingService\NameServerTests.cs" />
     <Compile Include="NetworkService\WritableNetworkServiceTests.cs" />
     <Compile Include="NetworkService\NetworkServiceTests.cs" />

--- a/lang/cs/Org.Apache.REEF.Network/Group/Config/StreamingCodecConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Config/StreamingCodecConfiguration.cs
@@ -21,12 +21,11 @@ using Org.Apache.REEF.Network.Group.Pipelining;
 using Org.Apache.REEF.Network.StreamingCodec;
 using Org.Apache.REEF.Tang.Formats;
 using Org.Apache.REEF.Tang.Util;
-using Org.Apache.REEF.Wake.Remote;
 
 namespace Org.Apache.REEF.Network.Group.Config
 {
     /// <summary>
-    /// Defines configuration for streaming codecs and pipelie message 
+    /// Defines configuration for streaming codecs and pipeline message 
     /// streaming codecs by taking streaming codec as input.
     /// </summary>
     /// <typeparam name="T">Generic type of message</typeparam>

--- a/lang/cs/Org.Apache.REEF.Network/Group/Config/StreamingCodecConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Config/StreamingCodecConfiguration.cs
@@ -1,0 +1,48 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using Org.Apache.REEF.Network.Group.Pipelining;
+using Org.Apache.REEF.Network.StreamingCodec;
+using Org.Apache.REEF.Tang.Formats;
+using Org.Apache.REEF.Tang.Util;
+using Org.Apache.REEF.Wake.Remote;
+
+namespace Org.Apache.REEF.Network.Group.Config
+{
+    /// <summary>
+    /// Defines configuration for streaming codecs and pipelie message 
+    /// streaming codecs by taking streaming codec as input.
+    /// </summary>
+    /// <typeparam name="T">Generic type of message</typeparam>
+    public sealed class StreamingCodecConfiguration<T> : ConfigurationModuleBuilder
+    {
+        /// <summary>
+        /// RequiredImpl for Codec. Client needs to set implementation for this paramter
+        /// </summary>
+        public static readonly RequiredImpl<IStreamingCodec<T>> Codec = new RequiredImpl<IStreamingCodec<T>>();
+
+        /// <summary>
+        /// Configuration Module for Codec
+        /// </summary>
+        public static ConfigurationModule Conf = new StreamingCodecConfiguration<T>()
+            .BindImplementation(GenericType<IStreamingCodec<T>>.Class, Codec)
+            .BindImplementation(GenericType<IStreamingCodec<PipelineMessage<T>>>.Class, GenericType<StreamingPipelineMessageCodec<T>>.Class)
+            .Build();
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Network/Group/Pipelining/StreamingPipelineMessageCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Pipelining/StreamingPipelineMessageCodec.cs
@@ -1,0 +1,97 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Wake.Remote;
+using System.Threading;
+using System.Threading.Tasks;
+using Org.Apache.REEF.Network.StreamingCodec;
+
+namespace Org.Apache.REEF.Network.Group.Pipelining
+{
+    /// <summary>
+    /// The streaming codec for PipelineMessage
+    /// </summary>
+    /// <typeparam name="T">The message type</typeparam>
+    public sealed class StreamingPipelineMessageCodec<T> : IStreamingCodec<PipelineMessage<T>>
+    {
+        /// <summary>
+        /// Creates new PipelineMessageCodec
+        /// </summary>
+        /// <param name="baseCodec">The codec for actual message in PipelineMessage</param>
+        [Inject]
+        private StreamingPipelineMessageCodec(IStreamingCodec<T> baseCodec)
+        {
+            BaseCodec = baseCodec;
+        }
+                
+        /// <summary>
+        /// Codec for actual message T
+        /// </summary>
+        public IStreamingCodec<T> BaseCodec { get; private set; }
+
+        /// <summary>
+        /// Instantiate the class from the reader.
+        /// </summary>
+        /// <param name="reader">The reader from which to read</param>
+        ///<returns>The Pipeline Message read from the reader</returns>
+        public PipelineMessage<T> Read(IDataReader reader)
+        {
+            var message = BaseCodec.Read(reader);
+            var isLast = reader.ReadBoolean();
+            return new PipelineMessage<T>(message, isLast);
+        }
+
+        /// <summary>
+        /// Writes the class fields to the writer.
+        /// </summary>
+        /// <param name="obj">The object to be encoded</param>
+        /// <param name="writer">The writer to which to write</param>
+        public void Write(PipelineMessage<T> obj, IDataWriter writer)
+        {
+            BaseCodec.Write(obj.Data, writer);
+            writer.WriteBoolean(obj.IsLast);
+        }
+
+        ///  <summary>
+        ///  Instantiate the class from the reader.
+        ///  </summary>
+        ///  <param name="reader">The reader from which to read</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>The Pipeline Message  read from the reader</returns>
+        public async Task<PipelineMessage<T>> ReadAsync(IDataReader reader, CancellationToken token)
+        {
+            var message = await BaseCodec.ReadAsync(reader, token);
+            var isLast = await reader.ReadBooleanAsync(token);
+            return new PipelineMessage<T>(message, isLast);
+        }
+
+        /// <summary>
+        /// Writes the class fields to the writer.
+        /// </summary>
+        /// <param name="obj">The object to be encoded</param>
+        /// <param name="writer">The writer to which to write</param>
+        /// <param name="token">Cancellation token</param>
+        public async System.Threading.Tasks.Task WriteAsync(PipelineMessage<T> obj, IDataWriter writer, CancellationToken token)
+        {
+            await BaseCodec.WriteAsync(obj.Data, writer, token);
+            await writer.WriteBooleanAsync(obj.IsLast, token);
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
+++ b/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
@@ -50,12 +50,19 @@ under the License.
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="StreamingCodec\CommonStreamingCodecs\FloatArrayStreamingCodec.cs" />
+    <Compile Include="StreamingCodec\CommonStreamingCodecs\DoubleArrayStreamingCodec.cs" />
+    <Compile Include="StreamingCodec\CommonStreamingCodecs\FloatStreamingCodec.cs" />
+    <Compile Include="StreamingCodec\CommonStreamingCodecs\IntArrayStreamingCodec.cs" />
+    <Compile Include="StreamingCodec\CommonStreamingCodecs\DoubleStreamingCodec.cs" />
+    <Compile Include="StreamingCodec\CommonStreamingCodecs\IntStreamingCodec.cs" />
     <Compile Include="Group\Codec\GcmMessageProto.cs" />
     <Compile Include="Group\Codec\GroupCommunicationMessageCodec.cs" />
     <Compile Include="Group\Config\CodecConfiguration.cs" />
     <Compile Include="Group\Config\GroupCommConfigurationOptions.cs" />
     <Compile Include="Group\Config\PipelineDataConverterConfiguration.cs" />
     <Compile Include="Group\Config\ReduceFunctionConfiguration.cs" />
+    <Compile Include="Group\Config\StreamingCodecConfiguration.cs" />
     <Compile Include="Group\Driver\ICommunicationGroupDriver.cs" />
     <Compile Include="Group\Driver\IGroupCommDriver.cs" />
     <Compile Include="Group\Driver\Impl\CommunicationGroupDriver.cs" />
@@ -79,6 +86,7 @@ under the License.
     <Compile Include="Group\Operators\Impl\ScatterSender.cs" />
     <Compile Include="Group\Operators\Impl\Sender.cs" />
     <Compile Include="Group\Operators\IOperatorSpec.cs" />
+    <Compile Include="Group\Pipelining\StreamingPipelineMessageCodec.cs" />
     <Compile Include="Group\Task\IOperatorTopology.cs" />
     <Compile Include="Group\Operators\IReduceFunction.cs" />
     <Compile Include="Group\Operators\IReduceReceiver.cs" />
@@ -147,6 +155,8 @@ under the License.
     <Compile Include="NetworkService\WritableNsConnection.cs" />
     <Compile Include="NetworkService\WritableNsMessage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StreamingCodec\CodecToStreamingCodec.cs" />
+    <Compile Include="StreamingCodec\IStreamingCodec.cs" />
     <Compile Include="Utilities\BlockingCollectionExtensions.cs" />
     <Compile Include="Utilities\Utils.cs" />
   </ItemGroup>

--- a/lang/cs/Org.Apache.REEF.Network/StreamingCodec/CodecToStreamingCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/StreamingCodec/CodecToStreamingCodec.cs
@@ -1,0 +1,75 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Wake.Remote;
+
+namespace Org.Apache.REEF.Network.StreamingCodec
+{
+    /// <summary>
+    /// Converts codec to streaming codec
+    /// </summary>
+    /// <typeparam name="T">Message type</typeparam>
+    public sealed class CodecToStreamingCodec<T> : IStreamingCodec<T>
+    {
+        private readonly ICodec<T> _codec;
+            
+        [Inject]
+        private CodecToStreamingCodec(ICodec<T> codec)
+        {
+            _codec = codec;
+        }
+
+        public T Read(IDataReader reader)
+        {
+            int length = reader.ReadInt32();
+            byte[] byteArr = new byte[length];
+            reader.Read(ref byteArr, 0, length);
+            return _codec.Decode(byteArr);
+        }
+
+        public void Write(T obj, IDataWriter writer)
+        {
+            var byteArr = _codec.Encode(obj);
+            writer.WriteInt32(byteArr.Length);
+            writer.Write(byteArr, 0, byteArr.Length);
+        }
+
+        public async Task<T> ReadAsync(IDataReader reader, CancellationToken token)
+        {
+            int length = await reader.ReadInt32Async(token);
+            byte[] byteArr = new byte[length];
+            await reader.ReadAsync(byteArr, 0, length, token);
+            return _codec.Decode(byteArr);
+        }
+
+        public async Task WriteAsync(T obj, IDataWriter writer, CancellationToken token)
+        {
+            var byteArr = _codec.Encode(obj);
+            await writer.WriteInt32Async(byteArr.Length, token);
+            await writer.WriteAsync(byteArr, 0, byteArr.Length, token);
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Network/StreamingCodec/CodecToStreamingCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/StreamingCodec/CodecToStreamingCodec.cs
@@ -17,10 +17,6 @@
  * under the License.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Org.Apache.REEF.Tang.Annotations;

--- a/lang/cs/Org.Apache.REEF.Network/StreamingCodec/CommonStreamingCodecs/DoubleArrayStreamingCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/StreamingCodec/CommonStreamingCodecs/DoubleArrayStreamingCodec.cs
@@ -1,0 +1,109 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Wake.Remote;
+
+namespace Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs
+{
+    /// <summary>
+    /// Streaming codec for double array
+    /// </summary>
+    public sealed class DoubleArrayStreamingCodec : IStreamingCodec<double[]>
+    {
+        /// <summary>
+        /// Injectable constructor
+        /// </summary>
+        [Inject]
+        private DoubleArrayStreamingCodec()
+        {
+        }
+
+        /// <summary>
+        /// Instantiate the class from the reader.
+        /// </summary>
+        /// <param name="reader">The reader from which to read</param>
+        ///<returns>The double array read from the reader</returns>
+        public double[] Read(IDataReader reader)
+        {
+            int length = reader.ReadInt32();
+            byte[] buffer = new byte[sizeof(double)*length];
+            reader.Read(ref buffer, 0, buffer.Length);
+            double[] doubleArr = new double[length];
+            Buffer.BlockCopy(buffer, 0, doubleArr, 0, buffer.Length);
+            return doubleArr;
+        }
+
+        /// <summary>
+        /// Writes the double array to the writer.
+        /// </summary>
+        /// <param name="obj">The double array to be encoded</param>
+        /// <param name="writer">The writer to which to write</param>
+        public void Write(double[] obj, IDataWriter writer)
+        {
+            if (obj == null)
+            {
+                throw new ArgumentNullException("obj", "double array is null");
+            }
+
+            writer.WriteInt32(obj.Length);
+            byte[] buffer = new byte[sizeof(double) * obj.Length];
+            Buffer.BlockCopy(obj, 0, buffer, 0, buffer.Length);
+            writer.Write(buffer, 0, buffer.Length);
+        }
+
+        ///  <summary>
+        ///  Instantiate the class from the reader.
+        ///  </summary>
+        ///  <param name="reader">The reader from which to read</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>The double array read from the reader</returns>
+        public async Task<double[]> ReadAsync(IDataReader reader, CancellationToken token)
+        {
+            int length = await reader.ReadInt32Async(token);
+            byte[] buffer = new byte[sizeof(double) * length];
+            await reader.ReadAsync(buffer, 0, buffer.Length, token);
+            double[] doubleArr = new double[length];
+            Buffer.BlockCopy(buffer, 0, doubleArr, 0, sizeof(double) * length);
+            return doubleArr;
+        }
+
+        /// <summary>
+        /// Writes the double array to the writer.
+        /// </summary>
+        /// <param name="obj">The double array to be encoded</param>
+        /// <param name="writer">The writer to which to write</param>
+        /// <param name="token">Cancellation token</param>
+        public async Task WriteAsync(double[] obj, IDataWriter writer, CancellationToken token)
+        {
+            if (obj == null)
+            {
+                throw new ArgumentNullException("obj", "double array is null");
+            }
+
+            await writer.WriteInt32Async(obj.Length, token);
+            byte[] buffer = new byte[sizeof(double) * obj.Length];
+            Buffer.BlockCopy(obj, 0, buffer, 0, sizeof(double) * obj.Length);
+            await writer.WriteAsync(buffer, 0, buffer.Length, token);
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Network/StreamingCodec/CommonStreamingCodecs/DoubleStreamingCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/StreamingCodec/CommonStreamingCodecs/DoubleStreamingCodec.cs
@@ -1,0 +1,82 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System.Threading;
+using System.Threading.Tasks;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Wake.Remote;
+
+namespace Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs
+{
+    /// <summary>
+    /// Streaming codec for double
+    /// </summary>
+    public sealed class DoubleStreamingCodec : IStreamingCodec<double>
+    {
+        /// <summary>
+        /// Injectable constructor
+        /// </summary>
+        [Inject]
+        private DoubleStreamingCodec()
+        {
+        }
+
+        /// <summary>
+        /// Instantiate the class from the reader.
+        /// </summary>
+        /// <param name="reader">The reader from which to read</param>
+        ///<returns>The double read from the reader</returns>
+        public double Read(IDataReader reader)
+        {
+            return reader.ReadDouble();
+        }
+
+        /// <summary>
+        /// Writes the double to the writer.
+        /// </summary>
+        /// <param name="obj">The double to be encoded</param>
+        /// <param name="writer">The writer to which to write</param>
+        public void Write(double obj, IDataWriter writer)
+        {
+            writer.WriteDouble(obj);
+        }
+
+        ///  <summary>
+        ///  Instantiate the class from the reader.
+        ///  </summary>
+        ///  <param name="reader">The reader from which to read</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>The double read from the reader</returns>
+        public async Task<double> ReadAsync(IDataReader reader, CancellationToken token)
+        {
+            return await reader.ReadDoubleAsync(token);
+        }
+
+        /// <summary>
+        /// Writes the double to the writer.
+        /// </summary>
+        /// <param name="obj">The double to be encoded</param>
+        /// <param name="writer">The writer to which to write</param>
+        /// <param name="token">Cancellation token</param>
+        public async Task WriteAsync(double obj, IDataWriter writer, CancellationToken token)
+        {
+            await writer.WriteDoubleAsync(obj, token);
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Network/StreamingCodec/CommonStreamingCodecs/FloatArrayStreamingCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/StreamingCodec/CommonStreamingCodecs/FloatArrayStreamingCodec.cs
@@ -1,0 +1,109 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Wake.Remote;
+
+namespace Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs
+{
+    /// <summary>
+    /// Streaming codec for float array
+    /// </summary>
+    public sealed class FloatArrayStreamingCodec : IStreamingCodec<float[]>
+    {
+        /// <summary>
+        /// Injectable constructor
+        /// </summary>
+        [Inject]
+        private FloatArrayStreamingCodec()
+        {
+        }
+
+        /// <summary>
+        /// Instantiate the class from the reader.
+        /// </summary>
+        /// <param name="reader">The reader from which to read</param>
+        ///<returns>The float array read from the reader</returns>
+        public float[] Read(IDataReader reader)
+        {
+            int length = reader.ReadInt32();
+            byte[] buffer = new byte[sizeof(float)*length];
+            reader.Read(ref buffer, 0, buffer.Length);
+            float[] floatArr = new float[length];
+            Buffer.BlockCopy(buffer, 0, floatArr, 0, buffer.Length);
+            return floatArr;
+        }
+
+        /// <summary>
+        /// Writes the float array to the writer.
+        /// </summary>
+        /// <param name="obj">The float array to be encoded</param>
+        /// <param name="writer">The writer to which to write</param>
+        public void Write(float[] obj, IDataWriter writer)
+        {
+            if (obj == null)
+            {
+                throw new ArgumentNullException("obj", "float array is null");
+            }
+
+            writer.WriteInt32(obj.Length);
+            byte[] buffer = new byte[sizeof(float) * obj.Length];
+            Buffer.BlockCopy(obj, 0, buffer, 0, buffer.Length);
+            writer.Write(buffer, 0, buffer.Length);
+        }
+
+        ///  <summary>
+        ///  Instantiate the class from the reader.
+        ///  </summary>
+        ///  <param name="reader">The reader from which to read</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>The float array read from the reader</returns>
+        public async Task<float[]> ReadAsync(IDataReader reader, CancellationToken token)
+        {
+            int length = await reader.ReadInt32Async(token);
+            byte[] buffer = new byte[sizeof(float) * length];
+            await reader.ReadAsync(buffer, 0, buffer.Length, token);
+            float[] floatArr = new float[length];
+            Buffer.BlockCopy(buffer, 0, floatArr, 0, sizeof(float) * length);
+            return floatArr;
+        }
+
+        /// <summary>
+        /// Writes the float array to the writer.
+        /// </summary>
+        /// <param name="obj">The float array to be encoded</param>
+        /// <param name="writer">The writer to which to write</param>
+        /// <param name="token">Cancellation token</param>
+        public async Task WriteAsync(float[] obj, IDataWriter writer, CancellationToken token)
+        {
+            if (obj == null)
+            {
+                throw new ArgumentNullException("obj", "float array is null");
+            }
+
+            await writer.WriteInt32Async(obj.Length, token);
+            byte[] buffer = new byte[sizeof(float) * obj.Length];
+            Buffer.BlockCopy(obj, 0, buffer, 0, sizeof(float) * obj.Length);
+            await writer.WriteAsync(buffer, 0, buffer.Length, token);
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Network/StreamingCodec/CommonStreamingCodecs/FloatStreamingCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/StreamingCodec/CommonStreamingCodecs/FloatStreamingCodec.cs
@@ -1,0 +1,82 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System.Threading;
+using System.Threading.Tasks;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Wake.Remote;
+
+namespace Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs
+{
+    /// <summary>
+    /// Streaming codec for float
+    /// </summary>
+    public sealed class FloatStreamingCodec : IStreamingCodec<float>
+    {
+        /// <summary>
+        /// Injectable constructor
+        /// </summary>
+        [Inject]
+        private FloatStreamingCodec()
+        {
+        }
+
+        /// <summary>
+        /// Instantiate the class from the reader.
+        /// </summary>
+        /// <param name="reader">The reader from which to read</param>
+        ///<returns>The float read from the reader</returns>
+        public float Read(IDataReader reader)
+        {
+            return reader.ReadFloat();
+        }
+
+        /// <summary>
+        /// Writes the float to the writer.
+        /// </summary>
+        /// <param name="obj">The float to be encoded</param>
+        /// <param name="writer">The writer to which to write</param>
+        public void Write(float obj, IDataWriter writer)
+        {
+            writer.WriteFloat(obj);
+        }
+
+        ///  <summary>
+        ///  Instantiate the class from the reader.
+        ///  </summary>
+        ///  <param name="reader">The reader from which to read</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>The float read from the reader</returns>
+        public async Task<float> ReadAsync(IDataReader reader, CancellationToken token)
+        {
+            return await reader.ReadFloatAsync(token);
+        }
+
+        /// <summary>
+        /// Writes the float to the writer.
+        /// </summary>
+        /// <param name="obj">The float to be encoded</param>
+        /// <param name="writer">The writer to which to write</param>
+        /// <param name="token">Cancellation token</param>
+        public async Task WriteAsync(float obj, IDataWriter writer, CancellationToken token)
+        {
+            await writer.WriteFloatAsync(obj, token);
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Network/StreamingCodec/CommonStreamingCodecs/IntArrayStreamingCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/StreamingCodec/CommonStreamingCodecs/IntArrayStreamingCodec.cs
@@ -1,0 +1,109 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Wake.Remote;
+
+namespace Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs
+{
+    /// <summary>
+    /// Streaming codec for integer array
+    /// </summary>
+    public sealed class IntArrayStreamingCodec : IStreamingCodec<int[]>
+    {
+        /// <summary>
+        /// Injectable constructor
+        /// </summary>
+        [Inject]
+        private IntArrayStreamingCodec()
+        {
+        }
+
+        /// <summary>
+        /// Instantiate the class from the reader.
+        /// </summary>
+        /// <param name="reader">The reader from which to read</param>
+        ///<returns>The integer array read from the reader</returns>
+        public int[] Read(IDataReader reader)
+        {
+            int length = reader.ReadInt32();
+            byte[] buffer = new byte[sizeof(int)*length];
+            reader.Read(ref buffer, 0, buffer.Length);
+            int[] intArr = new int[length];
+            Buffer.BlockCopy(buffer, 0, intArr, 0, buffer.Length);
+            return intArr;
+        }
+
+        /// <summary>
+        /// Writes the integer array to the writer.
+        /// </summary>
+        /// <param name="obj">The integer array to be encoded</param>
+        /// <param name="writer">The writer to which to write</param>
+        public void Write(int[] obj, IDataWriter writer)
+        {
+            if (obj == null)
+            {
+                throw new ArgumentNullException("obj", "integer array is null");
+            }
+
+            writer.WriteInt32(obj.Length);
+            byte[] buffer = new byte[sizeof(int) * obj.Length];
+            Buffer.BlockCopy(obj, 0, buffer, 0, buffer.Length);
+            writer.Write(buffer, 0, buffer.Length);
+        }
+
+        ///  <summary>
+        ///  Instantiate the class from the reader.
+        ///  </summary>
+        ///  <param name="reader">The reader from which to read</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>The integer array read from the reader</returns>
+        public async Task<int[]> ReadAsync(IDataReader reader, CancellationToken token)
+        {
+            int length = await reader.ReadInt32Async(token);
+            byte[] buffer = new byte[sizeof(int) * length];
+            await reader.ReadAsync(buffer, 0, buffer.Length, token);
+            int[] intArr = new int[length];
+            Buffer.BlockCopy(buffer, 0, intArr, 0, sizeof(int) * length);
+            return intArr;
+        }
+
+        /// <summary>
+        /// Writes the integer array to the writer.
+        /// </summary>
+        /// <param name="obj">The integer array to be encoded</param>
+        /// <param name="writer">The writer to which to write</param>
+        /// <param name="token">Cancellation token</param>
+        public async Task WriteAsync(int[] obj, IDataWriter writer, CancellationToken token)
+        {
+            if (obj == null)
+            {
+                throw new ArgumentNullException("obj", "integer array is null");
+            }
+
+            await writer.WriteInt32Async(obj.Length, token);
+            byte[] buffer = new byte[sizeof(int) * obj.Length];
+            Buffer.BlockCopy(obj, 0, buffer, 0, sizeof(int) * obj.Length);
+            await writer.WriteAsync(buffer, 0, buffer.Length, token);
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Network/StreamingCodec/CommonStreamingCodecs/IntStreamingCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/StreamingCodec/CommonStreamingCodecs/IntStreamingCodec.cs
@@ -1,0 +1,82 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System.Threading;
+using System.Threading.Tasks;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Wake.Remote;
+
+namespace Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs
+{
+    /// <summary>
+    /// Streaming codec for integer
+    /// </summary>
+    public sealed class IntStreamingCodec : IStreamingCodec<int>
+    {
+        /// <summary>
+        /// Injectable constructor
+        /// </summary>
+        [Inject]
+        private IntStreamingCodec()
+        {
+        }
+
+        /// <summary>
+        /// Instantiate the class from the reader.
+        /// </summary>
+        /// <param name="reader">The reader from which to read</param>
+        ///<returns>The iinteger read from the reader</returns>
+        public int Read(IDataReader reader)
+        {
+            return reader.ReadInt32();
+        }
+
+        /// <summary>
+        /// Writes the integer to the writer.
+        /// </summary>
+        /// <param name="obj">The integer to be encoded</param>
+        /// <param name="writer">The writer to which to write</param>
+        public void Write(int obj, IDataWriter writer)
+        {
+            writer.WriteInt32(obj);
+        }
+
+        ///  <summary>
+        ///  Instantiate the class from the reader.
+        ///  </summary>
+        ///  <param name="reader">The reader from which to read</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>The integer read from the reader</returns>
+        public async Task<int> ReadAsync(IDataReader reader, CancellationToken token)
+        {
+            return await reader.ReadInt32Async(token);
+        }
+
+        /// <summary>
+        /// Writes the integer to the writer.
+        /// </summary>
+        /// <param name="obj">The integer to be encoded</param>
+        /// <param name="writer">The writer to which to write</param>
+        /// <param name="token">Cancellation token</param>
+        public async Task WriteAsync(int obj, IDataWriter writer, CancellationToken token)
+        {
+            await writer.WriteInt32Async(obj, token);
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Network/StreamingCodec/IStreamingCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/StreamingCodec/IStreamingCodec.cs
@@ -17,11 +17,6 @@
  * under the License.
  */
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Org.Apache.REEF.Wake.Remote;

--- a/lang/cs/Org.Apache.REEF.Network/StreamingCodec/IStreamingCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/StreamingCodec/IStreamingCodec.cs
@@ -1,0 +1,66 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Org.Apache.REEF.Wake.Remote;
+
+namespace Org.Apache.REEF.Network.StreamingCodec
+{
+    /// <summary>
+    /// Codec Interface that external users should implement to directly write to the stream
+    /// </summary>
+    public interface IStreamingCodec<T>
+    {
+        /// <summary>
+        /// Instantiate the class from the reader.
+        /// </summary>
+        /// <param name="reader">The reader from which to read</param>
+        ///<returns>The instance of type T read from the reader</returns>
+        T Read(IDataReader reader);
+
+        /// <summary>
+        /// Writes the class fields to the writer.
+        /// </summary>
+        /// <param name="obj">The object of type T to be encoded</param>
+        /// <param name="writer">The writer to which to write</param>
+        void Write(T obj, IDataWriter writer);
+
+        ///  <summary>
+        ///  Instantiate the class from the reader.
+        ///  </summary>
+        ///  <param name="reader">The reader from which to read</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>The instance of type T read from the reader</returns>
+        Task<T> ReadAsync(IDataReader reader, CancellationToken token);
+
+        /// <summary>
+        /// Writes the class fields to the writer.
+        /// </summary>
+        /// <param name="obj">The object of type T to be encoded</param>
+        /// <param name="writer">The writer to which to write</param>
+        /// <param name="token">Cancellation token</param>
+        Task WriteAsync(T obj, IDataWriter writer, CancellationToken token);
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamDataReader.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamDataReader.cs
@@ -18,10 +18,7 @@
  */
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Org.Apache.REEF.Utilities.Diagnostics;

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamDataReader.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamDataReader.cs
@@ -47,6 +47,11 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
         /// <param name="stream">Stream from which to read</param>
         public StreamDataReader(Stream stream)
         {
+            if (stream == null)
+            {
+                throw new ArgumentNullException("stream", "input stream cannot be null");
+            }
+
             _stream = stream;
         }
 

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamDataWriter.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamDataWriter.cs
@@ -40,6 +40,11 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
         /// <param name="stream">Stream from which to read</param>
         public StreamDataWriter(Stream stream)
         {
+            if (stream == null)
+            {
+                throw new ArgumentNullException("stream", "input stream cannot be null");
+            }
+
             _stream = stream;
         }
 

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamDataWriter.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamDataWriter.cs
@@ -18,10 +18,7 @@
  */
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 


### PR DESCRIPTION
[REEF-261]: Make the GroupCommunicationOperator layer memory efficient by introducing StreamingCodec

This addressed the issue by
  * allowing users directly to write streaming codecs.
  * allowing users directly to write non-streaming codecs. In this case we write the wrapper code that directly converts this codec in to streamingcodec

JIRA: [REEF-261](https://issues.apache.org/jira/browse/REEF-261)