### PR TITLE
[REEF-406]: Give user an option to configure the TCPPortProvider in B…

### DIFF
--- a/lang/cs/Org.Apache.REEF.Network.Examples.Client/BroadcastAndReduceClient.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples.Client/BroadcastAndReduceClient.cs
@@ -37,7 +37,7 @@ namespace Org.Apache.REEF.Network.Examples.Client
 {
     class BroadcastAndReduceClient
     {
-        public void RunBroadcastAndReduce(bool runOnYarn, int numTasks)
+        public void RunBroadcastAndReduce(bool runOnYarn, int numTasks, int startingPortNo, int portRange)
         {
             const int numIterations = 10;
             const string driverId = "BroadcastReduceDriver";
@@ -60,6 +60,12 @@ namespace Org.Apache.REEF.Network.Examples.Client
                 .BindNamedParameter<GroupTestConfig.NumEvaluators, int>(
                     GenericType<GroupTestConfig.NumEvaluators>.Class,
                     numTasks.ToString(CultureInfo.InvariantCulture))
+                .BindNamedParameter<GroupTestConfig.StartingPort, int>(
+                    GenericType<GroupTestConfig.StartingPort>.Class,
+                    startingPortNo.ToString(CultureInfo.InvariantCulture))
+                .BindNamedParameter<GroupTestConfig.PortRange, int>(
+                    GenericType<GroupTestConfig.PortRange>.Class,
+                    portRange.ToString(CultureInfo.InvariantCulture))
                 .Build();
 
             IConfiguration groupCommDriverConfig = TangFactory.GetTang().NewConfigurationBuilder()

--- a/lang/cs/Org.Apache.REEF.Network.Examples.Client/PipelineBroadcastAndReduceClient.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples.Client/PipelineBroadcastAndReduceClient.cs
@@ -41,7 +41,7 @@ namespace Org.Apache.REEF.Network.Examples.Client
 {
     public class PipelineBroadcastAndReduceClient
     {
-        public void RunPipelineBroadcastAndReduce(bool runOnYarn, int numTasks, int startingPortNo, int portRange)
+        public void RunPipelineBroadcastAndReduce(bool runOnYarn, int numTasks, int startingPortNo, int portRange, int arraySize, int chunkSize)
         {
             IConfiguration driverConfig = TangFactory.GetTang().NewConfigurationBuilder(
                 DriverBridgeConfiguration.ConfigurationModule
@@ -62,13 +62,16 @@ namespace Org.Apache.REEF.Network.Examples.Client
                     numTasks.ToString(CultureInfo.InvariantCulture))
                 .BindNamedParameter<GroupTestConfig.ChunkSize, int>(
                     GenericType<GroupTestConfig.ChunkSize>.Class,
-                    GroupTestConstants.ChunkSize.ToString(CultureInfo.InvariantCulture))
+                    chunkSize.ToString(CultureInfo.InvariantCulture))
                 .BindNamedParameter<GroupTestConfig.StartingPort, int>(
                     GenericType<GroupTestConfig.StartingPort>.Class,
                     startingPortNo.ToString(CultureInfo.InvariantCulture))
                 .BindNamedParameter<GroupTestConfig.PortRange, int>(
                     GenericType<GroupTestConfig.PortRange>.Class,
                     portRange.ToString(CultureInfo.InvariantCulture))
+                .BindNamedParameter<GroupTestConfig.ArraySize, int>(
+                    GenericType<GroupTestConfig.ArraySize>.Class,
+                    arraySize.ToString(CultureInfo.InvariantCulture))
                 .Build();
 
             IConfiguration groupCommDriverConfig = TangFactory.GetTang().NewConfigurationBuilder()

--- a/lang/cs/Org.Apache.REEF.Network.Examples.Client/PipelineBroadcastAndReduceClient.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples.Client/PipelineBroadcastAndReduceClient.cs
@@ -41,13 +41,15 @@ namespace Org.Apache.REEF.Network.Examples.Client
 {
     public class PipelineBroadcastAndReduceClient
     {
-        public void RunPipelineBroadcastAndReduce(bool runOnYarn, int numTasks)
+        public void RunPipelineBroadcastAndReduce(bool runOnYarn, int numTasks, int startingPortNo, int portRange)
         {
             IConfiguration driverConfig = TangFactory.GetTang().NewConfigurationBuilder(
                 DriverBridgeConfiguration.ConfigurationModule
                     .Set(DriverBridgeConfiguration.OnDriverStarted, GenericType<PipelinedBroadcastReduceDriver>.Class)
-                    .Set(DriverBridgeConfiguration.OnEvaluatorAllocated, GenericType<PipelinedBroadcastReduceDriver>.Class)
-                    .Set(DriverBridgeConfiguration.OnEvaluatorRequested, GenericType<PipelinedBroadcastReduceDriver>.Class)
+                    .Set(DriverBridgeConfiguration.OnEvaluatorAllocated,
+                        GenericType<PipelinedBroadcastReduceDriver>.Class)
+                    .Set(DriverBridgeConfiguration.OnEvaluatorRequested,
+                        GenericType<PipelinedBroadcastReduceDriver>.Class)
                     .Set(DriverBridgeConfiguration.OnEvaluatorFailed, GenericType<PipelinedBroadcastReduceDriver>.Class)
                     .Set(DriverBridgeConfiguration.OnContextActive, GenericType<PipelinedBroadcastReduceDriver>.Class)
                     .Set(DriverBridgeConfiguration.CustomTraceLevel, Level.Info.ToString())
@@ -58,9 +60,15 @@ namespace Org.Apache.REEF.Network.Examples.Client
                 .BindNamedParameter<GroupTestConfig.NumEvaluators, int>(
                     GenericType<GroupTestConfig.NumEvaluators>.Class,
                     numTasks.ToString(CultureInfo.InvariantCulture))
-                 .BindNamedParameter<GroupTestConfig.ChunkSize, int>(
+                .BindNamedParameter<GroupTestConfig.ChunkSize, int>(
                     GenericType<GroupTestConfig.ChunkSize>.Class,
                     GroupTestConstants.ChunkSize.ToString(CultureInfo.InvariantCulture))
+                .BindNamedParameter<GroupTestConfig.StartingPort, int>(
+                    GenericType<GroupTestConfig.StartingPort>.Class,
+                    startingPortNo.ToString(CultureInfo.InvariantCulture))
+                .BindNamedParameter<GroupTestConfig.PortRange, int>(
+                    GenericType<GroupTestConfig.PortRange>.Class,
+                    portRange.ToString(CultureInfo.InvariantCulture))
                 .Build();
 
             IConfiguration groupCommDriverConfig = TangFactory.GetTang().NewConfigurationBuilder()

--- a/lang/cs/Org.Apache.REEF.Network.Examples.Client/Run.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples.Client/Run.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Collections.Generic;
+using Org.Apache.REEF.Wake.Remote.Parameters;
 
 namespace Org.Apache.REEF.Network.Examples.Client
 {
@@ -28,7 +29,12 @@ namespace Org.Apache.REEF.Network.Examples.Client
         {
             Console.WriteLine("start running client: " + DateTime.Now);
             bool runOnYarn = false;
+            int numNodes = 9;
+            int startPort = 8900;
+            int portRange = 1000;
+
             List<string> testToRun = new List<string>();
+            
             if (args != null)
             {
                 if (args.Length > 0)
@@ -36,7 +42,22 @@ namespace Org.Apache.REEF.Network.Examples.Client
                     runOnYarn = bool.Parse(args[0].ToLower());
                 }
 
-                for (int i = 1; i < args.Length; i++)
+                if (args.Length > 1)
+                {
+                    numNodes = int.Parse(args[1]);
+                }
+
+                if (args.Length > 2)
+                {
+                    startPort = int.Parse(args[2]);
+                }
+
+                if (args.Length > 3)
+                {
+                    portRange = int.Parse(args[3]);
+                }
+
+                for (int i = 4; i < args.Length; i++)
                 {
                     testToRun.Add(args[i].ToLower());
                 }
@@ -44,13 +65,14 @@ namespace Org.Apache.REEF.Network.Examples.Client
 
             if (testToRun.Contains("RunPipelineBroadcastAndReduce".ToLower()) || testToRun.Contains("all") || testToRun.Count == 0)
             {
-                new PipelineBroadcastAndReduceClient().RunPipelineBroadcastAndReduce(runOnYarn, 9);
+                new PipelineBroadcastAndReduceClient().RunPipelineBroadcastAndReduce(runOnYarn, numNodes, startPort,
+                    portRange);
                 Console.WriteLine("RunPipelineBroadcastAndReduce completed!!!");
             }
 
             if (testToRun.Contains("RunBroadcastAndReduce".ToLower()) || testToRun.Contains("all") || testToRun.Count == 0)
             {
-                new BroadcastAndReduceClient().RunBroadcastAndReduce(runOnYarn, 9);
+                new BroadcastAndReduceClient().RunBroadcastAndReduce(runOnYarn, numNodes, startPort, portRange);
                 Console.WriteLine("RunBroadcastAndReduce completed!!!");
             }           
         }

--- a/lang/cs/Org.Apache.REEF.Network.Examples.Client/Run.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples.Client/Run.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Collections.Generic;
+using Org.Apache.REEF.Network.Examples.GroupCommunication;
 using Org.Apache.REEF.Wake.Remote.Parameters;
 
 namespace Org.Apache.REEF.Network.Examples.Client
@@ -32,8 +33,7 @@ namespace Org.Apache.REEF.Network.Examples.Client
             int numNodes = 9;
             int startPort = 8900;
             int portRange = 1000;
-
-            List<string> testToRun = new List<string>();
+            string testToRun = "RunBroadcastAndReduce";
             
             if (args != null)
             {
@@ -57,20 +57,29 @@ namespace Org.Apache.REEF.Network.Examples.Client
                     portRange = int.Parse(args[3]);
                 }
 
-                for (int i = 4; i < args.Length; i++)
+                if (args.Length > 4)
                 {
-                    testToRun.Add(args[i].ToLower());
+                    testToRun = args[4].ToLower();
                 }
             }
 
-            if (testToRun.Contains("RunPipelineBroadcastAndReduce".ToLower()) || testToRun.Contains("all") || testToRun.Count == 0)
+            if (testToRun.Equals("RunPipelineBroadcastAndReduce".ToLower()) || testToRun.Equals("all"))
             {
+                int arraySize = GroupTestConstants.ArrayLength;
+                int chunkSize = GroupTestConstants.ChunkSize;
+
+                if (args.Length > 5)
+                {
+                    arraySize = int.Parse(args[5]);
+                    chunkSize = int.Parse(args[6]);
+                }
+
                 new PipelineBroadcastAndReduceClient().RunPipelineBroadcastAndReduce(runOnYarn, numNodes, startPort,
-                    portRange);
+                    portRange, arraySize, chunkSize);
                 Console.WriteLine("RunPipelineBroadcastAndReduce completed!!!");
             }
 
-            if (testToRun.Contains("RunBroadcastAndReduce".ToLower()) || testToRun.Contains("all") || testToRun.Count == 0)
+            if (testToRun.Equals("RunBroadcastAndReduce".ToLower()) || testToRun.Equals("all"))
             {
                 new BroadcastAndReduceClient().RunBroadcastAndReduce(runOnYarn, numNodes, startPort, portRange);
                 Console.WriteLine("RunBroadcastAndReduce completed!!!");

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/GroupTestConfig.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/GroupTestConfig.cs
@@ -52,5 +52,15 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication
         public class ChunkSize : Name<int>
         {
         }
+
+        [NamedParameter(Documentation = "Starting port for TcpPortProvider", DefaultValue = "8900")]
+        public class StartingPort : Name<int>
+        {
+        }
+
+        [NamedParameter(Documentation = "Port Range count for TcpPortProvider", DefaultValue = "1000")]
+        public class PortRange : Name<int>
+        {
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedBroadcastReduceDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedBroadcastReduceDriver.cs
@@ -43,6 +43,7 @@ using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Logging;
 using Org.Apache.REEF.Wake.Remote;
 using Org.Apache.REEF.Wake.Remote.Impl;
+using Org.Apache.REEF.Wake.Remote.Parameters;
 
 namespace Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastReduceDriverAndTasks
 {
@@ -57,12 +58,15 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastR
         private readonly IGroupCommDriver _groupCommDriver;
         private readonly ICommunicationGroupDriver _commGroup;
         private readonly TaskStarter _groupCommTaskStarter;
+        private IConfiguration _tcpPortProviderConfig;
 
         [Inject]
         public PipelinedBroadcastReduceDriver(
             [Parameter(typeof (GroupTestConfig.NumEvaluators))] int numEvaluators,
-            [Parameter(typeof(GroupTestConfig.NumIterations))] int numIterations,
-            [Parameter(typeof(GroupTestConfig.ChunkSize))] int chunkSize,
+            [Parameter(typeof (GroupTestConfig.NumIterations))] int numIterations,
+            [Parameter(typeof (GroupTestConfig.StartingPort))] int startingPort,
+            [Parameter(typeof (GroupTestConfig.PortRange))] int portRange,
+            [Parameter(typeof (GroupTestConfig.ChunkSize))] int chunkSize,
             GroupCommDriver groupCommDriver)
         {
             Logger.Log(Level.Info, "entering the driver code " + chunkSize);
@@ -71,6 +75,13 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastR
             _numEvaluators = numEvaluators;
             _numIterations = numIterations;
             _chunkSize = chunkSize;
+
+            _tcpPortProviderConfig = TangFactory.GetTang().NewConfigurationBuilder()
+                .BindNamedParameter<TcpPortRangeStart, int>(GenericType<TcpPortRangeStart>.Class,
+                    startingPort.ToString(CultureInfo.InvariantCulture))
+                .BindNamedParameter<TcpPortRangeCount, int>(GenericType<TcpPortRangeCount>.Class,
+                    portRange.ToString(CultureInfo.InvariantCulture))
+                .Build();
 
             IConfiguration codecConfig = CodecConfiguration<int[]>.Conf
                 .Set(CodecConfiguration<int[]>.Codec, GenericType<IntArrayCodec>.Class)
@@ -125,6 +136,7 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastR
         {
             IConfiguration contextConf = _groupCommDriver.GetContextConfiguration();
             IConfiguration serviceConf = _groupCommDriver.GetServiceConfiguration();
+            serviceConf = Configurations.Merge(serviceConf, _tcpPortProviderConfig);
             allocatedEvaluator.SubmitContextAndService(contextConf, serviceConf);
         }
 

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedBroadcastReduceDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedBroadcastReduceDriver.cs
@@ -53,12 +53,12 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastR
 
         private readonly int _numEvaluators;
         private readonly int _numIterations;
-        private readonly int _chunkSize;
+        private readonly int _arraySize;
 
         private readonly IGroupCommDriver _groupCommDriver;
         private readonly ICommunicationGroupDriver _commGroup;
         private readonly TaskStarter _groupCommTaskStarter;
-        private IConfiguration _tcpPortProviderConfig;
+        private readonly IConfiguration _tcpPortProviderConfig;
 
         [Inject]
         public PipelinedBroadcastReduceDriver(
@@ -67,6 +67,7 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastR
             [Parameter(typeof (GroupTestConfig.StartingPort))] int startingPort,
             [Parameter(typeof (GroupTestConfig.PortRange))] int portRange,
             [Parameter(typeof (GroupTestConfig.ChunkSize))] int chunkSize,
+            [Parameter(typeof(GroupTestConfig.ArraySize))] int arraySize,
             GroupCommDriver groupCommDriver)
         {
             Logger.Log(Level.Info, "entering the driver code " + chunkSize);
@@ -74,7 +75,7 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastR
             Identifier = "BroadcastStartHandler";
             _numEvaluators = numEvaluators;
             _numIterations = numIterations;
-            _chunkSize = chunkSize;
+            _arraySize = arraySize;
 
             _tcpPortProviderConfig = TangFactory.GetTang().NewConfigurationBuilder()
                 .BindNamedParameter<TcpPortRangeStart, int>(GenericType<TcpPortRangeStart>.Class,
@@ -98,7 +99,7 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastR
                     .Build())
                 .BindNamedParameter<GroupTestConfig.ChunkSize, int>(
                     GenericType<GroupTestConfig.ChunkSize>.Class,
-                    GroupTestConstants.ChunkSize.ToString(CultureInfo.InvariantCulture))
+                    chunkSize.ToString(CultureInfo.InvariantCulture))
                 .Build();
 
             _groupCommDriver = groupCommDriver;
@@ -160,7 +161,7 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastR
                         _numIterations.ToString(CultureInfo.InvariantCulture))
                     .BindNamedParameter<GroupTestConfig.ArraySize, int>(
                         GenericType<GroupTestConfig.ArraySize>.Class,
-                        GroupTestConstants.ArrayLength.ToString(CultureInfo.InvariantCulture))
+                        _arraySize.ToString(CultureInfo.InvariantCulture))
                     .Build();
 
                 _commGroup.AddTask(GroupTestConstants.MasterTaskId);
@@ -183,7 +184,7 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastR
                         _numIterations.ToString(CultureInfo.InvariantCulture))
                     .BindNamedParameter<GroupTestConfig.ArraySize, int>(
                         GenericType<GroupTestConfig.ArraySize>.Class,
-                        GroupTestConstants.ArrayLength.ToString(CultureInfo.InvariantCulture))
+                        _arraySize.ToString(CultureInfo.InvariantCulture))
                     .Build();
 
                 _commGroup.AddTask(slaveTaskId);

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedMasterTask.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedMasterTask.cs
@@ -73,7 +73,7 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastR
                 _broadcastSender.Send(intArr);
                 int[] sum = _sumReducer.Reduce();
 
-                Logger.Log(Level.Info, "Received sum: {0} on iteration: {1}", sum, i);
+                Logger.Log(Level.Info, "Received sum: {0} on iteration: {1} with array length: {2}", sum[0], i, sum.Length);
 
                 int expected = TriangleNumber(i) * _numReduceSenders;
 


### PR DESCRIPTION
[REEF-406]: Give user an option to configure the TCPPortProvider in BroadcastAndReduceClient and PipelineBroadcastAndReduceClient

This addressed the issue by
	* Allowing user to specify the starting port number and range via command line.
	* Binding this information in the driver configuration.

JIRA: [REEF-406](https://issues.apache.org/jira/browse/REEF-406)