### PR TITLE
[REEF-409] Pass the rackName from the runtime to the top of REEF stack

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceAllocationEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceAllocationEvent.java
@@ -51,4 +51,10 @@ public interface ResourceAllocationEvent {
    * @return Number of virtual CPU cores on the resource
    */
   Optional<Integer> getVirtualCores();
+
+  /**
+   * @return Rack name of the resource
+   */
+  Optional<String> getRackName();
+
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceAllocationEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceAllocationEventImpl.java
@@ -39,7 +39,6 @@ public final class ResourceAllocationEventImpl implements ResourceAllocationEven
     this.nodeId = BuilderUtils.notNull(builder.nodeId);
     this.virtualCores = Optional.ofNullable(builder.virtualCores);
     this.rackName = Optional.ofNullable(builder.rackName);
-
   }
 
   @Override
@@ -117,7 +116,7 @@ public final class ResourceAllocationEventImpl implements ResourceAllocationEven
     /**
      * @see ResourceAllocationEvent#getRackName()
      */
-    public Builder setRackName(String rackName) {
+    public Builder setRackName(final String rackName) {
       this.rackName = rackName;
       return this;
     }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceAllocationEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceAllocationEventImpl.java
@@ -30,12 +30,16 @@ public final class ResourceAllocationEventImpl implements ResourceAllocationEven
   private final int resourceMemory;
   private final String nodeId;
   private final Optional<Integer> virtualCores;
+  private final Optional<String> rackName;
+
 
   private ResourceAllocationEventImpl(final Builder builder) {
     this.identifier = BuilderUtils.notNull(builder.identifier);
     this.resourceMemory = BuilderUtils.notNull(builder.resourceMemory);
     this.nodeId = BuilderUtils.notNull(builder.nodeId);
     this.virtualCores = Optional.ofNullable(builder.virtualCores);
+    this.rackName = Optional.ofNullable(builder.rackName);
+
   }
 
   @Override
@@ -58,6 +62,11 @@ public final class ResourceAllocationEventImpl implements ResourceAllocationEven
     return virtualCores;
   }
 
+  @Override
+  public Optional<String> getRackName() {
+    return rackName;
+  }
+
   public static Builder newBuilder() {
     return new Builder();
   }
@@ -70,6 +79,8 @@ public final class ResourceAllocationEventImpl implements ResourceAllocationEven
     private Integer resourceMemory;
     private String nodeId;
     private Integer virtualCores;
+    private String rackName;
+
 
     /**
      * @see ResourceAllocationEvent#getIdentifier()
@@ -100,6 +111,14 @@ public final class ResourceAllocationEventImpl implements ResourceAllocationEven
      */
     public Builder setVirtualCores(final int virtualCores) {
       this.virtualCores = virtualCores;
+      return this;
+    }
+
+    /**
+     * @see ResourceAllocationEvent#getRackName()
+     */
+    public Builder setRackName(String rackName) {
+      this.rackName = rackName;
       return this;
     }
 

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/LocalRuntimeConfiguration.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/LocalRuntimeConfiguration.java
@@ -25,6 +25,7 @@ import org.apache.reef.runtime.common.files.RuntimeClasspathProvider;
 import org.apache.reef.runtime.common.parameters.JVMHeapSlack;
 import org.apache.reef.runtime.local.LocalClasspathProvider;
 import org.apache.reef.runtime.local.client.parameters.MaxNumberOfEvaluators;
+import org.apache.reef.runtime.local.client.parameters.RackNames;
 import org.apache.reef.runtime.local.client.parameters.RootFolder;
 import org.apache.reef.tang.ConfigurationProvider;
 import org.apache.reef.tang.formats.ConfigurationModule;
@@ -65,7 +66,10 @@ public class LocalRuntimeConfiguration extends ConfigurationModuleBuilder {
    */
   public static final OptionalImpl<ConfigurationProvider> DRIVER_CONFIGURATION_PROVIDERS = new OptionalImpl<>();
 
-
+  /**
+   * The rack names that will be available in the local runtime
+   */
+  public static final OptionalParameter<String> RACK_NAMES = new OptionalParameter<>();
 
 
   /**
@@ -82,6 +86,7 @@ public class LocalRuntimeConfiguration extends ConfigurationModuleBuilder {
       .bindNamedParameter(RootFolder.class, RUNTIME_ROOT_FOLDER)
       .bindNamedParameter(JVMHeapSlack.class, JVM_HEAP_SLACK)
       .bindSetEntry(DriverConfigurationProviders.class, DRIVER_CONFIGURATION_PROVIDERS)
+      .bindSetEntry(RackNames.class, RACK_NAMES)
       .build();
 
 

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/parameters/RackNames.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/parameters/RackNames.java
@@ -27,7 +27,7 @@ import java.util.Set;
  * The name of the default racks available in the local runtime.
  */
 @NamedParameter(short_name = "racks", doc = "The name of the racks the containers will be placed on", default_values = {RackNames.DEFAULT_RACK_NAME})
-public class RackNames implements Name<Set<String>> {
+public final class RackNames implements Name<Set<String>> {
     private RackNames() {}
     public static final String DEFAULT_RACK_NAME = "/default-rack";
 }

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/parameters/RackNames.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/parameters/RackNames.java
@@ -16,29 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.tests;
+package org.apache.reef.runtime.local.client.parameters;
 
-import org.apache.reef.client.DriverLauncher;
-import org.apache.reef.client.LauncherStatus;
-import org.apache.reef.tang.Configuration;
-import org.apache.reef.tang.exceptions.InjectionException;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+import java.util.Set;
 
 /**
- * Abstract base class for TestEnvironments
+ * The name of the default racks available in the local runtime.
  */
-public abstract class TestEnvironmentBase implements TestEnvironment {
-
-  @Override
-  public LauncherStatus run(final Configuration driverConfiguration) {
-    return run(getRuntimeConfiguration(), driverConfiguration);
-  }
-
-  @Override
-  public LauncherStatus run(final Configuration runtimeConfiguration, Configuration driverConfiguration) {
-    try {
-      return DriverLauncher.getLauncher(runtimeConfiguration).run(driverConfiguration, getTestTimeout());
-    } catch (final InjectionException e) {
-      throw new RuntimeException(e);
-    }
-  }
+@NamedParameter(short_name = "racks", doc = "The name of the racks the containers will be placed on", default_values = {RackNames.DEFAULT_RACK_NAME})
+public class RackNames implements Name<Set<String>> {
+    private RackNames() {}
+    public static final String DEFAULT_RACK_NAME = "/default-rack";
 }

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/Container.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/Container.java
@@ -82,4 +82,10 @@ interface Container extends AutoCloseable {
    */
   @Override
   void close();
+
+  /**
+   * @return the rack name where this container is located
+   */
+  String getRackName();
+
 }

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
@@ -28,6 +28,7 @@ import org.apache.reef.runtime.common.driver.resourcemanager.NodeDescriptorEvent
 import org.apache.reef.runtime.common.files.REEFFileNames;
 import org.apache.reef.runtime.common.utils.RemoteManager;
 import org.apache.reef.runtime.local.client.parameters.MaxNumberOfEvaluators;
+import org.apache.reef.runtime.local.client.parameters.RackNames;
 import org.apache.reef.runtime.local.client.parameters.RootFolder;
 import org.apache.reef.runtime.local.process.ReefRunnableProcessObserver;
 import org.apache.reef.tang.annotations.Parameter;
@@ -40,11 +41,13 @@ import org.apache.reef.wake.time.runtime.event.RuntimeStart;
 import org.apache.reef.wake.time.runtime.event.RuntimeStop;
 
 import javax.inject.Inject;
+
 import java.io.File;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -74,6 +77,9 @@ final class ContainerManager implements AutoCloseable {
   private final REEFFileNames fileNames;
   private final ReefRunnableProcessObserver processObserver;
   private final String localAddress;
+  // for now is a single rack, it will be a set in the next commit
+  private final String availableRack;
+
 
   @Inject
   ContainerManager(
@@ -82,8 +88,9 @@ final class ContainerManager implements AutoCloseable {
       final REEFFileNames fileNames,
       @Parameter(MaxNumberOfEvaluators.class) final int capacity,
       @Parameter(RootFolder.class) final String rootFolderName,
-      @Parameter(RuntimeParameters.NodeDescriptorHandler.class) final 
+      @Parameter(RuntimeParameters.NodeDescriptorHandler.class) final
       EventHandler<NodeDescriptorEvent> nodeDescriptorHandler,
+      @Parameter(RackNames.class) final Set<String> rackNames,
       final ReefRunnableProcessObserver processObserver,
       final LocalAddressProvider localAddressProvider) {
     this.capacity = capacity;
@@ -93,6 +100,10 @@ final class ContainerManager implements AutoCloseable {
     this.nodeDescriptorHandler = nodeDescriptorHandler;
     this.rootFolder = new File(rootFolderName);
     this.localAddress = localAddressProvider.getLocalAddress();
+    // this is safe, we are guaranteed that this is not empty (default value)
+    // we will just 1 rack for now, the next commit will include creating
+    // containers in different racks.
+    this.availableRack = rackNames.iterator().next();
 
     LOG.log(Level.FINEST, "Initializing Container Manager with {0} containers", capacity);
 
@@ -133,7 +144,7 @@ final class ContainerManager implements AutoCloseable {
       this.freeNodeList.add(id);
       nodeDescriptorHandler.onNext(NodeDescriptorEventImpl.newBuilder()
           .setIdentifier(id)
-          .setRackName("/default-rack")
+          .setRackName(availableRack)
           .setHostName(this.localAddress)
           .setPort(i)
           .setMemorySize(512) // TODO: Find the actual system memory on this machine.
@@ -153,7 +164,7 @@ final class ContainerManager implements AutoCloseable {
       processFolder.mkdirs();
       // setting rackName to null for now, will end up using the default one
       final ProcessContainer container = new ProcessContainer(
-          this.errorHandlerRID, nodeId, processID, processFolder, megaBytes, numberOfCores, null, this.fileNames, this.processObserver);
+          this.errorHandlerRID, nodeId, processID, processFolder, megaBytes, numberOfCores, availableRack, this.fileNames, this.processObserver);
       this.containers.put(container.getContainerID(), container);
       LOG.log(Level.FINE, "Allocated {0}", container.getContainerID());
       return container;

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
@@ -151,8 +151,9 @@ final class ContainerManager implements AutoCloseable {
       final String processID = nodeId + "-" + String.valueOf(System.currentTimeMillis());
       final File processFolder = new File(this.rootFolder, processID);
       processFolder.mkdirs();
+      // setting rackName to null for now, will end up using the default one
       final ProcessContainer container = new ProcessContainer(
-          this.errorHandlerRID, nodeId, processID, processFolder, megaBytes, numberOfCores, this.fileNames, this.processObserver);
+          this.errorHandlerRID, nodeId, processID, processFolder, megaBytes, numberOfCores, null, this.fileNames, this.processObserver);
       this.containers.put(container.getContainerID(), container);
       LOG.log(Level.FINE, "Allocated {0}", container.getContainerID());
       return container;

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalDriverConfiguration.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalDriverConfiguration.java
@@ -27,6 +27,7 @@ import org.apache.reef.runtime.common.files.RuntimeClasspathProvider;
 import org.apache.reef.runtime.common.parameters.JVMHeapSlack;
 import org.apache.reef.runtime.local.LocalClasspathProvider;
 import org.apache.reef.runtime.local.client.parameters.MaxNumberOfEvaluators;
+import org.apache.reef.runtime.local.client.parameters.RackNames;
 import org.apache.reef.runtime.local.client.parameters.RootFolder;
 import org.apache.reef.tang.formats.ConfigurationModule;
 import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
@@ -52,6 +53,11 @@ public class LocalDriverConfiguration extends ConfigurationModuleBuilder {
   public static final OptionalParameter<Double> JVM_HEAP_SLACK = new OptionalParameter<>();
 
   /**
+  * The rack names that will be available in the local runtime
+  */
+  public static final OptionalParameter<String> RACK_NAMES = new OptionalParameter<>();
+
+  /**
    * The remote identifier to use for communications back to the client.
    */
   public static final OptionalParameter<String> CLIENT_REMOTE_IDENTIFIER = new OptionalParameter<>();
@@ -70,6 +76,7 @@ public class LocalDriverConfiguration extends ConfigurationModuleBuilder {
       .bindNamedParameter(MaxNumberOfEvaluators.class, MAX_NUMBER_OF_EVALUATORS)
       .bindNamedParameter(RootFolder.class, ROOT_FOLDER)
       .bindNamedParameter(JVMHeapSlack.class, JVM_HEAP_SLACK)
+      .bindSetEntry(RackNames.class, RACK_NAMES)
       .bindImplementation(RuntimeClasspathProvider.class, LocalClasspathProvider.class)
       .build();
 }

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ProcessContainer.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ProcessContainer.java
@@ -49,6 +49,7 @@ final class ProcessContainer implements Container {
   private final String containedID;
   private final int megaBytes;
   private final int numberOfCores;
+  private final String rackName;
   private final REEFFileNames fileNames;
   private final File reefFolder;
   private final File localFolder;
@@ -69,6 +70,7 @@ final class ProcessContainer implements Container {
                    final File folder,
                    final int megaBytes,
                    final int numberOfCores,
+                   final String rackName,
                    final REEFFileNames fileNames,
                    final ReefRunnableProcessObserver processObserver) {
     this.errorHandlerRID = errorHandlerRID;
@@ -77,6 +79,7 @@ final class ProcessContainer implements Container {
     this.folder = folder;
     this.megaBytes = megaBytes;
     this.numberOfCores = numberOfCores;
+    this.rackName = rackName;
     this.fileNames = fileNames;
     this.processObserver = processObserver;
     this.reefFolder = new File(folder, fileNames.getREEFFolderName());
@@ -144,6 +147,11 @@ final class ProcessContainer implements Container {
   }
 
   @Override
+  public String getRackName() {
+    return this.rackName;
+  }
+
+  @Override
   public File getFolder() {
     return this.folder;
   }
@@ -172,7 +180,8 @@ final class ProcessContainer implements Container {
         "containedID='" + containedID + '\'' +
         ", nodeID='" + nodeID + '\'' +
         ", errorHandlerRID='" + errorHandlerRID + '\'' +
-        ", folder=" + folder +
+        ", folder=" + folder + '\'' +
+        ", rack=" + rackName +
         '}';
   }
 }

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ResourceManager.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ResourceManager.java
@@ -221,6 +221,7 @@ public final class ResourceManager {
               .setNodeId(container.getNodeID())
               .setResourceMemory(container.getMemory())
               .setVirtualCores(container.getNumberOfCores())
+              .setRackName(container.getRackName())
               .build();
 
       LOG.log(Level.FINEST, "Allocating container: {0}", container);

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/rack/awareness/RackNameParameter.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/rack/awareness/RackNameParameter.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.tests.rack.awareness;
+import org.apache.reef.runtime.local.client.parameters.RackNames;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(default_value = RackNames.DEFAULT_RACK_NAME, short_name = "rack")
+public class RackNameParameter implements Name<String> {
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/TestEnvironment.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/TestEnvironment.java
@@ -55,4 +55,6 @@ public interface TestEnvironment {
   int getTestTimeout();
 
   LauncherStatus run(final Configuration driverConfiguration);
+
+  LauncherStatus run(final Configuration runtimeConfiguration, Configuration driverConfiguration);
 }

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/TestEnvironment.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/TestEnvironment.java
@@ -56,5 +56,4 @@ public interface TestEnvironment {
 
   LauncherStatus run(final Configuration driverConfiguration);
 
-  LauncherStatus run(final Configuration runtimeConfiguration, Configuration driverConfiguration);
 }

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/TestEnvironmentBase.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/TestEnvironmentBase.java
@@ -30,13 +30,8 @@ public abstract class TestEnvironmentBase implements TestEnvironment {
 
   @Override
   public LauncherStatus run(final Configuration driverConfiguration) {
-    return run(getRuntimeConfiguration(), driverConfiguration);
-  }
-
-  @Override
-  public LauncherStatus run(final Configuration runtimeConfiguration, Configuration driverConfiguration) {
     try {
-      return DriverLauncher.getLauncher(runtimeConfiguration).run(driverConfiguration, getTestTimeout());
+      return DriverLauncher.getLauncher(getRuntimeConfiguration()).run(driverConfiguration, getTestTimeout());
     } catch (final InjectionException e) {
       throw new RuntimeException(e);
     }

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTest.java
@@ -52,6 +52,11 @@ public final class RackAwareEvaluatorTest {
     this.testEnvironment.tearDown();
   }
 
+  /**
+  * Tests whether the runtime passes the rack information to the driver
+  * The success scenario is if it receives the default rack, fails otherwise
+  */
+  @Test
   public void testRackAwareEvaluatorRunningOnDefaultRack() {
     //Given
     final Configuration driverConfiguration = DriverConfiguration.CONF
@@ -67,6 +72,10 @@ public final class RackAwareEvaluatorTest {
     Assert.assertTrue("Job state after execution: " + status, status.isSuccess());
   }
 
+  /**
+   * Test whether the runtime passes the rack information to the driver
+   * The success scenario is if it receives rack1, fails otherwise
+   */
   @Test
   public void testRackAwareEvaluatorRunningOnRack1() {
     //Given
@@ -78,10 +87,13 @@ public final class RackAwareEvaluatorTest {
         .build();
 
     // update the drive config with the rack to assert on
-    final Configuration testDriverConfig = Tang.Factory.getTang().newConfigurationBuilder(driverConfiguration).bindNamedParameter(RackNameParameter.class, RACK1).build();
+    final Configuration testDriverConfig = Tang.Factory.getTang().newConfigurationBuilder(driverConfiguration)
+        .bindNamedParameter(RackNameParameter.class, RACK1).build();
 
     // update the runtime config with the rack available using the config module
-    final Configuration testRuntimeConfig = Tang.Factory.getTang().newConfigurationBuilder(this.testEnvironment.getRuntimeConfiguration()).bindSetEntry(RackNames.class, RACK1).build();
+    final Configuration testRuntimeConfig = Tang.Factory.getTang()
+        .newConfigurationBuilder(this.testEnvironment.getRuntimeConfiguration()).bindSetEntry(RackNames.class, RACK1)
+        .build();
 
     // When
     final LauncherStatus status = this.testEnvironment.run(testRuntimeConfig, testDriverConfig);

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTest.java
@@ -30,15 +30,12 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.logging.Logger;
-
 /**
  * Tests whether an Evaluator receives its rack information. For now, the rack name is hardcoded to "/default-rack".
  * In the future, when the user can specify which racks to execute on, this test will make more sense
  */
 public final class RackAwareEvaluatorTest {
 
-  private static final Logger LOG = Logger.getLogger(RackAwareEvaluatorTest.class.getName());
   private final TestEnvironment testEnvironment = TestEnvironmentFactory.getNewTestEnvironment();
 
 
@@ -66,7 +63,6 @@ public final class RackAwareEvaluatorTest {
     final LauncherStatus status = this.testEnvironment.run(driverConfiguration);
     // Then
     Assert.assertTrue("Job state after execution: " + status, status.isSuccess());
-    LOG.info("Success!!!");
   }
 
 }

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.rack.awareness;
+
+import org.apache.reef.client.DriverConfiguration;
+import org.apache.reef.client.LauncherStatus;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tests.TestEnvironment;
+import org.apache.reef.tests.TestEnvironmentFactory;
+import org.apache.reef.tests.library.driver.OnDriverStartedAllocateOne;
+import org.apache.reef.util.EnvironmentUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.logging.Logger;
+
+/**
+ * Tests whether an Evaluator receives its rack information. For now, the rack name is hardcoded to "/default-rack".
+ * In the future, when the user can specify which racks to execute on, this test will make more sense
+ */
+public final class RackAwareEvaluatorTest {
+
+  private static final Logger LOG = Logger.getLogger(RackAwareEvaluatorTest.class.getName());
+  private final TestEnvironment testEnvironment = TestEnvironmentFactory.getNewTestEnvironment();
+
+
+  @Before
+  public void setUp() throws Exception {
+    testEnvironment.setUp();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    this.testEnvironment.tearDown();
+  }
+
+  @Test
+  public void testRackAwareEvaluatorRunningOnDefaultRack() {
+    //Given
+    final Configuration driverConfiguration = DriverConfiguration.CONF
+        .set(DriverConfiguration.DRIVER_IDENTIFIER, "TEST_RackAwareEvaluator")
+        .set(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getClassLocation(RackAwareEvaluatorTestDriver.class))
+        .set(DriverConfiguration.ON_DRIVER_STARTED, OnDriverStartedAllocateOne.class)
+        .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, RackAwareEvaluatorTestDriver.EvaluatorAllocatedHandler.class)
+        .build();
+
+    // When
+    final LauncherStatus status = this.testEnvironment.run(driverConfiguration);
+    // Then
+    Assert.assertTrue("Job state after execution: " + status, status.isSuccess());
+    LOG.info("Success!!!");
+  }
+
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTest.java
@@ -19,10 +19,12 @@
 package org.apache.reef.tests.rack.awareness;
 
 import org.apache.reef.client.DriverConfiguration;
+import org.apache.reef.client.DriverLauncher;
 import org.apache.reef.client.LauncherStatus;
 import org.apache.reef.runtime.local.client.parameters.RackNames;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.tests.LocalTestEnvironment;
 import org.apache.reef.tests.TestEnvironment;
 import org.apache.reef.tests.library.driver.OnDriverStartedAllocateOne;
@@ -77,7 +79,7 @@ public final class RackAwareEvaluatorTest {
    * The success scenario is if it receives rack1, fails otherwise
    */
   @Test
-  public void testRackAwareEvaluatorRunningOnRack1() {
+  public void testRackAwareEvaluatorRunningOnRack1() throws InjectionException {
     //Given
     final Configuration driverConfiguration = DriverConfiguration.CONF
         .set(DriverConfiguration.DRIVER_IDENTIFIER, "TEST_RackAwareEvaluator")
@@ -96,7 +98,8 @@ public final class RackAwareEvaluatorTest {
         .build();
 
     // When
-    final LauncherStatus status = this.testEnvironment.run(testRuntimeConfig, testDriverConfig);
+    final LauncherStatus status = DriverLauncher.getLauncher(testRuntimeConfig)
+                                              .run(testDriverConfig, this.testEnvironment.getTestTimeout());
     // Then
     Assert.assertTrue("Job state after execution: " + status, status.isSuccess());
   }

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTestDriver.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTestDriver.java
@@ -21,9 +21,8 @@ package org.apache.reef.tests.rack.awareness;
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
 import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.tang.annotations.Unit;
+import org.apache.reef.tests.library.exceptions.DriverSideFailure;
 import org.apache.reef.wake.EventHandler;
-import org.junit.Assert;
-
 import javax.inject.Inject;
 
 @Unit
@@ -47,7 +46,10 @@ final class RackAwareEvaluatorTestDriver {
     public void onNext(final AllocatedEvaluator allocatedEvaluator) {
 
       final String actual = allocatedEvaluator.getEvaluatorDescriptor().getNodeDescriptor().getRackDescriptor().getName();
-      Assert.assertEquals(expectedRackName, actual);
+      if (!expectedRackName.equals(actual)) {
+        throw new DriverSideFailure("The rack received is different that the expected one, received " + actual
+            + " expected " + expectedRackName);
+      }
       allocatedEvaluator.close();
     }
   }

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTestDriver.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTestDriver.java
@@ -25,12 +25,8 @@ import org.junit.Assert;
 
 import javax.inject.Inject;
 
-import java.util.logging.Logger;
-
 @Unit
 final class RackAwareEvaluatorTestDriver {
-
-  private static final Logger LOG = Logger.getLogger(RackAwareEvaluatorTestDriver.class.getName());
 
   // hardcoded not to use the constant in ResourceCatalogImpl, which is local runtime dependent
   // TODO future iterations so change this
@@ -49,7 +45,6 @@ final class RackAwareEvaluatorTestDriver {
     public void onNext(final AllocatedEvaluator allocatedEvaluator) {
 
       final String actual = allocatedEvaluator.getEvaluatorDescriptor().getNodeDescriptor().getRackDescriptor().getName();
-      LOG.info("Received rack name " + actual);
       Assert.assertEquals(DEFAULT_RACK, actual);
       allocatedEvaluator.close();
     }

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTestDriver.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTestDriver.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.rack.awareness;
+
+import org.apache.reef.driver.evaluator.AllocatedEvaluator;
+import org.apache.reef.tang.annotations.Unit;
+import org.apache.reef.wake.EventHandler;
+import org.junit.Assert;
+
+import javax.inject.Inject;
+
+import java.util.logging.Logger;
+
+@Unit
+final class RackAwareEvaluatorTestDriver {
+
+  private static final Logger LOG = Logger.getLogger(RackAwareEvaluatorTestDriver.class.getName());
+
+  // hardcoded not to use the constant in ResourceCatalogImpl, which is local runtime dependent
+  // TODO future iterations so change this
+  private final String DEFAULT_RACK = "/default-rack";
+
+  @Inject
+  RackAwareEvaluatorTestDriver() {
+  }
+
+  /**
+   * Verifies whether the rack received is the default rack
+   */
+  final class EvaluatorAllocatedHandler implements EventHandler<AllocatedEvaluator> {
+
+    @Override
+    public void onNext(final AllocatedEvaluator allocatedEvaluator) {
+
+      final String actual = allocatedEvaluator.getEvaluatorDescriptor().getNodeDescriptor().getRackDescriptor().getName();
+      LOG.info("Received rack name " + actual);
+      Assert.assertEquals(DEFAULT_RACK, actual);
+      allocatedEvaluator.close();
+    }
+  }
+}
+
+

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTestDriver.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTestDriver.java
@@ -19,6 +19,7 @@
 package org.apache.reef.tests.rack.awareness;
 
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
+import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.tang.annotations.Unit;
 import org.apache.reef.wake.EventHandler;
 import org.junit.Assert;
@@ -28,12 +29,13 @@ import javax.inject.Inject;
 @Unit
 final class RackAwareEvaluatorTestDriver {
 
-  // hardcoded not to use the constant in ResourceCatalogImpl, which is local runtime dependent
-  // TODO future iterations so change this
-  private final String DEFAULT_RACK = "/default-rack";
+
+
+  private final String expectedRackName;
 
   @Inject
-  RackAwareEvaluatorTestDriver() {
+  RackAwareEvaluatorTestDriver(@Parameter(RackNameParameter.class) final String rackName) {
+    this.expectedRackName = rackName;
   }
 
   /**
@@ -45,7 +47,7 @@ final class RackAwareEvaluatorTestDriver {
     public void onNext(final AllocatedEvaluator allocatedEvaluator) {
 
       final String actual = allocatedEvaluator.getEvaluatorDescriptor().getNodeDescriptor().getRackDescriptor().getName();
-      Assert.assertEquals(DEFAULT_RACK, actual);
+      Assert.assertEquals(expectedRackName, actual);
       allocatedEvaluator.close();
     }
   }

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * Tests whether the rack information is passed back to the evaluators.
+ * Tests whether the rack information is correctly carried from the runtime to the Driver
  */
 package org.apache.reef.tests.rack.awareness;

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Tests whether the rack information is passed back to the evaluators.
+ */
+package org.apache.reef.tests.rack.awareness;


### PR DESCRIPTION
This work bubbles up the rack information from the runtime (after the resource is allocated) towards the evaluators allocation handlers.
The ResourceAllocationEvent interface now includes an optional rack name, which is populated by the respective runtimes when the resource is allocated.
The ProcessContainer is created with a null rack for now, it ends up using the default one.
Added a unit test that tests the whole cycle, checking if the default rack is the one retrieved.

JIRA:
  [REEF-409] (https://issues.apache.org/jira/browse/REEF-409)

This closes
