### PR TITLE
[REEF-407]: Convert checkstyle violations to build breaks

### DIFF
--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/JavaBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/JavaBridge.java
@@ -25,6 +25,7 @@ public class JavaBridge {
     try {
       System.loadLibrary(CPP_BRIDGE);
     } catch (UnsatisfiedLinkError e) {
+      // TODO[JIRA REEF-383] Document/Refactor JavaBridge
     }
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorStatusManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorStatusManager.java
@@ -55,6 +55,10 @@ final class EvaluatorStatusManager {
           case FAILED:
           case KILLED:
             return true;
+          case RUNNING:
+            break;
+          default:
+            throw new RuntimeException("Unknown state: " + to);
         }
       }
       case SUBMITTED: {
@@ -64,6 +68,10 @@ final class EvaluatorStatusManager {
           case FAILED:
           case KILLED:
             return true;
+          case ALLOCATED:
+            break;
+          default:
+            throw new RuntimeException("Unknown state: " + to);
         }
       }
       case RUNNING: {
@@ -72,8 +80,19 @@ final class EvaluatorStatusManager {
           case FAILED:
           case KILLED:
             return true;
+          case ALLOCATED:
+          case SUBMITTED:
+            break;
+          default:
+            throw new RuntimeException("Unknown state: " + to);
         }
       }
+      case DONE:
+      case FAILED:
+      case KILLED:
+        break;
+      default:
+        throw new RuntimeException("Unknown state: " + from);
     }
 
     LOG.warning("Illegal evaluator state transition from " + from + " to " + to + ".");

--- a/lang/java/reef-common/src/main/resources/checkstyle.xml
+++ b/lang/java/reef-common/src/main/resources/checkstyle.xml
@@ -49,10 +49,16 @@
 -->
 
 <module name="Checker">
+    <!-- By default violations of all checks are errors -->
+    <!-- Exceptions are configured for violations which are not cleaned up yet -->
+    <!-- The goal is to have no exceptions -->
+    <property name="severity" value="error"/>
 
     <!-- Checks that a package.html file exists for each package.     -->
     <!-- See http://checkstyle.sf.net/config_javadoc.html#PackageHtml -->
-    <module name="JavadocPackage"/>
+    <module name="JavadocPackage">
+        <property name="severity" value="warning"/>
+    </module>
 
     <!-- Checks whether files end with a new line.                        -->
     <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
@@ -65,9 +71,11 @@
     <module name="FileLength"/>
     <module name="FileTabCharacter"/>
 
+    <!-- not a check -->
     <module name="SuppressWarningsFilter"/>
 
     <module name="TreeWalker">
+        <!-- not a check -->
         <module name="SuppressWarningsHolder"/>
 
         <!-- Checks for Javadoc comments.                     -->
@@ -75,20 +83,39 @@
         <module name="JavadocType">
             <property name="scope" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
+            <property name="severity" value="warning"/>
         </module>
-        <module name="JavadocStyle"/>
+        <module name="JavadocStyle">
+            <property name="severity" value="warning"/>
+        </module>
 
         <!-- Checks for Naming Conventions.                  -->
         <!-- See http://checkstyle.sf.net/config_naming.html -->
-        <module name="ConstantName"/>
-        <module name="LocalFinalVariableName"/>
-        <module name="LocalVariableName"/>
-        <module name="MemberName"/>
-        <module name="MethodName"/>
+        <module name="ConstantName">
+            <property name="severity" value="warning"/>
+        </module>
+        <module name="LocalFinalVariableName">
+            <property name="severity" value="warning"/>
+        </module>
+        <module name="LocalVariableName">
+            <property name="severity" value="warning"/>
+        </module>
+        <module name="MemberName">
+            <property name="severity" value="warning"/>
+        </module>
+        <module name="MethodName">
+            <property name="severity" value="warning"/>
+        </module>
         <module name="PackageName"/>
-        <module name="ParameterName"/>
-        <module name="StaticVariableName"/>
-        <module name="TypeName"/>
+        <module name="ParameterName">
+            <property name="severity" value="warning"/>
+        </module>
+        <module name="StaticVariableName">
+            <property name="severity" value="warning"/>
+        </module>
+        <module name="TypeName">
+            <property name="severity" value="warning"/>
+        </module>
 
 
         <!-- Checks for Headers                                -->
@@ -122,11 +149,13 @@
         <module name="LineLength">
             <property name="ignorePattern" value="^import"/>
             <property name="max" value="120"/>
+            <property name="severity" value="warning"/>
         </module>
         <module name="MethodLength"/>
         <module name="ParameterNumber">
             <property name="max" value="7"/>
             <property name="tokens" value="METHOD_DEF"/>
+            <property name="severity" value="warning"/>
         </module>
 
         <!-- Checks for whitespace                               -->
@@ -168,6 +197,7 @@
         <module name="EqualsHashCode"/>
         <module name="HiddenField">
             <property name="ignoreConstructorParameter" value="true"/>
+            <property name="severity" value="warning"/>
         </module>
         <module name="IllegalInstantiation"/>
         <module name="InnerAssignment"/>
@@ -180,7 +210,9 @@
         <module name="FinalClass"/>
         <module name="HideUtilityClassConstructor"/>
         <module name="InterfaceIsType"/>
-        <module name="VisibilityModifier"/>
+        <module name="VisibilityModifier">
+            <property name="severity" value="warning"/>
+        </module>
 
 
         <!-- Miscellaneous other checks.                   -->
@@ -189,9 +221,13 @@
         <module name="Indentation">
             <property name="basicOffset" value="2"/>
             <property name="caseIndent" value="0"/>
+            <property name="severity" value="warning"/>
         </module>
-        <module name="TodoComment"/>
+        <module name="TodoComment">
+            <property name="severity" value="warning"/>
+        </module>
         <module name="UpperEll"/>
     </module>
 
 </module>
+

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/WakeProfiler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/WakeProfiler.java
@@ -26,11 +26,6 @@ import org.apache.reef.tang.InjectionFuture;
 import org.apache.reef.tang.types.ConstructorDef;
 import org.apache.reef.tang.util.MonotonicHashMap;
 import org.apache.reef.tang.util.ReflectionUtilities;
-import org.apache.reef.wake.EventHandler;
-import org.apache.reef.wake.Stage;
-import org.apache.reef.wake.rx.Observable;
-import org.apache.reef.wake.rx.Observer;
-import org.apache.reef.wake.rx.RxStage;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;

--- a/pom.xml
+++ b/pom.xml
@@ -279,7 +279,7 @@ under the License.
                     <version>${maven-checkstyle-plugin.version}</version>
                     <configuration>
                         <configLocation>lang/java/reef-common/src/main/resources/checkstyle.xml</configLocation>
-                        <failOnViolation>false</failOnViolation>
+                        <failOnViolation>true</failOnViolation>
                         <format>xml</format>
                         <format>html</format>
                         <outputFile>${project.build.directory}/test/checkstyle-errors.xml</outputFile>
@@ -334,6 +334,16 @@ under the License.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${maven-checkstyle-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                            <goal>checkstyle</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This addressed the issue by
  * Configuring checkstyle to be executed as part of the build
  * Configuring checkstyle errors to cause build break
  * Making severity of checkstyle violations "error" by default
  * Making severify of violations of checks which are not cleaned up yet "warning" (so they don't cause build breaks)
  * Fixing several leftover violations of checks which have been cleaned up previously

JIRA: [REEF-407](https://issues.apache.org/jira/browse/REEF-407)