### PR TITLE
[REEF-401] Triage TODO comments in Java code, part 1: introduce TODO[JIRA ...] format

### DIFF
--- a/lang/java/reef-common/src/main/resources/checkstyle.xml
+++ b/lang/java/reef-common/src/main/resources/checkstyle.xml
@@ -225,6 +225,11 @@
         </module>
         <module name="TodoComment">
             <property name="severity" value="warning"/>
+            <property name="format" value="TODO[^\[][^J][^I][^R][^A]"/>
+        </module>
+        <module name="TodoComment">
+            <property name="severity" value="info"/>
+            <property name="format" value="TODO\[JIRA"/>
         </module>
         <module name="UpperEll"/>
     </module>


### PR DESCRIPTION
This addressed the issue by
  * Introducing different severities of TodoComment check depending on whether TODO is followed by [JIRA ...] or not

This change does not enforce new format of TODOs yet.

JIRA: [REEF-401](https://issues.apache.org/jira/browse/REEF-401)