### PR TITLE
[REEF-415] Fix broken links at reef.incubator.apache.org

### DIFF
--- a/website/src/site/markdown/faq.md
+++ b/website/src/site/markdown/faq.md
@@ -58,4 +58,4 @@ ________________________________________________
 
 ###<a name="how"></a>How can I get started?
 
-Check out the [REEF Tutorial](tutorial.html) and the [Contributing](contributing.html) page and join the community! 
+Check out the [REEF Tutorial](https://cwiki.apache.org/confluence/display/REEF/Tutorials) and the [Contributing](https://cwiki.apache.org/confluence/display/REEF/Contributing) page and join the community!

--- a/website/src/site/markdown/index.md
+++ b/website/src/site/markdown/index.md
@@ -42,9 +42,9 @@ The official home for the REEF (and Tang and Wake) source code is at the Apache 
 
 or directly access its GitHub page [here](https://github.com/apache/incubator-reef).
 
-Detailed information about REEF and using it can be found in the [FAQ](faq.html) and the [Tutorial](tutorial.html).
+Detailed information about REEF and using it can be found in the [FAQ](faq.html) and the [Tutorial](https://cwiki.apache.org/confluence/display/REEF/Tutorials).
 
-If you wish to contribute, start at the [Contributing](contributing.html) tutorial or the [Committer Guide](committer-guide.html)!
+If you wish to contribute, start at the [Contributing](https://cwiki.apache.org/confluence/display/REEF/Contributing) tutorial or the [Committer Guide](https://cwiki.apache.org/confluence/display/REEF/Committer+Guide)!
 
 ###Further questions?
 

--- a/website/src/site/markdown/tang.md
+++ b/website/src/site/markdown/tang.md
@@ -438,7 +438,7 @@ Running the program now produces a bit of additional output:
 
 InjectionPlan objects can be serialized to protocol buffers.  The following file documents their format:
 
-[https://github.com/apache/incubator-reef/blob/master/reef-tang/tang/src/main/proto/injection_plan.proto](https://github.com/apache/incubator-reef/blob/master/reef-tang/tang/src/main/proto/injection_plan.proto)
+[https://github.com/apache/incubator-reef/blob/master/lang/java/reef-tang/tang/src/main/proto/injection_plan.proto](https://github.com/apache/incubator-reef/blob/master/lang/java/reef-tang/tang/src/main/proto/injection_plan.proto)
 
 ###<a name="classHierarchy"></a>ClassHierarchy
 
@@ -448,8 +448,8 @@ Internally, in the example above, TypeHierarchy walks the class definition for T
 
 ClassHierarchy objects can be serialized to protocol buffers.  The following file documents their format:
 
-[https://github.com/apache/incubator-reef/blob/master/reef-tang/tang/src/main/proto/class_hierarchy.proto](https://github.com/apache/incubator-reef/blob/master/reef-tang/tang/src/main/proto/class_hierarchy.proto)
+[https://github.com/apache/incubator-reef/blob/master/lang/java/reef-tang/tang/src/main/proto/class_hierarchy.proto](https://github.com/apache/incubator-reef/blob/master/lang/java/reef-tang/tang/src/main/proto/class_hierarchy.proto)
 
 The java interfaces are available in this package:
 
-[https://github.com/apache/incubator-reef/tree/master/reef-tang/tang/src/main/java/org/apache/reef/tang/types](https://github.com/apache/incubator-reef/tree/master/reef-tang/tang/src/main/java/org/apache/reef/tang/types)
+[https://github.com/apache/incubator-reef/tree/master/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types](https://github.com/apache/incubator-reef/tree/master/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types)


### PR DESCRIPTION
This addressed the issue by
  * fixing links to point to existing pages

JIRA: [REEF-415](https://issues.apache.org/jira/browse/REEF-415)