### PR TITLE
REEF-411: Assign configured racks to random nodes in the Local Runtime

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/CollectionUtils.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/CollectionUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.util;
+
+import java.util.Collection;
+
+/**
+ * Utilities for collection classes.
+ */
+public final class CollectionUtils {
+
+   private CollectionUtils() {
+     //avoid instantiation
+   }
+
+
+  /**
+   * Checks if the collection is null or empty
+   * @param parameter the collection
+   * @return true if the collection is null or empty
+   */
+  public static <T> boolean isEmpty(final Collection<T> parameter) {
+    return parameter == null || parameter.isEmpty();
+  }
+
+  /**
+   * Checks if the collection is not null and not empty
+   * @param parameter the collection
+   * @return true if the collection is not null nor empty
+   *
+   */
+  public static <T> boolean isNotEmpty(final Collection<T> parameter) {
+    return !isEmpty(parameter);
+  }
+
+
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/CollectionUtils.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/CollectionUtils.java
@@ -25,13 +25,13 @@ import java.util.Collection;
  */
 public final class CollectionUtils {
 
-   private CollectionUtils() {
-     //avoid instantiation
-   }
+  private CollectionUtils() {
+    // avoid instantiation
+  }
 
 
   /**
-   * Checks if the collection is null or empty
+   * Checks if the collection is null or empty.
    * @param parameter the collection
    * @return true if the collection is null or empty
    */
@@ -40,7 +40,7 @@ public final class CollectionUtils {
   }
 
   /**
-   * Checks if the collection is not null and not empty
+   * Checks if the collection is not null and not empty.
    * @param parameter the collection
    * @return true if the collection is not null nor empty
    *

--- a/lang/java/reef-runtime-local/pom.xml
+++ b/lang/java/reef-runtime-local/pom.xml
@@ -42,6 +42,10 @@ under the License.
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>        
     </dependencies>
 
     <build>

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
@@ -181,7 +181,7 @@ final class ContainerManager implements AutoCloseable {
    */
   private Collection<String> normalize(final Collection<String> rackNames,
       final boolean validateEnd) {
-    final List<String> normalizedRackNames = new ArrayList<>();
+    final List<String> normalizedRackNames = new ArrayList<>(rackNames.size());
     final Iterator<String> it = rackNames.iterator();
     while (it.hasNext()) {
       String rackName = it.next().trim();

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
@@ -18,20 +18,26 @@
  */
 package org.apache.reef.runtime.local.driver;
 
+import org.apache.commons.lang.Validate;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.client.FailedRuntime;
 import org.apache.reef.proto.ReefServiceProtos;
+import org.apache.reef.runtime.common.driver.api.ResourceRequestEvent;
 import org.apache.reef.runtime.common.driver.api.RuntimeParameters;
 import org.apache.reef.runtime.common.driver.resourcemanager.NodeDescriptorEvent;
 import org.apache.reef.runtime.common.driver.resourcemanager.NodeDescriptorEventImpl;
 import org.apache.reef.runtime.common.files.REEFFileNames;
 import org.apache.reef.runtime.common.utils.RemoteManager;
+import org.apache.reef.runtime.local.client.parameters.DefaultMemorySize;
+import org.apache.reef.runtime.local.client.parameters.DefaultNumberOfCores;
 import org.apache.reef.runtime.local.client.parameters.MaxNumberOfEvaluators;
 import org.apache.reef.runtime.local.client.parameters.RackNames;
 import org.apache.reef.runtime.local.client.parameters.RootFolder;
 import org.apache.reef.runtime.local.process.ReefRunnableProcessObserver;
 import org.apache.reef.tang.annotations.Parameter;
+import org.apache.reef.util.CollectionUtils;
+import org.apache.reef.util.Optional;
 import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.remote.RemoteMessage;
 import org.apache.reef.wake.remote.address.LocalAddressProvider;
@@ -42,7 +48,10 @@ import org.apache.reef.wake.time.runtime.event.RuntimeStop;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -60,6 +69,10 @@ final class ContainerManager implements AutoCloseable {
 
   private static final Logger LOG = Logger.getLogger(ContainerManager.class.getName());
 
+  private static final Collection<String> DEFAULT_RACKS = Arrays.asList(RackNames.DEFAULT_RACK_NAME);
+  private static final String PATH_SEPARATOR = "/";
+  private static final String ANY = "*";
+
   /**
    * Map from containerID -> Container.
    */
@@ -67,20 +80,31 @@ final class ContainerManager implements AutoCloseable {
 
   /**
    * Map of free, unallocated nodes by rack, by their Node ID.
+   * <RackName,<NodeId, True>>
+   * Used a map instead of a list as the value for faster lookup
    */
-  private final Map<String, List<String>> freeNodesPerRack = new HashMap<>();
+  private final Map<String, Map<String, Boolean>> freeNodesPerRack = new HashMap<>();
+
+  /**
+   * Inverted index, map of <NodeId, RackName>
+   */
+  private final Map<String, String> racksPerNode = new HashMap<>();
+
   /**
    * Capacity of each rack (as even as possible)
    */
   private final Map<String, Integer> capacityPerRack = new HashMap<>();
 
+  private final int capacity;
+  private final int defaultMemorySize;
+  private final int defaultNumberOfCores;
   private final String errorHandlerRID;
   private final EventHandler<NodeDescriptorEvent> nodeDescriptorHandler;
   private final File rootFolder;
   private final REEFFileNames fileNames;
   private final ReefRunnableProcessObserver processObserver;
   private final String localAddress;
-  private final Set<String> availableRacks;
+  private final Collection<String> availableRacks;
 
   @Inject
   ContainerManager(
@@ -93,14 +117,19 @@ final class ContainerManager implements AutoCloseable {
       EventHandler<NodeDescriptorEvent> nodeDescriptorHandler,
       @Parameter(RackNames.class) final Set<String> rackNames,
       final ReefRunnableProcessObserver processObserver,
-      final LocalAddressProvider localAddressProvider) {
+      final LocalAddressProvider localAddressProvider,
+      @Parameter(DefaultMemorySize.class) final int defaultMemorySize,
+      @Parameter(DefaultNumberOfCores.class) final int defaultNumberOfCores) {
+    this.capacity = capacity;
+    this.defaultMemorySize = defaultMemorySize;
+    this.defaultNumberOfCores = defaultNumberOfCores;
     this.fileNames = fileNames;
     this.processObserver = processObserver;
     this.errorHandlerRID = remoteManager.getMyIdentifier();
     this.nodeDescriptorHandler = nodeDescriptorHandler;
     this.rootFolder = new File(rootFolderName);
     this.localAddress = localAddressProvider.getLocalAddress();
-    this.availableRacks = rackNames;
+    this.availableRacks = normalize(rackNames);
 
     LOG.log(Level.FINEST, "Initializing Container Manager with {0} containers", capacity);
 
@@ -131,20 +160,55 @@ final class ContainerManager implements AutoCloseable {
       }
     });
 
-    init(capacity, rackNames);
+    init(rackNames);
 
     LOG.log(Level.FINE, "Initialized Container Manager with {0} containers", capacity);
   }
 
+  private Collection<String> normalize(final Collection<String> rackNames) {
+    return normalize(rackNames, true);
+  }
 
-  private void init(final int capacity, final Set<String> rackNames) {
+  /**
+   * Normalizes the rack names.
+   *
+   * @param rackNames
+   *          the rack names to normalize
+   * @param validateEnd
+   *          if true, throws an exception if the name ends with ANY (*)
+   * @return a normalized collection
+   */
+  private Collection<String> normalize(final Collection<String> rackNames,
+      final boolean validateEnd) {
+    final List<String> normalizedRackNames = new ArrayList<>();
+    final Iterator<String> it = rackNames.iterator();
+    while (it.hasNext()) {
+      String rackName = it.next().trim();
+      Validate.notEmpty(rackName, "Rack names cannot be empty");
+      // should start with a separator
+      if (!rackName.startsWith(PATH_SEPARATOR)) {
+        rackName = PATH_SEPARATOR + rackName;
+      }
+      // remove the ending separator
+      if (rackName.endsWith(PATH_SEPARATOR)) {
+        rackName = rackName.substring(0, rackName.length() - 1);
+      }
+      if (validateEnd) {
+        Validate.isTrue(!rackName.endsWith(ANY));
+      }
+      normalizedRackNames.add(rackName);
+    }
+    return normalizedRackNames;
+  }
+
+  private void init(final Set<String> rackNames) {
     // evenly distribute the containers among the racks
     // if rack names are not specified, the default rack will be used, so the denominator will always be > 0
     final int capacityPerRack = capacity / rackNames.size();
     int missing = capacity % rackNames.size();
     // initialize the freeNodesPerRackList and the capacityPerRack
     for (final String rackName : rackNames) {
-      this.freeNodesPerRack.put(rackName, new ArrayList<String>());
+      this.freeNodesPerRack.put(rackName, new HashMap<String, Boolean>());
       this.capacityPerRack.put(rackName, capacityPerRack);
       if (missing > 0) {
         this.capacityPerRack.put(rackName, this.capacityPerRack.get(rackName) + 1);
@@ -161,39 +225,160 @@ final class ContainerManager implements AutoCloseable {
       final int rackCapacity = this.capacityPerRack.get(rackName);
       for (int i = 0; i < rackCapacity; i++) {
         final String id = idmaker.getNextID();
-        this.freeNodesPerRack.get(rackName).add(id);
+        this.racksPerNode.put(id, rackName);
+        this.freeNodesPerRack.get(rackName).put(id, Boolean.TRUE);
         this.nodeDescriptorHandler.onNext(NodeDescriptorEventImpl.newBuilder()
             .setIdentifier(id)
             .setRackName(rackName)
             .setHostName(this.localAddress)
             .setPort(j)
-            .setMemorySize(512) // TODO: Find the actual system memory on this machine.
+            .setMemorySize(this.defaultMemorySize) // TODO: Find the actual system memory on this machine.
             .build());
         j++;
       }
     }
   }
 
-  boolean hasContainerAvailable(final String rackName) {
-    // if rack name does not exist, return false
-    if (!freeNodesPerRack.containsKey(rackName)) {
-      return false;
-    }
-    return this.freeNodesPerRack.get(rackName).size() > 0;
+  private Collection<String> getRackNamesOrDefault(final List<String> rackNames) {
+    return CollectionUtils.isNotEmpty(rackNames) ? normalize(rackNames, false)
+        : DEFAULT_RACKS;
   }
 
-  Container allocateOne(final int megaBytes, final int numberOfCores, final String rackName) {
-    synchronized (this.containers) {
-      final String nodeId = this.freeNodesPerRack.get(rackName).remove(0);
-      final String processID = nodeId + "-" + String.valueOf(System.currentTimeMillis());
-      final File processFolder = new File(this.rootFolder, processID);
-      processFolder.mkdirs();
-      final ProcessContainer container = new ProcessContainer(
-          this.errorHandlerRID, nodeId, processID, processFolder, megaBytes, numberOfCores, rackName, this.fileNames, this.processObserver);
-      this.containers.put(container.getContainerID(), container);
-      LOG.log(Level.FINE, "Allocated {0}", container.getContainerID());
-      return container;
+
+  /**
+   * Returns the node name of the container to be allocated if it's available, selected from the list of preferred
+   * node names. If the list is empty, then an empty optional is returned
+   *
+   * @param rackNames
+   *          the list of preferred racks
+   * @return the node name where to allocate the container
+   */
+  private Optional<String> getPreferredNode(final List<String> nodeNames) {
+    if (CollectionUtils.isNotEmpty(nodeNames)) {
+      for (final String nodeName : nodeNames) {
+        final String possibleRack = racksPerNode.get(nodeName);
+        if (possibleRack != null
+            && freeNodesPerRack.get(possibleRack).containsKey(nodeName)) {
+          return Optional.of(nodeName);
+        }
+      }
     }
+    return Optional.empty();
+  }
+
+  /**
+   * Returns the rack where to allocate the container, selected from the list of
+   * preferred rack names. If the list is empty, and there's space in the default
+   * rack, then the default rack is returned. The relax locality semantic is
+   * enabled if the list of rack names contains '/*', otherwise relax locality
+   * is considered disabled
+   *
+   * @param rackNames
+   *          the list of preferred racks
+   * @return the rack name where to allocate the container
+   */
+  private Optional<String> getPreferredRack(final List<String> rackNames) {
+    final Collection<String> normalized = getRackNamesOrDefault(rackNames);
+    for (final String rackName : normalized) {
+      // if it does not end with the any modifier,
+      // then we should do an exact match
+      if (!rackName.endsWith(ANY)) {
+        if (freeNodesPerRack.containsKey(rackName)
+            && freeNodesPerRack.get(rackName).size() > 0) {
+          return Optional.of(rackName);
+        }
+      } else {
+        // if ends with the any modifier, we do a prefix match
+        final Iterator<String> it = availableRacks.iterator();
+        while (it.hasNext()) {
+          final String possibleRackName = it.next();
+          // remove the any modifier
+          final String newRackName = rackName.substring(0,
+              rackName.length() - 1);
+          if (possibleRackName.startsWith(newRackName)) {
+            if (freeNodesPerRack.get(possibleRackName).size() > 0) {
+              return Optional.of(possibleRackName);
+            }
+          }
+        }
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Allocates a container based on a request event. First it tries to match a
+   * given node, if it cannot, it tries to get a spot in a rack
+   *
+   * @param requestEvent
+   *          the request event
+   * @return an optional with the container if allocated
+   */
+  Optional<Container> allocateContainer(final ResourceRequestEvent requestEvent) {
+    Container container = null;
+    final Optional<String> nodeName = getPreferredNode(requestEvent
+        .getNodeNameList());
+    if (nodeName.isPresent()) {
+      container = allocateBasedOnNode(
+          requestEvent.getMemorySize().orElse(this.defaultMemorySize),
+          requestEvent.getVirtualCores().orElse(this.defaultNumberOfCores),
+          nodeName.get());
+    } else {
+      final Optional<String> rackName = getPreferredRack(requestEvent
+          .getRackNameList());
+      if (rackName.isPresent()) {
+        container = allocateBasedOnRack(
+            requestEvent.getMemorySize().orElse(this.defaultMemorySize),
+            requestEvent.getVirtualCores().orElse(this.defaultNumberOfCores),
+            rackName.get());
+      }
+    }
+    return Optional.ofNullable(container);
+  }
+
+  private Container allocateBasedOnNode(final int megaBytes,
+      final int numberOfCores, final String nodeId) {
+    synchronized (this.containers) {
+      // get the rack name
+      final String rackName = this.racksPerNode.get(nodeId);
+      // remove if from the free map
+      this.freeNodesPerRack.get(rackName).remove(nodeId);
+      // allocate
+      return allocate(megaBytes, numberOfCores, nodeId, rackName);
+    }
+  }
+
+  private Container allocateBasedOnRack(final int megaBytes,
+      final int numberOfCores, final String rackName) {
+    synchronized (this.containers) {
+      // get the first free nodeId in the rack
+      final Set<String> freeNodes = this.freeNodesPerRack.get(rackName)
+          .keySet();
+      final Iterator<String> it = freeNodes.iterator();
+      if (!it.hasNext()) {
+        throw new IllegalArgumentException(
+            "There should be a free node in the specified rack " + rackName);
+      }
+      final String nodeId = it.next();
+      // remove it from the free map
+      this.freeNodesPerRack.get(rackName).remove(nodeId);
+      // allocate
+      return allocate(megaBytes, numberOfCores, nodeId, rackName);
+    }
+  }
+
+  private Container allocate(final int megaBytes, final int numberOfCores,
+      final String nodeId, final String rackName) {
+    final String processID = nodeId + "-"
+        + String.valueOf(System.currentTimeMillis());
+    final File processFolder = new File(this.rootFolder, processID);
+    processFolder.mkdirs();
+    final ProcessContainer container = new ProcessContainer(
+        this.errorHandlerRID, nodeId, processID, processFolder, megaBytes,
+        numberOfCores, rackName, this.fileNames, this.processObserver);
+    this.containers.put(container.getContainerID(), container);
+    LOG.log(Level.FINE, "Allocated {0}", container.getContainerID());
+    return container;
   }
 
   void release(final String containerID) {
@@ -204,7 +389,7 @@ final class ContainerManager implements AutoCloseable {
         if (ctr.isRunning()) {
           ctr.close();
         }
-        this.freeNodesPerRack.get(ctr.getRackName()).add(ctr.getNodeID());
+        this.freeNodesPerRack.get(ctr.getRackName()).put(ctr.getNodeID(), Boolean.TRUE);
         this.containers.remove(ctr.getContainerID());
       } else {
         LOG.log(Level.INFO, "Ignoring release request for unknown containerID [{0}]", containerID);
@@ -239,4 +424,5 @@ final class ContainerManager implements AutoCloseable {
       }
     }
   }
+
 }

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
@@ -86,14 +86,14 @@ final class ContainerManager implements AutoCloseable {
   private final Map<String, Map<String, Boolean>> freeNodesPerRack = new HashMap<>();
 
   /**
-   * Inverted index, map of <NodeId, RackName>
+   * Inverted index, map of <NodeId, RackName>.
    */
   private final Map<String, String> racksPerNode = new HashMap<>();
 
   /**
-   * Capacity of each rack (as even as possible)
+   * Capacity of each rack (as even as possible).
    */
-  private final Map<String, Integer> capacityPerRack = new HashMap<>();
+  private final Map<String, Integer> capacitiesPerRack = new HashMap<>();
 
   private final int capacity;
   private final int defaultMemorySize;
@@ -133,14 +133,15 @@ final class ContainerManager implements AutoCloseable {
 
     LOG.log(Level.FINEST, "Initializing Container Manager with {0} containers", capacity);
 
-    remoteManager.registerHandler(ReefServiceProtos.RuntimeErrorProto.class, new EventHandler<RemoteMessage<ReefServiceProtos.RuntimeErrorProto>>() {
-      @Override
-      public void onNext(final RemoteMessage<ReefServiceProtos.RuntimeErrorProto> value) {
-        final FailedRuntime error = new FailedRuntime(value.getMessage());
-        LOG.log(Level.SEVERE, "FailedRuntime: " + error, error.getReason().orElse(null));
-        release(error.getId());
-      }
-    });
+    remoteManager.registerHandler(ReefServiceProtos.RuntimeErrorProto.class,
+        new EventHandler<RemoteMessage<ReefServiceProtos.RuntimeErrorProto>>() {
+          @Override
+          public void onNext(final RemoteMessage<ReefServiceProtos.RuntimeErrorProto> value) {
+            final FailedRuntime error = new FailedRuntime(value.getMessage());
+            LOG.log(Level.SEVERE, "FailedRuntime: " + error, error.getReason().orElse(null));
+            release(error.getId());
+          }
+        });
     clock.registerEventHandler(RuntimeStart.class, new EventHandler<Time>() {
       @Override
       public void onNext(final Time value) {
@@ -209,9 +210,9 @@ final class ContainerManager implements AutoCloseable {
     // initialize the freeNodesPerRackList and the capacityPerRack
     for (final String rackName : rackNames) {
       this.freeNodesPerRack.put(rackName, new HashMap<String, Boolean>());
-      this.capacityPerRack.put(rackName, capacityPerRack);
+      this.capacitiesPerRack.put(rackName, capacityPerRack);
       if (missing > 0) {
-        this.capacityPerRack.put(rackName, this.capacityPerRack.get(rackName) + 1);
+        this.capacitiesPerRack.put(rackName, this.capacitiesPerRack.get(rackName) + 1);
         missing--;
       }
     }
@@ -222,7 +223,7 @@ final class ContainerManager implements AutoCloseable {
     final IDMaker idmaker = new IDMaker("Node-");
     int j = 0;
     for (final String rackName : this.availableRacks) {
-      final int rackCapacity = this.capacityPerRack.get(rackName);
+      final int rackCapacity = this.capacitiesPerRack.get(rackName);
       for (int i = 0; i < rackCapacity; i++) {
         final String id = idmaker.getNextID();
         this.racksPerNode.put(id, rackName);
@@ -232,7 +233,7 @@ final class ContainerManager implements AutoCloseable {
             .setRackName(rackName)
             .setHostName(this.localAddress)
             .setPort(j)
-            .setMemorySize(this.defaultMemorySize) // TODO: Find the actual system memory on this machine.
+            .setMemorySize(this.defaultMemorySize) // TODO Find the actual system memory on this machine.
             .build());
         j++;
       }

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ResourceManager.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ResourceManager.java
@@ -73,8 +73,10 @@ public final class ResourceManager {
   @Inject
   ResourceManager(
       final ContainerManager containerManager,
-      @Parameter(RuntimeParameters.ResourceAllocationHandler.class) final EventHandler<ResourceAllocationEvent> allocationHandler,
-      @Parameter(RuntimeParameters.RuntimeStatusHandler.class) final EventHandler<RuntimeStatusEvent> runtimeStatusHandlerEventHandler,
+      @Parameter(RuntimeParameters.ResourceAllocationHandler.class)
+      final EventHandler<ResourceAllocationEvent> allocationHandler,
+      @Parameter(RuntimeParameters.RuntimeStatusHandler.class)
+      final EventHandler<RuntimeStatusEvent> runtimeStatusHandlerEventHandler,
       @Parameter(JVMHeapSlack.class) final double jvmHeapSlack,
       final ConfigurationSerializer configurationSerializer,
       final RemoteManager remoteManager,
@@ -158,7 +160,8 @@ public final class ResourceManager {
 
       final Container c = this.theContainers.get(launchRequest.getIdentifier());
 
-      try (final LoggingScope lb = this.loggingScopeFactory.getNewLoggingScope("ResourceManager.onResourceLaunchRequest:evaluatorConfigurationFile")) {
+      try (final LoggingScope lb = this.loggingScopeFactory
+          .getNewLoggingScope("ResourceManager.onResourceLaunchRequest:evaluatorConfigurationFile")) {
         // Add the global files and libraries.
         c.addGlobalFiles(this.fileNames.getGlobalFolder());
         c.addLocalFiles(getLocalFiles(launchRequest));
@@ -173,7 +176,8 @@ public final class ResourceManager {
         }
       }
 
-      try (final LoggingScope lc = this.loggingScopeFactory.getNewLoggingScope("ResourceManager.onResourceLaunchRequest:runCommand")) {
+      try (final LoggingScope lc = this.loggingScopeFactory
+          .getNewLoggingScope("ResourceManager.onResourceLaunchRequest:runCommand")) {
 
         final List<String> command = launchRequest.getProcess()
             .setErrorHandlerRID(this.remoteManager.getMyIdentifier())

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ResourceManager.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ResourceManager.java
@@ -33,13 +33,10 @@ import org.apache.reef.runtime.common.files.FileResource;
 import org.apache.reef.runtime.common.files.REEFFileNames;
 import org.apache.reef.runtime.common.parameters.JVMHeapSlack;
 import org.apache.reef.runtime.common.utils.RemoteManager;
-import org.apache.reef.runtime.local.client.parameters.DefaultMemorySize;
-import org.apache.reef.runtime.local.client.parameters.DefaultNumberOfCores;
-import org.apache.reef.runtime.local.client.parameters.RackNames;
 import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.tang.exceptions.BindException;
 import org.apache.reef.tang.formats.ConfigurationSerializer;
-import org.apache.reef.util.CollectionUtils;
+import org.apache.reef.util.Optional;
 import org.apache.reef.util.logging.LoggingScope;
 import org.apache.reef.util.logging.LoggingScopeFactory;
 import org.apache.reef.wake.EventHandler;
@@ -47,9 +44,7 @@ import org.apache.reef.wake.EventHandler;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -69,9 +64,6 @@ public final class ResourceManager {
   private final EventHandler<ResourceAllocationEvent> allocationHandler;
   private final ContainerManager theContainers;
   private final EventHandler<RuntimeStatusEvent> runtimeStatusHandlerEventHandler;
-  private final int defaultMemorySize;
-  private final int defaultNumberOfCores;
-  private final Set<String> availableRacks;
   private final ConfigurationSerializer configurationSerializer;
   private final RemoteManager remoteManager;
   private final REEFFileNames fileNames;
@@ -83,9 +75,6 @@ public final class ResourceManager {
       final ContainerManager containerManager,
       @Parameter(RuntimeParameters.ResourceAllocationHandler.class) final EventHandler<ResourceAllocationEvent> allocationHandler,
       @Parameter(RuntimeParameters.RuntimeStatusHandler.class) final EventHandler<RuntimeStatusEvent> runtimeStatusHandlerEventHandler,
-      @Parameter(DefaultMemorySize.class) final int defaultMemorySize,
-      @Parameter(DefaultNumberOfCores.class) final int defaultNumberOfCores,
-      @Parameter(RackNames.class) final Set<String> rackNames,
       @Parameter(JVMHeapSlack.class) final double jvmHeapSlack,
       final ConfigurationSerializer configurationSerializer,
       final RemoteManager remoteManager,
@@ -97,9 +86,6 @@ public final class ResourceManager {
     this.runtimeStatusHandlerEventHandler = runtimeStatusHandlerEventHandler;
     this.configurationSerializer = configurationSerializer;
     this.remoteManager = remoteManager;
-    this.defaultMemorySize = defaultMemorySize;
-    this.defaultNumberOfCores = defaultNumberOfCores;
-    this.availableRacks = rackNames;
     this.fileNames = fileNames;
     this.jvmHeapFactor = 1.0 - jvmHeapSlack;
     this.loggingScopeFactory = loggingScopeFactory;
@@ -203,23 +189,6 @@ public final class ResourceManager {
   }
 
   /**
-   * Check if the racks used in the request are the ones available in the local runtime, otherwise throw an exception
-   * @param rackNames the "user defined" rack names to simulate rack awareness in the local runtime
-   */
-  private void validateRackNames(final List<String> rackNames) {
-    for (final String rackName : rackNames) {
-      if (!availableRacks.contains(rackName)) {
-        throw new IllegalArgumentException("Rack requested for Evaluators does not exist in the local runtime: "
-            + rackName + ", available racks are: " + availableRacks.toString());
-      }
-    }
-  }
-
-  private List<String> getRackNamesOrDefault(final List<String> rackNames) {
-    return CollectionUtils.isNotEmpty(rackNames) ? rackNames : Arrays.asList(RackNames.DEFAULT_RACK_NAME);
-  }
-
-  /**
   /**
    * Checks the allocation queue for new allocations and if there are any
    * satisfies them.
@@ -229,59 +198,28 @@ public final class ResourceManager {
     if (requestQueue.hasOutStandingRequests()) {
       final ResourceRequest resourceRequest = requestQueue.head();
       final ResourceRequestEvent requestEvent = resourceRequest.getRequestProto();
-      final List<String> rackNames = getRackNamesOrDefault(requestEvent.getRackNameList());
-      validateRackNames(rackNames);
-      boolean allocated = false;
-      for (final String rackName : rackNames) {
-        if (theContainers.hasContainerAvailable(rackName)) {
-          requestQueue.satisfyOne();
-          // Allocate a Container
-          // Not taking into account the node names for now
-          final Container container = this.theContainers.allocateOne(
-                  requestEvent.getMemorySize().orElse(this.defaultMemorySize),
-                  requestEvent.getVirtualCores().orElse(this.defaultNumberOfCores),
-                  rackName);
+      final Optional<Container> cont = theContainers.allocateContainer(requestEvent);
+      if (cont.isPresent()) {
+        // Container has been allocated
+        requestQueue.satisfyOne();
+        final Container container = cont.get();
+        // Tell the receivers about it
+        final ResourceAllocationEvent alloc = ResourceAllocationEventImpl.newBuilder()
+            .setIdentifier(container.getContainerID()).setNodeId(container.getNodeID())
+            .setResourceMemory(container.getMemory()).setVirtualCores(container.getNumberOfCores())
+            .setRackName(container.getRackName()).build();
 
-          // Tell the receivers about it
-          final ResourceAllocationEvent alloc =
-              ResourceAllocationEventImpl.newBuilder()
-                  .setIdentifier(container.getContainerID())
-                  .setNodeId(container.getNodeID())
-                  .setResourceMemory(container.getMemory())
-                  .setVirtualCores(container.getNumberOfCores())
-                  .setRackName(container.getRackName())
-                  .build();
+        LOG.log(Level.FINEST, "Allocating container: {0}", container);
+        this.allocationHandler.onNext(alloc);
+        // update REEF
+        this.sendRuntimeStatus();
 
-          LOG.log(Level.FINEST, "Allocating container: {0}", container);
-          this.allocationHandler.onNext(alloc);
-          allocated = true;
-        }
-        // if we allocated the container, we break and update the status.
-        if (allocated) {
-          LOG.log(Level.FINEST, "Allocated on rack {0}", rackName);
-          break;
-        } else {
-          // if relax locality constraint is disabled, don't try on the other racks
-          if (Boolean.FALSE.equals(requestEvent.getRelaxLocality().get())) {
-            LOG.log(Level.FINEST, "Could not allocate on rack {0}, but relax locality constraint is disabled, breaking",
-                rackName);
-            break;
-          } else {
-            // if relax locality is enabled, keep on trying on the other racks
-            LOG.log(Level.FINEST,
-                "Could not allocate on rack {0}, but relax locality constraint is enabled, trying on other racks",
-                rackName);
-            continue;
-          }
-        }
-      }
-      // update REEF
-      this.sendRuntimeStatus();
-      if (allocated) {
         // Check whether we can satisfy another one.
         this.checkRequestQueue();
+      } else {
+        // could not allocate, update REEF
+        this.sendRuntimeStatus();
       }
-
     } else {
       // done
       this.sendRuntimeStatus();

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ResourceRequestQueue.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ResourceRequestQueue.java
@@ -67,4 +67,13 @@ final class ResourceRequestQueue {
     return this.requestQueue.size();
   }
 
+  /**
+   * Retrieves but does not remove the head of the queue
+   * @return the head of the queue
+   *
+   */
+  synchronized ResourceRequest head() {
+    return requestQueue.element();
+  }
+
 }

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ResourceRequestQueue.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ResourceRequestQueue.java
@@ -68,7 +68,7 @@ final class ResourceRequestQueue {
   }
 
   /**
-   * Retrieves but does not remove the head of the queue
+   * Retrieves but does not remove the head of the queue.
    * @return the head of the queue
    *
    */

--- a/lang/java/reef-runtime-local/src/test/java/org/apache/reef/runtime/local/driver/ResourceManagerTest.java
+++ b/lang/java/reef-runtime-local/src/test/java/org/apache/reef/runtime/local/driver/ResourceManagerTest.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runtime.local.driver;
+
+import org.apache.reef.runtime.common.driver.api.ResourceRequestEvent;
+import org.apache.reef.runtime.common.driver.api.ResourceRequestEventImpl;
+import org.apache.reef.runtime.common.driver.api.RuntimeParameters;
+import org.apache.reef.runtime.common.driver.resourcemanager.NodeDescriptorEvent;
+import org.apache.reef.runtime.common.driver.resourcemanager.ResourceAllocationEvent;
+import org.apache.reef.runtime.common.driver.resourcemanager.ResourceStatusEvent;
+import org.apache.reef.runtime.common.driver.resourcemanager.RuntimeStatusEvent;
+import org.apache.reef.runtime.common.files.REEFFileNames;
+import org.apache.reef.runtime.common.utils.RemoteManager;
+import org.apache.reef.runtime.local.client.parameters.MaxNumberOfEvaluators;
+import org.apache.reef.runtime.local.client.parameters.RackNames;
+import org.apache.reef.tang.Injector;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.apache.reef.tang.formats.ConfigurationSerializer;
+import org.apache.reef.util.logging.LoggingScopeFactory;
+import org.apache.reef.wake.EventHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.times;
+
+public class ResourceManagerTest {
+
+  Injector injector;
+
+  private ResourceManager resourceManager;
+  private RemoteManager remoteManager;
+  private EventHandler<ResourceStatusEvent> mockRuntimeResourceStatusHandler;
+  private EventHandler<NodeDescriptorEvent> mockNodeDescriptorHandler;
+  private EventHandler<ResourceAllocationEvent> mockResourceAllocationHandler;
+  private EventHandler<RuntimeStatusEvent> mockRuntimeStatusHandler;
+  private REEFFileNames filenames;
+  private ContainerManager containerManager;
+  private ConfigurationSerializer configurationSerializer;
+  private static final int DEFAULT_CORES = 2;
+  private static final int DEFAULT_MEMORY_SIZE = 512;
+  private static final double JVM_HEAP_SLACK = 0.1;
+  private LoggingScopeFactory loggingScopeFactory;
+
+  @SuppressWarnings("unchecked")
+  @Before
+  public void setUp() throws InjectionException {
+    injector = Tang.Factory.getTang().newInjector();
+    remoteManager = injector.getInstance(RemoteManager.class);
+    mockRuntimeResourceStatusHandler = mock(EventHandler.class);
+    injector.bindVolatileParameter(RuntimeParameters.ResourceStatusHandler.class, mockRuntimeResourceStatusHandler);
+    mockNodeDescriptorHandler = mock(EventHandler.class);
+    injector.bindVolatileParameter(RuntimeParameters.NodeDescriptorHandler.class, mockNodeDescriptorHandler);
+    mockResourceAllocationHandler = mock(EventHandler.class);
+    injector.bindVolatileParameter(RuntimeParameters.ResourceAllocationHandler.class, mockResourceAllocationHandler);
+    mockRuntimeStatusHandler = mock(EventHandler.class);
+    injector.bindVolatileParameter(RuntimeParameters.RuntimeStatusHandler.class, mockRuntimeStatusHandler);
+    configurationSerializer = injector.getInstance(ConfigurationSerializer.class);
+    filenames = injector.getInstance(REEFFileNames.class);
+    loggingScopeFactory = injector.getInstance(LoggingScopeFactory.class);
+  }
+
+  @After
+  public void tearDown() {
+    // no need to reset mocks, they are created again in the setup
+  }
+
+  /**
+   * Helper method to call the sendNodeDescriptors private method in the
+   * containerManager, which populates the available containers in each rack
+   */
+  private void sendNodeDescriptors() {
+    try {
+      final Method method = ContainerManager.class.getDeclaredMethod("sendNodeDescriptors");
+      method.setAccessible(true);
+      method.invoke(containerManager);
+    } catch (final Exception exc) {
+      throw new RuntimeException(exc);
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidRackPassedInTheRequest() throws InjectionException {
+    // Given
+    containerManager = injector.getInstance(ContainerManager.class);
+    final Set<String> availableRacks = new HashSet<String>(Arrays.asList("rack1"));
+    resourceManager = new ResourceManager(containerManager, mockResourceAllocationHandler, mockRuntimeStatusHandler,
+        DEFAULT_MEMORY_SIZE, DEFAULT_CORES, availableRacks, JVM_HEAP_SLACK, configurationSerializer, remoteManager,
+        filenames, loggingScopeFactory);
+    final ResourceRequestEvent request = ResourceRequestEventImpl.newBuilder().setResourceCount(2).setVirtualCores(1)
+        .setMemorySize(64).build();
+    // When
+    resourceManager.onResourceRequest(request);
+    // Then
+    // expect the exception to be thrown
+  }
+
+  @Test
+  public void testZeroAllocationsDueToContainersNotAvailableAndRelaxLocalityEnabled() throws InjectionException {
+    // Given
+    containerManager = injector.getInstance(ContainerManager.class);
+    final Set<String> availableRacks = new HashSet<String>(Arrays.asList(RackNames.DEFAULT_RACK_NAME));
+    resourceManager = new ResourceManager(containerManager, mockResourceAllocationHandler, mockRuntimeStatusHandler,
+        DEFAULT_MEMORY_SIZE, DEFAULT_CORES, availableRacks, JVM_HEAP_SLACK, configurationSerializer, remoteManager,
+        filenames, loggingScopeFactory);
+    final ResourceRequestEvent request = ResourceRequestEventImpl.newBuilder().setResourceCount(2).setVirtualCores(1)
+        .setMemorySize(64).build();
+    // When
+    resourceManager.onResourceRequest(request);
+    // Then
+    verify(mockResourceAllocationHandler, times(0)).onNext(any(ResourceAllocationEvent.class));
+    verify(mockRuntimeStatusHandler, times(1)).onNext(any(RuntimeStatusEvent.class));
+  }
+
+  @Test
+  public void testZeroAllocationsDueToContainersNotAvailableAndRelaxLocalityDisabled() throws InjectionException {
+    // Given
+    containerManager = injector.getInstance(ContainerManager.class);
+    final Set<String> availableRacks = new HashSet<String>(Arrays.asList(RackNames.DEFAULT_RACK_NAME));
+    resourceManager = new ResourceManager(containerManager, mockResourceAllocationHandler, mockRuntimeStatusHandler,
+        DEFAULT_MEMORY_SIZE, DEFAULT_CORES, availableRacks, JVM_HEAP_SLACK, configurationSerializer, remoteManager,
+        filenames, loggingScopeFactory);
+    final ResourceRequestEvent request = ResourceRequestEventImpl.newBuilder().setResourceCount(2).setVirtualCores(1)
+        .setMemorySize(64).setRelaxLocality(Boolean.FALSE).build();
+    // When
+    resourceManager.onResourceRequest(request);
+    // Then
+    verify(mockResourceAllocationHandler, times(0)).onNext(any(ResourceAllocationEvent.class));
+    verify(mockRuntimeStatusHandler, times(1)).onNext(any(RuntimeStatusEvent.class));
+  }
+
+  @Test
+  public void testTwoAllocationsInDifferentRacksDueToRelaxLocalityEnabled() throws InjectionException {
+    // Given
+    final List<String> availableRacks = Arrays.asList("rack1", "rack2");
+    final Set<String> availableRacksSet = new HashSet<String>(availableRacks);
+    injector.bindVolatileParameter(RackNames.class, availableRacksSet); // 2 available racks
+    injector.bindVolatileParameter(MaxNumberOfEvaluators.class, 2); // 1 evaluator per rack
+    containerManager = injector.getInstance(ContainerManager.class); // inject containerManager with this updated info
+    sendNodeDescriptors();
+    resourceManager = new ResourceManager(containerManager, mockResourceAllocationHandler, mockRuntimeStatusHandler,
+        DEFAULT_MEMORY_SIZE, DEFAULT_CORES, availableRacksSet, JVM_HEAP_SLACK, configurationSerializer, remoteManager,
+        filenames, loggingScopeFactory);
+    final ResourceRequestEvent request = ResourceRequestEventImpl.newBuilder().setResourceCount(2).setVirtualCores(1)
+        .setMemorySize(64).setRelaxLocality(Boolean.TRUE).addRackName(availableRacks.get(0)).addRackName(availableRacks.get(1)).build();
+    // When
+    resourceManager.onResourceRequest(request);
+    // Then
+    verify(mockResourceAllocationHandler, times(2)).onNext(any(ResourceAllocationEvent.class));
+    verify(mockRuntimeStatusHandler, times(3)).onNext(any(RuntimeStatusEvent.class));
+  }
+
+  @Test
+  public void testTwoAllocationsOnFourContainersAvailableInDefaultRack() throws InjectionException {
+    // Given
+    containerManager = injector.getInstance(ContainerManager.class);
+    sendNodeDescriptors();
+    final Set<String> availableRacks = new HashSet<String>(Arrays.asList(RackNames.DEFAULT_RACK_NAME));
+    resourceManager = new ResourceManager(containerManager, mockResourceAllocationHandler, mockRuntimeStatusHandler,
+        DEFAULT_MEMORY_SIZE, DEFAULT_CORES, availableRacks, JVM_HEAP_SLACK, configurationSerializer, remoteManager,
+        filenames, loggingScopeFactory);
+    final ResourceRequestEvent request = ResourceRequestEventImpl.newBuilder().setResourceCount(2).setVirtualCores(1)
+        .setMemorySize(64).build();
+    // When
+    resourceManager.onResourceRequest(request);
+    // Then
+    verify(mockResourceAllocationHandler, times(2)).onNext(any(ResourceAllocationEvent.class));
+    verify(mockRuntimeStatusHandler, times(3)).onNext(any(RuntimeStatusEvent.class));
+  }
+
+}

--- a/lang/java/reef-runtime-local/src/test/java/org/apache/reef/runtime/local/driver/ResourceManagerTest.java
+++ b/lang/java/reef-runtime-local/src/test/java/org/apache/reef/runtime/local/driver/ResourceManagerTest.java
@@ -52,9 +52,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.times;
 
+/**
+ * Unit test for Resource Manager (and ContainerManager) classes.
+ *
+ */
 public class ResourceManagerTest {
 
-  Injector injector;
+  private Injector injector;
 
   private ResourceManager resourceManager;
   private RemoteManager remoteManager;
@@ -65,8 +69,6 @@ public class ResourceManagerTest {
   private REEFFileNames filenames;
   private ContainerManager containerManager;
   private ConfigurationSerializer configurationSerializer;
-  private static final int DEFAULT_CORES = 2;
-  private static final int DEFAULT_MEMORY_SIZE = 512;
   private static final double JVM_HEAP_SLACK = 0.1;
   private LoggingScopeFactory loggingScopeFactory;
 
@@ -95,7 +97,7 @@ public class ResourceManagerTest {
 
   /**
    * Helper method to call the sendNodeDescriptors private method in the
-   * containerManager, which populates the available containers in each rack
+   * containerManager, which populates the available containers in each rack.
    */
   private void sendNodeDescriptors() {
     try {

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTest.java
@@ -78,7 +78,9 @@ public final class RackAwareEvaluatorTest {
    * Test whether the runtime passes the rack information to the driver
    * The success scenario is if it receives rack1, fails otherwise
    */
-  @Test
+  //@Test
+  // TODO Re-enable once we define the API to specify the information where resources should run on
+  // OnDriverStartedAllocateOne will need to be replaced, and contain that it wants to run in RACK1, which will be the only one available
   public void testRackAwareEvaluatorRunningOnRack1() throws InjectionException {
     //Given
     final Configuration driverConfiguration = DriverConfiguration.CONF

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTest.java
@@ -81,7 +81,7 @@ public final class RackAwareEvaluatorTest {
    */
   //@Test
   // TODO Re-enable once we define the API to specify the information where
-  // resources should run on.
+  // resources should run on (JIRA REEF-416)
   // OnDriverStartedAllocateOne will need to be replaced, and contain that it
   // wants to run in RACK1, which will be the only one available
   public void testRackAwareEvaluatorRunningOnRack1() throws InjectionException {

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTest.java
@@ -55,15 +55,16 @@ public final class RackAwareEvaluatorTest {
   }
 
   /**
-  * Tests whether the runtime passes the rack information to the driver
-  * The success scenario is if it receives the default rack, fails otherwise
+  * Tests whether the runtime passes the rack information to the driver.
+  * The success scenario is if it receives the default rack, fails otherwise.
   */
   @Test
   public void testRackAwareEvaluatorRunningOnDefaultRack() {
     //Given
     final Configuration driverConfiguration = DriverConfiguration.CONF
         .set(DriverConfiguration.DRIVER_IDENTIFIER, "TEST_RackAwareEvaluator")
-        .set(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getClassLocation(RackAwareEvaluatorTestDriver.class))
+        .set(DriverConfiguration.GLOBAL_LIBRARIES,
+            EnvironmentUtils.getClassLocation(RackAwareEvaluatorTestDriver.class))
         .set(DriverConfiguration.ON_DRIVER_STARTED, OnDriverStartedAllocateOne.class)
         .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, RackAwareEvaluatorTestDriver.EvaluatorAllocatedHandler.class)
         .build();
@@ -75,17 +76,20 @@ public final class RackAwareEvaluatorTest {
   }
 
   /**
-   * Test whether the runtime passes the rack information to the driver
+   * Test whether the runtime passes the rack information to the driver.
    * The success scenario is if it receives rack1, fails otherwise
    */
   //@Test
-  // TODO Re-enable once we define the API to specify the information where resources should run on
-  // OnDriverStartedAllocateOne will need to be replaced, and contain that it wants to run in RACK1, which will be the only one available
+  // TODO Re-enable once we define the API to specify the information where
+  // resources should run on.
+  // OnDriverStartedAllocateOne will need to be replaced, and contain that it
+  // wants to run in RACK1, which will be the only one available
   public void testRackAwareEvaluatorRunningOnRack1() throws InjectionException {
     //Given
     final Configuration driverConfiguration = DriverConfiguration.CONF
         .set(DriverConfiguration.DRIVER_IDENTIFIER, "TEST_RackAwareEvaluator")
-        .set(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getClassLocation(RackAwareEvaluatorTestDriver.class))
+        .set(DriverConfiguration.GLOBAL_LIBRARIES,
+            EnvironmentUtils.getClassLocation(RackAwareEvaluatorTestDriver.class))
         .set(DriverConfiguration.ON_DRIVER_STARTED, OnDriverStartedAllocateOne.class)
         .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, RackAwareEvaluatorTestDriver.EvaluatorAllocatedHandler.class)
         .build();


### PR DESCRIPTION
This work allows to put containers into the different racks available in
the local runtime, instead of just using the default rack.
If no rack is configured, the default one is used.
Some UTs were added

JIRA:
  [REEF-411](https://issues.apache.org/jira/browse/REEF-411)