### PR TITLE
[REEF-418]: Group Communication breaks down on actual cluster

### DIFF
--- a/lang/cs/Org.Apache.REEF.Network/NetworkService/WritableNetworkService.cs
+++ b/lang/cs/Org.Apache.REEF.Network/NetworkService/WritableNetworkService.cs
@@ -126,7 +126,7 @@ namespace Org.Apache.REEF.Network.NetworkService
             NamingClient.Register(id.ToString(), _remoteManager.LocalEndpoint);
 
             // Create and register incoming message handler
-            var anyEndpoint = new IPEndPoint(_remoteManager.LocalEndpoint.Address, 0);
+            var anyEndpoint = new IPEndPoint(IPAddress.Any, 0);
             _messageHandlerDisposable = _remoteManager.RegisterObserver(anyEndpoint, _messageHandler);
 
             Logger.Log(Level.Info, "End of Registering id {0} with network service.", id);


### PR DESCRIPTION
After the recent merge (see REEF-260), we found that once we run PipelineBroadcastAndBroadcast Reduce on actual cluster it fails while if we run it locally it passes. We found the issue to be in the WritableNetworkService where while registering observer we map it to a particular local IP address rather than any.
The aim of this JIRA is to make this one line change in the WritableNetworkService.
This addressed the issue by
* Registering observer in DefaultRemoteManager with IpAddress.Any in WritableNetworkService
JIRA: [REEF-418](https://issues.apache.org/jira/browse/REEF-418)