### PR TITLE
[REEF-423]: Move Streaming Codec classes from Network to Wake layer

### DIFF
--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/BroadcastReduceDriverAndTasks/BroadcastReduceDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/BroadcastReduceDriverAndTasks/BroadcastReduceDriver.cs
@@ -27,7 +27,7 @@ using Org.Apache.REEF.Driver;
 using Org.Apache.REEF.Driver.Bridge;
 using Org.Apache.REEF.Driver.Context;
 using Org.Apache.REEF.Driver.Evaluator;
-using Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs;
+using Org.Apache.REEF.Wake.StreamingCodec.CommonStreamingCodecs;
 using Org.Apache.REEF.Network.Group.Config;
 using Org.Apache.REEF.Network.Group.Driver;
 using Org.Apache.REEF.Network.Group.Driver.Impl;

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedBroadcastReduceDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedBroadcastReduceDriver.cs
@@ -27,7 +27,6 @@ using Org.Apache.REEF.Driver;
 using Org.Apache.REEF.Driver.Bridge;
 using Org.Apache.REEF.Driver.Context;
 using Org.Apache.REEF.Driver.Evaluator;
-using Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs;
 using Org.Apache.REEF.Network.Examples.GroupCommunication.BroadcastReduceDriverAndTasks;
 using Org.Apache.REEF.Network.Group.Config;
 using Org.Apache.REEF.Network.Group.Driver;
@@ -44,6 +43,7 @@ using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Logging;
 using Org.Apache.REEF.Wake.Remote;
 using Org.Apache.REEF.Wake.Remote.Parameters;
+using Org.Apache.REEF.Wake.StreamingCodec.CommonStreamingCodecs;
 
 namespace Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastReduceDriverAndTasks
 {

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/ScatterReduceDriverAndTasks/ScatterReduceDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/ScatterReduceDriverAndTasks/ScatterReduceDriver.cs
@@ -27,7 +27,6 @@ using Org.Apache.REEF.Driver;
 using Org.Apache.REEF.Driver.Bridge;
 using Org.Apache.REEF.Driver.Context;
 using Org.Apache.REEF.Driver.Evaluator;
-using Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs;
 using Org.Apache.REEF.Network.Examples.GroupCommunication.BroadcastReduceDriverAndTasks;
 using Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastReduceDriverAndTasks;
 using Org.Apache.REEF.Network.Group.Config;
@@ -44,6 +43,7 @@ using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Logging;
 using Org.Apache.REEF.Wake.Remote.Impl;
+using Org.Apache.REEF.Wake.StreamingCodec.CommonStreamingCodecs;
 
 namespace Org.Apache.REEF.Network.Examples.GroupCommunication.ScatterReduceDriverAndTasks
 {

--- a/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTests.cs
@@ -30,7 +30,6 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Common.Io;
 using Org.Apache.REEF.Common.Tasks;
-using Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs;
 using Org.Apache.REEF.Network.Examples.GroupCommunication;
 using Org.Apache.REEF.Network.Group.Config;
 using Org.Apache.REEF.Network.Group.Driver;
@@ -43,7 +42,6 @@ using Org.Apache.REEF.Network.Group.Task;
 using Org.Apache.REEF.Network.Group.Topology;
 using Org.Apache.REEF.Network.Naming;
 using Org.Apache.REEF.Network.NetworkService;
-using Org.Apache.REEF.Network.StreamingCodec;
 using Org.Apache.REEF.Network.Tests.NamingService;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Formats;
@@ -53,6 +51,8 @@ using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Wake.Remote;
 using Org.Apache.REEF.Wake.Remote.Impl;
+using Org.Apache.REEF.Wake.StreamingCodec;
+using Org.Apache.REEF.Wake.StreamingCodec.CommonStreamingCodecs;
 
 namespace Org.Apache.REEF.Network.Tests.GroupCommunication
 {

--- a/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTreeTopologyTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTreeTopologyTests.cs
@@ -21,7 +21,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs;
 using Org.Apache.REEF.Network.Group.Config;
 using Org.Apache.REEF.Network.Group.Driver;
 using Org.Apache.REEF.Network.Group.Driver.Impl;
@@ -34,6 +33,7 @@ using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Wake.Remote.Impl;
+using Org.Apache.REEF.Wake.StreamingCodec.CommonStreamingCodecs;
 
 namespace Org.Apache.REEF.Network.Tests.GroupCommunication
 {

--- a/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/StreamingCodecTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/StreamingCodecTests.cs
@@ -22,13 +22,13 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Org.Apache.REEF.Network.StreamingCodec;
-using Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Wake.Remote;
 using Org.Apache.REEF.Wake.Remote.Impl;
+using Org.Apache.REEF.Wake.StreamingCodec;
+using Org.Apache.REEF.Wake.StreamingCodec.CommonStreamingCodecs;
 
 namespace Org.Apache.REEF.Network.Tests.GroupCommunication
 {

--- a/lang/cs/Org.Apache.REEF.Network/Group/Config/CodecToStreamingCodecConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Config/CodecToStreamingCodecConfiguration.cs
@@ -18,10 +18,10 @@
  */
 
 using Org.Apache.REEF.Network.Group.Pipelining;
-using Org.Apache.REEF.Network.StreamingCodec;
 using Org.Apache.REEF.Tang.Formats;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Wake.Remote;
+using Org.Apache.REEF.Wake.StreamingCodec;
 
 namespace Org.Apache.REEF.Network.Group.Config
 {

--- a/lang/cs/Org.Apache.REEF.Network/Group/Config/StreamingCodecConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Config/StreamingCodecConfiguration.cs
@@ -18,9 +18,9 @@
  */
 
 using Org.Apache.REEF.Network.Group.Pipelining;
-using Org.Apache.REEF.Network.StreamingCodec;
 using Org.Apache.REEF.Tang.Formats;
 using Org.Apache.REEF.Tang.Util;
+using Org.Apache.REEF.Wake.StreamingCodec;
 
 namespace Org.Apache.REEF.Network.Group.Config
 {

--- a/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/GroupCommunicationMessage.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Driver/Impl/GroupCommunicationMessage.cs
@@ -19,9 +19,9 @@
 
 using System;
 using System.Threading;
-using Org.Apache.REEF.Network.StreamingCodec;
 using Org.Apache.REEF.Wake.Remote;
 using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Wake.StreamingCodec;
 
 namespace Org.Apache.REEF.Network.Group.Driver.Impl
 {

--- a/lang/cs/Org.Apache.REEF.Network/Group/Pipelining/StreamingPipelineMessageCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Pipelining/StreamingPipelineMessageCodec.cs
@@ -21,7 +21,7 @@ using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Wake.Remote;
 using System.Threading;
 using System.Threading.Tasks;
-using Org.Apache.REEF.Network.StreamingCodec;
+using Org.Apache.REEF.Wake.StreamingCodec;
 
 namespace Org.Apache.REEF.Network.Group.Pipelining
 {

--- a/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/OperatorTopology.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/OperatorTopology.cs
@@ -29,10 +29,10 @@ using Org.Apache.REEF.Network.Group.Driver.Impl;
 using Org.Apache.REEF.Network.Group.Operators;
 using Org.Apache.REEF.Network.Group.Operators.Impl;
 using Org.Apache.REEF.Network.NetworkService;
-using Org.Apache.REEF.Network.StreamingCodec;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Exceptions;
 using Org.Apache.REEF.Utilities.Logging;
+using Org.Apache.REEF.Wake.StreamingCodec;
 
 namespace Org.Apache.REEF.Network.Group.Task.Impl
 {

--- a/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
+++ b/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
@@ -52,13 +52,6 @@ under the License.
   <ItemGroup>
     <Compile Include="Group\Config\CodecToStreamingCodecConfiguration.cs" />
     <Compile Include="Group\Driver\Impl\GeneralGroupCommunicationMessage.cs" />
-    <Compile Include="StreamingCodec\CommonStreamingCodecs\FloatArrayStreamingCodec.cs" />
-    <Compile Include="StreamingCodec\CommonStreamingCodecs\DoubleArrayStreamingCodec.cs" />
-    <Compile Include="StreamingCodec\CommonStreamingCodecs\FloatStreamingCodec.cs" />
-    <Compile Include="StreamingCodec\CommonStreamingCodecs\IntArrayStreamingCodec.cs" />
-    <Compile Include="StreamingCodec\CommonStreamingCodecs\DoubleStreamingCodec.cs" />
-    <Compile Include="StreamingCodec\CommonStreamingCodecs\StringStreamingCodec.cs" />
-    <Compile Include="StreamingCodec\CommonStreamingCodecs\IntStreamingCodec.cs" />
     <Compile Include="Group\Config\CodecConfiguration.cs" />
     <Compile Include="Group\Config\GroupCommConfigurationOptions.cs" />
     <Compile Include="Group\Config\PipelineDataConverterConfiguration.cs" />
@@ -156,8 +149,6 @@ under the License.
     <Compile Include="NetworkService\WritableNsConnection.cs" />
     <Compile Include="NetworkService\WritableNsMessage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="StreamingCodec\CodecToStreamingCodec.cs" />
-    <Compile Include="StreamingCodec\IStreamingCodec.cs" />
     <Compile Include="Utilities\BlockingCollectionExtensions.cs" />
     <Compile Include="Utilities\Utils.cs" />
   </ItemGroup>

--- a/lang/cs/Org.Apache.REEF.Wake/Org.Apache.REEF.Wake.csproj
+++ b/lang/cs/Org.Apache.REEF.Wake/Org.Apache.REEF.Wake.csproj
@@ -131,6 +131,15 @@ under the License.
     <Compile Include="RX\IStaticObservable.cs" />
     <Compile Include="RX\ISubject.cs" />
     <Compile Include="RX\ObserverCompletedException.cs" />
+    <Compile Include="StreamingCodec\CodecToStreamingCodec.cs" />
+    <Compile Include="StreamingCodec\CommonStreamingCodecs\DoubleArrayStreamingCodec.cs" />
+    <Compile Include="StreamingCodec\CommonStreamingCodecs\DoubleStreamingCodec.cs" />
+    <Compile Include="StreamingCodec\CommonStreamingCodecs\FloatArrayStreamingCodec.cs" />
+    <Compile Include="StreamingCodec\CommonStreamingCodecs\FloatStreamingCodec.cs" />
+    <Compile Include="StreamingCodec\CommonStreamingCodecs\IntArrayStreamingCodec.cs" />
+    <Compile Include="StreamingCodec\CommonStreamingCodecs\IntStreamingCodec.cs" />
+    <Compile Include="StreamingCodec\CommonStreamingCodecs\StringStreamingCodec.cs" />
+    <Compile Include="StreamingCodec\IStreamingCodec.cs" />
     <Compile Include="Time\Event\Alarm.cs" />
     <Compile Include="Time\Event\StartTime.cs" />
     <Compile Include="Time\Event\StopTime.cs" />

--- a/lang/cs/Org.Apache.REEF.Wake/StreamingCodec/CodecToStreamingCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/StreamingCodec/CodecToStreamingCodec.cs
@@ -22,7 +22,7 @@ using System.Threading.Tasks;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Wake.Remote;
 
-namespace Org.Apache.REEF.Network.StreamingCodec
+namespace Org.Apache.REEF.Wake.StreamingCodec
 {
     /// <summary>
     /// Converts codec to streaming codec

--- a/lang/cs/Org.Apache.REEF.Wake/StreamingCodec/CommonStreamingCodecs/DoubleArrayStreamingCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/StreamingCodec/CommonStreamingCodecs/DoubleArrayStreamingCodec.cs
@@ -23,18 +23,18 @@ using System.Threading.Tasks;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Wake.Remote;
 
-namespace Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs
+namespace Org.Apache.REEF.Wake.StreamingCodec.CommonStreamingCodecs
 {
     /// <summary>
-    /// Streaming codec for float array
+    /// Streaming codec for double array
     /// </summary>
-    public sealed class FloatArrayStreamingCodec : IStreamingCodec<float[]>
+    public sealed class DoubleArrayStreamingCodec : IStreamingCodec<double[]>
     {
         /// <summary>
         /// Injectable constructor
         /// </summary>
         [Inject]
-        private FloatArrayStreamingCodec()
+        private DoubleArrayStreamingCodec()
         {
         }
 
@@ -42,31 +42,31 @@ namespace Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs
         /// Instantiate the class from the reader.
         /// </summary>
         /// <param name="reader">The reader from which to read</param>
-        ///<returns>The float array read from the reader</returns>
-        public float[] Read(IDataReader reader)
+        ///<returns>The double array read from the reader</returns>
+        public double[] Read(IDataReader reader)
         {
             int length = reader.ReadInt32();
-            byte[] buffer = new byte[sizeof(float)*length];
+            byte[] buffer = new byte[sizeof(double)*length];
             reader.Read(ref buffer, 0, buffer.Length);
-            float[] floatArr = new float[length];
-            Buffer.BlockCopy(buffer, 0, floatArr, 0, buffer.Length);
-            return floatArr;
+            double[] doubleArr = new double[length];
+            Buffer.BlockCopy(buffer, 0, doubleArr, 0, buffer.Length);
+            return doubleArr;
         }
 
         /// <summary>
-        /// Writes the float array to the writer.
+        /// Writes the double array to the writer.
         /// </summary>
-        /// <param name="obj">The float array to be encoded</param>
+        /// <param name="obj">The double array to be encoded</param>
         /// <param name="writer">The writer to which to write</param>
-        public void Write(float[] obj, IDataWriter writer)
+        public void Write(double[] obj, IDataWriter writer)
         {
             if (obj == null)
             {
-                throw new ArgumentNullException("obj", "float array is null");
+                throw new ArgumentNullException("obj", "double array is null");
             }
 
             writer.WriteInt32(obj.Length);
-            byte[] buffer = new byte[sizeof(float) * obj.Length];
+            byte[] buffer = new byte[sizeof(double) * obj.Length];
             Buffer.BlockCopy(obj, 0, buffer, 0, buffer.Length);
             writer.Write(buffer, 0, buffer.Length);
         }
@@ -76,33 +76,33 @@ namespace Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs
         ///  </summary>
         ///  <param name="reader">The reader from which to read</param>
         /// <param name="token">Cancellation token</param>
-        /// <returns>The float array read from the reader</returns>
-        public async Task<float[]> ReadAsync(IDataReader reader, CancellationToken token)
+        /// <returns>The double array read from the reader</returns>
+        public async Task<double[]> ReadAsync(IDataReader reader, CancellationToken token)
         {
             int length = await reader.ReadInt32Async(token);
-            byte[] buffer = new byte[sizeof(float) * length];
+            byte[] buffer = new byte[sizeof(double) * length];
             await reader.ReadAsync(buffer, 0, buffer.Length, token);
-            float[] floatArr = new float[length];
-            Buffer.BlockCopy(buffer, 0, floatArr, 0, sizeof(float) * length);
-            return floatArr;
+            double[] doubleArr = new double[length];
+            Buffer.BlockCopy(buffer, 0, doubleArr, 0, sizeof(double) * length);
+            return doubleArr;
         }
 
         /// <summary>
-        /// Writes the float array to the writer.
+        /// Writes the double array to the writer.
         /// </summary>
-        /// <param name="obj">The float array to be encoded</param>
+        /// <param name="obj">The double array to be encoded</param>
         /// <param name="writer">The writer to which to write</param>
         /// <param name="token">Cancellation token</param>
-        public async Task WriteAsync(float[] obj, IDataWriter writer, CancellationToken token)
+        public async Task WriteAsync(double[] obj, IDataWriter writer, CancellationToken token)
         {
             if (obj == null)
             {
-                throw new ArgumentNullException("obj", "float array is null");
+                throw new ArgumentNullException("obj", "double array is null");
             }
 
             await writer.WriteInt32Async(obj.Length, token);
-            byte[] buffer = new byte[sizeof(float) * obj.Length];
-            Buffer.BlockCopy(obj, 0, buffer, 0, sizeof(float) * obj.Length);
+            byte[] buffer = new byte[sizeof(double) * obj.Length];
+            Buffer.BlockCopy(obj, 0, buffer, 0, sizeof(double) * obj.Length);
             await writer.WriteAsync(buffer, 0, buffer.Length, token);
         }
     }

--- a/lang/cs/Org.Apache.REEF.Wake/StreamingCodec/CommonStreamingCodecs/DoubleStreamingCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/StreamingCodec/CommonStreamingCodecs/DoubleStreamingCodec.cs
@@ -22,18 +22,18 @@ using System.Threading.Tasks;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Wake.Remote;
 
-namespace Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs
+namespace Org.Apache.REEF.Wake.StreamingCodec.CommonStreamingCodecs
 {
     /// <summary>
-    /// Streaming codec for float
+    /// Streaming codec for double
     /// </summary>
-    public sealed class FloatStreamingCodec : IStreamingCodec<float>
+    public sealed class DoubleStreamingCodec : IStreamingCodec<double>
     {
         /// <summary>
         /// Injectable constructor
         /// </summary>
         [Inject]
-        private FloatStreamingCodec()
+        private DoubleStreamingCodec()
         {
         }
 
@@ -41,20 +41,20 @@ namespace Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs
         /// Instantiate the class from the reader.
         /// </summary>
         /// <param name="reader">The reader from which to read</param>
-        ///<returns>The float read from the reader</returns>
-        public float Read(IDataReader reader)
+        ///<returns>The double read from the reader</returns>
+        public double Read(IDataReader reader)
         {
-            return reader.ReadFloat();
+            return reader.ReadDouble();
         }
 
         /// <summary>
-        /// Writes the float to the writer.
+        /// Writes the double to the writer.
         /// </summary>
-        /// <param name="obj">The float to be encoded</param>
+        /// <param name="obj">The double to be encoded</param>
         /// <param name="writer">The writer to which to write</param>
-        public void Write(float obj, IDataWriter writer)
+        public void Write(double obj, IDataWriter writer)
         {
-            writer.WriteFloat(obj);
+            writer.WriteDouble(obj);
         }
 
         ///  <summary>
@@ -62,21 +62,21 @@ namespace Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs
         ///  </summary>
         ///  <param name="reader">The reader from which to read</param>
         /// <param name="token">Cancellation token</param>
-        /// <returns>The float read from the reader</returns>
-        public async Task<float> ReadAsync(IDataReader reader, CancellationToken token)
+        /// <returns>The double read from the reader</returns>
+        public async Task<double> ReadAsync(IDataReader reader, CancellationToken token)
         {
-            return await reader.ReadFloatAsync(token);
+            return await reader.ReadDoubleAsync(token);
         }
 
         /// <summary>
-        /// Writes the float to the writer.
+        /// Writes the double to the writer.
         /// </summary>
-        /// <param name="obj">The float to be encoded</param>
+        /// <param name="obj">The double to be encoded</param>
         /// <param name="writer">The writer to which to write</param>
         /// <param name="token">Cancellation token</param>
-        public async Task WriteAsync(float obj, IDataWriter writer, CancellationToken token)
+        public async Task WriteAsync(double obj, IDataWriter writer, CancellationToken token)
         {
-            await writer.WriteFloatAsync(obj, token);
+            await writer.WriteDoubleAsync(obj, token);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Wake/StreamingCodec/CommonStreamingCodecs/FloatArrayStreamingCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/StreamingCodec/CommonStreamingCodecs/FloatArrayStreamingCodec.cs
@@ -23,18 +23,18 @@ using System.Threading.Tasks;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Wake.Remote;
 
-namespace Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs
+namespace Org.Apache.REEF.Wake.StreamingCodec.CommonStreamingCodecs
 {
     /// <summary>
-    /// Streaming codec for double array
+    /// Streaming codec for float array
     /// </summary>
-    public sealed class DoubleArrayStreamingCodec : IStreamingCodec<double[]>
+    public sealed class FloatArrayStreamingCodec : IStreamingCodec<float[]>
     {
         /// <summary>
         /// Injectable constructor
         /// </summary>
         [Inject]
-        private DoubleArrayStreamingCodec()
+        private FloatArrayStreamingCodec()
         {
         }
 
@@ -42,31 +42,31 @@ namespace Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs
         /// Instantiate the class from the reader.
         /// </summary>
         /// <param name="reader">The reader from which to read</param>
-        ///<returns>The double array read from the reader</returns>
-        public double[] Read(IDataReader reader)
+        ///<returns>The float array read from the reader</returns>
+        public float[] Read(IDataReader reader)
         {
             int length = reader.ReadInt32();
-            byte[] buffer = new byte[sizeof(double)*length];
+            byte[] buffer = new byte[sizeof(float)*length];
             reader.Read(ref buffer, 0, buffer.Length);
-            double[] doubleArr = new double[length];
-            Buffer.BlockCopy(buffer, 0, doubleArr, 0, buffer.Length);
-            return doubleArr;
+            float[] floatArr = new float[length];
+            Buffer.BlockCopy(buffer, 0, floatArr, 0, buffer.Length);
+            return floatArr;
         }
 
         /// <summary>
-        /// Writes the double array to the writer.
+        /// Writes the float array to the writer.
         /// </summary>
-        /// <param name="obj">The double array to be encoded</param>
+        /// <param name="obj">The float array to be encoded</param>
         /// <param name="writer">The writer to which to write</param>
-        public void Write(double[] obj, IDataWriter writer)
+        public void Write(float[] obj, IDataWriter writer)
         {
             if (obj == null)
             {
-                throw new ArgumentNullException("obj", "double array is null");
+                throw new ArgumentNullException("obj", "float array is null");
             }
 
             writer.WriteInt32(obj.Length);
-            byte[] buffer = new byte[sizeof(double) * obj.Length];
+            byte[] buffer = new byte[sizeof(float) * obj.Length];
             Buffer.BlockCopy(obj, 0, buffer, 0, buffer.Length);
             writer.Write(buffer, 0, buffer.Length);
         }
@@ -76,33 +76,33 @@ namespace Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs
         ///  </summary>
         ///  <param name="reader">The reader from which to read</param>
         /// <param name="token">Cancellation token</param>
-        /// <returns>The double array read from the reader</returns>
-        public async Task<double[]> ReadAsync(IDataReader reader, CancellationToken token)
+        /// <returns>The float array read from the reader</returns>
+        public async Task<float[]> ReadAsync(IDataReader reader, CancellationToken token)
         {
             int length = await reader.ReadInt32Async(token);
-            byte[] buffer = new byte[sizeof(double) * length];
+            byte[] buffer = new byte[sizeof(float) * length];
             await reader.ReadAsync(buffer, 0, buffer.Length, token);
-            double[] doubleArr = new double[length];
-            Buffer.BlockCopy(buffer, 0, doubleArr, 0, sizeof(double) * length);
-            return doubleArr;
+            float[] floatArr = new float[length];
+            Buffer.BlockCopy(buffer, 0, floatArr, 0, sizeof(float) * length);
+            return floatArr;
         }
 
         /// <summary>
-        /// Writes the double array to the writer.
+        /// Writes the float array to the writer.
         /// </summary>
-        /// <param name="obj">The double array to be encoded</param>
+        /// <param name="obj">The float array to be encoded</param>
         /// <param name="writer">The writer to which to write</param>
         /// <param name="token">Cancellation token</param>
-        public async Task WriteAsync(double[] obj, IDataWriter writer, CancellationToken token)
+        public async Task WriteAsync(float[] obj, IDataWriter writer, CancellationToken token)
         {
             if (obj == null)
             {
-                throw new ArgumentNullException("obj", "double array is null");
+                throw new ArgumentNullException("obj", "float array is null");
             }
 
             await writer.WriteInt32Async(obj.Length, token);
-            byte[] buffer = new byte[sizeof(double) * obj.Length];
-            Buffer.BlockCopy(obj, 0, buffer, 0, sizeof(double) * obj.Length);
+            byte[] buffer = new byte[sizeof(float) * obj.Length];
+            Buffer.BlockCopy(obj, 0, buffer, 0, sizeof(float) * obj.Length);
             await writer.WriteAsync(buffer, 0, buffer.Length, token);
         }
     }

--- a/lang/cs/Org.Apache.REEF.Wake/StreamingCodec/CommonStreamingCodecs/FloatStreamingCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/StreamingCodec/CommonStreamingCodecs/FloatStreamingCodec.cs
@@ -19,43 +19,64 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Wake.Remote;
 
-namespace Org.Apache.REEF.Network.StreamingCodec
+namespace Org.Apache.REEF.Wake.StreamingCodec.CommonStreamingCodecs
 {
     /// <summary>
-    /// Codec Interface that external users should implement to directly write to the stream
+    /// Streaming codec for float
     /// </summary>
-    public interface IStreamingCodec<T>
+    public sealed class FloatStreamingCodec : IStreamingCodec<float>
     {
+        /// <summary>
+        /// Injectable constructor
+        /// </summary>
+        [Inject]
+        private FloatStreamingCodec()
+        {
+        }
+
         /// <summary>
         /// Instantiate the class from the reader.
         /// </summary>
         /// <param name="reader">The reader from which to read</param>
-        ///<returns>The instance of type T read from the reader</returns>
-        T Read(IDataReader reader);
+        ///<returns>The float read from the reader</returns>
+        public float Read(IDataReader reader)
+        {
+            return reader.ReadFloat();
+        }
 
         /// <summary>
-        /// Writes the class fields to the writer.
+        /// Writes the float to the writer.
         /// </summary>
-        /// <param name="obj">The object of type T to be encoded</param>
+        /// <param name="obj">The float to be encoded</param>
         /// <param name="writer">The writer to which to write</param>
-        void Write(T obj, IDataWriter writer);
+        public void Write(float obj, IDataWriter writer)
+        {
+            writer.WriteFloat(obj);
+        }
 
         ///  <summary>
         ///  Instantiate the class from the reader.
         ///  </summary>
         ///  <param name="reader">The reader from which to read</param>
         /// <param name="token">Cancellation token</param>
-        /// <returns>The instance of type T read from the reader</returns>
-        Task<T> ReadAsync(IDataReader reader, CancellationToken token);
+        /// <returns>The float read from the reader</returns>
+        public async Task<float> ReadAsync(IDataReader reader, CancellationToken token)
+        {
+            return await reader.ReadFloatAsync(token);
+        }
 
         /// <summary>
-        /// Writes the class fields to the writer.
+        /// Writes the float to the writer.
         /// </summary>
-        /// <param name="obj">The object of type T to be encoded</param>
+        /// <param name="obj">The float to be encoded</param>
         /// <param name="writer">The writer to which to write</param>
         /// <param name="token">Cancellation token</param>
-        Task WriteAsync(T obj, IDataWriter writer, CancellationToken token);
+        public async Task WriteAsync(float obj, IDataWriter writer, CancellationToken token)
+        {
+            await writer.WriteFloatAsync(obj, token);
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Wake/StreamingCodec/CommonStreamingCodecs/IntArrayStreamingCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/StreamingCodec/CommonStreamingCodecs/IntArrayStreamingCodec.cs
@@ -23,7 +23,7 @@ using System.Threading.Tasks;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Wake.Remote;
 
-namespace Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs
+namespace Org.Apache.REEF.Wake.StreamingCodec.CommonStreamingCodecs
 {
     /// <summary>
     /// Streaming codec for integer array

--- a/lang/cs/Org.Apache.REEF.Wake/StreamingCodec/CommonStreamingCodecs/IntStreamingCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/StreamingCodec/CommonStreamingCodecs/IntStreamingCodec.cs
@@ -22,7 +22,7 @@ using System.Threading.Tasks;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Wake.Remote;
 
-namespace Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs
+namespace Org.Apache.REEF.Wake.StreamingCodec.CommonStreamingCodecs
 {
     /// <summary>
     /// Streaming codec for integer

--- a/lang/cs/Org.Apache.REEF.Wake/StreamingCodec/CommonStreamingCodecs/StringStreamingCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/StreamingCodec/CommonStreamingCodecs/StringStreamingCodec.cs
@@ -22,18 +22,18 @@ using System.Threading.Tasks;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Wake.Remote;
 
-namespace Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs
+namespace Org.Apache.REEF.Wake.StreamingCodec.CommonStreamingCodecs
 {
     /// <summary>
-    /// Streaming codec for double
+    /// Streaming codec for string
     /// </summary>
-    public sealed class DoubleStreamingCodec : IStreamingCodec<double>
+    public sealed class StringStreamingCodec : IStreamingCodec<string>
     {
         /// <summary>
         /// Injectable constructor
         /// </summary>
         [Inject]
-        private DoubleStreamingCodec()
+        private StringStreamingCodec()
         {
         }
 
@@ -41,20 +41,20 @@ namespace Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs
         /// Instantiate the class from the reader.
         /// </summary>
         /// <param name="reader">The reader from which to read</param>
-        ///<returns>The double read from the reader</returns>
-        public double Read(IDataReader reader)
+        ///<returns>The string read from the reader</returns>
+        public string Read(IDataReader reader)
         {
-            return reader.ReadDouble();
+            return reader.ReadString();
         }
 
         /// <summary>
-        /// Writes the double to the writer.
+        /// Writes the string to the writer.
         /// </summary>
-        /// <param name="obj">The double to be encoded</param>
+        /// <param name="obj">The string to be encoded</param>
         /// <param name="writer">The writer to which to write</param>
-        public void Write(double obj, IDataWriter writer)
+        public void Write(string obj, IDataWriter writer)
         {
-            writer.WriteDouble(obj);
+            writer.WriteString(obj);
         }
 
         ///  <summary>
@@ -62,21 +62,21 @@ namespace Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs
         ///  </summary>
         ///  <param name="reader">The reader from which to read</param>
         /// <param name="token">Cancellation token</param>
-        /// <returns>The double read from the reader</returns>
-        public async Task<double> ReadAsync(IDataReader reader, CancellationToken token)
+        /// <returns>The string read from the reader</returns>
+        public async Task<string> ReadAsync(IDataReader reader, CancellationToken token)
         {
-            return await reader.ReadDoubleAsync(token);
+            return await reader.ReadStringAsync(token);
         }
 
         /// <summary>
-        /// Writes the double to the writer.
+        /// Writes the string to the writer.
         /// </summary>
-        /// <param name="obj">The double to be encoded</param>
+        /// <param name="obj">The string to be encoded</param>
         /// <param name="writer">The writer to which to write</param>
         /// <param name="token">Cancellation token</param>
-        public async Task WriteAsync(double obj, IDataWriter writer, CancellationToken token)
+        public async Task WriteAsync(string obj, IDataWriter writer, CancellationToken token)
         {
-            await writer.WriteDoubleAsync(obj, token);
+            await writer.WriteStringAsync(obj, token);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Wake/StreamingCodec/IStreamingCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/StreamingCodec/IStreamingCodec.cs
@@ -19,64 +19,43 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Wake.Remote;
 
-namespace Org.Apache.REEF.Network.StreamingCodec.CommonStreamingCodecs
+namespace Org.Apache.REEF.Wake.StreamingCodec
 {
     /// <summary>
-    /// Streaming codec for string
+    /// Codec Interface that external users should implement to directly write to the stream
     /// </summary>
-    public sealed class StringStreamingCodec : IStreamingCodec<string>
+    public interface IStreamingCodec<T>
     {
-        /// <summary>
-        /// Injectable constructor
-        /// </summary>
-        [Inject]
-        private StringStreamingCodec()
-        {
-        }
-
         /// <summary>
         /// Instantiate the class from the reader.
         /// </summary>
         /// <param name="reader">The reader from which to read</param>
-        ///<returns>The string read from the reader</returns>
-        public string Read(IDataReader reader)
-        {
-            return reader.ReadString();
-        }
+        ///<returns>The instance of type T read from the reader</returns>
+        T Read(IDataReader reader);
 
         /// <summary>
-        /// Writes the string to the writer.
+        /// Writes the class fields to the writer.
         /// </summary>
-        /// <param name="obj">The string to be encoded</param>
+        /// <param name="obj">The object of type T to be encoded</param>
         /// <param name="writer">The writer to which to write</param>
-        public void Write(string obj, IDataWriter writer)
-        {
-            writer.WriteString(obj);
-        }
+        void Write(T obj, IDataWriter writer);
 
         ///  <summary>
         ///  Instantiate the class from the reader.
         ///  </summary>
         ///  <param name="reader">The reader from which to read</param>
         /// <param name="token">Cancellation token</param>
-        /// <returns>The string read from the reader</returns>
-        public async Task<string> ReadAsync(IDataReader reader, CancellationToken token)
-        {
-            return await reader.ReadStringAsync(token);
-        }
+        /// <returns>The instance of type T read from the reader</returns>
+        Task<T> ReadAsync(IDataReader reader, CancellationToken token);
 
         /// <summary>
-        /// Writes the string to the writer.
+        /// Writes the class fields to the writer.
         /// </summary>
-        /// <param name="obj">The string to be encoded</param>
+        /// <param name="obj">The object of type T to be encoded</param>
         /// <param name="writer">The writer to which to write</param>
         /// <param name="token">Cancellation token</param>
-        public async Task WriteAsync(string obj, IDataWriter writer, CancellationToken token)
-        {
-            await writer.WriteStringAsync(obj, token);
-        }
+        Task WriteAsync(T obj, IDataWriter writer, CancellationToken token);
     }
 }


### PR DESCRIPTION
This addressed the issue by
  * actually moving the StreamingCodec to Wake layer

JIRA: [REEF-423](https://issues.apache.org/jira/browse/REEF-423)