### PR TITLE
[REEF-416] Create API to specify racks (and nodes) in EvaluatorRequests

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/catalog/ResourceCatalog.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/catalog/ResourceCatalog.java
@@ -56,6 +56,13 @@ public interface ResourceCatalog {
    */
   NodeDescriptor getNode(String nodeId);
 
+  /**
+   * We are not using this. It will be removed in the future. In order to do
+   * evaluator requests with specific rack names or node names, you should take
+   * a look at {@link EvaluatorRequest} new API.
+   *
+   */
+  @Deprecated
   public interface Descriptor {
 
     String getName();

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequest.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequest.java
@@ -22,6 +22,9 @@ import org.apache.reef.annotations.Provided;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Public;
 import org.apache.reef.driver.catalog.ResourceCatalog;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * A request for one ore more Evaluators.
@@ -34,16 +37,30 @@ public final class EvaluatorRequest {
   private final int megaBytes;
   private final int number;
   private final int cores;
+  @Deprecated
   private final ResourceCatalog.Descriptor descriptor;
+  private final List<String> nodeNames;
+  private final List<String> rackNames;
 
+  @Deprecated
   EvaluatorRequest(final int number,
                    final int megaBytes,
                    final int cores,
                    final ResourceCatalog.Descriptor descriptor) {
+    this(number, megaBytes, cores, new ArrayList<String>(), new ArrayList<String>());
+  }
+
+  EvaluatorRequest(final int number,
+      final int megaBytes,
+      final int cores,
+      final List<String> nodeNames,
+      final List<String> rackNames) {
     this.number = number;
     this.megaBytes = megaBytes;
     this.cores = cores;
-    this.descriptor = descriptor;
+    this.nodeNames = nodeNames;
+    this.rackNames = rackNames;
+    this.descriptor = null;
   }
 
   /**
@@ -86,6 +103,7 @@ public final class EvaluatorRequest {
    * @return the {@link org.apache.reef.driver.catalog.NodeDescriptor} used as the template for this
    * {@link EvaluatorRequest}.
    */
+  @Deprecated
   public ResourceCatalog.Descriptor getDescriptor() {
     return this.descriptor;
   }
@@ -98,14 +116,31 @@ public final class EvaluatorRequest {
   }
 
   /**
+   * @return the node names that we prefer the Evaluator to run on
+   */
+  public List<String> getNodeNames() {
+    return Collections.unmodifiableList(nodeNames);
+  }
+
+  /**
+   * @return the rack names that we prefer the Evaluator to run on
+   */
+  public List<String> getRackNames() {
+    return Collections.unmodifiableList(rackNames);
+  }
+
+  /**
    * {@link EvaluatorRequest}s are build using this Builder.
    */
   public static final class Builder implements org.apache.reef.util.Builder<EvaluatorRequest> {
 
     private int n = 1;
+    @Deprecated
     private ResourceCatalog.Descriptor descriptor = null;
     private int megaBytes = -1;
     private int cores = 1; //if not set, default to 1
+    private final List<String> nodeNames = new ArrayList<>();
+    private final List<String> rackNames = new ArrayList<>();
 
     private Builder() {
     }
@@ -147,11 +182,27 @@ public final class EvaluatorRequest {
     }
 
     /**
+     * Add a node name.
+     */
+    public Builder addNodeName(final String nodeName) {
+      this.nodeNames.add(nodeName);
+      return this;
+    }
+
+    /**
+     * Add a rack name.
+     */
+    public Builder addRackName(final String rackName) {
+      this.rackNames.add(rackName);
+      return this;
+    }
+
+    /**
      * Builds the {@link EvaluatorRequest}.
      */
     @Override
     public EvaluatorRequest build() {
-      return new EvaluatorRequest(this.n, this.megaBytes, this.cores, this.descriptor);
+      return new EvaluatorRequest(this.n, this.megaBytes, this.cores, this.nodeNames, this.rackNames);
     }
 
     /**
@@ -162,6 +213,7 @@ public final class EvaluatorRequest {
      * @param rd the descriptor used to pre-fill this request.
      * @return this
      */
+    @Deprecated
     public Builder fromDescriptor(final ResourceCatalog.Descriptor rd) {
       this.descriptor = rd;
       return this;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Implementation of the Evaluator REEF APIs.
+ */
+package org.apache.reef.driver.evaluator;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/EvaluatorRequestorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/EvaluatorRequestorImpl.java
@@ -18,8 +18,6 @@
  */
 package org.apache.reef.runtime.common.driver;
 
-import org.apache.reef.driver.catalog.NodeDescriptor;
-import org.apache.reef.driver.catalog.RackDescriptor;
 import org.apache.reef.driver.catalog.ResourceCatalog;
 import org.apache.reef.driver.evaluator.EvaluatorRequest;
 import org.apache.reef.driver.evaluator.EvaluatorRequestor;
@@ -29,6 +27,7 @@ import org.apache.reef.util.logging.LoggingScope;
 import org.apache.reef.util.logging.LoggingScopeFactory;
 
 import javax.inject.Inject;
+
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -59,7 +58,8 @@ public final class EvaluatorRequestorImpl implements EvaluatorRequestor {
 
   @Override
   public synchronized void submit(final EvaluatorRequest req) {
-    LOG.log(Level.FINEST, "Got an EvaluatorRequest: number: {0}, memory = {1}, cores = {2}.", new Object[]{req.getNumber(), req.getMegaBytes(), req.getNumberOfCores()});
+    LOG.log(Level.FINEST, "Got an EvaluatorRequest: number: {0}, memory = {1}, cores = {2}.",
+        new Object[] {req.getNumber(), req.getMegaBytes(), req.getNumberOfCores()});
 
     if (req.getMegaBytes() <= 0) {
       throw new IllegalArgumentException("Given an unsupported memory size: " + req.getMegaBytes());
@@ -70,26 +70,27 @@ public final class EvaluatorRequestorImpl implements EvaluatorRequestor {
     if (req.getNumber() <= 0) {
       throw new IllegalArgumentException("Given an unsupported number of evaluators: " + req.getNumber());
     }
+    if (req.getNodeNames() == null) {
+      throw new IllegalArgumentException("Node names cannot be null");
+    }
+    if (req.getRackNames() == null) {
+      throw new IllegalArgumentException("Rack names cannot be null");
+    }
 
     try (LoggingScope ls = loggingScopeFactory.evaluatorSubmit(req.getNumber())) {
-      final ResourceRequestEventImpl.Builder request = ResourceRequestEventImpl
+      final ResourceRequestEventImpl.Builder requestBuilder = ResourceRequestEventImpl
           .newBuilder()
           .setResourceCount(req.getNumber())
           .setVirtualCores(req.getNumberOfCores())
           .setMemorySize(req.getMegaBytes());
 
-      final ResourceCatalog.Descriptor descriptor = req.getDescriptor();
-      if (descriptor != null) {
-        if (descriptor instanceof RackDescriptor) {
-          request.addRackName(descriptor.getName());
-        } else if (descriptor instanceof NodeDescriptor) {
-          request.addNodeName(descriptor.getName());
-        } else {
-          throw new IllegalArgumentException("Unable to operate on descriptors of type " + descriptor.getClass().getName());
-        }
+      for (final String nodeName : req.getNodeNames()) {
+        requestBuilder.addNodeName(nodeName);
       }
-
-      this.resourceRequestHandler.onNext(request.build());
+      for (final String rackName : req.getRackNames()) {
+        requestBuilder.addRackName(rackName);
+      }
+      this.resourceRequestHandler.onNext(requestBuilder.build());
     }
   }
 }

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
@@ -161,7 +161,7 @@ final class ContainerManager implements AutoCloseable {
       }
     });
 
-    init(rackNames);
+    init(availableRacks);
 
     LOG.log(Level.FINE, "Initialized Container Manager with {0} containers", capacity);
   }
@@ -202,7 +202,7 @@ final class ContainerManager implements AutoCloseable {
     return normalizedRackNames;
   }
 
-  private void init(final Set<String> rackNames) {
+  private void init(final Collection<String> rackNames) {
     // evenly distribute the containers among the racks
     // if rack names are not specified, the default rack will be used, so the denominator will always be > 0
     final int capacityPerRack = capacity / rackNames.size();

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/rack/awareness/OnDriverStartedAllocateOneInRack.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/rack/awareness/OnDriverStartedAllocateOneInRack.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.rack.awareness;
+
+import org.apache.reef.driver.evaluator.EvaluatorRequest;
+import org.apache.reef.driver.evaluator.EvaluatorRequestor;
+import org.apache.reef.tang.annotations.Parameter;
+import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.time.event.StartTime;
+
+import javax.inject.Inject;
+
+/**
+ * A Driver start handler that requests a single Evaluator of size 64MB in the
+ * specified rack.
+ */
+public final class OnDriverStartedAllocateOneInRack implements EventHandler<StartTime> {
+
+  private final EvaluatorRequestor requestor;
+  private final String rackName;
+
+  @Inject
+  OnDriverStartedAllocateOneInRack(
+      final EvaluatorRequestor requestor,
+      @Parameter(RackNameParameter.class) final String rackName) {
+    this.requestor = requestor;
+    this.rackName = rackName;
+  }
+
+  @Override
+  public void onNext(final StartTime startTime) {
+    this.requestor.submit(EvaluatorRequest.newBuilder().setMemory(64).setNumber(1).setNumberOfCores(1)
+        .addRackName(rackName).build());
+  }
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTest.java
@@ -40,7 +40,7 @@ import org.junit.Test;
  */
 public final class RackAwareEvaluatorTest {
 
-  private static final String RACK1 = "rack1";
+  private static final String RACK1 = "/rack1";
   // runs on the local runtime
   private final TestEnvironment testEnvironment = new LocalTestEnvironment();
 
@@ -77,20 +77,16 @@ public final class RackAwareEvaluatorTest {
 
   /**
    * Test whether the runtime passes the rack information to the driver.
-   * The success scenario is if it receives rack1, fails otherwise
+   * The success scenario is if it receives /rack1, fails otherwise
    */
-  //@Test
-  // TODO Re-enable once we define the API to specify the information where
-  // resources should run on (JIRA REEF-416)
-  // OnDriverStartedAllocateOne will need to be replaced, and contain that it
-  // wants to run in RACK1, which will be the only one available
+  @Test
   public void testRackAwareEvaluatorRunningOnRack1() throws InjectionException {
     //Given
     final Configuration driverConfiguration = DriverConfiguration.CONF
         .set(DriverConfiguration.DRIVER_IDENTIFIER, "TEST_RackAwareEvaluator")
         .set(DriverConfiguration.GLOBAL_LIBRARIES,
             EnvironmentUtils.getClassLocation(RackAwareEvaluatorTestDriver.class))
-        .set(DriverConfiguration.ON_DRIVER_STARTED, OnDriverStartedAllocateOne.class)
+        .set(DriverConfiguration.ON_DRIVER_STARTED, OnDriverStartedAllocateOneInRack.class)
         .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, RackAwareEvaluatorTestDriver.EvaluatorAllocatedHandler.class)
         .build();
 


### PR DESCRIPTION
With this commit, evaluators can now be asked to run in different nodes or racks.
Nodes should be node names. Racks can be fully qualified names. Also the star wildcard can
be used at the end. For example, in order to ask for evaluators in any rack in datacenter 2, you can do /dc2/*
It includes a new EvaluatorRequest constructor, and it deprecates the descriptor interface.
Updated UTs (which also helped in fixing a bug)

JIRA: [REEF-416](https://issues.apache.org/jira/browse/REEF-416)

This Closes:
