### PR TITLE
[REEF-416] Create API to specify racks in EvaluatorRequests

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEventImpl.java
@@ -130,11 +130,33 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
     }
 
     /**
+     * Add a list of node names.
+     * @see {@link ResourceRequestEventImpl.Builder#addNodeName}
+     */
+    public Builder addNodeNames(final List<String> nodeNames) {
+      for (final String nodeName : nodeNames) {
+        addNodeName(nodeName);
+      }
+      return this;
+    }
+
+    /**
      * Add an entry to rackNameList.
      * @see ResourceRequestEvent#getRackNameList()
      */
     public Builder addRackName(final String rackName) {
       this.rackNameList.add(rackName);
+      return this;
+    }
+
+    /**
+     * Add a list of rack names.
+     * @see {@link ResourceRequestEventImpl.Builder#addRackName}
+     */
+    public Builder addRackNames(final List<String> rackNames) {
+      for (final String rackName : rackNames) {
+        addRackName(rackName);
+      }
       return this;
     }
 

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
@@ -161,7 +161,7 @@ final class ContainerManager implements AutoCloseable {
       }
     });
 
-    init(rackNames);
+    init();
 
     LOG.log(Level.FINE, "Initialized Container Manager with {0} containers", capacity);
   }
@@ -202,13 +202,13 @@ final class ContainerManager implements AutoCloseable {
     return normalizedRackNames;
   }
 
-  private void init(final Set<String> rackNames) {
+  private void init() {
     // evenly distribute the containers among the racks
     // if rack names are not specified, the default rack will be used, so the denominator will always be > 0
-    final int capacityPerRack = capacity / rackNames.size();
-    int missing = capacity % rackNames.size();
+    final int capacityPerRack = capacity / availableRacks.size();
+    int missing = capacity % availableRacks.size();
     // initialize the freeNodesPerRackList and the capacityPerRack
-    for (final String rackName : rackNames) {
+    for (final String rackName : availableRacks) {
       this.freeNodesPerRack.put(rackName, new HashMap<String, Boolean>());
       this.capacitiesPerRack.put(rackName, capacityPerRack);
       if (missing > 0) {

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/rack/awareness/OnDriverStartedAllocateOneInRack.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/rack/awareness/OnDriverStartedAllocateOneInRack.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.rack.awareness;
+
+import org.apache.reef.driver.evaluator.EvaluatorRequest;
+import org.apache.reef.driver.evaluator.EvaluatorRequestor;
+import org.apache.reef.tang.annotations.Parameter;
+import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.time.event.StartTime;
+
+import javax.inject.Inject;
+
+/**
+ * A Driver start handler that requests a single Evaluator of size 64MB in the
+ * specified rack.
+ */
+public final class OnDriverStartedAllocateOneInRack implements EventHandler<StartTime> {
+
+  private final EvaluatorRequestor requestor;
+  private final String rackName;
+
+  @Inject
+  OnDriverStartedAllocateOneInRack(
+      final EvaluatorRequestor requestor,
+      @Parameter(RackNameParameter.class) final String rackName) {
+    this.requestor = requestor;
+    this.rackName = rackName;
+  }
+
+  @Override
+  public void onNext(final StartTime startTime) {
+    this.requestor.submit(EvaluatorRequest.newBuilder().setMemory(64).setNumber(1).setNumberOfCores(1)
+        .addRackName(rackName).build());
+  }
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/rack/awareness/RackAwareEvaluatorTest.java
@@ -40,7 +40,7 @@ import org.junit.Test;
  */
 public final class RackAwareEvaluatorTest {
 
-  private static final String RACK1 = "rack1";
+  private static final String RACK1 = "/rack1";
   // runs on the local runtime
   private final TestEnvironment testEnvironment = new LocalTestEnvironment();
 
@@ -77,20 +77,16 @@ public final class RackAwareEvaluatorTest {
 
   /**
    * Test whether the runtime passes the rack information to the driver.
-   * The success scenario is if it receives rack1, fails otherwise
+   * The success scenario is if it receives /rack1, fails otherwise
    */
-  //@Test
-  // TODO Re-enable once we define the API to specify the information where
-  // resources should run on (JIRA REEF-416)
-  // OnDriverStartedAllocateOne will need to be replaced, and contain that it
-  // wants to run in RACK1, which will be the only one available
+  @Test
   public void testRackAwareEvaluatorRunningOnRack1() throws InjectionException {
     //Given
     final Configuration driverConfiguration = DriverConfiguration.CONF
         .set(DriverConfiguration.DRIVER_IDENTIFIER, "TEST_RackAwareEvaluator")
         .set(DriverConfiguration.GLOBAL_LIBRARIES,
             EnvironmentUtils.getClassLocation(RackAwareEvaluatorTestDriver.class))
-        .set(DriverConfiguration.ON_DRIVER_STARTED, OnDriverStartedAllocateOne.class)
+        .set(DriverConfiguration.ON_DRIVER_STARTED, OnDriverStartedAllocateOneInRack.class)
         .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, RackAwareEvaluatorTestDriver.EvaluatorAllocatedHandler.class)
         .build();
 


### PR DESCRIPTION
With this commit, evaluators can now be asked to run in different nodes or
racks. Nodes should be node names. Racks can be fully qualified names. Also the
star wildcard can be used at the end. For example, in order to ask for
evaluators in any rack in datacenter 2, you can do /dc2/* It includes a new
EvaluatorRequest constructor, and it deprecates the descriptor interface.
Updated UTs (which also helped in fixing a bug)

JIRA:
  [REEF-416](https://issues.apache.org/jira/browse/REEF-416)