### PR TITLE
[REEF-438]:Add a Java example for demonstrating TcpProvider with YARN…

### DIFF
--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloReefYarnTcp.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloReefYarnTcp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -25,7 +25,6 @@ import org.apache.reef.client.parameters.DriverConfigurationProviders;
 import org.apache.reef.io.TcpPortConfigurationProvider;
 import org.apache.reef.runtime.yarn.client.YarnClientConfiguration;
 import org.apache.reef.tang.Configuration;
-import org.apache.reef.tang.Configurations;
 import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeBegin;
@@ -60,24 +59,21 @@ public final class HelloReefYarnTcp {
         .build();
   }
 
-
   private static Configuration getRuntimeConfiguration(
       int tcpBeginPort,
       int tcpRangeCount,
       int tcpTryCount) {
-    final Configuration runtimeConfiguration = YarnClientConfiguration.CONF.build();
-    final Configuration userproviderConfiguration = Tang.Factory.getTang().newConfigurationBuilder()
+
+    return Tang.Factory.getTang().newConfigurationBuilder(YarnClientConfiguration.CONF.build())
         .bindSetEntry(DriverConfigurationProviders.class, TcpPortConfigurationProvider.class)
         .bindNamedParameter(TcpPortRangeBegin.class, Integer.toString(tcpBeginPort))
         .bindNamedParameter(TcpPortRangeCount.class, Integer.toString(tcpRangeCount))
         .bindNamedParameter(TcpPortRangeTryCount.class, Integer.toString(tcpTryCount))
         .build();
-    return Configurations.merge(runtimeConfiguration, userproviderConfiguration);
   }
 
   /**
    * Start Hello REEF job. Runs method runHelloReef().
-   *
    * @param args command line parameters.
    * @throws org.apache.reef.tang.exceptions.BindException      configuration error.
    * @throws org.apache.reef.tang.exceptions.InjectionException configuration error.

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloReefYarnTcp.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloReefYarnTcp.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.examples.hello;
+
+import org.apache.reef.client.DriverConfiguration;
+import org.apache.reef.client.DriverLauncher;
+import org.apache.reef.client.LauncherStatus;
+import org.apache.reef.client.parameters.DriverConfigurationProviders;
+import org.apache.reef.io.TcpPortConfigurationProvider;
+import org.apache.reef.runtime.yarn.client.YarnClientConfiguration;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Configurations;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
+import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeBegin;
+import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeCount;
+import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeTryCount;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * The Client for Hello REEF example.
+ */
+public final class HelloReefYarnTcp {
+
+  private static final Logger LOG = Logger.getLogger(HelloReefYarnTcp.class.getName());
+
+  /**
+   * Number of milliseconds to wait for the job to complete.
+   */
+  private static final int JOB_TIMEOUT = 150000; // 30 sec.
+
+  private HelloReefYarnTcp(){}
+  /**
+   * @return the configuration of the HelloREEF driver.
+   */
+  private static Configuration getDriverConfiguration() {
+    return DriverConfiguration.CONF
+        .set(DriverConfiguration.GLOBAL_LIBRARIES, HelloReefYarnTcp.class.getProtectionDomain().getCodeSource().getLocation().getFile())
+        .set(DriverConfiguration.DRIVER_IDENTIFIER, "HelloREEF")
+        .set(DriverConfiguration.ON_DRIVER_STARTED, HelloDriver.StartHandler.class)
+        .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, HelloDriver.EvaluatorAllocatedHandler.class)
+        .build();
+  }
+
+
+  private static Configuration getRuntimeConfiguration(
+      int tcpBeginPort,
+      int tcpRangeCount,
+      int tcpTryCount) {
+    final Configuration runtimeConfiguration = YarnClientConfiguration.CONF.build();
+    final Configuration userproviderConfiguration = Tang.Factory.getTang().newConfigurationBuilder()
+        .bindSetEntry(DriverConfigurationProviders.class, TcpPortConfigurationProvider.class)
+        .bindNamedParameter(TcpPortRangeBegin.class, Integer.toString(tcpBeginPort))
+        .bindNamedParameter(TcpPortRangeCount.class, Integer.toString(tcpRangeCount))
+        .bindNamedParameter(TcpPortRangeTryCount.class, Integer.toString(tcpTryCount))
+        .build();
+    return Configurations.merge(runtimeConfiguration, userproviderConfiguration);
+  }
+
+  /**
+   * Start Hello REEF job. Runs method runHelloReef().
+   *
+   * @param args command line parameters.
+   * @throws org.apache.reef.tang.exceptions.BindException      configuration error.
+   * @throws org.apache.reef.tang.exceptions.InjectionException configuration error.
+   */
+  public static final int defaultTcpBeginPort = 8900;
+  public static final int defaultTcpRangeCount = 10;
+  public static final int defaultTcpRangeTryCount = 1111;
+  public static void main(final String[] args) throws InjectionException {
+    final int tcpBeginPort = args.length > 0 ? Integer.valueOf(args[0]) : defaultTcpBeginPort;
+    final int tcpRangeCount = args.length > 1 ? Integer.valueOf(args[1]) : defaultTcpRangeCount;
+    final int tcpTryCount = args.length > 2 ? Integer.valueOf(args[2]) : defaultTcpRangeTryCount;
+    Configuration runtimeConfiguration = getRuntimeConfiguration(tcpBeginPort, tcpRangeCount, tcpTryCount);
+    final LauncherStatus status = DriverLauncher
+        .getLauncher(runtimeConfiguration)
+        .run(getDriverConfiguration(), JOB_TIMEOUT);
+    LOG.log(Level.INFO, "REEF job completed: {0}", status);
+  }
+}


### PR DESCRIPTION
… environment.

This addressed the issue by adding an example for demonstrating
TcpProvider usage with YARN environment.

JIRA: [REEF-438](https://issues.apache.org/jira/browse/REEF-438)

This closes #