### PR TITLE
[REEF-436] Allow the tests projects access to internal APIs

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Properties/AssemblyInfo.cs
@@ -18,6 +18,7 @@
  */
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -52,3 +53,6 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.12.0.0")]
 [assembly: AssemblyFileVersion("0.12.0.0")]
+
+// Allow the tests access to `internal` APIs
+[assembly: InternalsVisibleTo("Org.Apache.REEF.Common.Tests")]

--- a/lang/cs/Org.Apache.REEF.Network/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Properties/AssemblyInfo.cs
@@ -18,6 +18,7 @@
  */
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -52,3 +53,6 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.12.0.0")]
 [assembly: AssemblyFileVersion("0.12.0.0")]
+
+// Allow the tests access to `internal` APIs
+[assembly: InternalsVisibleTo("Org.Apache.REEF.Network.Tests")]

--- a/lang/cs/Org.Apache.REEF.Tang/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Properties/AssemblyInfo.cs
@@ -18,6 +18,7 @@
  */
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -52,3 +53,6 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.12.0.0")]
 [assembly: AssemblyFileVersion("0.12.0.0")]
+
+// Allow the tests access to `internal` APIs
+[assembly: InternalsVisibleTo("Org.Apache.REEF.Tang.Tests")]

--- a/lang/cs/Org.Apache.REEF.Wake/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Properties/AssemblyInfo.cs
@@ -18,6 +18,7 @@
  */
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -52,3 +53,6 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.12.0.0")]
 [assembly: AssemblyFileVersion("0.12.0.0")]
+
+// Allow the tests access to `internal` APIs
+[assembly: InternalsVisibleTo("Org.Apache.REEF.Wake.Tests")]


### PR DESCRIPTION
This change allows the `.Tests` projects access to the `internal` APIs of the project they test.

JIRA:
  [REEF-436](https://issues.apache.org/jira/browse/REEF-436)