### PR TITLE
[REEF-436] Fix: Add missing license header (for Allow the tests proje…

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU/API/UpdateResult.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/API/UpdateResult.cs
@@ -1,4 +1,23 @@
-﻿namespace Org.Apache.REEF.IMRU.API
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Org.Apache.REEF.IMRU.API
 {
     /// <summary>
     /// Represents the output of an IUpdateFunction.


### PR DESCRIPTION
…cts access to internal APIs)

Adds a missing license header from the previous commit for REEF-436.

JIRA:
  [REEF-436](https://issues.apache.org/jira/browse/REEF-436)

Pull Request:
  This closes #