### PR TITLE
[REEF-449]  Exclude snk file from rat checking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,12 +247,13 @@ under the License.
                             <exclude>**/*.md</exclude>
                             <!-- The below are sometimes created during tests -->
                             <exclude>REEF_LOCAL_RUNTIME/**</exclude>
-                            <!-- The Visual Studio build files -->
+                            <!-- The Visual Studio and Nuget build files -->
                             <exclude>**/*.sln*</exclude>
                             <exclude>**/*.vcxproj*</exclude>
                             <exclude>**/*.csproj*</exclude>
                             <exclude>**/*.opensdf*</exclude>
                             <exclude>**/*.sdf*</exclude>
+                            <exclude>**/*.snk</exclude>
                             <!-- The below are auto generated during the .Net build -->
                             <exclude>**/bin/**</exclude>
                             <exclude>**/obj/**</exclude>


### PR DESCRIPTION
The Jenkins server's picking up the snk files to do rat check. Although most of local machines like windows and Mac don't check it. We would like to exclude it to avoid build failure.

JIRA: REEF-449(https://issues.apache.org/jira/browse/REEF-449)

This closes #

Author: Julia Wang  Email: jwang98052@yahoo.com