### PR TITLE
[REEF-453]  Race condition in GroupCommunication Client initialization

### DIFF
--- a/lang/cs/Org.Apache.REEF.Network/Group/Config/GroupCommConfigurationOptions.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Config/GroupCommConfigurationOptions.cs
@@ -44,18 +44,27 @@ namespace Org.Apache.REEF.Network.Group.Config
         {
         }
 
-        [NamedParameter("Retry times", defaultValue: "5")]
-        public class RetryCount : Name<int>
+        /// <summary>
+        /// Each Communication group needs to check and wait until all the other nodes in the group are registered to the NameServer
+        /// Sleep time is set between each retry. 
+        /// </summary>
+        [NamedParameter("sleep time to wait for nodes to be registered", defaultValue: "500")]
+        internal sealed class SleepTimeWaitingForRegistration : Name<int>
         {
         }
 
-        [NamedParameter("sleep time to wait for handlers to be registered", defaultValue: "500")]
-        public class SleepTimeWaitingForHandler : Name<int>
-        {
-        }
-
-        [NamedParameter("Retry times to wait for handlers to be registered", defaultValue: "5")]
-        public class RetryCountWaitingForHanler : Name<int>
+        /// <summary>
+        /// Each Communication group needs to check and wait until all the other nodes in the group are registered to the NameServer
+        /// </summary>
+        /// <remarks>
+        /// When there are many nodes, e.g over 100, the wating time might be pretty long. 
+        /// We don't want to set it too low in case some nodes are just slow, if we simply throw an exception, that is not right. 
+        /// We don't want it to try endlessly in case some node is really dead, we should come out with exception. 
+        /// We want it to return as soon as all nodes in the group are registered, So increasing retry count is better than increasing sleep time.
+        /// Current default sleep time is 500ms. Default retry is 500. Total is 250000ms, tha tis 250s, little bit more than 4 min
+        /// </remarks>
+        [NamedParameter("Retry times to wait for nodes to be registered", defaultValue: "500")]
+        internal sealed class RetryCountWaitingForRegistration : Name<int>
         {
         }
 

--- a/lang/cs/Org.Apache.REEF.Network/Group/Config/GroupCommConfigurationOptions.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Config/GroupCommConfigurationOptions.cs
@@ -57,11 +57,11 @@ namespace Org.Apache.REEF.Network.Group.Config
         /// Each Communication group needs to check and wait until all the other nodes in the group are registered to the NameServer
         /// </summary>
         /// <remarks>
-        /// When there are many nodes, e.g over 100, the wating time might be pretty long. 
+        /// When there are many nodes, e.g over 100, the waiting time might be pretty long. 
         /// We don't want to set it too low in case some nodes are just slow, if we simply throw an exception, that is not right. 
         /// We don't want it to try endlessly in case some node is really dead, we should come out with exception. 
         /// We want it to return as soon as all nodes in the group are registered, So increasing retry count is better than increasing sleep time.
-        /// Current default sleep time is 500ms. Default retry is 500. Total is 250000ms, tha tis 250s, little bit more than 4 min
+        /// Current default sleep time is 500ms. Default retry is 500. Total is 250000ms, that is 250s, little bit more than 4 min
         /// </remarks>
         [NamedParameter("Retry times to wait for nodes to be registered", defaultValue: "500")]
         internal sealed class RetryCountWaitingForRegistration : Name<int>

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/IGroupCommOperatorInternal.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/IGroupCommOperatorInternal.cs
@@ -1,0 +1,29 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Org.Apache.REEF.Network.Group.Operators
+{
+    internal interface IGroupCommOperatorInternal
+    {
+        /// <summary>
+        /// Ensure all parent and children nodes in the topology are registered with teh Name Service.
+        /// </summary>
+        void WaitForRegistration();
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ScatterSender.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Operators/Impl/ScatterSender.cs
@@ -33,10 +33,11 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
     /// of the IScatterReceivers.
     /// </summary>
     /// <typeparam name="T">The message type</typeparam>
-    public sealed class ScatterSender<T> : IScatterSender<T>
+    public sealed class ScatterSender<T> : IScatterSender<T>, IGroupCommOperatorInternal
     {
         private const int DefaultVersion = 1;
         private readonly IOperatorTopology<T> _topology;
+        private readonly bool _initialize ;
 
         /// <summary>
         /// Creates a new ScatterSender.
@@ -59,14 +60,10 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
             GroupName = groupName;
             Version = DefaultVersion;
             _topology = topology;
+            _initialize = initialize;
 
             var msgHandler = Observer.Create<GeneralGroupCommunicationMessage>(message => topology.OnNext(message));
             networkHandler.Register(operatorName, msgHandler);
-
-            if (initialize)
-            {
-                topology.Initialize();
-            }
         }
 
         public string OperatorName { get; private set; }
@@ -107,6 +104,17 @@ namespace Org.Apache.REEF.Network.Group.Operators.Impl
         public void Send(List<T> elements, List<string> order)
         {
             _topology.ScatterToChildren(elements, order, MessageType.Data);
+        }
+
+        /// <summary>
+        /// Ensure all parent and children nodes in the topology are registered with teh Name Service.
+        /// </summary>
+        void IGroupCommOperatorInternal.WaitForRegistration()
+        {
+            if (_initialize)
+            {
+                _topology.Initialize();
+            }
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network/Group/Task/ICommunicationGroupClientInternal.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Task/ICommunicationGroupClientInternal.cs
@@ -1,0 +1,29 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Org.Apache.REEF.Network.Group.Task
+{
+    internal interface ICommunicationGroupClientInternal : ICommunicationGroupClient
+    {
+        /// <summary>
+        /// Call each Operator to easure all the nodes in the topology group has been registered
+        /// </summary>
+        void WaitingForRegistration();
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Network/Group/Task/IOperatorTopology.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Task/IOperatorTopology.cs
@@ -32,6 +32,13 @@ namespace Org.Apache.REEF.Network.Group.Task
     public interface IOperatorTopology<T>
     {
         /// <summary>
+        /// Initializes operator topology.
+        /// Waits until all Tasks in the CommunicationGroup have registered themselves
+        /// with the Name Service.
+        /// </summary>
+        void Initialize();
+
+        /// <summary>
         /// Sends the message to the parent Task.
         /// </summary>
         /// <param name="message">The message to send</param>

--- a/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/OperatorTopology.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Group/Task/Impl/OperatorTopology.cs
@@ -57,6 +57,7 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
         private string _driverId;
         private readonly int _timeout;
         private readonly int _retryCount;
+        private readonly int _sleepTime;
 
         private readonly NodeStruct<T> _parent;
         private readonly List<NodeStruct<T>> _children;
@@ -75,7 +76,8 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
         /// <param name="taskId">The operator's Task identifier</param>
         /// <param name="driverId">The identifer for the driver</param>
         /// <param name="timeout">Timeout value for cancellation token</param>
-        /// <param name="retryCount">Number of times to retry registration</param>
+        /// <param name="retryCount">Number of times to retry wating for registration</param>
+        /// <param name="sleepTime">Sleep time between retry wating for registration</param>
         /// <param name="rootId">The identifier for the root Task in the topology graph</param>
         /// <param name="childIds">The set of child Task identifiers in the topology graph</param>
         /// <param name="networkService">The network service</param>
@@ -88,7 +90,8 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
             [Parameter(typeof(TaskConfigurationOptions.Identifier))] string taskId,
             [Parameter(typeof(GroupCommConfigurationOptions.DriverId))] string driverId,
             [Parameter(typeof(GroupCommConfigurationOptions.Timeout))] int timeout,
-            [Parameter(typeof(GroupCommConfigurationOptions.RetryCount))] int retryCount,
+            [Parameter(typeof(GroupCommConfigurationOptions.RetryCountWaitingForRegistration))] int retryCount,
+            [Parameter(typeof(GroupCommConfigurationOptions.SleepTimeWaitingForRegistration))] int sleepTime,
             [Parameter(typeof(GroupCommConfigurationOptions.TopologyRootTaskId))] string rootId,
             [Parameter(typeof(GroupCommConfigurationOptions.TopologyChildTaskIds))] ISet<string> childIds,
             WritableNetworkService<GeneralGroupCommunicationMessage> networkService,
@@ -101,6 +104,7 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
             _driverId = driverId;
             _timeout = timeout;
             _retryCount = retryCount;
+            _sleepTime = sleepTime;
             _nameClient = networkService.NamingClient;
             _sender = sender;
             _nodesWithData = new BlockingCollection<NodeStruct<T>>();
@@ -529,7 +533,7 @@ namespace Org.Apache.REEF.Network.Group.Task.Impl
                     return;
                 }
 
-                Thread.Sleep(500);
+                Thread.Sleep(_sleepTime);
             }
 
             throw new IllegalStateException("Failed to initialize operator topology for node: " + identifier);

--- a/lang/cs/Org.Apache.REEF.Network/NetworkService/WritableNetworkService.cs
+++ b/lang/cs/Org.Apache.REEF.Network/NetworkService/WritableNetworkService.cs
@@ -69,6 +69,11 @@ namespace Org.Apache.REEF.Network.NetworkService
             _remoteManager = remoteManagerFactory.GetInstance<WritableNsMessage<T>>(localAddress, nsPort);
             _messageHandler = messageHandler;
 
+            // Create and register incoming message handler
+            // TODO[REEF-419] This should use the TcpPortProvider mechanism
+            var anyEndpoint = new IPEndPoint(IPAddress.Any, 0);
+            _messageHandlerDisposable = _remoteManager.RegisterObserver(anyEndpoint, _messageHandler);
+
             _nameClient = nameClient;
             _connectionMap = new Dictionary<IIdentifier, IConnection<T>>();
 
@@ -121,11 +126,6 @@ namespace Org.Apache.REEF.Network.NetworkService
 
             _localIdentifier = id;
             NamingClient.Register(id.ToString(), _remoteManager.LocalEndpoint);
-
-            // Create and register incoming message handler
-            // TODO[REEF-419] This should use the TcpPortProvider mechanism
-            var anyEndpoint = new IPEndPoint(IPAddress.Any, 0);
-            _messageHandlerDisposable = _remoteManager.RegisterObserver(anyEndpoint, _messageHandler);
 
             Logger.Log(Level.Info, "End of Registering id {0} with network service.", id);
         }

--- a/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
+++ b/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
@@ -67,6 +67,7 @@ under the License.
     <Compile Include="Group\Operators\IBroadcastReceiver.cs" />
     <Compile Include="Group\Operators\IBroadcastSender.cs" />
     <Compile Include="Group\Operators\IGroupCommOperator.cs" />
+    <Compile Include="Group\Operators\IGroupCommOperatorInternal.cs" />
     <Compile Include="Group\Operators\Impl\BroadcastOperatorSpec.cs" />
     <Compile Include="Group\Operators\Impl\BroadcastReceiver.cs" />
     <Compile Include="Group\Operators\Impl\BroadcastSender.cs" />
@@ -81,6 +82,7 @@ under the License.
     <Compile Include="Group\Operators\Impl\Sender.cs" />
     <Compile Include="Group\Operators\IOperatorSpec.cs" />
     <Compile Include="Group\Pipelining\StreamingPipelineMessageCodec.cs" />
+    <Compile Include="Group\Task\ICommunicationGroupClientInternal.cs" />
     <Compile Include="Group\Task\IOperatorTopology.cs" />
     <Compile Include="Group\Operators\IReduceFunction.cs" />
     <Compile Include="Group\Operators\IReduceReceiver.cs" />


### PR DESCRIPTION
In GroupCommClient constructor, we register the task node to Name Server first, then instantiate CommunicationGroupClient, which will instantiate Operators and register handlers. In Operator constructors, we check if its parents and children are all registered based on the topology. There is a chance that a parent or a child was registered, but haven't completed the initialization, resulting a race condition.

This PR moves the registration in GroupCommClient as the last line in the constructor. And movs the initialize checking out of the Operator constructors. Initialize will be called when client gets Operator from CommunicationGroupClient. This would ensure all the registration happens after constructors. And registration checking happens after all the constructors.

JIRA: REEF-453(https://issues.apache.org/jira/browse/REEF-453)

This closes #

Author: Julia Wang  Email: jwang98052@yahoo.com