### PR TITLE
[REEF-454] Allow for per-job queues

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/JobSubmissionEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/JobSubmissionEvent.java
@@ -76,6 +76,8 @@ public interface JobSubmissionEvent {
 
   /**
    * @return Queue to submit the Job to
+   * @deprecated in 0.12. Use org.apache.reef.runtime.yarn.client.YarnDriverConfiguration#QUEUE instead.
    */
+  @Deprecated
   Optional<String> getQueue();
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/JobSubmissionEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/JobSubmissionEventImpl.java
@@ -184,7 +184,9 @@ public final class JobSubmissionEventImpl implements JobSubmissionEvent {
 
     /**
      * @see JobSubmissionEvent#getQueue()
+     * @deprecated in 0.12. Use org.apache.reef.runtime.yarn.client.YarnDriverConfiguration#QUEUE instead.
      */
+    @Deprecated
     public Builder setQueue(final String queue) {
       this.queue = queue;
       return this;

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/YarnDriverConfiguration.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/YarnDriverConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runtime.yarn.client;
+
+import org.apache.reef.annotations.audience.ClientSide;
+import org.apache.reef.annotations.audience.Public;
+import org.apache.reef.runtime.yarn.client.parameters.JobQueue;
+import org.apache.reef.tang.formats.ConfigurationModule;
+import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
+import org.apache.reef.tang.formats.OptionalParameter;
+
+/**
+ * Additional YARN-Specific configuration options to be merged with DriverConfiguration.
+ */
+@Public
+@ClientSide
+public final class YarnDriverConfiguration extends ConfigurationModuleBuilder {
+
+  /**
+   * The queue to submit this Driver to.
+   */
+  public static final OptionalParameter<String> QUEUE = new OptionalParameter<>();
+
+  /**
+   * ConfigurationModule to set YARN-Specific configuration options to be merged with DriverConfiguration.
+   */
+  public static final ConfigurationModule CONF = new YarnDriverConfiguration()
+      .bindNamedParameter(JobQueue.class, QUEUE)
+      .build();
+}


### PR DESCRIPTION
This adds `YarnDriverConfiguration` that can be filled out by an application and merged into their DriverConfiguration to set the queue to submit the job to.

This also makes sure the `YarnClientConfiguration.YARN_QUEUE_NAME` is actually used (it wasn't). It now provides the default for when the new per-job setting isn't used.

Lastly, this change deprecates `JobSubmissionEvent.getQueue()` which was never used in the first place. Its purpose is now served by the mechanism introduced here.

JIRA:
  [REEF-454](https://issues.apache.org/jira/browse/REEF-454)