### PR TITLE
[REEF-466]  Friend access was granted with public key but the module …

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Properties/AssemblyInfo.cs
@@ -55,8 +55,13 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("0.12.0.0")]
 
 // Allow the tests access to `internal` APIs
+
+#if DEBUG
+[assembly: InternalsVisibleTo("Org.Apache.REEF.Common.Tests")]
+#else
 [assembly: InternalsVisibleTo("Org.Apache.REEF.Common.Tests, publickey=" +
  "00240000048000009400000006020000002400005253413100040000010001005df3e621d886a9" +
  "9c03469d0f93a9f5d45aa2c883f50cd158759e93673f759ec4657fd84cc79d2db38ef1a2d914cc" +
  "b7c717846a897e11dd22eb260a7ce2da2dccf0263ea63e2b3f7dac24f28882aa568ef544341d17" +
  "618392a1095f4049ad079d4f4f0b429bb535699155fd6a7652ec7d6c1f1ba2b560f11ef3a86b5945d288cf")]
+#endif

--- a/lang/cs/Org.Apache.REEF.IMRU/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/Properties/AssemblyInfo.cs
@@ -33,8 +33,12 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("0.12.0.0")]
 [assembly: AssemblyFileVersion("0.12.0.0")]
 // Allow the tests project access to `internal` APIs
+#if DEBUG
+[assembly: InternalsVisibleTo("Org.Apache.REEF.IMRU.Tests")]
+#else
 [assembly: InternalsVisibleTo("Org.Apache.REEF.IMRU.Tests, publickey=" +
  "00240000048000009400000006020000002400005253413100040000010001005df3e621d886a9" +
  "9c03469d0f93a9f5d45aa2c883f50cd158759e93673f759ec4657fd84cc79d2db38ef1a2d914cc" +
  "b7c717846a897e11dd22eb260a7ce2da2dccf0263ea63e2b3f7dac24f28882aa568ef544341d17" +
  "618392a1095f4049ad079d4f4f0b429bb535699155fd6a7652ec7d6c1f1ba2b560f11ef3a86b5945d288cf")]
+#endif

--- a/lang/cs/Org.Apache.REEF.Network/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Properties/AssemblyInfo.cs
@@ -55,8 +55,12 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("0.12.0.0")]
 
 // Allow the tests access to `internal` APIs
+#if DEBUG
+[assembly: InternalsVisibleTo("Org.Apache.REEF.Network.Tests")]
+#else
 [assembly: InternalsVisibleTo("Org.Apache.REEF.Network.Tests, publickey=" +
  "00240000048000009400000006020000002400005253413100040000010001005df3e621d886a9" +
  "9c03469d0f93a9f5d45aa2c883f50cd158759e93673f759ec4657fd84cc79d2db38ef1a2d914cc" +
  "b7c717846a897e11dd22eb260a7ce2da2dccf0263ea63e2b3f7dac24f28882aa568ef544341d17" +
  "618392a1095f4049ad079d4f4f0b429bb535699155fd6a7652ec7d6c1f1ba2b560f11ef3a86b5945d288cf")]
+#endif

--- a/lang/cs/Org.Apache.REEF.Tang/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Properties/AssemblyInfo.cs
@@ -55,8 +55,12 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("0.12.0.0")]
 
 // Allow the tests access to `internal` APIs
+#if DEBUG
+[assembly: InternalsVisibleTo("Org.Apache.REEF.Tang.Tests")]
+#else
 [assembly: InternalsVisibleTo("Org.Apache.REEF.Tang.Tests, publickey=" +
  "00240000048000009400000006020000002400005253413100040000010001005df3e621d886a9" +
  "9c03469d0f93a9f5d45aa2c883f50cd158759e93673f759ec4657fd84cc79d2db38ef1a2d914cc" +
  "b7c717846a897e11dd22eb260a7ce2da2dccf0263ea63e2b3f7dac24f28882aa568ef544341d17" +
  "618392a1095f4049ad079d4f4f0b429bb535699155fd6a7652ec7d6c1f1ba2b560f11ef3a86b5945d288cf")]
+#endif

--- a/lang/cs/Org.Apache.REEF.Wake/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Properties/AssemblyInfo.cs
@@ -55,8 +55,12 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("0.12.0.0")]
 
 // Allow the tests access to `internal` APIs
+#if DEBUG
+[assembly: InternalsVisibleTo("Org.Apache.REEF.Wake.Tests")]
+#else
 [assembly: InternalsVisibleTo("Org.Apache.REEF.Wake.Tests, publickey=" +
  "00240000048000009400000006020000002400005253413100040000010001005df3e621d886a9" +
  "9c03469d0f93a9f5d45aa2c883f50cd158759e93673f759ec4657fd84cc79d2db38ef1a2d914cc" +
  "b7c717846a897e11dd22eb260a7ce2da2dccf0263ea63e2b3f7dac24f28882aa568ef544341d17" +
  "618392a1095f4049ad079d4f4f0b429bb535699155fd6a7652ec7d6c1f1ba2b560f11ef3a86b5945d288cf")]
+#endif

--- a/lang/cs/build.props
+++ b/lang/cs/build.props
@@ -30,8 +30,6 @@ under the License.
 
   <!-- Common build configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>$(SolutionDir)\keyfile.snk</AssemblyOriginatorKeyFile>
     <PlatformTarget>x64</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>

--- a/lang/cs/build.props
+++ b/lang/cs/build.props
@@ -30,6 +30,8 @@ under the License.
 
   <!-- Common build configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(SolutionDir)\keyfile.snk</AssemblyOriginatorKeyFile>
     <PlatformTarget>x64</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>


### PR DESCRIPTION
…is not signed

There is an error in debug build as friend access was granted with public key but the module is not signed.
This PR is to sign debug build as well to avoid the issue so that both debug and release build can share the same AssemblyInfo file.

JIRA: REEF-466(https://issues.apache.org/jira/browse/REEF-466)

This closes #

Author: Julia Wang  Email: jwang98052@yahoo.com