### PR TITLE
[REEF-460]: Remove all generated files on mvn clean

### DIFF
--- a/lang/java/reef-examples/src/test/java/org/apache/reef/examples/hello/HelloHttpTest.java
+++ b/lang/java/reef-examples/src/test/java/org/apache/reef/examples/hello/HelloHttpTest.java
@@ -33,6 +33,7 @@ public class HelloHttpTest {
 
     final Configuration runtimeConfiguration = LocalRuntimeConfiguration.CONF
         .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, 2)
+        .set(LocalRuntimeConfiguration.RUNTIME_ROOT_FOLDER, "target/REEF_LOCAL_RUNTIME")
         .build();
 
     final LauncherStatus status = HelloREEFHttp.runHelloReef(runtimeConfiguration, 10 * 1000);

--- a/lang/java/reef-runtime-local/src/test/java/org/apache/reef/runtime/local/driver/ResourceManagerTest.java
+++ b/lang/java/reef-runtime-local/src/test/java/org/apache/reef/runtime/local/driver/ResourceManagerTest.java
@@ -29,7 +29,9 @@ import org.apache.reef.runtime.common.files.REEFFileNames;
 import org.apache.reef.runtime.common.utils.RemoteManager;
 import org.apache.reef.runtime.local.client.parameters.MaxNumberOfEvaluators;
 import org.apache.reef.runtime.local.client.parameters.RackNames;
+import org.apache.reef.runtime.local.client.parameters.RootFolder;
 import org.apache.reef.tang.Injector;
+import org.apache.reef.tang.JavaConfigurationBuilder;
 import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.tang.formats.ConfigurationSerializer;
@@ -47,10 +49,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.*;
 
 /**
  * Unit test for Resource Manager (and ContainerManager) classes.
@@ -75,7 +74,9 @@ public class ResourceManagerTest {
   @SuppressWarnings("unchecked")
   @Before
   public void setUp() throws InjectionException {
-    injector = Tang.Factory.getTang().newInjector();
+    JavaConfigurationBuilder cb = Tang.Factory.getTang().newConfigurationBuilder();
+    cb.bindNamedParameter(RootFolder.class, "target/REEF_LOCAL_RUNTIME");
+    injector = Tang.Factory.getTang().newInjector(cb.build());
     remoteManager = injector.getInstance(RemoteManager.class);
     mockRuntimeResourceStatusHandler = mock(EventHandler.class);
     injector.bindVolatileParameter(RuntimeParameters.ResourceStatusHandler.class, mockRuntimeResourceStatusHandler);

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/LocalTestEnvironment.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/LocalTestEnvironment.java
@@ -45,6 +45,7 @@ public final class LocalTestEnvironment extends TestEnvironmentBase implements T
     if (null == rootFolder) {
       return LocalRuntimeConfiguration.CONF
           .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, MAX_NUMBER_OF_EVALUATORS)
+          .set(LocalRuntimeConfiguration.RUNTIME_ROOT_FOLDER, "target/REEF_LOCAL_RUNTIME")
           .build();
     } else {
       return LocalRuntimeConfiguration.CONF


### PR DESCRIPTION
This pull request addressed the issue by
* Change test root folder to `target/REEF_LOCAL_RUNTIME`

JIRA: [REEF-460](https://issues.apache.org/jira/browse/REEF-460)