### PR TITLE
[REEF-475]: Remove reef-tests/reef/temp folder after the test is finished

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/ConfigurableDirectoryTempFileCreator.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/ConfigurableDirectoryTempFileCreator.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.io;
+
+import org.apache.reef.annotations.Provided;
+import org.apache.reef.io.parameters.TempFileRootFolder;
+import org.apache.reef.tang.annotations.Parameter;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Creates temp files in a directory named "temp" within  the configured directory.
+ */
+@Provided
+public final class ConfigurableDirectoryTempFileCreator implements TempFileCreator {
+  private static final Logger LOG = Logger.getLogger(ConfigurableDirectoryTempFileCreator.class.getName());
+  private final File tempFolderAsFile;
+  private final Path tempFolderAsPath;
+
+  @Inject
+  ConfigurableDirectoryTempFileCreator(
+      @Parameter(TempFileRootFolder.class) final String rootFolder) throws IOException {
+    this.tempFolderAsFile = new File(rootFolder);
+    this.tempFolderAsFile.mkdirs();
+    this.tempFolderAsPath = this.tempFolderAsFile.toPath();
+    LOG.log(Level.FINE, "Temporary files and folders will be created in [{0}]",
+        this.tempFolderAsFile.getAbsolutePath());
+  }
+
+
+  @Override
+  public File createTempFile(final String prefix, final String suffix) throws IOException {
+    final File result = File.createTempFile(prefix, suffix, this.tempFolderAsFile);
+    if (LOG.isLoggable(Level.FINEST)) {
+      LOG.log(Level.FINEST, "Created temporary file: {0}", result.getAbsolutePath());
+    }
+    return result;
+  }
+
+  @Override
+  public File createTempDirectory(final String prefix, final FileAttribute<?> fileAttributes) throws IOException {
+    final File result = Files.createTempDirectory(this.tempFolderAsPath, prefix, fileAttributes).toFile();
+    if (LOG.isLoggable(Level.FINEST)) {
+      LOG.log(Level.FINEST, "Created temporary folder: {0}", result.getAbsolutePath());
+    }
+    return result;
+  }
+
+  @Override
+  public File createTempDirectory(final String prefix) throws IOException {
+    final File result = Files.createTempDirectory(this.tempFolderAsPath, prefix).toFile();
+    if (LOG.isLoggable(Level.FINEST)) {
+      LOG.log(Level.FINEST, "Created temporary folder: {0}", result.getAbsolutePath());
+    }
+    return result;
+  }
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/parameters/TempFileRootFolder.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/parameters/TempFileRootFolder.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.io.parameters;
+
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "directory for temp files", default_value = "./reef/temp")
+public final class TempFileRootFolder implements Name<String> {
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/parameters/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/parameters/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Parameters for reef-common.src.main.java.org.apache.reef.io.
+ */
+package org.apache.reef.io.parameters;

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/LocalTestEnvironment.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/LocalTestEnvironment.java
@@ -18,8 +18,14 @@
  */
 package org.apache.reef.tests;
 
+import org.apache.reef.io.ConfigurableDirectoryTempFileCreator;
+import org.apache.reef.io.TempFileCreator;
+import org.apache.reef.io.parameters.TempFileRootFolder;
 import org.apache.reef.runtime.local.client.LocalRuntimeConfiguration;
 import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Configurations;
+import org.apache.reef.tang.JavaConfigurationBuilder;
+import org.apache.reef.tang.Tang;
 
 /**
  * A TestEnvironment for the local resourcemanager.
@@ -42,17 +48,19 @@ public final class LocalTestEnvironment extends TestEnvironmentBase implements T
   public synchronized final Configuration getRuntimeConfiguration() {
     assert (this.ready);
     final String rootFolder = System.getProperty("org.apache.reef.runtime.local.folder");
+    final JavaConfigurationBuilder jcb = Tang.Factory.getTang().newConfigurationBuilder();
+    jcb.bindNamedParameter(TempFileRootFolder.class, "./target/reef/temp");
+    jcb.bindImplementation(TempFileCreator.class, ConfigurableDirectoryTempFileCreator.class);
     if (null == rootFolder) {
-      return LocalRuntimeConfiguration.CONF
+      return Configurations.merge(jcb.build(), LocalRuntimeConfiguration.CONF
           .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, MAX_NUMBER_OF_EVALUATORS)
           .set(LocalRuntimeConfiguration.RUNTIME_ROOT_FOLDER, "target/REEF_LOCAL_RUNTIME")
-          .build();
+          .build());
     } else {
-      return LocalRuntimeConfiguration.CONF
+      return Configurations.merge(jcb.build(), LocalRuntimeConfiguration.CONF
           .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, MAX_NUMBER_OF_EVALUATORS)
           .set(LocalRuntimeConfiguration.RUNTIME_ROOT_FOLDER, rootFolder)
-          .build();
-
+          .build());
     }
   }
 


### PR DESCRIPTION
This pull request addressed the issue by

* Creating a `ConfigurableDirectoryTempFileCreator`, which is an instance of `TempFileCreator'.
* Configuring the temp file directory in `LocalTestEnvironment` to `target/reef/temp`.

JIRA: [REEF-475](https://issues.apache.org/jira/browse/REEF-475)