### PR TITLE
[REEF-477]  Modify TestBridgeClient to remove the dependency on old client code

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/Common/JavaClientLauncher.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/JavaClientLauncher.cs
@@ -20,6 +20,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using Org.Apache.REEF.Client.API.Exceptions;
@@ -57,6 +58,11 @@ namespace Org.Apache.REEF.Client.Common
                 RedirectStandardOutput = true,
                 RedirectStandardError = true
             };
+
+            string cmd = string.Format(CultureInfo.CurrentCulture, "Launch Java with command: {0} {1}",
+                startInfo.FileName, startInfo.Arguments);
+            Logger.Log(Level.Info, cmd);
+
             var process = Process.Start(startInfo);
             if (process != null)
             {

--- a/lang/cs/Org.Apache.REEF.Examples.HelloCLRBridge/ClrBridgeClient.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloCLRBridge/ClrBridgeClient.cs
@@ -23,9 +23,13 @@ using Org.Apache.REEF.Client.API;
 using Org.Apache.REEF.Client.Local;
 using Org.Apache.REEF.Client.YARN;
 using Org.Apache.REEF.Common.Evaluator;
+using Org.Apache.REEF.Common.Io;
+using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.Driver;
 using Org.Apache.REEF.Driver.Defaults;
 using Org.Apache.REEF.Examples.HelloCLRBridge.Handlers;
+using Org.Apache.REEF.Examples.Tasks.HelloTask;
+using Org.Apache.REEF.Network.Naming;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
@@ -69,8 +73,21 @@ namespace Org.Apache.REEF.Examples.HelloCLRBridge
                 .Set(DriverConfiguration.OnDriverRestartTaskRunning, GenericType<HelloDriverRestartRunningTaskHandler>.Class)
                 .Build();
 
+            var driverCondig = TangFactory.GetTang().NewConfigurationBuilder(helloDriverConfiguration)
+                .BindSetEntry<SetOfAssemblies, string>(GenericType<SetOfAssemblies>.Class,
+                    typeof (IDriver).Assembly.GetName().Name)
+                .BindSetEntry<SetOfAssemblies, string>(GenericType<SetOfAssemblies>.Class,
+                    typeof (ITask).Assembly.GetName().Name)
+                .BindSetEntry<SetOfAssemblies, string>(GenericType<SetOfAssemblies>.Class,
+                    typeof (HelloTask).Assembly.GetName().Name)
+                .BindSetEntry<SetOfAssemblies, string>(GenericType<SetOfAssemblies>.Class,
+                    typeof (INameClient).Assembly.GetName().Name)
+                .BindSetEntry<SetOfAssemblies, string>(GenericType<SetOfAssemblies>.Class,
+                    typeof (NameClient).Assembly.GetName().Name)
+                .Build();
+
             var helloJobSubmission = _jobSubmissionBuilderFactory.GetJobSubmissionBuilder()
-                .AddDriverConfiguration(helloDriverConfiguration)
+                .AddDriverConfiguration(driverCondig)
                 .AddGlobalAssemblyForType(typeof(HelloDriverStartHandler))
                 .SetJobIdentifier("HelloDriver")
                 .Build();

--- a/lang/cs/Org.Apache.REEF.Examples.HelloCLRBridge/ClrBridgeClient.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloCLRBridge/ClrBridgeClient.cs
@@ -80,14 +80,15 @@ namespace Org.Apache.REEF.Examples.HelloCLRBridge
 
         /// <summary>
         /// </summary>
-        /// <param name="name"></param>
+        /// <param name="runOnYarn"></param>
+        /// <param name="runtimeFolder"></param>
         /// <returns></returns>
-        private static IConfiguration GetRuntimeConfiguration(string name)
+        private static IConfiguration GetRuntimeConfiguration(string runOnYarn, string runtimeFolder)
         {
-            switch (name)
+            switch (runOnYarn)
             {
                 case Local:
-                    var dir = Path.Combine(".", "REEF_LOCAL_RUNTIME");
+                    var dir = Path.Combine(".", runtimeFolder);
                     return LocalRuntimeClientConfiguration.ConfigurationModule
                         .Set(LocalRuntimeClientConfiguration.NumberOfEvaluators, "2")
                         .Set(LocalRuntimeClientConfiguration.RuntimeFolder, dir)
@@ -95,7 +96,7 @@ namespace Org.Apache.REEF.Examples.HelloCLRBridge
                 case YARN:
                     return YARNClientConfiguration.ConfigurationModule.Build();
                 default:
-                    throw new Exception("Unknown runtime: " + name);
+                    throw new Exception("Unknown runtime: " + runOnYarn);
             }
         }
 
@@ -106,7 +107,9 @@ namespace Org.Apache.REEF.Examples.HelloCLRBridge
 
         public static void Run(string[] args)
         {
-            TangFactory.GetTang().NewInjector(GetRuntimeConfiguration(args.Length > 0 ? args[0] : Local)).GetInstance<ClrBridgeClient>().Run();
+            string runOnYarn = args.Length > 0 ? args[0] : Local;
+            string runtimeFolder = args.Length > 1 ? args[1] : "REEF_LOCAL_RUNTIME";
+            TangFactory.GetTang().NewInjector(GetRuntimeConfiguration(runOnYarn, runtimeFolder)).GetInstance<ClrBridgeClient>().Run();
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Examples.HelloCLRBridge/ClrBridgeClient.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloCLRBridge/ClrBridgeClient.cs
@@ -72,7 +72,7 @@ namespace Org.Apache.REEF.Examples.HelloCLRBridge
             var helloJobSubmission = _jobSubmissionBuilderFactory.GetJobSubmissionBuilder()
                 .AddDriverConfiguration(helloDriverConfiguration)
                 .AddGlobalAssemblyForType(typeof(HelloDriverStartHandler))
-                .SetJobIdentifier("HelloDriverStartHandler")
+                .SetJobIdentifier("HelloDriver")
                 .Build();
 
             _reefClient.Submit(helloJobSubmission);

--- a/lang/cs/Org.Apache.REEF.Examples.HelloCLRBridge/ClrBridgeClient.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloCLRBridge/ClrBridgeClient.cs
@@ -87,7 +87,7 @@ namespace Org.Apache.REEF.Examples.HelloCLRBridge
             switch (name)
             {
                 case Local:
-                    var dir = Path.Combine(Directory.GetCurrentDirectory(), "REEF_LOCAL_RUNTIME");
+                    var dir = Path.Combine(".", "REEF_LOCAL_RUNTIME");
                     return LocalRuntimeClientConfiguration.ConfigurationModule
                         .Set(LocalRuntimeClientConfiguration.NumberOfEvaluators, "2")
                         .Set(LocalRuntimeClientConfiguration.RuntimeFolder, dir)
@@ -100,6 +100,11 @@ namespace Org.Apache.REEF.Examples.HelloCLRBridge
         }
 
         public static void Main(string[] args)
+        {
+            Run(args);
+        }
+
+        public static void Run(string[] args)
         {
             TangFactory.GetTang().NewInjector(GetRuntimeConfiguration(args.Length > 0 ? args[0] : Local)).GetInstance<ClrBridgeClient>().Run();
         }

--- a/lang/cs/Org.Apache.REEF.Examples.HelloCLRBridge/Org.Apache.REEF.Examples.HelloCLRBridge.csproj
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloCLRBridge/Org.Apache.REEF.Examples.HelloCLRBridge.csproj
@@ -83,9 +83,13 @@ under the License.
       <Project>{cdfb3464-4041-42b1-9271-83af24cd5008}</Project>
       <Name>Org.Apache.REEF.Wake</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Org.Apache.REEF.Examples\Org.Apache.REEF.Examples.csproj">
+    <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Examples\Org.Apache.REEF.Examples.csproj">
       <Project>{75503f90-7b82-4762-9997-94b5c68f15db}</Project>
       <Name>Org.Apache.REEF.Examples</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Network\Org.Apache.REEF.Network.csproj">
+      <Project>{883ce800-6a6a-4e0a-b7fe-c054f4f2c1dc}</Project>
+      <Name>Org.Apache.REEF.Network</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestBridgeClient.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestBridgeClient.cs
@@ -79,7 +79,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         [TestMethod, Priority(1), TestCategory("FunctionalGated")]
         [DeploymentItem(@".")]
         [Timeout(180 * 1000)]
-        public void TestLoadAssemliesFromTestFolder()
+        public void TestLoadAssembliesFromTestFolder()
         {
             var files = new HashSet<string>(Directory.GetFiles(Directory.GetCurrentDirectory())
                 .Where(e => !(string.IsNullOrWhiteSpace(e)))

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestBridgeClient.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestBridgeClient.cs
@@ -33,6 +33,18 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
     {
         private static readonly Logger LOGGER = Logger.GetLogger(typeof(TestBridgeClient));
 
+        [TestInitialize()]
+        public void TestSetup()
+        {
+            Init();
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            Console.WriteLine("Post test check and clean up");
+        }
+
         [TestMethod, Priority(1), TestCategory("FunctionalGated")]
         [Description("Run CLR Bridge on local runtime")]
         [DeploymentItem(@".")]
@@ -57,6 +69,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
             string[] a = new[] { runOnYarn ? "yarn" : "local", testRuntimeFolder };
             ClrBridgeClient.Run(a);
             ValidateSuccessForLocalRuntime(2, testRuntimeFolder);
+            CleanUp(testRuntimeFolder);
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestBridgeClient.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestBridgeClient.cs
@@ -33,20 +33,6 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
     {
         private static readonly Logger LOGGER = Logger.GetLogger(typeof(TestBridgeClient));
 
-        [TestInitialize()]
-        public void TestSetup()
-        {
-            CleanUp();
-            Init();
-        }
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            Console.WriteLine("Post test check and clean up");
-            CleanUp();
-        }
-
         [TestMethod, Priority(1), TestCategory("FunctionalGated")]
         [Description("Run CLR Bridge on local runtime")]
         [DeploymentItem(@".")]
@@ -54,7 +40,6 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         public void CanRunClrBridgeExampleOnYarn()
         {
             RunClrBridgeClient(true);
-            ValidateSuccessForLocalRuntime(2);
         }
 
         [TestMethod, Priority(1), TestCategory("FunctionalGated")]
@@ -64,13 +49,14 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         public void CanRunClrBridgeExampleOnLocalRuntime()
         {
             RunClrBridgeClient(false);
-            ValidateSuccessForLocalRuntime(2);
         }
 
         private void RunClrBridgeClient(bool runOnYarn)
         {
-            string[] a = new[] { runOnYarn ? "yarn" : "local" };
+            string testRuntimeFolder = defaultRuntimeFolder + testNumber++;
+            string[] a = new[] { runOnYarn ? "yarn" : "local", testRuntimeFolder };
             ClrBridgeClient.Run(a);
+            ValidateSuccessForLocalRuntime(2, testRuntimeFolder);
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
@@ -59,7 +59,7 @@ namespace Org.Apache.REEF.Tests.Functional
         private readonly string _runCommand = Path.Combine(_binFolder, _cmdFile);
 
         // TODO: once things stablize, we would like to toggle this to be false and only enable when needed for debugging test failures.
-        private readonly bool _enableRealtimeLogUpload = true; 
+        private readonly bool _enableRealtimeLogUpload = false; 
 
         protected string TestId { get; set; }
 
@@ -146,6 +146,7 @@ namespace Org.Apache.REEF.Tests.Functional
             const string failedTaskIndication = "Java_com_microsoft_reef_javabridge_NativeInterop_ClrSystemFailedTaskHandlerOnNext";
             const string failedEvaluatorIndication = "Java_com_microsoft_reef_javabridge_NativeInterop_ClrSystemFailedEvaluatorHandlerOnNext";
             string[] lines = File.ReadAllLines(GetLogFile(_stdout, testFolder));
+            Console.WriteLine("Lines read from log file : " + lines.Count());
             string[] successIndicators = lines.Where(s => s.Contains(successIndication)).ToArray();
             string[] failedTaskIndicators = lines.Where(s => s.Contains(failedTaskIndication)).ToArray();
             string[] failedIndicators = lines.Where(s => s.Contains(failedEvaluatorIndication)).ToArray();

--- a/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
@@ -33,18 +33,39 @@ under the License.
     <BuildPackage>false</BuildPackage>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.WindowsAzure.Storage">
-      <HintPath>$(PackagesDir)\WindowsAzure.Storage.4.3.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    <Reference Include="Microsoft.Azure.KeyVault.Core">
+      <HintPath>$(SolutionDir)\packages\Microsoft.Azure.KeyVault.Core.0.9.1-preview\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>$(SolutionDir)\packages\Microsoft.Data.Edm.5.6.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>$(SolutionDir)\packages\Microsoft.Data.OData.5.6.2\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>$(SolutionDir)\packages\Microsoft.Data.Services.Client.5.6.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.4.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>$(SolutionDir)\packages\WindowsAzure.Storage.4.4.1-preview\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Spatial, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>$(SolutionDir)\packages\System.Spatial.5.6.2\lib\net40\System.Spatial.dll</HintPath>
+    </Reference>
     <Reference Include="System.Reactive.Core">
       <HintPath>$(PackagesDir)\Rx-Core.$(RxVersion)\lib\net45\System.Reactive.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Interfaces">
       <HintPath>$(PackagesDir)\Rx-Interfaces.$(RxVersion)\lib\net45\System.Reactive.Interfaces.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Evaluator\EvaluatorConfigurationsTests.cs" />
@@ -73,7 +94,9 @@ under the License.
     <None Include="$(SolutionDir)\Org.Apache.REEF.Client\run.cmd">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Common\Org.Apache.REEF.Common.csproj">
@@ -119,6 +142,10 @@ under the License.
     <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Network.Examples\Org.Apache.REEF.Network.Examples.csproj">
       <Project>{b1b43b60-ddd0-4805-a9b4-ba84a0ccb7c7}</Project>
       <Name>Org.Apache.REEF.Network.Examples</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Org.Apache.REEF.Examples.HelloCLRBridge\Org.Apache.REEF.Examples.HelloCLRBridge.csproj">
+      <Project>{159f7d70-8acc-4d97-9f6d-2fc4ca0d8682}</Project>
+      <Name>Org.Apache.REEF.Examples.HelloCLRBridge</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/lang/cs/Org.Apache.REEF.Tests/packages.config
+++ b/lang/cs/Org.Apache.REEF.Tests/packages.config
@@ -18,15 +18,16 @@ specific language governing permissions and limitations
 under the License.
 -->
 <packages>
-  <package id="Microsoft.Data.Edm" version="5.6.3" targetFramework="net45" />
-  <package id="Microsoft.Data.OData" version="5.6.3" targetFramework="net45" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.3" targetFramework="net45" />
-  <package id="Microsoft.Hadoop.Avro" version="1.4.0.0" targetFramework="net45" />
+  <package id="Microsoft.Azure.KeyVault.Core" version="0.9.1-preview" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net45" />
+  <package id="Microsoft.Hadoop.Avro" version="1.4.0.0" targetFsramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
-  <package id="System.Spatial" version="5.6.3" targetFramework="net45" />
-  <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.2" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="4.4.1-preview" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This PR added test cases to test the new CllrBridgeClient and removed the tests that calls old client exe.

JIRA: REEF-477(https://issues.apache.org/jira/browse/REEF-477)

This closes #

Author: Julia Wang  Email: juliaw@apache.org