### PR TITLE
[REEF-478] Introduce caching in NameClient LookUp function

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Io/INameClient.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Io/INameClient.cs
@@ -48,9 +48,10 @@ namespace Org.Apache.REEF.Common.Io
         /// Looks up the IPEndpoint for the registered identifier.
         /// </summary>
         /// <param name="id">The identifier to look up</param>
+        /// <param name="useCache">flag for using cache</param>
         /// <returns>The mapped IPEndpoint for the identifier, or null if
         /// the identifier has not been registered with the NameService</returns>
-        IPEndPoint Lookup(string id);
+        IPEndPoint Lookup(string id, bool useCache = false);
 
         /// <summary>
         /// Looks up the IPEndpoint for each of the registered identifiers in the list.

--- a/lang/cs/Org.Apache.REEF.Common/Io/INameClient.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Io/INameClient.cs
@@ -51,7 +51,7 @@ namespace Org.Apache.REEF.Common.Io
         /// <param name="useCache">flag for using cache</param>
         /// <returns>The mapped IPEndpoint for the identifier, or null if
         /// the identifier has not been registered with the NameService</returns>
-        IPEndPoint Lookup(string id, bool useCache = false);
+        IPEndPoint Lookup(string id);
 
         /// <summary>
         /// Looks up the IPEndpoint for each of the registered identifiers in the list.

--- a/lang/cs/Org.Apache.REEF.Network/Naming/NameCache.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Naming/NameCache.cs
@@ -1,0 +1,56 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System;
+using System.Net;
+using System.Runtime.Caching;
+using Org.Apache.REEF.Tang.Annotations;
+
+namespace Org.Apache.REEF.Network.Naming
+{
+    internal class NameCache
+    {
+        private readonly MemoryCache _cache;
+        private readonly double _expirationDuration;
+
+        [Inject]
+        private NameCache(
+            [Parameter(typeof (NameCacheConfiguration.CacheEntryExpiryTime))] double expirationDuration)
+        {
+            _cache = new MemoryCache("NameClientCache");
+            _expirationDuration = expirationDuration;
+        }
+
+        public void Set(string identifier, IPEndPoint value)
+        {
+            _cache.Set(identifier, value, DateTimeOffset.Now.AddMilliseconds(_expirationDuration));
+        }
+
+        public IPEndPoint Get(string identifier)
+        {
+            var entry = _cache.Get(identifier);
+            return entry as IPEndPoint;
+        }
+
+        public void RemoveEntry(string identifier)
+        {
+            _cache.Remove(identifier);
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Network/Naming/NameCacheConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Naming/NameCacheConfiguration.cs
@@ -1,0 +1,32 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using Org.Apache.REEF.Tang.Annotations;
+
+namespace Org.Apache.REEF.Network.Naming
+{
+    public static class NameCacheConfiguration
+    {
+        [NamedParameter("Time interval before the cache entry expires", "timeinterval", "300000")]
+        public class CacheEntryExpiryTime : Name<double>
+        {
+        }
+
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Network/Naming/NameClient.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Naming/NameClient.cs
@@ -27,6 +27,7 @@ using Org.Apache.REEF.Common.Io;
 using Org.Apache.REEF.Network.Naming.Codec;
 using Org.Apache.REEF.Network.Naming.Events;
 using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Utilities.Diagnostics;
 using Org.Apache.REEF.Utilities.Logging;
 using Org.Apache.REEF.Wake;
@@ -54,8 +55,8 @@ namespace Org.Apache.REEF.Network.Naming
 
         private NameLookupClient _lookupClient;
         private NameRegisterClient _registerClient;
-        private Dictionary<string, NameAssignment> _lookUpCache;
         private bool _disposed;
+        private readonly NameCache _cache;
 
         /// <summary>
         /// Constructs a NameClient to register, lookup, and unregister IPEndpoints
@@ -64,13 +65,33 @@ namespace Org.Apache.REEF.Network.Naming
         /// <param name="remoteAddress">The ip address of the NameServer</param>
         /// <param name="remotePort">The port of the NameServer</param>
         [Inject]
-        public NameClient(
+        private NameClient(
             [Parameter(typeof(NamingConfigurationOptions.NameServerAddress))] string remoteAddress, 
             [Parameter(typeof(NamingConfigurationOptions.NameServerPort))] int remotePort)
         {
             IPEndPoint remoteEndpoint = new IPEndPoint(IPAddress.Parse(remoteAddress), remotePort);
             Initialize(remoteEndpoint);
             _disposed = false;
+            _cache = TangFactory.GetTang().NewInjector().GetInstance<NameCache>();
+        }
+
+        /// <summary>
+        /// Constructs a NameClient to register, lookup, and unregister IPEndpoints
+        /// with the NameServer.
+        /// </summary>
+        /// <param name="remoteAddress">The ip address of the NameServer</param>
+        /// <param name="remotePort">The port of the NameServer</param>
+        /// <param name="cache">The NameCache for caching IpAddresses</param>
+        [Inject]
+        private NameClient(
+            [Parameter(typeof(NamingConfigurationOptions.NameServerAddress))] string remoteAddress,
+            [Parameter(typeof(NamingConfigurationOptions.NameServerPort))] int remotePort,
+            NameCache cache)
+        {
+            IPEndPoint remoteEndpoint = new IPEndPoint(IPAddress.Parse(remoteAddress), remotePort);
+            Initialize(remoteEndpoint);
+            _disposed = false;
+            _cache = cache;
         }
 
         /// <summary>
@@ -81,6 +102,7 @@ namespace Org.Apache.REEF.Network.Naming
         public NameClient(IPEndPoint remoteEndpoint) 
         {
             Initialize(remoteEndpoint);
+            _cache = TangFactory.GetTang().NewInjector().GetInstance<NameCache>();
             _disposed = false;
         }
 
@@ -125,27 +147,26 @@ namespace Org.Apache.REEF.Network.Naming
         /// Synchronously looks up the IPEndpoint for the registered identifier.
         /// </summary>
         /// <param name="id">The identifier to look up</param>
-        /// <param name="useCache">flag for using cache</param>
         /// <returns>The mapped IPEndpoint for the identifier, or null if
         /// the identifier has not been registered with the NameService</returns>
-        public IPEndPoint Lookup(string id, bool useCache = false)
+        public IPEndPoint Lookup(string id)
         {
             if (id == null)
             {
                 Exceptions.Throw(new ArgumentNullException("id"), _logger);
             }
 
-            NameAssignment value;
+            IPEndPoint value = _cache.Get(id);
 
-            if (useCache && _lookUpCache.TryGetValue(id, out value))
+            if (value != null)
             {
-                return value.Endpoint;
+                return value;
             }
 
             List<NameAssignment> assignments = Lookup(new List<string> { id });
             if (assignments != null && assignments.Count > 0)
             {
-                _lookUpCache[id] = assignments.First();
+                _cache.Set(id, assignments.First().Endpoint);
                 return assignments.First().Endpoint;
             }
 
@@ -226,7 +247,6 @@ namespace Org.Apache.REEF.Network.Naming
 
             _lookupClient = new NameLookupClient(_client, _lookupResponseQueue, _getAllResponseQueue);
             _registerClient = new NameRegisterClient(_client, _registerResponseQueue, _unregisterResponseQueue);
-            _lookUpCache = new Dictionary<string, NameAssignment>();
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Network/NetworkService/NsConnection.cs
+++ b/lang/cs/Org.Apache.REEF.Network/NetworkService/NsConnection.cs
@@ -76,7 +76,7 @@ namespace Org.Apache.REEF.Network.NetworkService
             string destStr = _destId.ToString();
             LOGGER.Log(Level.Verbose, "Network service opening connection to {0}...", destStr);
 
-            IPEndPoint destAddr = _nameClient.Lookup(_destId.ToString(), true);
+            IPEndPoint destAddr = _nameClient.Lookup(_destId.ToString());
             if (destAddr == null)
             {
                 throw new RemotingException("Cannot register Identifier with NameService");

--- a/lang/cs/Org.Apache.REEF.Network/NetworkService/NsConnection.cs
+++ b/lang/cs/Org.Apache.REEF.Network/NetworkService/NsConnection.cs
@@ -76,7 +76,7 @@ namespace Org.Apache.REEF.Network.NetworkService
             string destStr = _destId.ToString();
             LOGGER.Log(Level.Verbose, "Network service opening connection to {0}...", destStr);
 
-            IPEndPoint destAddr = _nameClient.Lookup(_destId.ToString());
+            IPEndPoint destAddr = _nameClient.Lookup(_destId.ToString(), true);
             if (destAddr == null)
             {
                 throw new RemotingException("Cannot register Identifier with NameService");

--- a/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
+++ b/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
@@ -46,6 +46,7 @@ under the License.
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -129,6 +130,8 @@ under the License.
     <Compile Include="Naming\Events\NamingUnregisterRequest.cs" />
     <Compile Include="Naming\Events\NamingUnregisterResponse.cs" />
     <Compile Include="Naming\INameServer.cs" />
+    <Compile Include="Naming\NameCache.cs" />
+    <Compile Include="Naming\NameCacheConfiguration.cs" />
     <Compile Include="Naming\NameClient.cs" />
     <Compile Include="Naming\NameLookupClient.cs" />
     <Compile Include="Naming\NameRegisterClient.cs" />


### PR DESCRIPTION
[REEF-478] Introduce caching in NameClient LookUp function

This addressed the issue by
  * Introducing destination string to IPEndPoint Cache. Subsequent look ups are handled locally using the cache. For applications like heartbeat in REEF where we might want to always get IP address from remote nameserver, the optional flag is given that turns off the cache by default.

JIRA:478 (https://issues.apache.org/jira/browse/REEF-478)