### PR TITLE
[REEF-479] Introduce time mesuarements in BroadcastReduce and PipelineBroadcadtReduce in Network.Examples.Client

### DIFF
--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/BroadcastReduceDriverAndTasks/MasterTask.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/BroadcastReduceDriverAndTasks/MasterTask.cs
@@ -90,9 +90,9 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.BroadcastReduceDri
                 if (i >= 2)
                 {
                     Logger.Log(Level.Info,
-                        "Average time (milliseconds) taken for broadcast: " +
-                        broadcastTime.ElapsedMilliseconds/((double) (i - 1)) +
-                        " and reduce: " + reduceTime.ElapsedMilliseconds/((double) (i - 1)));
+                        string.Format("Average time (milliseconds) taken for broadcast: {0} and reduce: {1}",
+                            broadcastTime.ElapsedMilliseconds/((double) (i - 1)),
+                            reduceTime.ElapsedMilliseconds/((double) (i - 1))));
                 }
             }
 

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/BroadcastReduceDriverAndTasks/SlaveTask.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/BroadcastReduceDriverAndTasks/SlaveTask.cs
@@ -76,9 +76,9 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.BroadcastReduceDri
                 if (i >= 1)
                 {
                     Logger.Log(Level.Info,
-                        "Average time (milliseconds) taken for broadcast: " +
-                        broadcastTime.ElapsedMilliseconds/((double) i) +
-                        " and reduce: " + reduceTime.ElapsedMilliseconds/((double) i));
+                        string.Format("Average time (milliseconds) taken for broadcast: {0} and reduce: {1}",
+                            broadcastTime.ElapsedMilliseconds / ((double)i),
+                            reduceTime.ElapsedMilliseconds / ((double)i)));
                 }
             }
 

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/BroadcastReduceDriverAndTasks/SlaveTask.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/BroadcastReduceDriverAndTasks/SlaveTask.cs
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+using System.Diagnostics;
 using System.Linq;
 using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.Network.Group.Operators;
@@ -28,7 +29,7 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.BroadcastReduceDri
 {
     public class SlaveTask : ITask
     {
-        private static readonly Logger _logger = Logger.GetLogger(typeof(SlaveTask));
+        private static readonly Logger Logger = Logger.GetLogger(typeof(SlaveTask));
 
         private readonly int _numIterations;
         private readonly IGroupCommClient _groupCommClient;
@@ -41,7 +42,7 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.BroadcastReduceDri
             [Parameter(typeof(GroupTestConfig.NumIterations))] int numIters,
             IGroupCommClient groupCommClient)
         {
-            _logger.Log(Level.Info, "Hello from slave task");
+            Logger.Log(Level.Info, "Hello from slave task");
 
             _numIterations = numIters;
             _groupCommClient = groupCommClient;
@@ -52,16 +53,33 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.BroadcastReduceDri
 
         public byte[] Call(byte[] memento)
         {
+            Stopwatch broadcastTime = new Stopwatch();
+            Stopwatch reduceTime = new Stopwatch();
+
             for (int i = 0; i < _numIterations; i++)
             {
+                broadcastTime.Start();
                 // Receive n from Master Task
                 int n = _broadcastReceiver.Receive();
-                _logger.Log(Level.Info, "Calculating TriangleNumber({0}) on slave task...", n);
+                broadcastTime.Stop();
+
+                Logger.Log(Level.Info, "Calculating TriangleNumber({0}) on slave task...", n);
 
                 // Calculate the nth Triangle number and send it back to driver
                 int triangleNum = TriangleNumber(n);
-                _logger.Log(Level.Info, "Sending sum: {0} on iteration {1}.", triangleNum, i);
+                Logger.Log(Level.Info, "Sending sum: {0} on iteration {1}.", triangleNum, i);
+                
+                reduceTime.Start();
                 _triangleNumberSender.Send(triangleNum);
+                reduceTime.Stop();
+                
+                if (i >= 1)
+                {
+                    Logger.Log(Level.Info,
+                        "Average time (milliseconds) taken for broadcast: " +
+                        broadcastTime.ElapsedMilliseconds/((double) i) +
+                        " and reduce: " + reduceTime.ElapsedMilliseconds/((double) i));
+                }
             }
 
             return null;

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedMasterTask.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedMasterTask.cs
@@ -103,9 +103,9 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastR
                 if (i >= 2)
                 {
                     Logger.Log(Level.Info,
-                        "Average time (milliseconds) taken for broadcast: " +
-                        broadcastTime.ElapsedMilliseconds / ((double)(i - 1)) +
-                        " and reduce: " + reduceTime.ElapsedMilliseconds / ((double)(i - 1)));
+                        string.Format("Average time (milliseconds) taken for broadcast: {0} and reduce: {1}",
+                            broadcastTime.ElapsedMilliseconds/((double) (i - 1)),
+                            reduceTime.ElapsedMilliseconds/((double) (i - 1))));
                 }
             }
 

--- a/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedSlaveTask.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples/GroupCommunication/PipelineBroadcastReduceDriverAndTasks/PipelinedSlaveTask.cs
@@ -95,8 +95,9 @@ namespace Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastR
                 if (i >= 1)
                 {
                     Logger.Log(Level.Info,
-                        "Average time (milliseconds) taken for broadcast: " + broadcastTime.ElapsedMilliseconds / ((double)i) +
-                        " and reduce: " + reduceTime.ElapsedMilliseconds / ((double)i));
+                        string.Format("Average time (milliseconds) taken for broadcast: {0} and reduce: {1}",
+                            broadcastTime.ElapsedMilliseconds/((double) i),
+                            reduceTime.ElapsedMilliseconds/((double) i)));
                 }
             }
 


### PR DESCRIPTION
[REEF-479] Introduce time mesuarements in BroadcastReduce and PipelineBroadcadtReduce in Network.Examples.Client

This addressed the issue by
  * Introducing time measurements using StopWatch in master and slave tasks.
  * Making the intermediate computations between broadcast and reduce minimal so as to measure the time of round trip correctly.

JIRA:
  [479](https://issues.apache.org/jira/browse/REEF-479)