### PR TITLE
[REEF-480] Too many open file descriptors in NetworkServiceTest runni…

### DIFF
--- a/lang/java/reef-io/src/test/java/org/apache/reef/services/network/NamingTest.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/services/network/NamingTest.java
@@ -96,33 +96,32 @@ public class NamingTest {
     final Injector injector = Tang.Factory.getTang().newInjector();
     injector.bindVolatileParameter(NameServerParameters.NameServerIdentifierFactory.class, this.factory);
     injector.bindVolatileInstance(LocalAddressProvider.class, this.localAddressProvider);
-    final NameServer server = injector.getInstance(NameServer.class);
-    this.port = server.getPort();
-    for (final Identifier id : idToAddrMap.keySet()) {
-      server.register(id, idToAddrMap.get(id));
+    try (final NameServer server = injector.getInstance(NameServer.class)) {
+      this.port = server.getPort();
+      for (final Identifier id : idToAddrMap.keySet()) {
+        server.register(id, idToAddrMap.get(id));
+      }
+
+      // run a client
+      try (final NameLookupClient client = new NameLookupClient(localAddress, this.port,
+          10000, this.factory, retryCount, retryTimeout, new NameCache(this.TTL), this.localAddressProvider)) {
+
+        final Identifier id1 = this.factory.getNewInstance("task1");
+        final Identifier id2 = this.factory.getNewInstance("task2");
+
+        final Map<Identifier, InetSocketAddress> respMap = new HashMap<Identifier, InetSocketAddress>();
+        InetSocketAddress addr1 = client.lookup(id1);
+        respMap.put(id1, addr1);
+        InetSocketAddress addr2 = client.lookup(id2);
+        respMap.put(id2, addr2);
+
+        for (final Identifier id : respMap.keySet()) {
+          LOG.log(Level.FINEST, "Mapping: {0} -> {1}", new Object[]{id, respMap.get(id)});
+        }
+
+        Assert.assertTrue(isEqual(idToAddrMap, respMap));
+      }
     }
-
-    // run a client
-    final NameLookupClient client = new NameLookupClient(localAddress, this.port,
-        10000, this.factory, retryCount, retryTimeout, new NameCache(this.TTL), this.localAddressProvider);
-
-    final Identifier id1 = this.factory.getNewInstance("task1");
-    final Identifier id2 = this.factory.getNewInstance("task2");
-
-    final Map<Identifier, InetSocketAddress> respMap = new HashMap<Identifier, InetSocketAddress>();
-    InetSocketAddress addr1 = client.lookup(id1);
-    respMap.put(id1, addr1);
-    InetSocketAddress addr2 = client.lookup(id2);
-    respMap.put(id2, addr2);
-
-    for (final Identifier id : respMap.keySet()) {
-      LOG.log(Level.FINEST, "Mapping: {0} -> {1}", new Object[]{id, respMap.get(id)});
-    }
-
-    Assert.assertTrue(isEqual(idToAddrMap, respMap));
-
-    client.close();
-    server.close();
   }
 
   /**
@@ -151,76 +150,75 @@ public class NamingTest {
       final Injector injector = Tang.Factory.getTang().newInjector();
       injector.bindVolatileParameter(NameServerParameters.NameServerIdentifierFactory.class, this.factory);
       injector.bindVolatileInstance(LocalAddressProvider.class, this.localAddressProvider);
-      final NameServer server = injector.getInstance(NameServer.class);
-      this.port = server.getPort();
-      for (final Identifier id : idToAddrMap.keySet()) {
-        server.register(id, idToAddrMap.get(id));
+      try (final NameServer server = injector.getInstance(NameServer.class)) {
+        this.port = server.getPort();
+        for (final Identifier id : idToAddrMap.keySet()) {
+          server.register(id, idToAddrMap.get(id));
+        }
+
+        // run a client
+        try (final NameLookupClient client = new NameLookupClient(localAddress, this.port,
+            10000, this.factory, retryCount, retryTimeout, new NameCache(this.TTL), this.localAddressProvider)) {
+
+          final Identifier id1 = this.factory.getNewInstance("task1");
+          final Identifier id2 = this.factory.getNewInstance("task2");
+          final Identifier id3 = this.factory.getNewInstance("task3");
+
+          final ExecutorService e = Executors.newCachedThreadPool();
+
+          final ConcurrentMap<Identifier, InetSocketAddress> respMap = new ConcurrentHashMap<Identifier, InetSocketAddress>();
+
+          final Future<?> f1 = e.submit(new Runnable() {
+            @Override
+            public void run() {
+              InetSocketAddress addr = null;
+              try {
+                addr = client.lookup(id1);
+              } catch (final Exception e) {
+                LOG.log(Level.SEVERE, "Lookup failed", e);
+                Assert.fail(e.toString());
+              }
+              respMap.put(id1, addr);
+            }
+          });
+          final Future<?> f2 = e.submit(new Runnable() {
+            @Override
+            public void run() {
+              InetSocketAddress addr = null;
+              try {
+                addr = client.lookup(id2);
+              } catch (final Exception e) {
+                LOG.log(Level.SEVERE, "Lookup failed", e);
+                Assert.fail(e.toString());
+              }
+              respMap.put(id2, addr);
+            }
+          });
+          final Future<?> f3 = e.submit(new Runnable() {
+            @Override
+            public void run() {
+              InetSocketAddress addr = null;
+              try {
+                addr = client.lookup(id3);
+              } catch (final Exception e) {
+                LOG.log(Level.SEVERE, "Lookup failed", e);
+                Assert.fail(e.toString());
+              }
+              respMap.put(id3, addr);
+            }
+          });
+
+          f1.get();
+          f2.get();
+          f3.get();
+
+          for (final Identifier id : respMap.keySet()) {
+            LOG.log(Level.FINEST, "Mapping: {0} -> {1}", new Object[]{id, respMap.get(id)});
+          }
+
+          Assert.assertTrue(isEqual(idToAddrMap, respMap));
+        }
       }
-
-      // run a client
-      final NameLookupClient client = new NameLookupClient(localAddress, this.port,
-          10000, this.factory, retryCount, retryTimeout, new NameCache(this.TTL), this.localAddressProvider);
-
-      final Identifier id1 = this.factory.getNewInstance("task1");
-      final Identifier id2 = this.factory.getNewInstance("task2");
-      final Identifier id3 = this.factory.getNewInstance("task3");
-
-      final ExecutorService e = Executors.newCachedThreadPool();
-
-      final ConcurrentMap<Identifier, InetSocketAddress> respMap = new ConcurrentHashMap<Identifier, InetSocketAddress>();
-
-      final Future<?> f1 = e.submit(new Runnable() {
-        @Override
-        public void run() {
-          InetSocketAddress addr = null;
-          try {
-            addr = client.lookup(id1);
-          } catch (final Exception e) {
-            LOG.log(Level.SEVERE, "Lookup failed", e);
-            Assert.fail(e.toString());
-          }
-          respMap.put(id1, addr);
-        }
-      });
-      final Future<?> f2 = e.submit(new Runnable() {
-        @Override
-        public void run() {
-          InetSocketAddress addr = null;
-          try {
-            addr = client.lookup(id2);
-          } catch (final Exception e) {
-            LOG.log(Level.SEVERE, "Lookup failed", e);
-            Assert.fail(e.toString());
-          }
-          respMap.put(id2, addr);
-        }
-      });
-      final Future<?> f3 = e.submit(new Runnable() {
-        @Override
-        public void run() {
-          InetSocketAddress addr = null;
-          try {
-            addr = client.lookup(id3);
-          } catch (final Exception e) {
-            LOG.log(Level.SEVERE, "Lookup failed", e);
-            Assert.fail(e.toString());
-          }
-          respMap.put(id3, addr);
-        }
-      });
-
-      f1.get();
-      f2.get();
-      f3.get();
-
-      for (final Identifier id : respMap.keySet()) {
-        LOG.log(Level.FINEST, "Mapping: {0} -> {1}", new Object[]{id, respMap.get(id)});
-      }
-
-      Assert.assertTrue(isEqual(idToAddrMap, respMap));
-
-      client.close();
-      server.close();
     }
   }
 
@@ -237,55 +235,55 @@ public class NamingTest {
     final Injector injector = Tang.Factory.getTang().newInjector();
     injector.bindVolatileParameter(NameServerParameters.NameServerIdentifierFactory.class, this.factory);
     injector.bindVolatileInstance(LocalAddressProvider.class, this.localAddressProvider);
-    final NameServer server = injector.getInstance(NameServer.class);
-    this.port = server.getPort();
-    final String localAddress = localAddressProvider.getLocalAddress();
+    try (final NameServer server = injector.getInstance(NameServer.class)) {
+      this.port = server.getPort();
+      final String localAddress = localAddressProvider.getLocalAddress();
 
-    // names to start with
-    final Map<Identifier, InetSocketAddress> idToAddrMap = new HashMap<Identifier, InetSocketAddress>();
-    idToAddrMap.put(this.factory.getNewInstance("task1"), new InetSocketAddress(localAddress, 7001));
-    idToAddrMap.put(this.factory.getNewInstance("task2"), new InetSocketAddress(localAddress, 7002));
+      // names to start with
+      final Map<Identifier, InetSocketAddress> idToAddrMap = new HashMap<Identifier, InetSocketAddress>();
+      idToAddrMap.put(this.factory.getNewInstance("task1"), new InetSocketAddress(localAddress, 7001));
+      idToAddrMap.put(this.factory.getNewInstance("task2"), new InetSocketAddress(localAddress, 7002));
 
-    // registration
-    // invoke registration from the client side
-    final NameRegistryClient client = new NameRegistryClient(localAddress, this.port, this.factory, this.localAddressProvider);
-    for (final Identifier id : idToAddrMap.keySet()) {
-      client.register(id, idToAddrMap.get(id));
+      // registration
+      // invoke registration from the client side
+      try (final NameRegistryClient client = new NameRegistryClient(localAddress,
+          this.port, this.factory, this.localAddressProvider)) {
+        for (final Identifier id : idToAddrMap.keySet()) {
+          client.register(id, idToAddrMap.get(id));
+        }
+
+        // wait
+        final Set<Identifier> ids = idToAddrMap.keySet();
+        busyWait(server, ids.size(), ids);
+
+        // check the server side
+        Map<Identifier, InetSocketAddress> serverMap = new HashMap<Identifier, InetSocketAddress>();
+        Iterable<NameAssignment> nas = server.lookup(ids);
+
+        for (final NameAssignment na : nas) {
+          LOG.log(Level.FINEST, "Mapping: {0} -> {1}",
+              new Object[]{na.getIdentifier(), na.getAddress()});
+          serverMap.put(na.getIdentifier(), na.getAddress());
+        }
+
+        Assert.assertTrue(isEqual(idToAddrMap, serverMap));
+
+        // un-registration
+        for (final Identifier id : idToAddrMap.keySet()) {
+          client.unregister(id);
+        }
+
+        // wait
+        busyWait(server, 0, ids);
+
+        serverMap = new HashMap<Identifier, InetSocketAddress>();
+        nas = server.lookup(ids);
+        for (final NameAssignment na : nas)
+          serverMap.put(na.getIdentifier(), na.getAddress());
+
+        Assert.assertEquals(0, serverMap.size());
+      }
     }
-
-    // wait
-    final Set<Identifier> ids = idToAddrMap.keySet();
-    busyWait(server, ids.size(), ids);
-
-    // check the server side 
-    Map<Identifier, InetSocketAddress> serverMap = new HashMap<Identifier, InetSocketAddress>();
-    Iterable<NameAssignment> nas = server.lookup(ids);
-
-    for (final NameAssignment na : nas) {
-      LOG.log(Level.FINEST, "Mapping: {0} -> {1}",
-          new Object[]{na.getIdentifier(), na.getAddress()});
-      serverMap.put(na.getIdentifier(), na.getAddress());
-    }
-
-    Assert.assertTrue(isEqual(idToAddrMap, serverMap));
-
-    // un-registration
-    for (final Identifier id : idToAddrMap.keySet()) {
-      client.unregister(id);
-    }
-
-    // wait
-    busyWait(server, 0, ids);
-
-    serverMap = new HashMap<Identifier, InetSocketAddress>();
-    nas = server.lookup(ids);
-    for (final NameAssignment na : nas)
-      serverMap.put(na.getIdentifier(), na.getAddress());
-
-    Assert.assertEquals(0, serverMap.size());
-
-    client.close();
-    server.close();
   }
 
   /**
@@ -302,66 +300,66 @@ public class NamingTest {
     final Injector injector = Tang.Factory.getTang().newInjector();
     injector.bindVolatileParameter(NameServerParameters.NameServerIdentifierFactory.class, this.factory);
     injector.bindVolatileInstance(LocalAddressProvider.class, this.localAddressProvider);
-    final NameServer server = injector.getInstance(NameServer.class);
-    this.port = server.getPort();
+    try (final NameServer server = injector.getInstance(NameServer.class)) {
+      this.port = server.getPort();
 
-    final Map<Identifier, InetSocketAddress> idToAddrMap = new HashMap<Identifier, InetSocketAddress>();
-    idToAddrMap.put(this.factory.getNewInstance("task1"), new InetSocketAddress(localAddress, 7001));
-    idToAddrMap.put(this.factory.getNewInstance("task2"), new InetSocketAddress(localAddress, 7002));
+      final Map<Identifier, InetSocketAddress> idToAddrMap = new HashMap<Identifier, InetSocketAddress>();
+      idToAddrMap.put(this.factory.getNewInstance("task1"), new InetSocketAddress(localAddress, 7001));
+      idToAddrMap.put(this.factory.getNewInstance("task2"), new InetSocketAddress(localAddress, 7002));
 
-    // registration
-    // invoke registration from the client side
-    Configuration nameResolverConf = NameResolverConfiguration.CONF
-        .set(NameResolverConfiguration.NAME_SERVER_HOSTNAME, localAddress)
-        .set(NameResolverConfiguration.NAME_SERVICE_PORT, this.port)
-        .set(NameResolverConfiguration.CACHE_TIMEOUT, this.TTL)
-        .set(NameResolverConfiguration.RETRY_TIMEOUT, retryTimeout)
-        .set(NameResolverConfiguration.RETRY_COUNT, retryCount)
-        .build();
+      // registration
+      // invoke registration from the client side
+      Configuration nameResolverConf = NameResolverConfiguration.CONF
+          .set(NameResolverConfiguration.NAME_SERVER_HOSTNAME, localAddress)
+          .set(NameResolverConfiguration.NAME_SERVICE_PORT, this.port)
+          .set(NameResolverConfiguration.CACHE_TIMEOUT, this.TTL)
+          .set(NameResolverConfiguration.RETRY_TIMEOUT, retryTimeout)
+          .set(NameResolverConfiguration.RETRY_COUNT, retryCount)
+          .build();
 
-    final NameResolver client = Tang.Factory.getTang().newInjector(nameResolverConf).getInstance(NameClient.class);
-    for (final Identifier id : idToAddrMap.keySet()) {
-      client.register(id, idToAddrMap.get(id));
+      try (final NameResolver client
+               = Tang.Factory.getTang().newInjector(nameResolverConf).getInstance(NameClient.class)) {
+        for (final Identifier id : idToAddrMap.keySet()) {
+          client.register(id, idToAddrMap.get(id));
+        }
+
+        // wait
+        final Set<Identifier> ids = idToAddrMap.keySet();
+        busyWait(server, ids.size(), ids);
+
+        // lookup
+        final Identifier id1 = this.factory.getNewInstance("task1");
+        final Identifier id2 = this.factory.getNewInstance("task2");
+
+        final Map<Identifier, InetSocketAddress> respMap = new HashMap<Identifier, InetSocketAddress>();
+        InetSocketAddress addr1 = client.lookup(id1);
+        respMap.put(id1, addr1);
+        InetSocketAddress addr2 = client.lookup(id2);
+        respMap.put(id2, addr2);
+
+        for (final Identifier id : respMap.keySet()) {
+          LOG.log(Level.FINEST, "Mapping: {0} -> {1}", new Object[]{id, respMap.get(id)});
+        }
+
+        Assert.assertTrue(isEqual(idToAddrMap, respMap));
+
+        // un-registration
+        for (final Identifier id : idToAddrMap.keySet()) {
+          client.unregister(id);
+        }
+
+        // wait
+        busyWait(server, 0, ids);
+
+        final Map<Identifier, InetSocketAddress> serverMap = new HashMap<Identifier, InetSocketAddress>();
+        addr1 = server.lookup(id1);
+        if (addr1 != null) serverMap.put(id1, addr1);
+        addr2 = server.lookup(id1);
+        if (addr2 != null) serverMap.put(id2, addr2);
+
+        Assert.assertEquals(0, serverMap.size());
+      }
     }
-
-    // wait
-    final Set<Identifier> ids = idToAddrMap.keySet();
-    busyWait(server, ids.size(), ids);
-
-    // lookup
-    final Identifier id1 = this.factory.getNewInstance("task1");
-    final Identifier id2 = this.factory.getNewInstance("task2");
-
-    final Map<Identifier, InetSocketAddress> respMap = new HashMap<Identifier, InetSocketAddress>();
-    InetSocketAddress addr1 = client.lookup(id1);
-    respMap.put(id1, addr1);
-    InetSocketAddress addr2 = client.lookup(id2);
-    respMap.put(id2, addr2);
-
-    for (final Identifier id : respMap.keySet()) {
-      LOG.log(Level.FINEST, "Mapping: {0} -> {1}", new Object[]{id, respMap.get(id)});
-    }
-
-    Assert.assertTrue(isEqual(idToAddrMap, respMap));
-
-    // un-registration
-    for (final Identifier id : idToAddrMap.keySet()) {
-      client.unregister(id);
-    }
-
-    // wait
-    busyWait(server, 0, ids);
-
-    final Map<Identifier, InetSocketAddress> serverMap = new HashMap<Identifier, InetSocketAddress>();
-    addr1 = server.lookup(id1);
-    if (addr1 != null) serverMap.put(id1, addr1);
-    addr2 = server.lookup(id1);
-    if (addr2 != null) serverMap.put(id2, addr2);
-
-    Assert.assertEquals(0, serverMap.size());
-
-    client.close();
-    server.close();
   }
 
   private boolean isEqual(final Map<Identifier, InetSocketAddress> map1,

--- a/lang/java/reef-io/src/test/java/org/apache/reef/services/network/NetworkConnectionServiceTest.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/services/network/NetworkConnectionServiceTest.java
@@ -77,6 +77,7 @@ public class NetworkConnectionServiceTest {
           monitor.mwait();
         } catch (NetworkException e) {
           e.printStackTrace();
+          throw new RuntimeException(e);
         }
       }
     }
@@ -205,6 +206,7 @@ public class NetworkConnectionServiceTest {
             monitor.mwait();
           } catch (NetworkException e) {
             e.printStackTrace();
+            throw new RuntimeException(e);
           }
           final long end = System.currentTimeMillis();
 
@@ -257,6 +259,7 @@ public class NetworkConnectionServiceTest {
                 monitor.mwait();
               } catch (NetworkException e) {
                 e.printStackTrace();
+                throw new RuntimeException(e);
               }
             }
           } catch (Exception e) {

--- a/lang/java/reef-io/src/test/java/org/apache/reef/services/network/NetworkConnectionServiceTest.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/services/network/NetworkConnectionServiceTest.java
@@ -64,10 +64,10 @@ public class NetworkConnectionServiceTest {
   private void runMessagingNetworkConnectionService(Codec<String> codec) throws Exception {
     final int numMessages = 2000;
     final Monitor monitor = new Monitor();
-    try (final NetworkMessagingTest messagingTest = new NetworkMessagingTest(localAddress)) {
-      messagingTest.registerTestConnectionFactory(groupCommClientId, numMessages, monitor, codec);
+    try (final NetworkMessagingTestService messagingTestService = new NetworkMessagingTestService(localAddress)) {
+      messagingTestService.registerTestConnectionFactory(groupCommClientId, numMessages, monitor, codec);
 
-      try (final Connection<String> conn = messagingTest.getConnectionFromSenderToReceiver(groupCommClientId)) {
+      try (final Connection<String> conn = messagingTestService.getConnectionFromSenderToReceiver(groupCommClientId)) {
         try {
           conn.open();
           for (int count = 0; count < numMessages; ++count) {
@@ -105,18 +105,18 @@ public class NetworkConnectionServiceTest {
 
     final int groupcommMessages = 1000;
     final Monitor monitor = new Monitor();
-    try (final NetworkMessagingTest messagingTest = new NetworkMessagingTest(localAddress)) {
+    try (final NetworkMessagingTestService messagingTestService = new NetworkMessagingTestService(localAddress)) {
 
-      messagingTest.registerTestConnectionFactory(groupCommClientId, groupcommMessages, monitor, stringCodec);
+      messagingTestService.registerTestConnectionFactory(groupCommClientId, groupcommMessages, monitor, stringCodec);
 
       final int shuffleMessages = 2000;
       final Monitor monitor2 = new Monitor();
-      messagingTest.registerTestConnectionFactory(shuffleClientId, shuffleMessages, monitor2, integerCodec);
+      messagingTestService.registerTestConnectionFactory(shuffleClientId, shuffleMessages, monitor2, integerCodec);
 
       executor.submit(new Runnable() {
         @Override
         public void run() {
-          try (final Connection<String> conn = messagingTest.getConnectionFromSenderToReceiver(groupCommClientId)) {
+          try (final Connection<String> conn = messagingTestService.getConnectionFromSenderToReceiver(groupCommClientId)) {
             conn.open();
             for (int count = 0; count < groupcommMessages; ++count) {
               // send messages to the receiver.
@@ -133,7 +133,7 @@ public class NetworkConnectionServiceTest {
       executor.submit(new Runnable() {
         @Override
         public void run() {
-          try (final Connection<Integer> conn = messagingTest.getConnectionFromSenderToReceiver(shuffleClientId)) {
+          try (final Connection<Integer> conn = messagingTestService.getConnectionFromSenderToReceiver(shuffleClientId)) {
             conn.open();
             for (int count = 0; count < shuffleMessages; ++count) {
               // send messages to the receiver.
@@ -183,8 +183,8 @@ public class NetworkConnectionServiceTest {
       final int numMessages = 300000 / (Math.max(1, size / 512));
       final Monitor monitor = new Monitor();
       final Codec<String> codec = new StringCodec();
-      try (final NetworkMessagingTest messagingTest = new NetworkMessagingTest(localAddress)) {
-        messagingTest.registerTestConnectionFactory(groupCommClientId, numMessages, monitor, codec);
+      try (final NetworkMessagingTestService messagingTestService = new NetworkMessagingTestService(localAddress)) {
+        messagingTestService.registerTestConnectionFactory(groupCommClientId, numMessages, monitor, codec);
 
         // build the message
         final StringBuilder msb = new StringBuilder();
@@ -193,7 +193,7 @@ public class NetworkConnectionServiceTest {
         }
         final String message = msb.toString();
 
-        try (final Connection<String> conn = messagingTest.getConnectionFromSenderToReceiver(groupCommClientId)) {
+        try (final Connection<String> conn = messagingTestService.getConnectionFromSenderToReceiver(groupCommClientId)) {
 
           long start = System.currentTimeMillis();
           try {
@@ -234,12 +234,12 @@ public class NetworkConnectionServiceTest {
 
       e.submit(new Runnable() {
         public void run() {
-          try (final NetworkMessagingTest messagingTest = new NetworkMessagingTest(localAddress)) {
+          try (final NetworkMessagingTestService messagingTestService = new NetworkMessagingTestService(localAddress)) {
             final Monitor monitor = new Monitor();
             final Codec<String> codec = new StringCodec();
 
-            messagingTest.registerTestConnectionFactory(groupCommClientId, numMessages, monitor, codec);
-            try (final Connection<String> conn = messagingTest.getConnectionFromSenderToReceiver(groupCommClientId)) {
+            messagingTestService.registerTestConnectionFactory(groupCommClientId, numMessages, monitor, codec);
+            try (final Connection<String> conn = messagingTestService.getConnectionFromSenderToReceiver(groupCommClientId)) {
 
               // build the message
               final StringBuilder msb = new StringBuilder();
@@ -288,8 +288,8 @@ public class NetworkConnectionServiceTest {
       final int totalNumMessages = numMessages * numThreads;
       final Monitor monitor = new Monitor();
       final Codec<String> codec = new StringCodec();
-      try (final NetworkMessagingTest messagingTest = new NetworkMessagingTest(localAddress)) {
-        messagingTest.registerTestConnectionFactory(groupCommClientId, totalNumMessages, monitor, codec);
+      try (final NetworkMessagingTestService messagingTestService = new NetworkMessagingTestService(localAddress)) {
+        messagingTestService.registerTestConnectionFactory(groupCommClientId, totalNumMessages, monitor, codec);
 
         final ExecutorService e = Executors.newCachedThreadPool();
 
@@ -299,7 +299,7 @@ public class NetworkConnectionServiceTest {
           msb.append("1");
         }
         final String message = msb.toString();
-        try (final Connection<String> conn = messagingTest.getConnectionFromSenderToReceiver(groupCommClientId)) {
+        try (final Connection<String> conn = messagingTestService.getConnectionFromSenderToReceiver(groupCommClientId)) {
 
           final long start = System.currentTimeMillis();
           for (int i = 0; i < numThreads; i++) {
@@ -345,9 +345,9 @@ public class NetworkConnectionServiceTest {
       final int numMessages = 300 / (Math.max(1, size / 512));
       final Monitor monitor = new Monitor();
       final Codec<String> codec = new StringCodec();
-      try (final NetworkMessagingTest messagingTest = new NetworkMessagingTest(localAddress)) {
-        messagingTest.registerTestConnectionFactory(groupCommClientId, numMessages, monitor, codec);
-        try (final Connection<String> conn = messagingTest.getConnectionFromSenderToReceiver(groupCommClientId)) {
+      try (final NetworkMessagingTestService messagingTestService = new NetworkMessagingTestService(localAddress)) {
+        messagingTestService.registerTestConnectionFactory(groupCommClientId, numMessages, monitor, codec);
+        try (final Connection<String> conn = messagingTestService.getConnectionFromSenderToReceiver(groupCommClientId)) {
 
           // build the message
           final StringBuilder msb = new StringBuilder();

--- a/lang/java/reef-io/src/test/java/org/apache/reef/services/network/util/NetworkMessagingTestService.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/services/network/util/NetworkMessagingTestService.java
@@ -44,8 +44,8 @@ import java.util.logging.Logger;
 /**
  * Helper class for NetworkConnectionService test.
  */
-public final class NetworkMessagingTest implements AutoCloseable{
-  private static final Logger LOG = Logger.getLogger(NetworkMessagingTest.class.getName());
+public final class NetworkMessagingTestService implements AutoCloseable {
+  private static final Logger LOG = Logger.getLogger(NetworkMessagingTestService.class.getName());
 
   private final IdentifierFactory factory;
   private final NetworkConnectionService receiverNetworkConnService;
@@ -56,7 +56,7 @@ public final class NetworkMessagingTest implements AutoCloseable{
   private final NameResolver receiverResolver;
   private final NameResolver senderResolver;
 
-  public NetworkMessagingTest(final String localAddress) throws InjectionException {
+  public NetworkMessagingTestService(final String localAddress) throws InjectionException {
     // name server
     final Injector injector = Tang.Factory.getTang().newInjector();
     this.nameServer = injector.getInstance(NameServer.class);


### PR DESCRIPTION
…ng in Linux

This addressed the issue by
  * Fixed NetworkMessagingTest.close() to close receiverResolver and senderResolver
  * Used try-with-resoureces

JIRA:
  [REEF-480](https://issues.apache.org/jira/browse/REEF-480)