### PR TITLE
[REEF-477]  Modify TestBridgeClient to remove the dependency on old Client code

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/Common/JavaClientLauncher.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/JavaClientLauncher.cs
@@ -20,6 +20,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using Org.Apache.REEF.Client.API.Exceptions;
@@ -57,6 +58,10 @@ namespace Org.Apache.REEF.Client.Common
                 RedirectStandardOutput = true,
                 RedirectStandardError = true
             };
+
+            Logger.Log(Level.Info, string.Format(CultureInfo.CurrentCulture, "Launch Java with command: {0} {1}",
+                startInfo.FileName, startInfo.Arguments));
+
             var process = Process.Start(startInfo);
             if (process != null)
             {

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverBridgeConfigurationOptions.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverBridgeConfigurationOptions.cs
@@ -152,5 +152,10 @@ namespace Org.Apache.REEF.Driver.Bridge
         public class TraceLevel : Name<string>
         {
         }
+
+        [NamedParameter]
+        public class SetOfAssemblies : Name<ISet<string>>
+        {
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Examples.HelloCLRBridge/ClrBridgeClient.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloCLRBridge/ClrBridgeClient.cs
@@ -24,8 +24,11 @@ using Org.Apache.REEF.Client.Local;
 using Org.Apache.REEF.Client.YARN;
 using Org.Apache.REEF.Common.Evaluator;
 using Org.Apache.REEF.Driver;
+using Org.Apache.REEF.Driver.Bridge;
 using Org.Apache.REEF.Driver.Defaults;
 using Org.Apache.REEF.Examples.HelloCLRBridge.Handlers;
+using Org.Apache.REEF.Examples.Tasks.HelloTask;
+using Org.Apache.REEF.Network.Naming;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
@@ -69,10 +72,15 @@ namespace Org.Apache.REEF.Examples.HelloCLRBridge
                 .Set(DriverConfiguration.OnDriverRestartTaskRunning, GenericType<HelloDriverRestartRunningTaskHandler>.Class)
                 .Build();
 
+            var driverCondig = TangFactory.GetTang().NewConfigurationBuilder(helloDriverConfiguration)
+                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(HelloTask).Assembly.GetName().Name)
+                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(NameClient).Assembly.GetName().Name)
+                .Build();
+
             var helloJobSubmission = _jobSubmissionBuilderFactory.GetJobSubmissionBuilder()
-                .AddDriverConfiguration(helloDriverConfiguration)
+                .AddDriverConfiguration(driverCondig)
                 .AddGlobalAssemblyForType(typeof(HelloDriverStartHandler))
-                .SetJobIdentifier("HelloDriverStartHandler")
+                .SetJobIdentifier("HelloDriver")
                 .Build();
 
             _reefClient.Submit(helloJobSubmission);
@@ -80,14 +88,15 @@ namespace Org.Apache.REEF.Examples.HelloCLRBridge
 
         /// <summary>
         /// </summary>
-        /// <param name="name"></param>
+        /// <param name="runOnYarn"></param>
+        /// <param name="runtimeFolder"></param>
         /// <returns></returns>
-        private static IConfiguration GetRuntimeConfiguration(string name)
+        private static IConfiguration GetRuntimeConfiguration(string runOnYarn, string runtimeFolder)
         {
-            switch (name)
+            switch (runOnYarn)
             {
                 case Local:
-                    var dir = Path.Combine(Directory.GetCurrentDirectory(), "REEF_LOCAL_RUNTIME");
+                    var dir = Path.Combine(".", runtimeFolder);
                     return LocalRuntimeClientConfiguration.ConfigurationModule
                         .Set(LocalRuntimeClientConfiguration.NumberOfEvaluators, "2")
                         .Set(LocalRuntimeClientConfiguration.RuntimeFolder, dir)
@@ -95,13 +104,20 @@ namespace Org.Apache.REEF.Examples.HelloCLRBridge
                 case YARN:
                     return YARNClientConfiguration.ConfigurationModule.Build();
                 default:
-                    throw new Exception("Unknown runtime: " + name);
+                    throw new Exception("Unknown runtime: " + runOnYarn);
             }
         }
 
         public static void Main(string[] args)
         {
-            TangFactory.GetTang().NewInjector(GetRuntimeConfiguration(args.Length > 0 ? args[0] : Local)).GetInstance<ClrBridgeClient>().Run();
+            Run(args);
+        }
+
+        public static void Run(string[] args)
+        {
+            string runOnYarn = args.Length > 0 ? args[0] : Local;
+            string runtimeFolder = args.Length > 1 ? args[1] : "REEF_LOCAL_RUNTIME";
+            TangFactory.GetTang().NewInjector(GetRuntimeConfiguration(runOnYarn, runtimeFolder)).GetInstance<ClrBridgeClient>().Run();
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Examples.HelloCLRBridge/Org.Apache.REEF.Examples.HelloCLRBridge.csproj
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloCLRBridge/Org.Apache.REEF.Examples.HelloCLRBridge.csproj
@@ -83,9 +83,13 @@ under the License.
       <Project>{cdfb3464-4041-42b1-9271-83af24cd5008}</Project>
       <Name>Org.Apache.REEF.Wake</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Org.Apache.REEF.Examples\Org.Apache.REEF.Examples.csproj">
+    <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Examples\Org.Apache.REEF.Examples.csproj">
       <Project>{75503f90-7b82-4762-9997-94b5c68f15db}</Project>
       <Name>Org.Apache.REEF.Examples</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Network\Org.Apache.REEF.Network.csproj">
+      <Project>{883ce800-6a6a-4e0a-b7fe-c054f4f2c1dc}</Project>
+      <Name>Org.Apache.REEF.Network</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/lang/cs/Org.Apache.REEF.Examples.HelloCLRBridge/Org.Apache.REEF.Examples.HelloCLRBridge.csproj
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloCLRBridge/Org.Apache.REEF.Examples.HelloCLRBridge.csproj
@@ -71,6 +71,14 @@ under the License.
       <Project>{1b983182-9c30-464c-948d-f87eb93a8240}</Project>
       <Name>Org.Apache.REEF.Evaluator</Name>
     </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Examples\Org.Apache.REEF.Examples.csproj">
+      <Project>{75503f90-7b82-4762-9997-94b5c68f15db}</Project>
+      <Name>Org.Apache.REEF.Examples</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Network\Org.Apache.REEF.Network.csproj">
+      <Project>{883ce800-6a6a-4e0a-b7fe-c054f4f2c1dc}</Project>
+      <Name>Org.Apache.REEF.Network</Name>
+    </ProjectReference>
     <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Tang\Org.Apache.REEF.Tang.csproj">
       <Project>{97dbb573-3994-417a-9f69-ffa25f00d2a6}</Project>
       <Name>Org.Apache.REEF.Tang</Name>
@@ -82,14 +90,6 @@ under the License.
     <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Wake\Org.Apache.REEF.Wake.csproj">
       <Project>{cdfb3464-4041-42b1-9271-83af24cd5008}</Project>
       <Name>Org.Apache.REEF.Wake</Name>
-    </ProjectReference>
-    <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Examples\Org.Apache.REEF.Examples.csproj">
-      <Project>{75503f90-7b82-4762-9997-94b5c68f15db}</Project>
-      <Name>Org.Apache.REEF.Examples</Name>
-    </ProjectReference>
-    <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Network\Org.Apache.REEF.Network.csproj">
-      <Project>{883ce800-6a6a-4e0a-b7fe-c054f4f2c1dc}</Project>
-      <Name>Org.Apache.REEF.Network</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
@@ -44,21 +44,21 @@ namespace Org.Apache.REEF.Tests.Functional
         protected const string _stderr = "driver.stderr";
         protected const string _cmdFile = "run.cmd";
         protected const string _binFolder = ".";
+
+        protected static int TestNumber = 1;
+        protected const string DefaultRuntimeFolder = "REEF_LOCAL_RUNTIME";
+
+        private readonly static Logger Logger = Logger.GetLogger(typeof(ReefFunctionalTest));
         private const string StorageAccountKeyEnvironmentVariable = "REEFTestStorageAccountKey";
         private const string StorageAccountNameEnvironmentVariable = "REEFTestStorageAccountName";
-
-        private static Logger Logger = Logger.GetLogger(typeof(ReefFunctionalTest));
-            
-
-        private bool _testSuccess = false;
-        private bool _onLocalRuntime = false;
         private readonly string _className = Constants.BridgeLaunchClass;
         private readonly string _clrFolder = ".";
         private readonly string _reefJar = Path.Combine(_binFolder, Constants.JavaBridgeJarFileName);
         private readonly string _runCommand = Path.Combine(_binFolder, _cmdFile);
+        private bool _testSuccess = false;
+        private bool _onLocalRuntime = false;
 
-        // TODO: once things stablize, we would like to toggle this to be false and only enable when needed for debugging test failures.
-        private readonly bool _enableRealtimeLogUpload = true; 
+        private readonly bool _enableRealtimeLogUpload = false;
 
         protected string TestId { get; set; }
 
@@ -111,7 +111,7 @@ namespace Org.Apache.REEF.Tests.Functional
             ClrClientHelper.Run(appDlls, driverBridgeConfig, new DriverSubmissionSettings() { RunOnYarn = runOnYarn, JavaLogLevel = javaLogSettings }, _reefJar, _runCommand, _clrFolder, _className);
         }
 
-        protected void CleanUp()
+        protected void CleanUp(string testFolder = DefaultRuntimeFolder)
         {
             Console.WriteLine("Cleaning up test.");
 
@@ -125,7 +125,7 @@ namespace Org.Apache.REEF.Tests.Functional
             // Wait for file upload task to complete
             Thread.Sleep(500);
 
-            string dir = Path.Combine(Directory.GetCurrentDirectory(), "REEF_LOCAL_RUNTIME");
+            string dir = Path.Combine(Directory.GetCurrentDirectory(), testFolder);
             try
             {
                 if (Directory.Exists(dir))
@@ -139,12 +139,13 @@ namespace Org.Apache.REEF.Tests.Functional
             }   
         }
 
-        protected void ValidateSuccessForLocalRuntime(int numberOfEvaluatorsToClose)
+        protected void ValidateSuccessForLocalRuntime(int numberOfEvaluatorsToClose, string testFolder = DefaultRuntimeFolder)
         {
             const string successIndication = "EXIT: ActiveContextClr2Java::Close";
             const string failedTaskIndication = "Java_com_microsoft_reef_javabridge_NativeInterop_ClrSystemFailedTaskHandlerOnNext";
             const string failedEvaluatorIndication = "Java_com_microsoft_reef_javabridge_NativeInterop_ClrSystemFailedEvaluatorHandlerOnNext";
-            string[] lines = File.ReadAllLines(GetLogFile(_stdout));
+            string[] lines = File.ReadAllLines(GetLogFile(_stdout, testFolder));
+            Console.WriteLine("Lines read from log file : " + lines.Count());
             string[] successIndicators = lines.Where(s => s.Contains(successIndication)).ToArray();
             string[] failedTaskIndicators = lines.Where(s => s.Contains(failedTaskIndication)).ToArray();
             string[] failedIndicators = lines.Where(s => s.Contains(failedEvaluatorIndication)).ToArray();
@@ -165,9 +166,11 @@ namespace Org.Apache.REEF.Tests.Functional
             }
         }
 
-        protected string GetLogFile(string logFileName)
+        protected string GetLogFile(string logFileName, string testFolder = DefaultRuntimeFolder)
         {
-            string driverContainerDirectory = Directory.GetDirectories(Path.Combine(Directory.GetCurrentDirectory(), "REEF_LOCAL_RUNTIME"), "driver", SearchOption.AllDirectories).SingleOrDefault();
+            string driverContainerDirectory = Directory.GetDirectories(Path.Combine(Directory.GetCurrentDirectory(), testFolder), "driver", SearchOption.AllDirectories).SingleOrDefault();
+            Console.WriteLine("GetLogFile, driverContainerDirectory:" + driverContainerDirectory);
+
             if (string.IsNullOrWhiteSpace(driverContainerDirectory))
             {
                 throw new InvalidOperationException("Cannot find driver container directory");
@@ -201,9 +204,9 @@ namespace Org.Apache.REEF.Tests.Functional
         }
 
         /// <summary>
-        /// Assembles the storage account connection string from the envrionment.
+        /// Assembles the storage account connection string from the environment.
         /// </summary>
-        /// <returns>the storage account connection string assembled from the envrionment.</returns>
+        /// <returns>the storage account connection string assembled from the environment.</returns>
         /// <exception cref="Exception">If the environment variables aren't set.</exception>
         private static string GetStorageConnectionString()
         {
@@ -220,7 +223,7 @@ namespace Org.Apache.REEF.Tests.Functional
         }
 
         /// <summary>
-        /// Fetchs the value of the given environment variable
+        /// Fetch the value of the given environment variable
         /// </summary>
         /// <param name="variableName"></param>
         /// <param name="errorMessageIfNotAvailable"></param>
@@ -238,6 +241,5 @@ namespace Org.Apache.REEF.Tests.Functional
             }
             return result;
         }
-
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Tests/Org.Apache.REEF.Tests.csproj
@@ -120,6 +120,10 @@ under the License.
       <Project>{b1b43b60-ddd0-4805-a9b4-ba84a0ccb7c7}</Project>
       <Name>Org.Apache.REEF.Network.Examples</Name>
     </ProjectReference>
+    <ProjectReference Include="$(SolutionDir)\Org.Apache.REEF.Examples.HelloCLRBridge\Org.Apache.REEF.Examples.HelloCLRBridge.csproj">
+      <Project>{159f7d70-8acc-4d97-9f6d-2fc4ca0d8682}</Project>
+      <Name>Org.Apache.REEF.Examples.HelloCLRBridge</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />


### PR DESCRIPTION
*This PR added test cases to test the new ClrBridgeClient and removed the tests that calls old client exe.

*It also modified ClassHierarchyGeneratingDriverStartObserver to allow  client to bind assemblies to be loaded for class hierarchy. This is to avoid to load too many unnecessary assemblies and add them into the class hierarchy.

*It disabled RealtimeLogUpload as it is not required now and causes some noises.

JIRA: REEF-477(https://issues.apache.org/jira/browse/REEF-477)

This closes #

Author: Julia Wang  Email: juliaw@apache.org