### PR TITLE
[REEF-481] Make ClockTest predictable

### DIFF
--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/ClockTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/ClockTest.java
@@ -139,7 +139,7 @@ public class ClockTest {
     try {
       for (int i = 0; i < numThreads; ++i)
         stage.onNext(null);
-      eventCountLatch.await(10, TimeUnit.SECONDS);
+      Assert.assertTrue(eventCountLatch.await(10, TimeUnit.SECONDS));
     } finally {
       stage.close();
       clock.close();


### PR DESCRIPTION
  This makes Clock tests more predictable by deleting removable Thread.sleep.

JIRA:
  [REEF-481](https://issues.apache.org/jira/browse/REEF-481)