### PR TITLE
[REEF-440] Enforce checkstyle checks in "Naming" category

### DIFF
--- a/lang/cs/Org.Apache.REEF.Bridge/InteropLogger.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/InteropLogger.cpp
@@ -33,7 +33,7 @@ namespace Org {
 						fwprintf(stdout, formatBuf);
 						fflush(stdout);
 					}
-					_jmidLog = env->GetMethodID(_jclassInteropLogger, "Log", "(ILjava/lang/String;)V");
+					_jmidLog = env->GetMethodID(_jclassInteropLogger, "log", "(ILjava/lang/String;)V");
 					if (NULL == _jmidLog) {
 						swprintf_s(formatBuf, sizeof(formatBuf) / sizeof(wchar_t), L"_jmidLog %p\n", _jmidLog);
 						fwprintf(stdout, formatBuf);

--- a/lang/cs/Org.Apache.REEF.Bridge/JavaClrBridge.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/JavaClrBridge.cpp
@@ -96,13 +96,13 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_loadClrAsse
 
 /*
  * Class:     org_apache_reef_javabridge_NativeInterop
- * Method:    CallClrSystemOnStartHandler
+ * Method:    callClrSystemOnStartHandler
  * Signature: (Ljava/lang/String;Ljava/lang/String;Lorg/apache/reef/javabridge/EvaluatorRequestorBridge;)[J
  */
-JNIEXPORT jlongArray JNICALL Java_org_apache_reef_javabridge_NativeInterop_CallClrSystemOnStartHandler
+JNIEXPORT jlongArray JNICALL Java_org_apache_reef_javabridge_NativeInterop_callClrSystemOnStartHandler
 (JNIEnv * env, jclass jclassx, jstring dateTimeString, jstring httpServerPort, jobject jevaluatorRequestorBridge) {
   try {
-    ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_CallClrSystemOnStartHandler");
+    ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_callClrSystemOnStartHandler");
     const wchar_t* charConfig = UnicodeCppStringFromJavaString (env, dateTimeString);
     int lenConfig = env->GetStringLength(dateTimeString);
     String^  strConfig = Marshal::PtrToStringUni((IntPtr)(unsigned short*) charConfig, lenConfig);
@@ -117,26 +117,26 @@ JNIEXPORT jlongArray JNICALL Java_org_apache_reef_javabridge_NativeInterop_CallC
     return JavaLongArrayFromManagedLongArray(env, handlers);
   }
   catch (System::Exception^ ex) {
-    // we cannot get error back to java here since we don't have an object to call back (although we idealy should...)
-    ManagedLog::LOGGER->LogError("Exceptions in Java_org_apache_reef_javabridge_NativeInterop_CallClrSystemOnStartHandler", ex);
+    // we cannot get error back to java here since we don't have an object to call back (although we ideally should...)
+    ManagedLog::LOGGER->LogError("Exceptions in Java_org_apache_reef_javabridge_NativeInterop_callClrSystemOnStartHandler", ex);
     return NULL;
   }
 }
 
 /*
  * Class:     org_apache_reef_javabridge_NativeInterop
- * Method:    ClrSystemAllocatedEvaluatorHandlerOnNext
+ * Method:    clrSystemAllocatedEvaluatorHandlerOnNext
  * Signature: (JLorg/apache/reef/javabridge/AllocatedEvaluatorBridge;Lorg/apache/reef/javabridge/InteropLogger;)V
  */
-JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemAllocatedEvaluatorHandlerOnNext
+JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemAllocatedEvaluatorHandlerOnNext
 (JNIEnv *env, jclass cls, jlong handle, jobject jallocatedEvaluatorBridge, jobject jlogger) {
-  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_ClrSystemAllocatedEvaluatorHandlerOnNext:");
+  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_clrSystemAllocatedEvaluatorHandlerOnNext:");
   AllocatedEvaluatorClr2Java^ allocatedEval = gcnew AllocatedEvaluatorClr2Java(env, jallocatedEvaluatorBridge);
   try {
     ClrSystemHandlerWrapper::Call_ClrSystemAllocatedEvaluatorHandler_OnNext(handle, allocatedEval);
   }
   catch (System::Exception^ ex) {
-    String^ errorMessage = "Exception in Call_ClrSystemAllocatedEvaluatorHandler_OnNext";
+    String^ errorMessage = "Exception in Call_clrSystemAllocatedEvaluatorHandler_OnNext";
     ManagedLog::LOGGER->LogError(errorMessage, ex);
     allocatedEval -> OnError(errorMessage);
   }
@@ -144,12 +144,12 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemAl
 
 /*
  * Class:     org_apache_reef_javabridge_NativeInterop
- * Method:    ClrSystemActiveContextHandlerOnNext
+ * Method:    clrSystemActiveContextHandlerOnNext
  * Signature: (JLorg/apache/reef/javabridge/ActiveContextBridge;Lorg/apache/reef/javabridge/InteropLogger;)V
  */
-JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemActiveContextHandlerOnNext
+JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemActiveContextHandlerOnNext
 (JNIEnv *env, jclass cls, jlong handle, jobject jactiveContextBridge, jobject jlogger) {
-  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_ClrSystemActiveContextHandlerOnNext");
+  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_clrSystemActiveContextHandlerOnNext");
   ActiveContextClr2Java^ activeContextBrdige = gcnew ActiveContextClr2Java(env, jactiveContextBridge);
   try {
     ClrSystemHandlerWrapper::Call_ClrSystemActiveContextHandler_OnNext(handle, activeContextBrdige);
@@ -182,12 +182,12 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemEv
 
 /*
  * Class:     org_apache_reef_javabridge_NativeInterop
- * Method:    ClrSystemTaskMessageHandlerOnNext
+ * Method:    clrSystemTaskMessageHandlerOnNext
  * Signature: (J[BLorg/apache/reef/javabridge/TaskMessageBridge;Lorg/apache/reef/javabridge/InteropLogger;)V
  */
-JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemTaskMessageHandlerOnNext
+JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemTaskMessageHandlerOnNext
 (JNIEnv *env, jclass cls, jlong handle, jbyteArray jmessage, jobject jtaskMessageBridge, jobject jlogger) {
-  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_ClrSystemTaskMessageHandlerOnNext");
+  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_clrSystemTaskMessageHandlerOnNext");
   TaskMessageClr2Java^ taskMesageBridge = gcnew TaskMessageClr2Java(env, jtaskMessageBridge);
   array<byte>^ message = ManagedByteArrayFromJavaByteArray(env, jmessage);
   try {
@@ -202,12 +202,12 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemTa
 
 /*
  * Class:     org_apache_reef_javabridge_NativeInterop
- * Method:    ClrSysteFailedTaskHandlerOnNext
+ * Method:    clrSystemFailedTaskHandlerOnNext
  * Signature: (JLorg/apache/reef/javabridge/FailedTaskBridge;Lorg/apache/reef/javabridge/InteropLogger;)V
  */
-JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemFailedTaskHandlerOnNext
+JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemFailedTaskHandlerOnNext
 (JNIEnv *env , jclass cls, jlong handler, jobject jfailedTask, jobject jlogger) {
-  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_ClrSystemFailedTaskHandlerOnNext");
+  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_clrSystemFailedTaskHandlerOnNext");
   FailedTaskClr2Java^ failedTaskBridge = gcnew FailedTaskClr2Java(env, jfailedTask);
   try {
     ClrSystemHandlerWrapper::Call_ClrSystemFailedTask_OnNext(handler, failedTaskBridge);
@@ -221,12 +221,12 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemFa
 
 /*
  * Class:     org_apache_reef_javabridge_NativeInterop
- * Method:    ClrSysteFailedTaskHandlerOnNext
+ * Method:    clrSystemRunningTaskHandlerOnNext
  * Signature: (JLorg.apache.reef.javabridge/FailedTaskBridge;Lorg.apache.reef.javabridge/InteropLogger;)V
  */
-JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemRunningTaskHandlerOnNext
+JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemRunningTaskHandlerOnNext
 (JNIEnv *env , jclass cls, jlong handler, jobject jrunningTask, jobject jlogger) {
-  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_ClrSystemRunningTaskHandlerOnNext");
+  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_clrSystemRunningTaskHandlerOnNext");
   RunningTaskClr2Java^ runningTaskBridge = gcnew RunningTaskClr2Java(env, jrunningTask);
   try {
     ClrSystemHandlerWrapper::Call_ClrSystemRunningTask_OnNext(handler, runningTaskBridge);
@@ -240,12 +240,12 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemRu
 
 /*
  * Class:     org_apache_reef_javabridge_NativeInterop
- * Method:    ClrSystemFailedEvaluatorHandlerOnNext
+ * Method:    clrSystemFailedEvaluatorHandlerOnNext
  * Signature: (JLorg/apache/reef/javabridge/FailedEvaluatorBridge;Lorg/apache/reef/javabridge/InteropLogger;)V
  */
-JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemFailedEvaluatorHandlerOnNext
+JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemFailedEvaluatorHandlerOnNext
 (JNIEnv *env , jclass cls, jlong handler, jobject jfailedEvaluator, jobject jlogger) {
-  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_ClrSystemFailedEvaluatorHandlerOnNext");
+  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_clrSystemFailedEvaluatorHandlerOnNext");
   FailedEvaluatorClr2Java^ failedEvaluatorBridge = gcnew FailedEvaluatorClr2Java(env, jfailedEvaluator);
   try {
     ClrSystemHandlerWrapper::Call_ClrSystemFailedEvaluator_OnNext(handler, failedEvaluatorBridge);
@@ -259,12 +259,12 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemFa
 
 /*
  * Class:     org_apache_reef_javabridge_NativeInterop
- * Method:    ClrSystemHttpServerEventHandlerOnHttpRequest
+ * Method:    clrSystemHttpServerHandlerOnNext
  * Signature: (JLorg/apache/reef/javabridge/HttpServerEventBridge;Lorg/apache/reef/javabridge/InteropLogger;)V
  */
-JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemHttpServerHandlerOnNext
+JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemHttpServerHandlerOnNext
 (JNIEnv *env , jclass cls, jlong handler, jobject jhttpServerEventBridge, jobject jlogger) {
-  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_ClrSystemHttpServerHandlerOnNext");
+  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_clrSystemHttpServerHandlerOnNext");
   HttpServerClr2Java^ httpServerClr2Java = gcnew HttpServerClr2Java(env, jhttpServerEventBridge);
   try {
     ClrSystemHandlerWrapper::Call_ClrSystemHttpServer_OnNext(handler, httpServerClr2Java);
@@ -278,12 +278,12 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemHt
 
 /*
  * Class:     org_apache_reef_javabridge_NativeInterop
- * Method:    ClrSystemCompletedTaskHandlerOnNext
+ * Method:    clrSystemCompletedTaskHandlerOnNext
  * Signature: (JLorg/apache/reef/javabridge/CompletedTaskBridge;Lorg/apache/reef/javabridge/InteropLogger;)V
  */
-JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemCompletedTaskHandlerOnNext
+JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemCompletedTaskHandlerOnNext
 (JNIEnv *env , jclass cls, jlong handler, jobject jcompletedTask, jobject jlogger) {
-  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_ClrSystemCompletedTaskHandlerOnNext");
+  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_clrSystemCompletedTaskHandlerOnNext");
   CompletedTaskClr2Java^ completedTaskBridge = gcnew CompletedTaskClr2Java(env, jcompletedTask);
   try {
     ClrSystemHandlerWrapper::Call_ClrSystemCompletedTask_OnNext(handler, completedTaskBridge);
@@ -297,10 +297,10 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemCo
 
 /*
  * Class:     org_apache_reef_javabridge_NativeInterop
- * Method:    ClrBufferedLog
+ * Method:    clrBufferedLog
  * Signature: (ILjava/lang/String;)V
  */
-JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrBufferedLog
+JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrBufferedLog
 (JNIEnv *env, jclass cls, jint logLevel, jstring message) {
   try {
     if (!JavaClrBridge::LoggerWrapper::initialized) {
@@ -337,18 +337,18 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrBuffered
     JavaClrBridge::LoggerWrapper::logger->TraceEvent(eventType, 0, msg);
   }
   catch (System::Exception^ ex) {
-    ManagedLog::LOGGER->LogError("Exception in Java_javabridge_NativeInterop_ClrBufferedLog", ex);
+    ManagedLog::LOGGER->LogError("Exception in Java_javabridge_NativeInterop_clrBufferedLog", ex);
   }
 }
 
 /*
  * Class:     org_apache_reef_javabridge_NativeInterop
- * Method:    ClrSystemSupendedTaskHandlerOnNext
+ * Method:    clrSystemSuspendedTaskHandlerOnNext
  * Signature: (JLorg/apache/reef/javabridge/SuspendedTaskBridge;)V
  */
-JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemSupendedTaskHandlerOnNext
+JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemSuspendedTaskHandlerOnNext
 (JNIEnv *env , jclass cls, jlong handler, jobject jsuspendedTask) {
-  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_ClrSystemSupendedTaskHandlerOnNext");
+  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_clrSystemSuspendedTaskHandlerOnNext");
   SuspendedTaskClr2Java^ suspendedTaskBridge = gcnew SuspendedTaskClr2Java(env, jsuspendedTask);
   try {
     ClrSystemHandlerWrapper::Call_ClrSystemSuspendedTask_OnNext(handler, suspendedTaskBridge);
@@ -362,18 +362,18 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemSu
 
 /*
  * Class:     org_apache_reef_javabridge_NativeInterop
- * Method:    ClrSystemCompletdEvaluatorHandlerOnNext
+ * Method:    clrSystemCompletedEvaluatorHandlerOnNext
  * Signature: (JLorg/apache/reef/javabridge/CompletedEvaluatorBridge;)V
  */
-JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemCompletdEvaluatorHandlerOnNext
+JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemCompletedEvaluatorHandlerOnNext
 (JNIEnv *env , jclass cls, jlong handler, jobject jcompletedEvaluator) {
-  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_ClrSystemCompletdEvaluatorHandlerOnNext");
+  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_clrSystemCompletedEvaluatorHandlerOnNext");
   CompletedEvaluatorClr2Java^ completedEvaluatorBridge = gcnew CompletedEvaluatorClr2Java(env, jcompletedEvaluator);
   try {
     ClrSystemHandlerWrapper::Call_ClrSystemCompletedEvaluator_OnNext(handler, completedEvaluatorBridge);
   }
   catch (System::Exception^ ex) {
-    String^ errorMessage = "Exception in Call_ClrSystemSuspendedTask_OnNext";
+    String^ errorMessage = "Exception in Call_ClrSystemCompletedEvaluator_OnNext";
     ManagedLog::LOGGER->LogError(errorMessage, ex);
     completedEvaluatorBridge -> OnError(errorMessage);
   }
@@ -381,12 +381,12 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemCo
 
 /*
  * Class:     org_apache_reef_javabridge_NativeInterop
- * Method:    ClrSystemClosedContextHandlerOnNext
+ * Method:    clrSystemClosedContextHandlerOnNext
  * Signature: (JLorg/apache/reef/javabridge/ClosedContextBridge;)V
  */
-JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemClosedContextHandlerOnNext
+JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemClosedContextHandlerOnNext
 (JNIEnv *env , jclass cls, jlong handler, jobject jclosedContext) {
-  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_ClrSystemClosedContextHandlerOnNext");
+  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_clrSystemClosedContextHandlerOnNext");
   ClosedContextClr2Java^ closedContextBridge = gcnew ClosedContextClr2Java(env, jclosedContext);
   try {
     ClrSystemHandlerWrapper::Call_ClrSystemClosedContext_OnNext(handler, closedContextBridge);
@@ -400,12 +400,12 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemCl
 
 /*
  * Class:     org_apache_reef_javabridge_NativeInterop
- * Method:    ClrSystemFailedContextHandlerOnNext
+ * Method:    clrSystemFailedContextHandlerOnNext
  * Signature: (JLorg/apache/reef/javabridge/FailedContextBridge;)V
  */
-JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemFailedContextHandlerOnNext
+JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemFailedContextHandlerOnNext
 (JNIEnv *env , jclass cls, jlong handler, jobject jfailedContext) {
-  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_ClrSystemFailedContextHandlerOnNext");
+  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_clrSystemFailedContextHandlerOnNext");
   FailedContextClr2Java^ failedContextBridge = gcnew FailedContextClr2Java(env, jfailedContext);
   try {
     ClrSystemHandlerWrapper::Call_ClrSystemFailedContext_OnNext(handler, failedContextBridge);
@@ -419,12 +419,12 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemFa
 
 /*
  * Class:     org_apache_reef_javabridge_NativeInterop
- * Method:    ClrSystemContextMessageHandlerOnNext
+ * Method:    clrSystemContextMessageHandlerOnNext
  * Signature: (JLorg/apache/reef/javabridge/ContextMessageBridge;)V
  */
-JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemContextMessageHandlerOnNext
+JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemContextMessageHandlerOnNext
 (JNIEnv *env , jclass cls, jlong handler, jobject jcontextMessage) {
-  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_ClrSystemContextMessageHandlerOnNext");
+  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_clrSystemContextMessageHandlerOnNext");
   ContextMessageClr2Java^ contextMessageBridge = gcnew ContextMessageClr2Java(env, jcontextMessage);
   try {
     ClrSystemHandlerWrapper::Call_ClrSystemContextMessage_OnNext(handler, contextMessageBridge);
@@ -438,12 +438,12 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemCo
 
 /*
  * Class:     org_apache_reef_javabridge_NativeInterop
- * Method:    ClrSystemDriverRestartHandlerOnNext
+ * Method:    clrSystemDriverRestartHandlerOnNext
  * Signature: (J)V
  */
-JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemDriverRestartHandlerOnNext
+JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemDriverRestartHandlerOnNext
 (JNIEnv *env , jclass cls, jlong handler) {
-  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_ClrSystemDriverRestartHandlerOnNext");
+  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_clrSystemDriverRestartHandlerOnNext");
   try {
     ClrSystemHandlerWrapper::Call_ClrSystemDriverRestart_OnNext(handler);
   }
@@ -456,12 +456,12 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemDr
 
 /*
  * Class:     org_apache_reef_javabridge_NativeInterop
- * Method:    ClrSystemDriverRestartActiveContextHandlerOnNext
+ * Method:    clrSystemDriverRestartActiveContextHandlerOnNext
  * Signature: (JLorg/apache/reef/javabridge/ActiveContextBridge;)V
  */
-JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemDriverRestartActiveContextHandlerOnNext
+JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemDriverRestartActiveContextHandlerOnNext
 (JNIEnv *env, jclass cls, jlong handle, jobject jactiveContextBridge) {
-  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_ClrSystemDriverRestartActiveContextHandlerOnNext");
+  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_clrSystemDriverRestartActiveContextHandlerOnNext");
   ActiveContextClr2Java^ activeContextBrdige = gcnew ActiveContextClr2Java(env, jactiveContextBridge);
   try {
     ClrSystemHandlerWrapper::Call_ClrSystemDriverRestartActiveContextHandler_OnNext(handle, activeContextBrdige);
@@ -475,12 +475,12 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemDr
 
 /*
  * Class:     org_apache_reef_javabridge_NativeInterop
- * Method:    ClrSystemDriverRestartRunningTaskHandlerOnNext
+ * Method:    clrSystemDriverRestartRunningTaskHandlerOnNext
  * Signature: (JLorg/apache/reef/javabridge/RunningTaskBridge;)V
  */
-JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemDriverRestartRunningTaskHandlerOnNext
+JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemDriverRestartRunningTaskHandlerOnNext
 (JNIEnv *env , jclass cls, jlong handler, jobject jrunningTask) {
-  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_ClrSystemDriverRestartRunningTaskHandlerOnNext");
+  ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_clrSystemDriverRestartRunningTaskHandlerOnNext");
   RunningTaskClr2Java^ runningTaskBridge = gcnew RunningTaskClr2Java(env, jrunningTask);
   try {
     ClrSystemHandlerWrapper::Call_ClrSystemDriverRestartRunningTask_OnNext(handler, runningTaskBridge);

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
@@ -150,8 +150,8 @@ namespace Org.Apache.REEF.Tests.Functional
         protected void ValidateSuccessForLocalRuntime(int numberOfEvaluatorsToClose, string testFolder = DefaultRuntimeFolder)
         {
             const string successIndication = "EXIT: ActiveContextClr2Java::Close";
-            const string failedTaskIndication = "Java_com_microsoft_reef_javabridge_NativeInterop_ClrSystemFailedTaskHandlerOnNext";
-            const string failedEvaluatorIndication = "Java_com_microsoft_reef_javabridge_NativeInterop_ClrSystemFailedEvaluatorHandlerOnNext";
+            const string failedTaskIndication = "Java_com_microsoft_reef_javabridge_NativeInterop_clrSystemFailedTaskHandlerOnNext";
+            const string failedEvaluatorIndication = "Java_com_microsoft_reef_javabridge_NativeInterop_clrSystemFailedEvaluatorHandlerOnNext";
             string[] lines = File.ReadAllLines(GetLogFile(_stdout, testFolder));
             Console.WriteLine("Lines read from log file : " + lines.Count());
             string[] successIndicators = lines.Where(s => s.Contains(successIndication)).ToArray();

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/InteropLogger.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/InteropLogger.java
@@ -41,15 +41,13 @@ public class InteropLogger {
     levelHashMap.put(Level.ALL.intValue(), Level.ALL);
   }
 
-  public void Log(int intLevel, String message) {
+  public void log(int intLevel, String message) {
     if (levelHashMap.containsKey(intLevel)) {
       Level level = levelHashMap.get(intLevel);
       LOG.log(level, message);
     } else {
-
       LOG.log(Level.WARNING, "Level " + intLevel + " is not a valid Log level");
       LOG.log(Level.WARNING, message);
     }
-
   }
 }

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/NativeInterop.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/NativeInterop.java
@@ -23,138 +23,138 @@ import java.util.HashMap;
 public final class NativeInterop {
   public static final String CLASS_HIERARCHY_FILENAME = "clrClassHierarchy.bin";
   public static final String GLOBAL_LIBRARIES_FILENAME = "userSuppliedGlobalLibraries.txt";
-  public static final String AllocatedEvaluatorKey = "AllocatedEvaluator";
-  public static final String ActiveContextKey = "ActiveContext";
-  public static final String TaskMessageKey = "TaskMessage";
-  public static final String FailedTaskKey = "FailedTask";
-  public static final String FailedEvaluatorKey = "FailedEvaluator";
-  public static final String HttpServerKey = "HttpServerKey";
-  public static final String CompletedTaskKey = "CompletedTask";
-  public static final String RunningTaskKey = "RunningTask";
-  public static final String SuspendedTaskKey = "SuspendedTask";
-  public static final String CompletedEvaluatorKey = "CompletedEvaluator";
-  public static final String ClosedContextKey = "ClosedContext";
-  public static final String FailedContextKey = "FailedContext";
-  public static final String ContextMessageKey = "ContextMessage";
-  public static final String DriverRestartKey = "DriverRestart";
-  public static final String DriverRestartActiveContextKey = "DriverRestartActiveContext";
-  public static final String DriverRestartRunningTaskKey = "DriverRestartRunningTask";
-  public static final HashMap<String, Integer> Handlers = new HashMap<String, Integer>() {
+  public static final String ALLOCATED_EVALUATOR_KEY = "AllocatedEvaluator";
+  public static final String ACTIVE_CONTEXT_KEY = "ActiveContext";
+  public static final String TASK_MESSAGE_KEY = "TaskMessage";
+  public static final String FAILED_TASK_KEY = "FailedTask";
+  public static final String FAILED_EVALUATOR_KEY = "FailedEvaluator";
+  public static final String HTTP_SERVER_KEY = "HttpServerKey";
+  public static final String COMPLETED_TASK_KEY = "CompletedTask";
+  public static final String RUNNING_TASK_KEY = "RunningTask";
+  public static final String SUSPENDED_TASK_KEY = "SuspendedTask";
+  public static final String COMPLETED_EVALUATOR_KEY = "CompletedEvaluator";
+  public static final String CLOSED_CONTEXT_KEY = "ClosedContext";
+  public static final String FAILED_CONTEXT_KEY = "FailedContext";
+  public static final String CONTEXT_MESSAGE_KEY = "ContextMessage";
+  public static final String DRIVER_RESTART_KEY = "DriverRestart";
+  public static final String DRIVER_RESTART_ACTIVE_CONTEXT_KEY = "DriverRestartActiveContext";
+  public static final String DRIVER_RESTART_RUNNING_TASK_KEY = "DriverRestartRunningTask";
+  public static final HashMap<String, Integer> HANDLERS = new HashMap<String, Integer>() {
     {
-      put(AllocatedEvaluatorKey, 1);
-      put(ActiveContextKey, 2);
-      put(TaskMessageKey, 3);
-      put(FailedTaskKey, 4);
-      put(FailedEvaluatorKey, 5);
-      put(HttpServerKey, 6);
-      put(CompletedTaskKey, 7);
-      put(RunningTaskKey, 8);
-      put(SuspendedTaskKey, 9);
-      put(CompletedEvaluatorKey, 10);
-      put(ClosedContextKey, 11);
-      put(FailedContextKey, 12);
-      put(ContextMessageKey, 13);
-      put(DriverRestartKey, 14);
-      put(DriverRestartActiveContextKey, 15);
-      put(DriverRestartRunningTaskKey, 16);
+      put(ALLOCATED_EVALUATOR_KEY, 1);
+      put(ACTIVE_CONTEXT_KEY, 2);
+      put(TASK_MESSAGE_KEY, 3);
+      put(FAILED_TASK_KEY, 4);
+      put(FAILED_EVALUATOR_KEY, 5);
+      put(HTTP_SERVER_KEY, 6);
+      put(COMPLETED_TASK_KEY, 7);
+      put(RUNNING_TASK_KEY, 8);
+      put(SUSPENDED_TASK_KEY, 9);
+      put(COMPLETED_EVALUATOR_KEY, 10);
+      put(CLOSED_CONTEXT_KEY, 11);
+      put(FAILED_CONTEXT_KEY, 12);
+      put(CONTEXT_MESSAGE_KEY, 13);
+      put(DRIVER_RESTART_KEY, 14);
+      put(DRIVER_RESTART_ACTIVE_CONTEXT_KEY, 15);
+      put(DRIVER_RESTART_RUNNING_TASK_KEY, 16);
     }
   };
 
-  public static final int nHandlers = 17;
+  public static final int N_HANDLERS = 17;
 
   public static native void loadClrAssembly(String filePath);
 
-  public static native void ClrBufferedLog(int level, String message);
+  public static native void clrBufferedLog(int level, String message);
 
-  public static native long[] CallClrSystemOnStartHandler(
+  public static native long[] callClrSystemOnStartHandler(
       String dateTime,
       String httpServerPortNumber,
       EvaluatorRequestorBridge javaEvaluatorRequestorBridge);
 
-  public static native void ClrSystemAllocatedEvaluatorHandlerOnNext(
+  public static native void clrSystemAllocatedEvaluatorHandlerOnNext(
       long handle,
       AllocatedEvaluatorBridge javaEvaluatorBridge,
       InteropLogger interopLogger
   );
 
-  public static native void ClrSystemActiveContextHandlerOnNext(
+  public static native void clrSystemActiveContextHandlerOnNext(
       long handle,
       ActiveContextBridge javaActiveContextBridge,
       InteropLogger interopLogger
   );
 
-  public static native void ClrSystemTaskMessageHandlerOnNext(
+  public static native void clrSystemTaskMessageHandlerOnNext(
       long handle,
       byte[] mesage,
       TaskMessageBridge javaTaskMessageBridge,
       InteropLogger interopLogger
   );
 
-  public static native void ClrSystemFailedTaskHandlerOnNext(
+  public static native void clrSystemFailedTaskHandlerOnNext(
       long handle,
       FailedTaskBridge failedTaskBridge,
       InteropLogger interopLogger
   );
 
-  public static native void ClrSystemHttpServerHandlerOnNext(
+  public static native void clrSystemHttpServerHandlerOnNext(
       long handle,
       HttpServerEventBridge httpServerEventBridge,
       InteropLogger interopLogger
   );
 
-  public static native void ClrSystemFailedEvaluatorHandlerOnNext(
+  public static native void clrSystemFailedEvaluatorHandlerOnNext(
       long handle,
       FailedEvaluatorBridge failedEvaluatorBridge,
       InteropLogger interopLogger
   );
 
-  public static native void ClrSystemCompletedTaskHandlerOnNext(
+  public static native void clrSystemCompletedTaskHandlerOnNext(
       long handle,
       CompletedTaskBridge completedTaskBridge,
       InteropLogger interopLogger
   );
 
-  public static native void ClrSystemRunningTaskHandlerOnNext(
+  public static native void clrSystemRunningTaskHandlerOnNext(
       long handle,
       RunningTaskBridge runningTaskBridge,
       InteropLogger interopLogger
   );
 
-  public static native void ClrSystemSupendedTaskHandlerOnNext(
+  public static native void clrSystemSuspendedTaskHandlerOnNext(
       long handle,
       SuspendedTaskBridge suspendedTaskBridge
   );
 
-  public static native void ClrSystemCompletdEvaluatorHandlerOnNext(
+  public static native void clrSystemCompletedEvaluatorHandlerOnNext(
       long handle,
       CompletedEvaluatorBridge completedEvaluatorBridge
   );
 
-  public static native void ClrSystemClosedContextHandlerOnNext(
+  public static native void clrSystemClosedContextHandlerOnNext(
       long handle,
       ClosedContextBridge closedContextBridge
   );
 
-  public static native void ClrSystemFailedContextHandlerOnNext(
+  public static native void clrSystemFailedContextHandlerOnNext(
       long handle,
       FailedContextBridge failedContextBridge
   );
 
-  public static native void ClrSystemContextMessageHandlerOnNext(
+  public static native void clrSystemContextMessageHandlerOnNext(
       long handle,
       ContextMessageBridge contextMessageBridge
   );
 
-  public static native void ClrSystemDriverRestartHandlerOnNext(
+  public static native void clrSystemDriverRestartHandlerOnNext(
       long handle
   );
 
-  public static native void ClrSystemDriverRestartActiveContextHandlerOnNext(
+  public static native void clrSystemDriverRestartActiveContextHandlerOnNext(
       long handle,
       ActiveContextBridge activeContextBridge
   );
 
-  public static native void ClrSystemDriverRestartRunningTaskHandlerOnNext(
+  public static native void clrSystemDriverRestartRunningTaskHandlerOnNext(
       long handle,
       RunningTaskBridge runningTaskBridge
   );

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
@@ -195,38 +195,38 @@ public final class JobDriver {
       EvaluatorRequestorBridge evaluatorRequestorBridge =
           new EvaluatorRequestorBridge(JobDriver.this.evaluatorRequestor, false, loggingScopeFactory);
       long[] handlers =
-          NativeInterop.CallClrSystemOnStartHandler(startTime.toString(), portNumber, evaluatorRequestorBridge);
+          NativeInterop.callClrSystemOnStartHandler(startTime.toString(), portNumber, evaluatorRequestorBridge);
       if (handlers != null) {
-        if (handlers.length != NativeInterop.nHandlers) {
+        if (handlers.length != NativeInterop.N_HANDLERS) {
           throw new RuntimeException(
               String.format("%s handlers initialized in CLR while native bridge is expecting %s handlers",
                   String.valueOf(handlers.length),
-                  String.valueOf(NativeInterop.nHandlers)));
+                  String.valueOf(NativeInterop.N_HANDLERS)));
         }
-        this.allocatedEvaluatorHandler = handlers[NativeInterop.Handlers.get(NativeInterop.AllocatedEvaluatorKey)];
-        this.activeContextHandler = handlers[NativeInterop.Handlers.get(NativeInterop.ActiveContextKey)];
-        this.taskMessageHandler = handlers[NativeInterop.Handlers.get(NativeInterop.TaskMessageKey)];
-        this.failedTaskHandler = handlers[NativeInterop.Handlers.get(NativeInterop.FailedTaskKey)];
-        this.failedEvaluatorHandler = handlers[NativeInterop.Handlers.get(NativeInterop.FailedEvaluatorKey)];
-        this.httpServerEventHandler = handlers[NativeInterop.Handlers.get(NativeInterop.HttpServerKey)];
-        this.completedTaskHandler = handlers[NativeInterop.Handlers.get(NativeInterop.CompletedTaskKey)];
-        this.runningTaskHandler = handlers[NativeInterop.Handlers.get(NativeInterop.RunningTaskKey)];
-        this.suspendedTaskHandler = handlers[NativeInterop.Handlers.get(NativeInterop.SuspendedTaskKey)];
-        this.completedEvaluatorHandler = handlers[NativeInterop.Handlers.get(NativeInterop.CompletedEvaluatorKey)];
-        this.closedContextHandler = handlers[NativeInterop.Handlers.get(NativeInterop.ClosedContextKey)];
-        this.failedContextHandler = handlers[NativeInterop.Handlers.get(NativeInterop.FailedContextKey)];
-        this.contextMessageHandler = handlers[NativeInterop.Handlers.get(NativeInterop.ContextMessageKey)];
-        this.driverRestartHandler = handlers[NativeInterop.Handlers.get(NativeInterop.DriverRestartKey)];
+        this.allocatedEvaluatorHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.ALLOCATED_EVALUATOR_KEY)];
+        this.activeContextHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.ACTIVE_CONTEXT_KEY)];
+        this.taskMessageHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.TASK_MESSAGE_KEY)];
+        this.failedTaskHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.FAILED_TASK_KEY)];
+        this.failedEvaluatorHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.FAILED_EVALUATOR_KEY)];
+        this.httpServerEventHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.HTTP_SERVER_KEY)];
+        this.completedTaskHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.COMPLETED_TASK_KEY)];
+        this.runningTaskHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.RUNNING_TASK_KEY)];
+        this.suspendedTaskHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.SUSPENDED_TASK_KEY)];
+        this.completedEvaluatorHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.COMPLETED_EVALUATOR_KEY)];
+        this.closedContextHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.CLOSED_CONTEXT_KEY)];
+        this.failedContextHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.FAILED_CONTEXT_KEY)];
+        this.contextMessageHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.CONTEXT_MESSAGE_KEY)];
+        this.driverRestartHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.DRIVER_RESTART_KEY)];
         this.driverRestartActiveContextHandler =
-            handlers[NativeInterop.Handlers.get(NativeInterop.DriverRestartActiveContextKey)];
+            handlers[NativeInterop.HANDLERS.get(NativeInterop.DRIVER_RESTART_ACTIVE_CONTEXT_KEY)];
         this.driverRestartRunningTaskHandler =
-            handlers[NativeInterop.Handlers.get(NativeInterop.DriverRestartRunningTaskKey)];
+            handlers[NativeInterop.HANDLERS.get(NativeInterop.DRIVER_RESTART_RUNNING_TASK_KEY)];
       }
 
       try (final LoggingScope lp =
-               this.loggingScopeFactory.getNewLoggingScope("setupBridge::ClrSystemHttpServerHandlerOnNext")) {
+               this.loggingScopeFactory.getNewLoggingScope("setupBridge::clrSystemHttpServerHandlerOnNext")) {
         final HttpServerEventBridge httpServerEventBridge = new HttpServerEventBridge("SPEC");
-        NativeInterop.ClrSystemHttpServerHandlerOnNext(this.httpServerEventHandler, httpServerEventBridge,
+        NativeInterop.clrSystemHttpServerHandlerOnNext(this.httpServerEventHandler, httpServerEventBridge,
             this.interopLogger);
         final String specList = httpServerEventBridge.getUriSpecification();
         LOG.log(Level.INFO, "Starting http server, getUriSpecification: {0}", specList);
@@ -263,7 +263,7 @@ public final class JobDriver {
       }
       AllocatedEvaluatorBridge allocatedEvaluatorBridge =
           new AllocatedEvaluatorBridge(eval, JobDriver.this.nameServerInfo);
-      NativeInterop.ClrSystemAllocatedEvaluatorHandlerOnNext(JobDriver.this.allocatedEvaluatorHandler,
+      NativeInterop.clrSystemAllocatedEvaluatorHandlerOnNext(JobDriver.this.allocatedEvaluatorHandler,
           allocatedEvaluatorBridge, this.interopLogger);
     }
   }
@@ -278,7 +278,7 @@ public final class JobDriver {
         throw new RuntimeException("Active Context Handler not initialized by CLR.");
       }
       ActiveContextBridge activeContextBridge = activeContextBridgeFactory.getActiveContextBridge(context);
-      NativeInterop.ClrSystemActiveContextHandlerOnNext(JobDriver.this.activeContextHandler, activeContextBridge,
+      NativeInterop.clrSystemActiveContextHandlerOnNext(JobDriver.this.activeContextHandler, activeContextBridge,
           JobDriver.this.interopLogger);
     } catch (final Exception ex) {
       LOG.log(Level.SEVERE, "Fail to submit task to active context");
@@ -341,7 +341,7 @@ public final class JobDriver {
         } else {
           LOG.log(Level.INFO, "CLR CompletedTaskHandler handler set, handling things with CLR handler.");
           CompletedTaskBridge completedTaskBridge = new CompletedTaskBridge(task, activeContextBridgeFactory);
-          NativeInterop.ClrSystemCompletedTaskHandlerOnNext(JobDriver.this.completedTaskHandler, completedTaskBridge,
+          NativeInterop.clrSystemCompletedTaskHandlerOnNext(JobDriver.this.completedTaskHandler, completedTaskBridge,
               JobDriver.this.interopLogger);
         }
       }
@@ -397,7 +397,7 @@ public final class JobDriver {
       LOG.log(Level.INFO, message);
       FailedEvaluatorBridge failedEvaluatorBridge = new FailedEvaluatorBridge(eval, JobDriver.this.evaluatorRequestor,
           JobDriver.this.isRestarted, loggingScopeFactory);
-      NativeInterop.ClrSystemFailedEvaluatorHandlerOnNext(JobDriver.this.failedEvaluatorHandler, failedEvaluatorBridge,
+      NativeInterop.clrSystemFailedEvaluatorHandlerOnNext(JobDriver.this.failedEvaluatorHandler, failedEvaluatorBridge,
           JobDriver.this.interopLogger);
       int additionalRequestedEvaluatorNumber = failedEvaluatorBridge.getNewlyRequestedEvaluatorNumber();
       if (additionalRequestedEvaluatorNumber > 0) {
@@ -440,7 +440,7 @@ public final class JobDriver {
 
         try {
           final HttpServerEventBridge httpServerEventBridge = new HttpServerEventBridge(requestBytes);
-          NativeInterop.ClrSystemHttpServerHandlerOnNext(JobDriver.this.httpServerEventHandler, httpServerEventBridge,
+          NativeInterop.clrSystemHttpServerHandlerOnNext(JobDriver.this.httpServerEventHandler, httpServerEventBridge,
               JobDriver.this.interopLogger);
           final String responseBody = new String(httpServerEventBridge.getQueryResponseData(), "UTF-8");
           response.getWriter().println(responseBody);
@@ -466,7 +466,7 @@ public final class JobDriver {
       }
       try {
         FailedTaskBridge failedTaskBridge = new FailedTaskBridge(task, activeContextBridgeFactory);
-        NativeInterop.ClrSystemFailedTaskHandlerOnNext(JobDriver.this.failedTaskHandler, failedTaskBridge,
+        NativeInterop.clrSystemFailedTaskHandlerOnNext(JobDriver.this.failedTaskHandler, failedTaskBridge,
             JobDriver.this.interopLogger);
       } catch (final Exception ex) {
         LOG.log(Level.SEVERE, "Fail to invoke CLR failed task handler");
@@ -488,7 +488,7 @@ public final class JobDriver {
           LOG.log(Level.INFO, "RunningTask will be handled by CLR handler. Task Id: {0}", task.getId());
           try {
             final RunningTaskBridge runningTaskBridge = new RunningTaskBridge(task, activeContextBridgeFactory);
-            NativeInterop.ClrSystemRunningTaskHandlerOnNext(JobDriver.this.runningTaskHandler, runningTaskBridge,
+            NativeInterop.clrSystemRunningTaskHandlerOnNext(JobDriver.this.runningTaskHandler, runningTaskBridge,
                 JobDriver.this.interopLogger);
           } catch (final Exception ex) {
             LOG.log(Level.WARNING, "Fail to invoke CLR running task handler");
@@ -512,7 +512,7 @@ public final class JobDriver {
             if (JobDriver.this.clrBridgeSetup) {
               if (JobDriver.this.driverRestartRunningTaskHandler != 0) {
                 LOG.log(Level.INFO, "CLR driver restart RunningTask handler implemented, now handle it in CLR.");
-                NativeInterop.ClrSystemDriverRestartRunningTaskHandlerOnNext(
+                NativeInterop.clrSystemDriverRestartRunningTaskHandlerOnNext(
                     JobDriver.this.driverRestartRunningTaskHandler,
                     new RunningTaskBridge(task, activeContextBridgeFactory));
               } else {
@@ -545,7 +545,7 @@ public final class JobDriver {
             if (JobDriver.this.clrBridgeSetup) {
               if (JobDriver.this.driverRestartActiveContextHandler != 0) {
                 LOG.log(Level.INFO, "CLR driver restart ActiveContext handler implemented, now handle it in CLR.");
-                NativeInterop.ClrSystemDriverRestartActiveContextHandlerOnNext(
+                NativeInterop.clrSystemDriverRestartActiveContextHandlerOnNext(
                     JobDriver.this.driverRestartActiveContextHandler,
                     activeContextBridgeFactory.getActiveContextBridge(context));
               } else {
@@ -610,7 +610,7 @@ public final class JobDriver {
       try (final LoggingScope ls = loggingScopeFactory.driverRestartCompleted(driverRestartCompleted.getTimeStamp())) {
         if (JobDriver.this.driverRestartHandler != 0) {
           LOG.log(Level.INFO, "CLR driver restart handler implemented, now handle it in CLR.");
-          NativeInterop.ClrSystemDriverRestartHandlerOnNext(JobDriver.this.driverRestartHandler);
+          NativeInterop.clrSystemDriverRestartHandlerOnNext(JobDriver.this.driverRestartHandler);
         } else {
           LOG.log(Level.WARNING, "No CLR driver restart handler implemented, done with DriverRestartCompletedHandler.");
 
@@ -643,7 +643,7 @@ public final class JobDriver {
       if (JobDriver.this.taskMessageHandler != 0) {
         TaskMessageBridge taskMessageBridge = new TaskMessageBridge(taskMessage);
         // if CLR implements the task message handler, handle the bytes in CLR handler
-        NativeInterop.ClrSystemTaskMessageHandlerOnNext(JobDriver.this.taskMessageHandler, taskMessage.get(),
+        NativeInterop.clrSystemTaskMessageHandlerOnNext(JobDriver.this.taskMessageHandler, taskMessage.get(),
             taskMessageBridge, JobDriver.this.interopLogger);
       }
       //}
@@ -663,7 +663,7 @@ public final class JobDriver {
           SuspendedTaskBridge suspendedTaskBridge = new SuspendedTaskBridge(task, activeContextBridgeFactory);
           // if CLR implements the suspended task handler, handle it in CLR
           LOG.log(Level.INFO, "Handling the event of suspended task in CLR bridge.");
-          NativeInterop.ClrSystemSupendedTaskHandlerOnNext(JobDriver.this.suspendedTaskHandler, suspendedTaskBridge);
+          NativeInterop.clrSystemSuspendedTaskHandlerOnNext(JobDriver.this.suspendedTaskHandler, suspendedTaskBridge);
         }
         JobDriver.this.jobMessageObserver.sendMessageToClient(JVM_CODEC.encode(message));
       }
@@ -682,7 +682,7 @@ public final class JobDriver {
           CompletedEvaluatorBridge completedEvaluatorBridge = new CompletedEvaluatorBridge(evaluator);
           // if CLR implements the completed evaluator handler, handle it in CLR
           LOG.log(Level.INFO, "Handling the event of completed evaluator in CLR bridge.");
-          NativeInterop.ClrSystemCompletdEvaluatorHandlerOnNext(completedEvaluatorHandler, completedEvaluatorBridge);
+          NativeInterop.clrSystemCompletedEvaluatorHandlerOnNext(completedEvaluatorHandler, completedEvaluatorBridge);
         }
       }
     }
@@ -702,7 +702,7 @@ public final class JobDriver {
           ClosedContextBridge closedContextBridge = new ClosedContextBridge(context, activeContextBridgeFactory);
           // if CLR implements the closed context handler, handle it in CLR
           LOG.log(Level.INFO, "Handling the event of closed context in CLR bridge.");
-          NativeInterop.ClrSystemClosedContextHandlerOnNext(JobDriver.this.closedContextHandler, closedContextBridge);
+          NativeInterop.clrSystemClosedContextHandlerOnNext(JobDriver.this.closedContextHandler, closedContextBridge);
         }
         synchronized (JobDriver.this) {
           JobDriver.this.contexts.remove(context.getId());
@@ -725,7 +725,7 @@ public final class JobDriver {
           FailedContextBridge failedContextBridge = new FailedContextBridge(context, activeContextBridgeFactory);
           // if CLR implements the failed context handler, handle it in CLR
           LOG.log(Level.INFO, "Handling the event of failed context in CLR bridge.");
-          NativeInterop.ClrSystemFailedContextHandlerOnNext(JobDriver.this.failedContextHandler, failedContextBridge);
+          NativeInterop.clrSystemFailedContextHandlerOnNext(JobDriver.this.failedContextHandler, failedContextBridge);
         }
         synchronized (JobDriver.this) {
           JobDriver.this.contexts.remove(context.getId());
@@ -750,7 +750,7 @@ public final class JobDriver {
           ContextMessageBridge contextMessageBridge = new ContextMessageBridge(message);
           // if CLR implements the context message handler, handle it in CLR
           LOG.log(Level.INFO, "Handling the event of context message in CLR bridge.");
-          NativeInterop.ClrSystemContextMessageHandlerOnNext(JobDriver.this.contextMessageHandler,
+          NativeInterop.clrSystemContextMessageHandlerOnNext(JobDriver.this.contextMessageHandler,
               contextMessageBridge);
         }
       }

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/util/logging/CLRBufferedLogHandler.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/util/logging/CLRBufferedLogHandler.java
@@ -141,7 +141,7 @@ public class CLRBufferedLogHandler extends Handler {
       }
       try {
         final int level = getLevel(highestLevel);
-        NativeInterop.ClrBufferedLog(level, sb.toString());
+        NativeInterop.clrBufferedLog(level, sb.toString());
       } catch (Exception e) {
         System.err.println("Failed to perform CLRBufferedLogHandler");
       }

--- a/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/fs/FSCheckPointServiceConfiguration.java
+++ b/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/fs/FSCheckPointServiceConfiguration.java
@@ -66,13 +66,13 @@ public class FSCheckPointServiceConfiguration extends ConfigurationModuleBuilder
    */
   public static final OptionalParameter<String> PREFIX = new OptionalParameter<>();
   public static final ConfigurationModule CONF = new FSCheckPointServiceConfiguration()
-      .bindImplementation(CheckpointService.class, FSCheckpointService.class) // Use the HDFS based ccheckpoints
+      .bindImplementation(CheckpointService.class, FSCheckpointService.class) // Use the HDFS based checkpoints
       .bindImplementation(CheckpointNamingService.class, RandomNameCNS.class) // Use Random Names for the checkpoints
       .bindImplementation(CheckpointID.class, FSCheckpointID.class)
       .bindConstructor(FileSystem.class, FileSystemConstructor.class)
-      .bindNamedParameter(FileSystemConstructor.IS_LOCAL.class, IS_LOCAL)
+      .bindNamedParameter(FileSystemConstructor.IsLocal.class, IS_LOCAL)
       .bindNamedParameter(FSCheckpointService.PATH.class, PATH)
-      .bindNamedParameter(FSCheckpointService.REPLICATION_FACTOR.class, REPLICATION_FACTOR)
+      .bindNamedParameter(FSCheckpointService.ReplicationFactor.class, REPLICATION_FACTOR)
       .bindNamedParameter(RandomNameCNS.PREFIX.class, PREFIX)
       .build();
 
@@ -89,7 +89,7 @@ public class FSCheckPointServiceConfiguration extends ConfigurationModuleBuilder
     private final boolean loadConfig;
 
     @Inject
-    public FileSystemConstructor(@Parameter(IS_LOCAL.class) final boolean isLocal) {
+    public FileSystemConstructor(@Parameter(IsLocal.class) final boolean isLocal) {
       this.loadConfig = !isLocal;
     }
 
@@ -104,7 +104,7 @@ public class FSCheckPointServiceConfiguration extends ConfigurationModuleBuilder
     }
 
     @NamedParameter(doc = "Use local file system if true; otherwise, use HDFS.")
-    static class IS_LOCAL implements Name<Boolean> {
+    static class IsLocal implements Name<Boolean> {
     }
   }
 }

--- a/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/fs/FSCheckpointService.java
+++ b/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/fs/FSCheckpointService.java
@@ -51,7 +51,7 @@ public class FSCheckpointService implements CheckpointService {
   FSCheckpointService(final FileSystem fs,
                       @Parameter(PATH.class) final String basePath,
                       final CheckpointNamingService namingPolicy,
-                      @Parameter(REPLICATION_FACTOR.class) final short replication) {
+                      @Parameter(ReplicationFactor.class) final short replication) {
     this.fs = fs;
     this.base = new Path(basePath);
     this.namingPolicy = namingPolicy;
@@ -155,7 +155,7 @@ public class FSCheckpointService implements CheckpointService {
   }
 
   @NamedParameter(doc = "The replication factor to be used for the stored checkpoints", default_value = "3")
-  static class REPLICATION_FACTOR implements Name<Short> {
+  static class ReplicationFactor implements Name<Short> {
   }
 
   private static class FSCheckpointWriteChannel

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverLauncher.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverLauncher.java
@@ -191,7 +191,7 @@ public final class DriverLauncher {
       final Optional<Throwable> ex = job.getReason();
       LOG.log(Level.SEVERE, "Received an error for job " + job.getId(), ex);
       theJob = null;
-      setStatusAndNotify(LauncherStatus.FAILED(ex));
+      setStatusAndNotify(LauncherStatus.failed(ex));
     }
   }
 
@@ -215,7 +215,7 @@ public final class DriverLauncher {
     public void onNext(final FailedRuntime error) {
       LOG.log(Level.SEVERE, "Received a resourcemanager error", error.getReason());
       theJob = null;
-      setStatusAndNotify(LauncherStatus.FAILED(error.getReason()));
+      setStatusAndNotify(LauncherStatus.failed(error.getReason()));
     }
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/LauncherStatus.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/LauncherStatus.java
@@ -43,12 +43,30 @@ public final class LauncherStatus {
     this.error = Optional.ofNullable(ex);
   }
 
-  public static LauncherStatus FAILED(final Throwable ex) {
+  public static LauncherStatus failed(final Throwable ex) {
     return new LauncherStatus(State.FAILED, ex);
   }
 
-  public static LauncherStatus FAILED(final Optional<Throwable> ex) {
+  /**
+   * @deprecated in 0.12. Use Failed instead
+   */
+  @Deprecated
+  @SuppressWarnings("checkstyle:methodname")
+  public static LauncherStatus FAILED(final Throwable ex) {
+    return failed(ex);
+  }
+
+  public static LauncherStatus failed(final Optional<Throwable> ex) {
     return new LauncherStatus(State.FAILED, ex.orElse(null));
+  }
+
+  /**
+   * @deprecated in 0.12. Use Failed instead
+   */
+  @Deprecated
+  @SuppressWarnings("checkstyle:methodname")
+  public static LauncherStatus FAILED(final Optional<Throwable> ex) {
+    return failed(ex);
   }
 
   public Optional<Throwable> getError() {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/ContextRepresenters.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/ContextRepresenters.java
@@ -212,7 +212,7 @@ public final class ContextRepresenters {
     this.addContext(context);
     if (contextStatusProto.getRecovery()) {
       // when we get a recovered active context, always notify application
-      this.messageDispatcher.OnDriverRestartContextActive(context);
+      this.messageDispatcher.onDriverRestartContextActive(context);
     } else {
       if (notifyClientOnNewActiveContext) {
         this.messageDispatcher.onContextActive(context);

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
@@ -331,7 +331,7 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
           LOG.log(Level.INFO, "All [{0}] expected evaluators have checked in. Recovery completed.",
               expectedEvaluatorsNumber);
           this.driverStatusManager.setRestartCompleted();
-          this.messageDispatcher.OnDriverRestartCompleted(new DriverRestartCompleted(System.currentTimeMillis()));
+          this.messageDispatcher.onDriverRestartCompleted(new DriverRestartCompleted(System.currentTimeMillis()));
         } else {
           LOG.log(Level.INFO, "expecting [{0}] recovered evaluators, [{1}] evaluators have checked in.",
               new Object[]{expectedEvaluatorsNumber, numRecoveredContainers});

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorMessageDispatcher.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorMessageDispatcher.java
@@ -236,12 +236,30 @@ public final class EvaluatorMessageDispatcher {
     this.dispatchForRestartedDriver(RunningTask.class, runningTask);
   }
 
-  public void OnDriverRestartContextActive(final ActiveContext activeContext) {
+  public void onDriverRestartContextActive(final ActiveContext activeContext) {
     this.dispatchForRestartedDriver(ActiveContext.class, activeContext);
   }
 
-  public void OnDriverRestartCompleted(final DriverRestartCompleted restartCompleted) {
+  /*
+   * @deprecated in 0.12. Use onDriverRestartContextActive instead
+   */
+  @Deprecated
+  @SuppressWarnings("checkstyle:methodname")
+  public void OnDriverRestartContextActive1(final ActiveContext activeContext) {
+    onDriverRestartContextActive(activeContext);
+  }
+
+  public void onDriverRestartCompleted(final DriverRestartCompleted restartCompleted) {
     this.dispatchForRestartedDriver(DriverRestartCompleted.class, restartCompleted);
+  }
+
+  /*
+   * @deprecated in 0.12. Use onDriverRestartCompleted instead
+   */
+  @Deprecated
+  @SuppressWarnings("checkstyle:methodname")
+  public void OnDriverRestartCompleted1(final DriverRestartCompleted restartCompleted) {
+    onDriverRestartCompleted(restartCompleted);
   }
 
   boolean isEmpty() {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/EvaluatorConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/EvaluatorConfiguration.java
@@ -45,9 +45,9 @@ public final class EvaluatorConfiguration extends ConfigurationModuleBuilder {
   public static final OptionalParameter<String> APPLICATION_IDENTIFIER = new OptionalParameter<>();
 
   /**
-   * The EvaluatorConfigModuleBuilder which contains bindings shared for all kinds of Evaluators.
+   * The EVALUATOR_CONFIG_MODULE_BUILDER which contains bindings shared for all kinds of Evaluators.
    */
-  private static final ConfigurationModuleBuilder EvaluatorConfigModuleBuilder = new EvaluatorConfiguration()
+  private static final ConfigurationModuleBuilder EVALUATOR_CONFIG_MODULE_BUILDER = new EvaluatorConfiguration()
       .bindSetEntry(Clock.RuntimeStartHandler.class, EvaluatorRuntime.RuntimeStartHandler.class)
       .bindSetEntry(Clock.RuntimeStopHandler.class, EvaluatorRuntime.RuntimeStopHandler.class)
       .bindNamedParameter(DriverRemoteIdentifier.class, DRIVER_REMOTE_IDENTIFIER)
@@ -63,12 +63,12 @@ public final class EvaluatorConfiguration extends ConfigurationModuleBuilder {
   /**
    * This is ConfigurationModule for CLR Evaluator.
    */
-  public static final ConfigurationModule CONFCLR = EvaluatorConfigModuleBuilder.build();
+  public static final ConfigurationModule CONFCLR = EVALUATOR_CONFIG_MODULE_BUILDER.build();
 
   /**
    * This is ConfigurationModule for Java Evaluator.
    */
-  public static final ConfigurationModule CONF = EvaluatorConfigModuleBuilder
+  public static final ConfigurationModule CONF = EVALUATOR_CONFIG_MODULE_BUILDER
       .bindConstructor(ExecutorService.class, ExecutorServiceConstructor.class)
       .build();
 

--- a/lang/java/reef-common/src/main/resources/checkstyle.xml
+++ b/lang/java/reef-common/src/main/resources/checkstyle.xml
@@ -87,23 +87,15 @@
 
         <!-- Checks for Naming Conventions.                  -->
         <!-- See http://checkstyle.sf.net/config_naming.html -->
-        <module name="ConstantName">
-            <property name="severity" value="warning"/>
-        </module>
+        <module name="ConstantName"/>
         <module name="LocalFinalVariableName"/>
         <module name="LocalVariableName"/>
         <module name="MemberName"/>
-        <module name="MethodName">
-            <property name="severity" value="warning"/>
-        </module>
+        <module name="MethodName"/>
         <module name="PackageName"/>
         <module name="ParameterName"/>
-        <module name="StaticVariableName">
-            <property name="severity" value="warning"/>
-        </module>
-        <module name="TypeName">
-            <property name="severity" value="warning"/>
-        </module>
+        <module name="StaticVariableName"/>
+        <module name="TypeName"/>
 
 
         <!-- Checks for Headers                                -->

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloReefYarnTcp.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloReefYarnTcp.java
@@ -79,13 +79,13 @@ public final class HelloReefYarnTcp {
    * @throws org.apache.reef.tang.exceptions.BindException      configuration error.
    * @throws org.apache.reef.tang.exceptions.InjectionException configuration error.
    */
-  public static final int defaultTcpBeginPort = 8900;
-  public static final int defaultTcpRangeCount = 10;
-  public static final int defaultTcpRangeTryCount = 1111;
+  public static final int DEFAULT_TCP_BEGIN_PORT = 8900;
+  public static final int DEFAULT_TCP_RANGE_COUNT = 10;
+  public static final int DEFAULT_TCP_RANGE_TRY_COUNT = 1111;
   public static void main(final String[] args) throws InjectionException {
-    final int tcpBeginPort = args.length > 0 ? Integer.valueOf(args[0]) : defaultTcpBeginPort;
-    final int tcpRangeCount = args.length > 1 ? Integer.valueOf(args[1]) : defaultTcpRangeCount;
-    final int tcpTryCount = args.length > 2 ? Integer.valueOf(args[2]) : defaultTcpRangeTryCount;
+    final int tcpBeginPort = args.length > 0 ? Integer.valueOf(args[0]) : DEFAULT_TCP_BEGIN_PORT;
+    final int tcpRangeCount = args.length > 1 ? Integer.valueOf(args[1]) : DEFAULT_TCP_RANGE_COUNT;
+    final int tcpTryCount = args.length > 2 ? Integer.valueOf(args[2]) : DEFAULT_TCP_RANGE_TRY_COUNT;
     Configuration runtimeConfiguration = getRuntimeConfiguration(tcpBeginPort, tcpRangeCount, tcpTryCount);
     final LauncherStatus status = DriverLauncher
         .getLauncher(runtimeConfiguration)

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/Scheduler.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/Scheduler.java
@@ -89,20 +89,20 @@ final class Scheduler {
    */
   public synchronized SchedulerResponse cancelTask(final int taskId) {
     if (getTask(taskId, runningTasks) != null) {
-      return SchedulerResponse.FORBIDDEN("The task " + taskId + " is running");
+      return SchedulerResponse.forbidden("The task " + taskId + " is running");
     } else if (getTask(taskId, finishedTasks) != null) {
-      return SchedulerResponse.FORBIDDEN("The task " + taskId + " has been finished");
+      return SchedulerResponse.forbidden("The task " + taskId + " has been finished");
     }
 
     final TaskEntity task = getTask(taskId, taskQueue);
     if (task == null) {
       final String message =
           new StringBuilder().append("Task with ID ").append(taskId).append(" is not found").toString();
-      return SchedulerResponse.NOT_FOUND(message);
+      return SchedulerResponse.notFound(message);
     } else {
       taskQueue.remove(task);
       canceledTasks.add(task);
-      return SchedulerResponse.OK("Canceled " + taskId);
+      return SchedulerResponse.ok("Canceled " + taskId);
     }
   }
 
@@ -115,7 +115,7 @@ final class Scheduler {
       canceledTasks.add(task);
     }
     taskQueue.clear();
-    return SchedulerResponse.OK(count + " tasks removed.");
+    return SchedulerResponse.ok(count + " tasks removed.");
   }
 
   /**
@@ -142,7 +142,7 @@ final class Scheduler {
     for (final TaskEntity canceled : canceledTasks) {
       sb.append(" ").append(canceled.getId());
     }
-    return SchedulerResponse.OK(sb.toString());
+    return SchedulerResponse.ok(sb.toString());
   }
 
   /**
@@ -152,28 +152,28 @@ final class Scheduler {
 
     for (final TaskEntity running : runningTasks) {
       if (taskId == running.getId()) {
-        return SchedulerResponse.OK("Running : " + running.toString());
+        return SchedulerResponse.ok("Running : " + running.toString());
       }
     }
 
     for (final TaskEntity waiting : taskQueue) {
       if (taskId == waiting.getId()) {
-        return SchedulerResponse.OK("Waiting : " + waiting.toString());
+        return SchedulerResponse.ok("Waiting : " + waiting.toString());
       }
     }
 
     for (final TaskEntity finished : finishedTasks) {
       if (taskId == finished.getId()) {
-        return SchedulerResponse.OK("Finished : " + finished.toString());
+        return SchedulerResponse.ok("Finished : " + finished.toString());
       }
     }
 
     for (final TaskEntity finished : canceledTasks) {
       if (taskId == finished.getId()) {
-        return SchedulerResponse.OK("Canceled: " + finished.toString());
+        return SchedulerResponse.ok("Canceled: " + finished.toString());
       }
     }
-    return SchedulerResponse.NOT_FOUND(
+    return SchedulerResponse.notFound(
         new StringBuilder().append("Task with ID ").append(taskId).append(" is not found").toString());
   }
 

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerDriver.java
@@ -189,7 +189,7 @@ public final class SchedulerDriver {
    */
   public SchedulerResponse getTaskStatus(List<String> args) {
     if (args.size() != 1) {
-      return SchedulerResponse.BAD_REQUEST("Usage : only one ID at a time");
+      return SchedulerResponse.badRequest("Usage : only one ID at a time");
     }
 
     final Integer taskId = Integer.valueOf(args.get(0));
@@ -205,7 +205,7 @@ public final class SchedulerDriver {
    */
   public SchedulerResponse cancelTask(final List<String> args) {
     if (args.size() != 1) {
-      return SchedulerResponse.BAD_REQUEST("Usage : only one ID at a time");
+      return SchedulerResponse.badRequest("Usage : only one ID at a time");
     }
 
     final Integer taskId = Integer.valueOf(args.get(0));
@@ -220,7 +220,7 @@ public final class SchedulerDriver {
    */
   public SchedulerResponse submitCommands(final List<String> args) {
     if (args.size() != 1) {
-      return SchedulerResponse.BAD_REQUEST("Usage : only one command at a time");
+      return SchedulerResponse.badRequest("Usage : only one command at a time");
     }
 
     final String command = args.get(0);
@@ -236,7 +236,7 @@ public final class SchedulerDriver {
         requestEvaluator(1);
       }
     }
-    return SchedulerResponse.OK("Task ID : " + id);
+    return SchedulerResponse.ok("Task ID : " + id);
   }
 
   /**
@@ -246,15 +246,15 @@ public final class SchedulerDriver {
    */
   public SchedulerResponse setMaxEvaluators(final List<String> args) {
     if (args.size() != 1) {
-      return SchedulerResponse.BAD_REQUEST("Usage : Only one value can be used");
+      return SchedulerResponse.badRequest("Usage : Only one value can be used");
     }
 
     final int nTarget = Integer.valueOf(args.get(0));
 
     synchronized (SchedulerDriver.this) {
       if (nTarget < nActiveEval + nRequestedEval) {
-        return SchedulerResponse.FORBIDDEN(nActiveEval + nRequestedEval +
-          " evaluators are used now. Should be larger than that.");
+        return SchedulerResponse.forbidden(nActiveEval + nRequestedEval +
+            " evaluators are used now. Should be larger than that.");
       }
       nMaxEval = nTarget;
 
@@ -263,7 +263,7 @@ public final class SchedulerDriver {
             Math.min(scheduler.getNumPendingTasks(), nMaxEval - nActiveEval) - nRequestedEval;
         requestEvaluator(nToRequest);
       }
-      return SchedulerResponse.OK("You can use evaluators up to " + nMaxEval + " evaluators.");
+      return SchedulerResponse.ok("You can use evaluators up to " + nMaxEval + " evaluators.");
     }
   }
 

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerHttpHandler.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerHttpHandler.java
@@ -91,7 +91,7 @@ final class SchedulerHttpHandler implements HttpHandler {
       result = schedulerDriver.get().setMaxEvaluators(queryMap.get("num"));
       break;
     default:
-      result = SchedulerResponse.NOT_FOUND("Unsupported operation");
+      result = SchedulerResponse.notFound("Unsupported operation");
     }
 
     // Send response to the http client

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerResponse.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/SchedulerResponse.java
@@ -46,28 +46,28 @@ final class SchedulerResponse {
   /**
    * Create a response with OK status.
    */
-  public static SchedulerResponse OK(final String message){
+  public static SchedulerResponse ok(final String message){
     return new SchedulerResponse(SC_OK, message);
   }
 
   /**
    * Create a response with BAD_REQUEST status.
    */
-  public static SchedulerResponse BAD_REQUEST(final String message){
+  public static SchedulerResponse badRequest(final String message){
     return new SchedulerResponse(SC_BAD_REQUEST, message);
   }
 
   /**
    * Create a response with FORBIDDEN status.
    */
-  public static SchedulerResponse FORBIDDEN(final String message){
+  public static SchedulerResponse forbidden(final String message){
     return new SchedulerResponse(SC_FORBIDDEN, message);
   }
 
   /**
    * Create a response with NOT FOUND status.
    */
-  public static SchedulerResponse NOT_FOUND(final String message){
+  public static SchedulerResponse notFound(final String message){
     return new SchedulerResponse(SC_NOT_FOUND, message);
   }
 

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosDriverConfiguration.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosDriverConfiguration.java
@@ -73,11 +73,11 @@ public final class MesosDriverConfiguration extends ConfigurationModuleBuilder {
   public static final OptionalParameter<Double> JVM_HEAP_SLACK = new OptionalParameter<>();
 
   /**
-   * Capacity for runnning Mesos Scheduler Driver.
+   * Capacity for running Mesos Scheduler Driver.
    */
   public static final RequiredParameter<Integer> SCHEDULER_DRIVER_CAPACITY = new RequiredParameter<>();
 
-  public static ConfigurationModule CONF = new MesosDriverConfiguration()
+  public static final ConfigurationModule CONF = new MesosDriverConfiguration()
       .bindImplementation(ResourceLaunchHandler.class, MesosResourceLaunchHandler.class)
       .bindImplementation(ResourceReleaseHandler.class, MesosResourceReleaseHandler.class)
       .bindImplementation(ResourceRequestHandler.class, MesosResourceRequestHandler.class)

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverConfiguration.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverConfiguration.java
@@ -75,7 +75,7 @@ public class YarnDriverConfiguration extends ConfigurationModuleBuilder {
   public static final OptionalParameter<Double> JVM_HEAP_SLACK = new OptionalParameter<>();
 
 
-  public static ConfigurationModule CONF = new YarnDriverConfiguration()
+  public static final ConfigurationModule CONF = new YarnDriverConfiguration()
       // Bind the YARN runtime for the resource manager.
       .bindImplementation(ResourceLaunchHandler.class, YARNResourceLaunchHandler.class)
       .bindImplementation(ResourceReleaseHandler.class, YARNResourceReleaseHandler.class)

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/AvroConfigurationSerializer.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/AvroConfigurationSerializer.java
@@ -87,7 +87,7 @@ public final class AvroConfigurationSerializer implements ConfigurationSerialize
         String value = rawValue.toString();
         if (key.equals(ConfigurationBuilderImpl.IMPORT)) {
           configurationBuilder.getClassHierarchy().getNode(value);
-          final String[] tok = value.split(ReflectionUtilities.regexp);
+          final String[] tok = value.split(ReflectionUtilities.REGEXP);
           final String lastTok = tok[tok.length - 1];
           try {
             configurationBuilder.getClassHierarchy().getNode(lastTok);

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationFile.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationFile.java
@@ -118,7 +118,7 @@ public final class ConfigurationFile {
         try {
           if (key.equals(ConfigurationBuilderImpl.IMPORT)) {
             ci.getClassHierarchy().getNode(value);
-            final String[] tok = value.split(ReflectionUtilities.regexp);
+            final String[] tok = value.split(ReflectionUtilities.REGEXP);
             final String lastTok = tok[tok.length - 1];
             try {
               // ci.namespace.getNode(lastTok);

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/ReflectionUtilities.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/ReflectionUtilities.java
@@ -31,7 +31,15 @@ public final class ReflectionUtilities {
   /**
    * This is used to split Java classnames.  Currently, we split on . and on $
    */
+  public static final String REGEXP = "[\\.\\$]";
+  /**
+   * This is used to split Java classnames.  Currently, we split on . and on $
+   * @deprecated in 0.12. Use onClientKill instead
+   */
+  @Deprecated
+  @SuppressWarnings("checkstyle:constantname")
   public static final String regexp = "[\\.\\$]";
+
   /**
    * A map from numeric classes to the number of bits used by their representations.
    */
@@ -198,7 +206,7 @@ public final class ReflectionUtilities {
    */
   public static String getSimpleName(Type name) {
     final Class<?> clazz = getRawClass(name);
-    final String[] nameArray = clazz.getName().split(regexp);
+    final String[] nameArray = clazz.getName().split(REGEXP);
     final String ret = nameArray[nameArray.length - 1];
     if (ret.length() == 0) {
       throw new IllegalArgumentException("Class " + name + " has zero-length simple name.  Can't happen?!?");

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/TestDriverLauncher.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/TestDriverLauncher.java
@@ -114,7 +114,7 @@ public final class TestDriverLauncher {
     @Override
     public void onNext(final FailedRuntime error) {
       LOG.log(Level.INFO, "Received a runtime error: {0}", error);
-      launcher.setStatusAndNotify(LauncherStatus.FAILED(error.getReason()));
+      launcher.setStatusAndNotify(LauncherStatus.failed(error.getReason()));
     }
   }
 
@@ -126,7 +126,7 @@ public final class TestDriverLauncher {
     public void onNext(final FailedJob job) {
       final Optional<Throwable> ex = job.getReason();
       LOG.log(Level.INFO, "Received an error for job {0}: {1}", new Object[]{job.getId(), ex});
-      launcher.setStatusAndNotify(LauncherStatus.FAILED(ex));
+      launcher.setStatusAndNotify(LauncherStatus.failed(ex));
     }
   }
 }

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/messaging/driver/DriverMessaging.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/messaging/driver/DriverMessaging.java
@@ -154,7 +154,7 @@ public final class DriverMessaging {
     public void onNext(final FailedJob job) {
       LOG.log(Level.SEVERE, "Received an error for job " + job.getId(), job.getReason().orElse(null));
       synchronized (DriverMessaging.this) {
-        DriverMessaging.this.status = LauncherStatus.FAILED(job.getReason());
+        DriverMessaging.this.status = LauncherStatus.failed(job.getReason());
         DriverMessaging.this.notify();
       }
     }
@@ -165,7 +165,7 @@ public final class DriverMessaging {
     public void onNext(final FailedRuntime error) {
       LOG.log(Level.SEVERE, "Received a runtime error: " + error, error.getReason().orElse(null));
       synchronized (DriverMessaging.this) {
-        DriverMessaging.this.status = LauncherStatus.FAILED(error.getReason());
+        DriverMessaging.this.status = LauncherStatus.failed(error.getReason());
         DriverMessaging.this.notify();
       }
     }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/RangeTcpPortProvider.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/RangeTcpPortProvider.java
@@ -59,13 +59,14 @@ public final class RangeTcpPortProvider implements TcpPortProvider {
   }
 
   /**
-   * @deprecated have an instance injected instead.
+   * @deprecated in 0.12 have an instance injected instead.
    */
   @Deprecated
+  @SuppressWarnings("checkstyle:constantname")
   public static final RangeTcpPortProvider Default = new RangeTcpPortProvider(
-      Integer.parseInt(TcpPortRangeBegin.default_value),
-      Integer.parseInt(TcpPortRangeCount.default_value),
-          Integer.parseInt(TcpPortRangeTryCount.default_value));
+      Integer.parseInt(TcpPortRangeBegin.DEFAULT_VALUE),
+      Integer.parseInt(TcpPortRangeCount.DEFAULT_VALUE),
+      Integer.parseInt(TcpPortRangeTryCount.DEFAULT_VALUE));
 
   @Override
   public String toString() {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/parameters/TcpPortRangeBegin.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/parameters/TcpPortRangeBegin.java
@@ -24,9 +24,15 @@ import org.apache.reef.tang.annotations.NamedParameter;
 /**
  * First tcp port number to try.
  */
-@NamedParameter(doc = "First tcp port number to try", default_value = TcpPortRangeBegin.default_value)
+@NamedParameter(doc = "First tcp port number to try", default_value = TcpPortRangeBegin.DEFAULT_VALUE)
 public final class TcpPortRangeBegin implements Name<Integer> {
-  public static final String default_value = "10000";
+  public static final String DEFAULT_VALUE = "10000";
+  /**
+   * @deprecated in 0.12. Use DEFAULT_VALUE instead
+   */
+  @Deprecated
+  @SuppressWarnings("checkstyle:constantname")
+  public static final String default_value = DEFAULT_VALUE;
 
   /**
    * Empty private constructor to prohibit instantiation of utility class.

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/parameters/TcpPortRangeCount.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/parameters/TcpPortRangeCount.java
@@ -24,9 +24,15 @@ import org.apache.reef.tang.annotations.NamedParameter;
 /**
  * Number of tcp ports in the range.
  */
-@NamedParameter(doc = "Number of tcp ports in the range", default_value = TcpPortRangeCount.default_value)
+@NamedParameter(doc = "Number of tcp ports in the range", default_value = TcpPortRangeCount.DEFAULT_VALUE)
 public final class TcpPortRangeCount implements Name<Integer> {
-  public static final String default_value = "10000";
+  public static final String DEFAULT_VALUE = "10000";
+  /**
+   * @deprecated in 0.12. Use DEFAULT_VALUE instead
+   */
+  @Deprecated
+  @SuppressWarnings("checkstyle:constantname")
+  public static final String default_value = DEFAULT_VALUE;
 
   /**
    * Empty private constructor to prohibit instantiation of utility class.

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/parameters/TcpPortRangeTryCount.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/parameters/TcpPortRangeTryCount.java
@@ -24,9 +24,15 @@ import org.apache.reef.tang.annotations.NamedParameter;
 /**
  * Max number tries for port numbers.
  */
-@NamedParameter(doc = "Max number tries for port numbers", default_value = TcpPortRangeTryCount.default_value)
+@NamedParameter(doc = "Max number tries for port numbers", default_value = TcpPortRangeTryCount.DEFAULT_VALUE)
 public final class TcpPortRangeTryCount implements Name<Integer> {
-  public static final String default_value = "1000";
+  public static final String DEFAULT_VALUE = "1000";
+  /**
+   * @deprecated in 0.12. Use DEFAULT_VALUE instead
+   */
+  @Deprecated
+  @SuppressWarnings("checkstyle:constantname")
+  public static final String default_value = DEFAULT_VALUE;
 
   /**
    * Empty private constructor to prohibit instantiation of utility class.

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpServerReefEventHandler.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpServerReefEventHandler.java
@@ -146,7 +146,7 @@ public final class HttpServerReefEventHandler implements HttpHandler {
       response.getWriter().println("Enforced closing");
       break;
     case "kill":
-      reefStateManager.OnClientKill();
+      reefStateManager.onClientKill();
       response.getWriter().println("Killing");
       break;
     case "duration":

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/ReefEventStateManager.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/ReefEventStateManager.java
@@ -208,8 +208,18 @@ public final class ReefEventStateManager {
   /**
    * Kill driver by calling onComplete() . This method is called when client wants to kill the driver and evaluators.
    */
-  public void OnClientKill() {
+  public void onClientKill() {
     driverStatusManager.onComplete();
+  }
+
+  /**
+   * Kill driver by calling onComplete() . This method is called when client wants to kill the driver and evaluators.
+   * @deprecated in 0.12. Use onClientKill instead
+   */
+  @Deprecated
+  @SuppressWarnings("checkstyle:methodname")
+  public void OnClientKill() {
+    onClientKill();
   }
 
   /**


### PR DESCRIPTION
This addressed the issue by
  * marking misnamed fields/methods as deprecated
  * creating properly named fields/methods to duplicate the functionality of deprecated fields/methods
  * converting all checks in "Naming" category to error level

JIRA:
  [REEF-440](https://issues.apache.org/jira/browse/REEF-440)