### PR TITLE
[REEF-483] Add configuration in allowing other ways to preserve running evaluators aside from DFS

### DIFF
--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/Constants.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/Constants.java
@@ -20,6 +20,7 @@ package org.apache.reef.bridge.client;
 
 import org.apache.reef.client.DriverConfiguration;
 import org.apache.reef.client.DriverServiceConfiguration;
+import org.apache.reef.client.parameters.DriverRestartHandlersConfiguration;
 import org.apache.reef.io.network.naming.NameServerConfiguration;
 import org.apache.reef.javabridge.generic.JobDriver;
 import org.apache.reef.tang.Configuration;
@@ -40,18 +41,14 @@ public final class Constants {
       .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, JobDriver.AllocatedEvaluatorHandler.class)
       .set(DriverConfiguration.ON_EVALUATOR_FAILED, JobDriver.FailedEvaluatorHandler.class)
       .set(DriverConfiguration.ON_CONTEXT_ACTIVE, JobDriver.ActiveContextHandler.class)
-      .set(DriverConfiguration.ON_DRIVER_RESTART_CONTEXT_ACTIVE, JobDriver.DriverRestartActiveContextHandler.class)
       .set(DriverConfiguration.ON_CONTEXT_CLOSED, JobDriver.ClosedContextHandler.class)
       .set(DriverConfiguration.ON_CONTEXT_FAILED, JobDriver.FailedContextHandler.class)
       .set(DriverConfiguration.ON_CONTEXT_MESSAGE, JobDriver.ContextMessageHandler.class)
       .set(DriverConfiguration.ON_TASK_MESSAGE, JobDriver.TaskMessageHandler.class)
       .set(DriverConfiguration.ON_TASK_FAILED, JobDriver.FailedTaskHandler.class)
       .set(DriverConfiguration.ON_TASK_RUNNING, JobDriver.RunningTaskHandler.class)
-      .set(DriverConfiguration.ON_DRIVER_RESTART_TASK_RUNNING, JobDriver.DriverRestartRunningTaskHandler.class)
-      .set(DriverConfiguration.ON_DRIVER_RESTART_COMPLETED, JobDriver.DriverRestartCompletedHandler.class)
       .set(DriverConfiguration.ON_TASK_COMPLETED, JobDriver.CompletedTaskHandler.class)
       .set(DriverConfiguration.ON_DRIVER_STARTED, JobDriver.StartHandler.class)
-      .set(DriverConfiguration.ON_DRIVER_RESTARTED, JobDriver.RestartHandler.class)
       .set(DriverConfiguration.ON_TASK_SUSPENDED, JobDriver.SuspendedTaskHandler.class)
       .set(DriverConfiguration.ON_EVALUATOR_COMPLETED, JobDriver.CompletedEvaluatorHandler.class)
       .build();
@@ -67,13 +64,15 @@ public final class Constants {
           .set(DriverServiceConfiguration.ON_EVALUATOR_ALLOCATED,
               ReefEventStateManager.AllocatedEvaluatorStateHandler.class)
           .set(DriverServiceConfiguration.ON_CONTEXT_ACTIVE, ReefEventStateManager.ActiveContextStateHandler.class)
-          .set(DriverServiceConfiguration.ON_DRIVER_RESTART_CONTEXT_ACTIVE,
-              ReefEventStateManager.DrivrRestartActiveContextStateHandler.class)
           .set(DriverServiceConfiguration.ON_TASK_RUNNING, ReefEventStateManager.TaskRunningStateHandler.class)
-          .set(DriverServiceConfiguration.ON_DRIVER_RESTART_TASK_RUNNING,
-              ReefEventStateManager.DriverRestartTaskRunningStateHandler.class)
           .set(DriverServiceConfiguration.ON_DRIVER_STARTED, ReefEventStateManager.StartStateHandler.class)
           .set(DriverServiceConfiguration.ON_DRIVER_STOP, ReefEventStateManager.StopStateHandler.class)
+          .build(),
+      DriverRestartHandlersConfiguration.CONF
+          .set(DriverRestartHandlersConfiguration.ON_DRIVER_RESTART_CONTEXT_ACTIVE,
+              ReefEventStateManager.DriverRestartActiveContextStateHandler.class)
+          .set(DriverRestartHandlersConfiguration.ON_DRIVER_RESTART_TASK_RUNNING,
+              ReefEventStateManager.DriverRestartTaskRunningStateHandler.class)
           .build()
   );
 

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/Launch.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/Launch.java
@@ -153,6 +153,7 @@ public final class Launch {
       final Injector commandLineInjector = Tang.Factory.getTang().newInjector(parseCommandLine(removedArgs));
       final int waitTime = commandLineInjector.getNamedInstance(WaitTimeForDriver.class);
       final int driverMemory = commandLineInjector.getNamedInstance(DriverMemoryInMb.class);
+      final boolean isLocal = commandLineInjector.getNamedInstance(Local.class);
       final String driverIdentifier = commandLineInjector.getNamedInstance(DriverIdentifier.class);
       final String jobSubmissionDirectory = commandLineInjector.getNamedInstance(DriverJobSubmissionDirectory.class);
       final boolean submit = commandLineInjector.getNamedInstance(Submit.class);
@@ -161,10 +162,10 @@ public final class Launch {
       client.setDriverInfo(driverIdentifier, driverMemory, jobSubmissionDirectory);
 
       if (submit) {
-        client.submit(dotNetFolder, true, null);
+        client.submit(dotNetFolder, true, isLocal, null);
         client.waitForCompletion(waitTime);
       } else {
-        client.submit(dotNetFolder, false, config);
+        client.submit(dotNetFolder, false, isLocal, config);
         client.waitForCompletion(0);
       }
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverConfiguration.java
@@ -30,7 +30,6 @@ import org.apache.reef.driver.evaluator.CompletedEvaluator;
 import org.apache.reef.driver.evaluator.FailedEvaluator;
 import org.apache.reef.driver.parameters.*;
 import org.apache.reef.driver.task.*;
-import org.apache.reef.runtime.common.DriverRestartCompleted;
 import org.apache.reef.runtime.common.driver.DriverRuntimeConfiguration;
 import org.apache.reef.tang.formats.*;
 import org.apache.reef.wake.EventHandler;
@@ -89,11 +88,6 @@ public final class DriverConfiguration extends ConfigurationModuleBuilder {
   public static final RequiredImpl<EventHandler<StartTime>> ON_DRIVER_STARTED = new RequiredImpl<>();
 
   /**
-   * This event is fired in place of the ON_DRIVER_STARTED when the Driver is in fact restarted after failure.
-   */
-  public static final OptionalImpl<EventHandler<StartTime>> ON_DRIVER_RESTARTED = new OptionalImpl<>();
-
-  /**
    * The event handler invoked right before the driver shuts down. Defaults to ignore.
    */
   public static final OptionalImpl<EventHandler<StopTime>> ON_DRIVER_STOP = new OptionalImpl<>();
@@ -138,11 +132,6 @@ public final class DriverConfiguration extends ConfigurationModuleBuilder {
   public static final OptionalImpl<EventHandler<RunningTask>> ON_TASK_RUNNING = new OptionalImpl<>();
 
   /**
-   * Event handler for running tasks in previous evaluator, when driver restarted. Defaults to crash if not bound.
-   */
-  public static final OptionalImpl<EventHandler<RunningTask>> ON_DRIVER_RESTART_TASK_RUNNING = new OptionalImpl<>();
-
-  /**
    * Event handler for suspended tasks. Defaults to job failure if not bound. Rationale: many jobs don't support
    * task suspension. Hence, this parameter should be optional. The only sane default is to crash the job, then.
    */
@@ -173,11 +162,6 @@ public final class DriverConfiguration extends ConfigurationModuleBuilder {
   public static final OptionalImpl<EventHandler<ActiveContext>> ON_CONTEXT_ACTIVE = new OptionalImpl<>();
 
   /**
-   * Event handler for active context when driver restart. Defaults to closing the context if not bound.
-   */
-  public static final OptionalImpl<EventHandler<ActiveContext>> ON_DRIVER_RESTART_CONTEXT_ACTIVE = new OptionalImpl<>();
-
-  /**
    * Event handler for closed context. Defaults to logging if not bound.
    */
   public static final OptionalImpl<EventHandler<ClosedContext>> ON_CONTEXT_CLOSED = new OptionalImpl<>();
@@ -198,16 +182,9 @@ public final class DriverConfiguration extends ConfigurationModuleBuilder {
   public static final OptionalParameter<Integer> EVALUATOR_DISPATCHER_THREADS = new OptionalParameter<>();
 
   /**
-   * Event handler for the event of driver restart completion, default to logging if not bound.
-   */
-  public static final OptionalImpl<EventHandler<DriverRestartCompleted>> ON_DRIVER_RESTART_COMPLETED =
-      new OptionalImpl<>();
-
-  /**
    * ConfigurationModule to fill out to get a legal Driver Configuration.
    */
   public static final ConfigurationModule CONF = new DriverConfiguration().merge(DriverRuntimeConfiguration.CONF)
-
       .bindNamedParameter(DriverIdentifier.class, DRIVER_IDENTIFIER)
       .bindNamedParameter(DriverMemory.class, DRIVER_MEMORY)
       .bindNamedParameter(DriverJobSubmissionDirectory.class, DRIVER_JOB_SUBMISSION_DIRECTORY)
@@ -218,7 +195,6 @@ public final class DriverConfiguration extends ConfigurationModuleBuilder {
 
           // Driver start/stop handlers
       .bindSetEntry(DriverStartHandler.class, ON_DRIVER_STARTED)
-      .bindNamedParameter(DriverRestartHandler.class, ON_DRIVER_RESTARTED)
       .bindSetEntry(Clock.StartHandler.class, org.apache.reef.runtime.common.driver.DriverStartHandler.class)
       .bindSetEntry(Clock.StopHandler.class, ON_DRIVER_STOP)
 
@@ -229,7 +205,6 @@ public final class DriverConfiguration extends ConfigurationModuleBuilder {
 
           // Task handlers
       .bindSetEntry(TaskRunningHandlers.class, ON_TASK_RUNNING)
-      .bindSetEntry(DriverRestartTaskRunningHandlers.class, ON_DRIVER_RESTART_TASK_RUNNING)
       .bindSetEntry(TaskFailedHandlers.class, ON_TASK_FAILED)
       .bindSetEntry(TaskMessageHandlers.class, ON_TASK_MESSAGE)
       .bindSetEntry(TaskCompletedHandlers.class, ON_TASK_COMPLETED)
@@ -237,7 +212,6 @@ public final class DriverConfiguration extends ConfigurationModuleBuilder {
 
           // Context handlers
       .bindSetEntry(ContextActiveHandlers.class, ON_CONTEXT_ACTIVE)
-      .bindSetEntry(DriverRestartContextActiveHandlers.class, ON_DRIVER_RESTART_CONTEXT_ACTIVE)
       .bindSetEntry(ContextClosedHandlers.class, ON_CONTEXT_CLOSED)
       .bindSetEntry(ContextMessageHandlers.class, ON_CONTEXT_MESSAGE)
       .bindSetEntry(ContextFailedHandlers.class, ON_CONTEXT_FAILED)
@@ -249,6 +223,5 @@ public final class DriverConfiguration extends ConfigurationModuleBuilder {
 
           // Various parameters
       .bindNamedParameter(EvaluatorDispatcherThreads.class, EVALUATOR_DISPATCHER_THREADS)
-      .bindSetEntry(DriverRestartCompletedHandlers.class, ON_DRIVER_RESTART_COMPLETED)
       .build();
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverRestartConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverRestartConfiguration.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.client;
+
+import org.apache.reef.driver.parameters.*;
+import org.apache.reef.driver.restart.*;
+import org.apache.reef.tang.formats.*;
+
+/**
+ * The base configuration module for driver restart configurations of all runtimes.
+ * <p/>
+ */
+public abstract class DriverRestartConfiguration extends ConfigurationModuleBuilder {
+
+
+  public DriverRestartConfiguration() {
+    this.bindSetEntry(ServiceDriverRestartedHandlers.class, DriverRecoverEvaluatorsRestartHandler.class)
+        .bindSetEntry(ServiceEvaluatorAllocatedHandlers.class, EvaluatorPreservingEvaluatorAllocatedHandler.class)
+        .bindSetEntry(ServiceEvaluatorFailedHandlers.class, EvaluatorPreservingEvaluatorFailedHandler.class)
+        .bindSetEntry(ServiceEvaluatorCompletedHandlers.class, EvaluatorPreservingEvaluatorCompletedHandler.class);
+  }
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverServiceConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverServiceConfiguration.java
@@ -119,11 +119,6 @@ public final class DriverServiceConfiguration extends ConfigurationModuleBuilder
   public static final OptionalImpl<EventHandler<RunningTask>> ON_TASK_RUNNING = new OptionalImpl<>();
 
   /**
-   * Event handler for running tasks in previous evaluator, when driver restarted. Defaults to logging if not bound.
-   */
-  public static final OptionalImpl<EventHandler<RunningTask>> ON_DRIVER_RESTART_TASK_RUNNING = new OptionalImpl<>();
-
-  /**
    * Event handler for suspended tasks. Defaults to job failure if not bound. Rationale: many jobs don't support
    * task suspension. Hence, this parameter should be optional. The only sane default is to crash the job, then.
    */
@@ -136,11 +131,6 @@ public final class DriverServiceConfiguration extends ConfigurationModuleBuilder
    * Event handler for active context. Defaults to closing the context if not bound.
    */
   public static final OptionalImpl<EventHandler<ActiveContext>> ON_CONTEXT_ACTIVE = new OptionalImpl<>();
-
-  /**
-   * Event handler for active context when driver restart. Defaults to closing the context if not bound.
-   */
-  public static final OptionalImpl<EventHandler<ActiveContext>> ON_DRIVER_RESTART_CONTEXT_ACTIVE = new OptionalImpl<>();
 
   /**
    * Event handler for closed context. Defaults to logging if not bound.
@@ -179,7 +169,6 @@ public final class DriverServiceConfiguration extends ConfigurationModuleBuilder
 
           // Task handlers
       .bindSetEntry(ServiceTaskRunningHandlers.class, ON_TASK_RUNNING)
-      .bindSetEntry(DriverRestartTaskRunningHandlers.class, ON_DRIVER_RESTART_TASK_RUNNING)
       .bindSetEntry(ServiceTaskFailedHandlers.class, ON_TASK_FAILED)
       .bindSetEntry(ServiceTaskMessageHandlers.class, ON_TASK_MESSAGE)
       .bindSetEntry(ServiceTaskCompletedHandlers.class, ON_TASK_COMPLETED)
@@ -187,7 +176,6 @@ public final class DriverServiceConfiguration extends ConfigurationModuleBuilder
 
           // Context handlers
       .bindSetEntry(ServiceContextActiveHandlers.class, ON_CONTEXT_ACTIVE)
-      .bindSetEntry(DriverRestartContextActiveHandlers.class, ON_DRIVER_RESTART_CONTEXT_ACTIVE)
       .bindSetEntry(ServiceContextClosedHandlers.class, ON_CONTEXT_CLOSED)
       .bindSetEntry(ServiceContextMessageHandlers.class, ON_CONTEXT_MESSAGE)
       .bindSetEntry(ServiceContextFailedHandlers.class, ON_CONTEXT_FAILED)

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/parameters/DriverRestartHandlersConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/parameters/DriverRestartHandlersConfiguration.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.client.parameters;
+
+import org.apache.reef.driver.context.ActiveContext;
+import org.apache.reef.driver.parameters.DriverRestartCompletedHandlers;
+import org.apache.reef.driver.parameters.DriverRestartContextActiveHandlers;
+import org.apache.reef.driver.parameters.DriverRestartHandler;
+import org.apache.reef.driver.parameters.DriverRestartTaskRunningHandlers;
+import org.apache.reef.driver.task.RunningTask;
+import org.apache.reef.runtime.common.DriverRestartCompleted;
+import org.apache.reef.tang.formats.ConfigurationModule;
+import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
+import org.apache.reef.tang.formats.OptionalImpl;
+import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.time.event.StartTime;
+
+public final class DriverRestartHandlersConfiguration extends ConfigurationModuleBuilder {
+  /**
+   * This event is fired in place of the ON_DRIVER_STARTED when the Driver is in fact restarted after failure.
+   */
+  public static final OptionalImpl<EventHandler<StartTime>> ON_DRIVER_RESTARTED = new OptionalImpl<>();
+
+  /**
+   * Event handler for running tasks in previous evaluator, when driver restarted. Defaults to crash if not bound.
+   */
+  public static final OptionalImpl<EventHandler<RunningTask>> ON_DRIVER_RESTART_TASK_RUNNING = new OptionalImpl<>();
+
+  /**
+   * Event handler for active context when driver restart. Defaults to closing the context if not bound.
+   */
+  public static final OptionalImpl<EventHandler<ActiveContext>> ON_DRIVER_RESTART_CONTEXT_ACTIVE = new OptionalImpl<>();
+
+  /**
+   * Event handler for the event of driver restart completion, default to logging if not bound.
+   */
+  public static final OptionalImpl<EventHandler<DriverRestartCompleted>> ON_DRIVER_RESTART_COMPLETED =
+      new OptionalImpl<>();
+
+  public static final ConfigurationModule CONF = new DriverRestartHandlersConfiguration()
+      .bindSetEntry(DriverRestartHandler.class, ON_DRIVER_RESTARTED)
+      .bindSetEntry(DriverRestartTaskRunningHandlers.class, ON_DRIVER_RESTART_TASK_RUNNING)
+      .bindSetEntry(DriverRestartContextActiveHandlers.class, ON_DRIVER_RESTART_CONTEXT_ACTIVE)
+      .bindSetEntry(DriverRestartCompletedHandlers.class, ON_DRIVER_RESTART_COMPLETED)
+      .build();
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceDriverRestartedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceDriverRestartedHandlers.java
@@ -26,9 +26,10 @@ import org.apache.reef.wake.time.event.StartTime;
 import java.util.Set;
 
 /**
- * The StartTime event is routed to this EventHandler if there is a restart, instead of to DriverStartHandler.
+ * Service Handler for driver restarts.
  */
-@NamedParameter(doc = "The StartTime event is routed to this EventHandler if there is a restart, " +
-    "instead of to DriverStartHandler.")
-public final class DriverRestartHandler implements Name<Set<EventHandler<StartTime>>> {
+@NamedParameter(doc = "Service Handler for driver restarts.")
+public final class ServiceDriverRestartedHandlers implements Name<Set<EventHandler<StartTime>>> {
+  private ServiceDriverRestartedHandlers(){
+  }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRecoverEvaluatorsRestartHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRecoverEvaluatorsRestartHandler.java
@@ -16,19 +16,24 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.driver.parameters;
+package org.apache.reef.driver.restart;
 
-import org.apache.reef.tang.annotations.Name;
-import org.apache.reef.tang.annotations.NamedParameter;
 import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.time.event.StartTime;
 
-import java.util.Set;
+import javax.inject.Inject;
 
-/**
- * The StartTime event is routed to this EventHandler if there is a restart, instead of to DriverStartHandler.
- */
-@NamedParameter(doc = "The StartTime event is routed to this EventHandler if there is a restart, " +
-    "instead of to DriverStartHandler.")
-public final class DriverRestartHandler implements Name<Set<EventHandler<StartTime>>> {
+public final class DriverRecoverEvaluatorsRestartHandler implements EventHandler<StartTime> {
+
+  private final DriverRestartManager driverRestartManager;
+
+  @Inject
+  DriverRecoverEvaluatorsRestartHandler(final DriverRestartManager driverRestartManager) {
+    this.driverRestartManager = driverRestartManager;
+  }
+
+  @Override
+  public void onNext(final StartTime value) {
+    this.driverRestartManager.onRestartRecoverEvaluators();
+  }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartManager.java
@@ -16,19 +16,27 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.driver.parameters;
+package org.apache.reef.driver.restart;
 
-import org.apache.reef.tang.annotations.Name;
-import org.apache.reef.tang.annotations.NamedParameter;
-import org.apache.reef.wake.EventHandler;
-import org.apache.reef.wake.time.event.StartTime;
+public interface DriverRestartManager {
 
-import java.util.Set;
+  /**
+   * Determines whether or not the driver has been restarted.
+   */
+  boolean isRestart();
 
-/**
- * The StartTime event is routed to this EventHandler if there is a restart, instead of to DriverStartHandler.
- */
-@NamedParameter(doc = "The StartTime event is routed to this EventHandler if there is a restart, " +
-    "instead of to DriverStartHandler.")
-public final class DriverRestartHandler implements Name<Set<EventHandler<StartTime>>> {
+  /**
+   * Recovers evaluators on restart.
+   */
+  void onRestartRecoverEvaluators();
+
+  /**
+   * Records the evaluators when it is allocated.
+   */
+  void recordAllocatedEvaluator(String id);
+
+  /**
+   * Determines the evaluators when it is removed.
+   */
+  void recordRemovedEvaluator(String id);
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/EvaluatorPreservingEvaluatorAllocatedHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/EvaluatorPreservingEvaluatorAllocatedHandler.java
@@ -16,19 +16,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.driver.parameters;
+package org.apache.reef.driver.restart;
 
-import org.apache.reef.tang.annotations.Name;
-import org.apache.reef.tang.annotations.NamedParameter;
+import org.apache.reef.driver.evaluator.AllocatedEvaluator;
 import org.apache.reef.wake.EventHandler;
-import org.apache.reef.wake.time.event.StartTime;
 
-import java.util.Set;
+import javax.inject.Inject;
 
-/**
- * The StartTime event is routed to this EventHandler if there is a restart, instead of to DriverStartHandler.
- */
-@NamedParameter(doc = "The StartTime event is routed to this EventHandler if there is a restart, " +
-    "instead of to DriverStartHandler.")
-public final class DriverRestartHandler implements Name<Set<EventHandler<StartTime>>> {
+public final class EvaluatorPreservingEvaluatorAllocatedHandler implements EventHandler<AllocatedEvaluator> {
+  private final DriverRestartManager driverRestartManager;
+
+  @Inject
+  EvaluatorPreservingEvaluatorAllocatedHandler(final DriverRestartManager driverRestartManager) {
+    this.driverRestartManager = driverRestartManager;
+  }
+
+  @Override
+  public void onNext(final AllocatedEvaluator value) {
+    this.driverRestartManager.recordAllocatedEvaluator(value.getId());
+  }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/EvaluatorPreservingEvaluatorCompletedHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/EvaluatorPreservingEvaluatorCompletedHandler.java
@@ -16,19 +16,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.driver.parameters;
+package org.apache.reef.driver.restart;
 
-import org.apache.reef.tang.annotations.Name;
-import org.apache.reef.tang.annotations.NamedParameter;
+import org.apache.reef.driver.evaluator.CompletedEvaluator;
 import org.apache.reef.wake.EventHandler;
-import org.apache.reef.wake.time.event.StartTime;
 
-import java.util.Set;
+import javax.inject.Inject;
 
-/**
- * The StartTime event is routed to this EventHandler if there is a restart, instead of to DriverStartHandler.
- */
-@NamedParameter(doc = "The StartTime event is routed to this EventHandler if there is a restart, " +
-    "instead of to DriverStartHandler.")
-public final class DriverRestartHandler implements Name<Set<EventHandler<StartTime>>> {
+public final class EvaluatorPreservingEvaluatorCompletedHandler implements EventHandler<CompletedEvaluator> {
+  private final DriverRestartManager driverRestartManager;
+
+  @Inject
+  EvaluatorPreservingEvaluatorCompletedHandler(final DriverRestartManager driverRestartManager) {
+    this.driverRestartManager = driverRestartManager;
+  }
+
+  @Override
+  public void onNext(CompletedEvaluator value) {
+    this.driverRestartManager.recordRemovedEvaluator(value.getId());
+  }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/EvaluatorPreservingEvaluatorFailedHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/EvaluatorPreservingEvaluatorFailedHandler.java
@@ -16,19 +16,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.driver.parameters;
+package org.apache.reef.driver.restart;
 
-import org.apache.reef.tang.annotations.Name;
-import org.apache.reef.tang.annotations.NamedParameter;
+import org.apache.reef.driver.evaluator.FailedEvaluator;
 import org.apache.reef.wake.EventHandler;
-import org.apache.reef.wake.time.event.StartTime;
 
-import java.util.Set;
+import javax.inject.Inject;
 
-/**
- * The StartTime event is routed to this EventHandler if there is a restart, instead of to DriverStartHandler.
- */
-@NamedParameter(doc = "The StartTime event is routed to this EventHandler if there is a restart, " +
-    "instead of to DriverStartHandler.")
-public final class DriverRestartHandler implements Name<Set<EventHandler<StartTime>>> {
+public final class EvaluatorPreservingEvaluatorFailedHandler implements EventHandler<FailedEvaluator> {
+  private final DriverRestartManager driverRestartManager;
+
+  @Inject
+  EvaluatorPreservingEvaluatorFailedHandler(final DriverRestartManager driverRestartManager) {
+    this.driverRestartManager = driverRestartManager;
+  }
+
+  @Override
+  public void onNext(final FailedEvaluator value) {
+    this.driverRestartManager.recordRemovedEvaluator(value.getId());
+  }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/package-info.java
@@ -16,19 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.driver.parameters;
-
-import org.apache.reef.tang.annotations.Name;
-import org.apache.reef.tang.annotations.NamedParameter;
-import org.apache.reef.wake.EventHandler;
-import org.apache.reef.wake.time.event.StartTime;
-
-import java.util.Set;
-
 /**
- * The StartTime event is routed to this EventHandler if there is a restart, instead of to DriverStartHandler.
+ * This package provides restart event service handlers.
  */
-@NamedParameter(doc = "The StartTime event is routed to this EventHandler if there is a restart, " +
-    "instead of to DriverStartHandler.")
-public final class DriverRestartHandler implements Name<Set<EventHandler<StartTime>>> {
-}
+package org.apache.reef.driver.restart;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/EvaluatorPreserver.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/EvaluatorPreserver.java
@@ -16,19 +16,27 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.driver.parameters;
-
-import org.apache.reef.tang.annotations.Name;
-import org.apache.reef.tang.annotations.NamedParameter;
-import org.apache.reef.wake.EventHandler;
-import org.apache.reef.wake.time.event.StartTime;
+package org.apache.reef.runtime.common.driver;
 
 import java.util.Set;
 
 /**
- * The StartTime event is routed to this EventHandler if there is a restart, instead of to DriverStartHandler.
+ * A interface to preserve evaluators across driver restarts.
  */
-@NamedParameter(doc = "The StartTime event is routed to this EventHandler if there is a restart, " +
-    "instead of to DriverStartHandler.")
-public final class DriverRestartHandler implements Name<Set<EventHandler<StartTime>>> {
+public interface EvaluatorPreserver {
+  /**
+   * Called on driver restart when evaluators are to be recovered.
+   */
+  Set<String> recoverEvaluators();
+
+  /**
+   * Called when an evaluator is to be preserved.
+   */
+  void recordAllocatedEvaluator(final String id);
+
+  /**
+   * Called when an evaluator is to be removed.
+   * @param id
+   */
+  void recordRemovedEvaluator(final String id);
 }

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloDriver.java
@@ -68,6 +68,31 @@ public final class HelloDriver {
   }
 
   /**
+   * Handles the StartTime event: Fails intentionally.
+   */
+  public final class FailureToStartHandler implements EventHandler<StartTime> {
+    @Override
+    public void onNext(final StartTime startTime) {
+      throw new RuntimeException("Driver intentionally failed!");
+    }
+  }
+
+  /**
+   * Handles the StartTime event: Request as single Evaluator.
+   */
+  public final class RestartHandler implements EventHandler<StartTime> {
+    @Override
+    public void onNext(final StartTime startTime) {
+      HelloDriver.this.requestor.submit(EvaluatorRequest.newBuilder()
+          .setNumber(1)
+          .setMemory(64)
+          .setNumberOfCores(1)
+          .build());
+      LOG.log(Level.INFO, "Driver restarted and requested Evaluator.");
+    }
+  }
+
+  /**
    * Handles AllocatedEvaluator: Submit the HelloTask.
    */
   public final class EvaluatorAllocatedHandler implements EventHandler<AllocatedEvaluator> {

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEFYarnRestart.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEFYarnRestart.java
@@ -22,18 +22,17 @@ import org.apache.reef.client.DriverConfiguration;
 import org.apache.reef.client.DriverLauncher;
 import org.apache.reef.client.LauncherStatus;
 import org.apache.reef.runtime.yarn.client.YarnClientConfiguration;
+import org.apache.reef.runtime.yarn.driver.YarnDriverRestartConfiguration;
 import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Configurations;
 import org.apache.reef.tang.exceptions.InjectionException;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * The Client for running HelloREEF on YARN.
- */
-public final class HelloREEFYarn {
+public final class HelloREEFYarnRestart {
 
-  private static final Logger LOG = Logger.getLogger(HelloREEFYarn.class.getName());
+  private static final Logger LOG = Logger.getLogger(HelloREEFYarnRestart.class.getName());
 
   /**
    * Number of milliseconds to wait for the job to complete.
@@ -47,17 +46,21 @@ public final class HelloREEFYarn {
    * @return the configuration of the HelloREEF driver.
    */
   private static Configuration getDriverConfiguration() {
-    return DriverConfiguration.CONF
-        .set(DriverConfiguration.GLOBAL_LIBRARIES,
-            HelloREEFYarn.class.getProtectionDomain().getCodeSource().getLocation().getFile())
-        .set(DriverConfiguration.DRIVER_IDENTIFIER, "HelloREEF")
-        .set(DriverConfiguration.ON_DRIVER_STARTED, HelloDriver.StartHandler.class)
-        .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, HelloDriver.EvaluatorAllocatedHandler.class)
-        .build();
+    return
+        Configurations.merge(DriverConfiguration.CONF
+                .set(DriverConfiguration.GLOBAL_LIBRARIES,
+                    HelloREEFYarnRestart.class.getProtectionDomain().getCodeSource().getLocation().getFile())
+                .set(DriverConfiguration.DRIVER_IDENTIFIER, "HelloREEF")
+                .set(DriverConfiguration.ON_DRIVER_STARTED, HelloDriver.FailureToStartHandler.class)
+                .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, HelloDriver.EvaluatorAllocatedHandler.class)
+                .build(),
+            YarnDriverRestartConfiguration.CONF
+                .set(YarnDriverRestartConfiguration.ON_DRIVER_RESTARTED, HelloDriver.RestartHandler.class)
+                .build());
   }
 
   /**
-   * Start Hello REEF job. Runs method runHelloReef().
+   * Start Hello REEF job. Runs method runHelloReefYarnRestart().
    *
    * @param args command line parameters.
    * @throws org.apache.reef.tang.exceptions.BindException      configuration error.
@@ -74,6 +77,6 @@ public final class HelloREEFYarn {
   /**
    * Empty private constructor to prohibit instantiation of utility class.
    */
-  private HelloREEFYarn() {
+  private HelloREEFYarnRestart() {
   }
 }

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/YarnDriverConfiguration.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/YarnDriverConfiguration.java
@@ -18,7 +18,6 @@
  */
 package org.apache.reef.runtime.yarn.client;
 
-import org.apache.reef.annotations.audience.ClientSide;
 import org.apache.reef.annotations.audience.Public;
 import org.apache.reef.runtime.yarn.client.parameters.JobQueue;
 import org.apache.reef.tang.formats.ConfigurationModule;
@@ -29,7 +28,6 @@ import org.apache.reef.tang.formats.OptionalParameter;
  * Additional YARN-Specific configuration options to be merged with DriverConfiguration.
  */
 @Public
-@ClientSide
 public final class YarnDriverConfiguration extends ConfigurationModuleBuilder {
 
   /**

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/DFSEvaluatorPreserver.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/DFSEvaluatorPreserver.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runtime.yarn.driver;
+
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.IOUtils;
+import org.apache.reef.runtime.common.driver.EvaluatorPreserver;
+import org.apache.reef.runtime.common.driver.evaluator.EvaluatorManager;
+
+import javax.inject.Inject;
+import java.io.*;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * An Evaluator Preserver that uses the DFS on YARN.
+ */
+public final class DFSEvaluatorPreserver implements EvaluatorPreserver {
+  private static final Logger LOG = Logger.getLogger(DFSEvaluatorPreserver.class.getName());
+
+  private static final String ADD_FLAG = "+";
+
+  private static final String REMOVE_FLAG = "-";
+
+  @Inject
+  private DFSEvaluatorPreserver() {
+  }
+
+  @Override
+  public Set<String> recoverEvaluators() {
+    return getExpectedContainersFromLogReplay();
+  }
+
+  @Override
+  public void recordAllocatedEvaluator(final String id) {
+    this.logContainerAddition(id);
+  }
+
+  @Override
+  public void recordRemovedEvaluator(final String id) {
+    this.logContainerRemoval(id);
+  }
+
+  private synchronized void writeToEvaluatorLog(final String entry) throws IOException {
+    final org.apache.hadoop.conf.Configuration config = new org.apache.hadoop.conf.Configuration();
+    config.setBoolean("dfs.support.append", true);
+    config.setBoolean("dfs.support.broken.append", true);
+    final FileSystem fs = getFileSystemInstance();
+    final Path path = new Path(getChangeLogLocation());
+    final boolean appendToLog = fs.exists(path);
+
+    try (
+        final BufferedWriter bw = appendToLog ?
+            new BufferedWriter(new OutputStreamWriter(fs.append(path))) :
+            new BufferedWriter(new OutputStreamWriter(fs.create(path)));
+    ) {
+      bw.write(entry);
+    } catch (final IOException e) {
+      if (appendToLog) {
+        LOG.log(Level.FINE, "Unable to add an entry to the Evaluator log. Attempting append by delete and recreate", e);
+        appendByDeleteAndCreate(fs, path, entry);
+      }
+    }
+  }
+
+  private FileSystem getFileSystemInstance() throws IOException {
+    final org.apache.hadoop.conf.Configuration config = new org.apache.hadoop.conf.Configuration();
+    config.setBoolean("dfs.support.append", true);
+    config.setBoolean("dfs.support.broken.append", true);
+    return FileSystem.get(config);
+  }
+
+  /**
+   * For certain HDFS implementation, the append operation may not be supported (e.g., Azure blob - wasb)
+   * in this case, we will emulate the append operation by reading the content, appending entry at the end,
+   * then recreating the file with appended content.
+   *
+   * @throws java.io.IOException when the file can't be written.
+   */
+
+  private void appendByDeleteAndCreate(final FileSystem fs, final Path path, final String appendEntry)
+      throws IOException {
+    final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+    try (final InputStream inputStream = fs.open(path)) {
+      IOUtils.copyBytes(inputStream, outputStream, 4096, true);
+    }
+
+    final String newContent = outputStream.toString() + appendEntry;
+    fs.delete(path, true);
+
+    try (final FSDataOutputStream newOutput = fs.create(path);
+         final InputStream newInput = new ByteArrayInputStream(newContent.getBytes())) {
+      IOUtils.copyBytes(newInput, newOutput, 4096, true);
+    }
+
+  }
+
+  private String getChangeLogLocation() {
+    return "/ReefApplications/" + EvaluatorManager.getJobIdentifier() + "/evaluatorsChangesLog";
+  }
+
+  private void logContainerAddition(final String containerId) {
+    final String entry = ADD_FLAG + containerId + System.lineSeparator();
+    logContainerChange(entry);
+  }
+
+  private void logContainerRemoval(final String containerId) {
+    final String entry = REMOVE_FLAG + containerId + System.lineSeparator();
+    logContainerChange(entry);
+  }
+
+  private void logContainerChange(final String entry) {
+    try {
+      writeToEvaluatorLog(entry);
+    } catch (final IOException e) {
+      final String errorMsg = "Unable to log the change of container [" + entry +
+          "] to the container log. Driver restart won't work properly.";
+      LOG.log(Level.WARNING, errorMsg, e);
+      throw new RuntimeException(errorMsg);
+    }
+  }
+
+  private Set<String> getExpectedContainersFromLogReplay() {
+    final org.apache.hadoop.conf.Configuration config = new org.apache.hadoop.conf.Configuration();
+    config.setBoolean("dfs.support.append", true);
+    config.setBoolean("dfs.support.broken.append", true);
+    final Set<String> expectedContainers = new HashSet<>();
+    try {
+      final FileSystem fs = FileSystem.get(config);
+      final Path path = new Path(getChangeLogLocation());
+      if (!fs.exists(path)) {
+        // empty set
+        return expectedContainers;
+      } else {
+        final BufferedReader br = new BufferedReader(new InputStreamReader(fs.open(path)));
+        String line = br.readLine();
+        while (line != null) {
+          if (line.startsWith(ADD_FLAG)) {
+            final String containerId = line.substring(ADD_FLAG.length());
+            if (expectedContainers.contains(containerId)) {
+              throw new RuntimeException("Duplicated add container record found in the change log for container " +
+                  containerId);
+            }
+            expectedContainers.add(containerId);
+          } else if (line.startsWith(REMOVE_FLAG)) {
+            final String containerId = line.substring(REMOVE_FLAG.length());
+            if (!expectedContainers.contains(containerId)) {
+              throw new RuntimeException("Change log includes record that try to remove non-exist or duplicate " +
+                  "remove record for container + " + containerId);
+            }
+            expectedContainers.remove(containerId);
+          }
+          line = br.readLine();
+        }
+        br.close();
+      }
+    } catch (final IOException e) {
+      throw new RuntimeException("Cannot read from log file", e);
+    }
+    return expectedContainers;
+  }
+}

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverConfiguration.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverConfiguration.java
@@ -35,10 +35,7 @@ import org.apache.reef.runtime.yarn.YarnClasspathProvider;
 import org.apache.reef.runtime.yarn.driver.parameters.JobSubmissionDirectory;
 import org.apache.reef.runtime.yarn.driver.parameters.YarnHeartbeatPeriod;
 import org.apache.reef.runtime.yarn.util.YarnConfigurationConstructor;
-import org.apache.reef.tang.formats.ConfigurationModule;
-import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
-import org.apache.reef.tang.formats.OptionalParameter;
-import org.apache.reef.tang.formats.RequiredParameter;
+import org.apache.reef.tang.formats.*;
 import org.apache.reef.wake.time.Clock;
 
 /**
@@ -74,12 +71,12 @@ public class YarnDriverConfiguration extends ConfigurationModuleBuilder {
    */
   public static final OptionalParameter<Double> JVM_HEAP_SLACK = new OptionalParameter<>();
 
-
-  public static ConfigurationModule CONF = new YarnDriverConfiguration()
+  public static final ConfigurationModule CONF = new YarnDriverConfiguration()
       // Bind the YARN runtime for the resource manager.
       .bindImplementation(ResourceLaunchHandler.class, YARNResourceLaunchHandler.class)
       .bindImplementation(ResourceReleaseHandler.class, YARNResourceReleaseHandler.class)
       .bindImplementation(ResourceRequestHandler.class, YarnResourceRequestHandler.class)
+
       .bindConstructor(YarnConfiguration.class, YarnConfigurationConstructor.class)
       .bindSetEntry(Clock.RuntimeStartHandler.class, YARNRuntimeStartHandler.class)
       .bindSetEntry(Clock.RuntimeStopHandler.class, YARNRuntimeStopHandler.class)

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRestartConfiguration.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRestartConfiguration.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runtime.yarn.driver;
+
+import org.apache.reef.annotations.Provided;
+import org.apache.reef.annotations.audience.ClientSide;
+import org.apache.reef.annotations.audience.Public;
+import org.apache.reef.client.DriverRestartConfiguration;
+import org.apache.reef.driver.parameters.DriverRestartHandler;
+import org.apache.reef.driver.restart.*;
+import org.apache.reef.runtime.common.driver.EvaluatorPreserver;
+import org.apache.reef.runtime.yarn.driver.parameters.YarnEvaluatorPreserver;
+import org.apache.reef.tang.formats.ConfigurationModule;
+import org.apache.reef.tang.formats.OptionalImpl;
+import org.apache.reef.tang.formats.RequiredImpl;
+import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.time.event.StartTime;
+
+/**
+ * Use this ConfigurationModule to configure YARN-specific Restart options for the driver.
+ * Note that there is a required parameter ON_DRIVER_RESTARTED in DriverRestartConfiguration to bind.
+ * <p/>
+ */
+@ClientSide
+@Public
+@Provided
+public final class YarnDriverRestartConfiguration extends DriverRestartConfiguration {
+  /**
+   * This event is fired in place of the ON_DRIVER_STARTED when the Driver is in fact restarted after failure.
+   */
+  public static final RequiredImpl<EventHandler<StartTime>> ON_DRIVER_RESTARTED = new RequiredImpl<>();
+
+  /**
+   * The Evaluator Preserver implementation used for YARN. Defaults to DFSEvalutorPreserver.
+   */
+  public static final OptionalImpl<EvaluatorPreserver> EVALUATOR_PRESERVER = new OptionalImpl<>();
+
+  public static final ConfigurationModule CONF = new YarnDriverRestartConfiguration()
+      .bindNamedParameter(YarnEvaluatorPreserver.class, EVALUATOR_PRESERVER)
+      .bindImplementation(DriverRestartManager.class, YarnDriverRestartManager.class)
+      .bindSetEntry(DriverRestartHandler.class, ON_DRIVER_RESTARTED)
+      .build();
+}

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRestartManager.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRestartManager.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runtime.yarn.driver;
+
+import org.apache.hadoop.yarn.api.ApplicationConstants;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+import org.apache.hadoop.yarn.api.records.Container;
+import org.apache.hadoop.yarn.api.records.ContainerId;
+import org.apache.hadoop.yarn.util.ConverterUtils;
+import org.apache.reef.driver.restart.DriverRestartManager;
+import org.apache.reef.proto.ReefServiceProtos;
+import org.apache.reef.runtime.common.driver.DriverStatusManager;
+import org.apache.reef.runtime.common.driver.EvaluatorPreserver;
+import org.apache.reef.runtime.common.driver.resourcemanager.ResourceStatusEventImpl;
+import org.apache.reef.runtime.yarn.driver.parameters.YarnEvaluatorPreserver;
+import org.apache.reef.runtime.yarn.util.YarnTypes;
+import org.apache.reef.tang.annotations.Parameter;
+
+import javax.inject.Inject;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public final class YarnDriverRestartManager implements DriverRestartManager{
+
+  private static final Logger LOG = Logger.getLogger(YarnDriverRestartManager.class.getName());
+
+  private final EvaluatorPreserver evaluatorPreserver;
+  private final ApplicationMasterRegistration registration;
+  private final DriverStatusManager driverStatusManager;
+  private final REEFEventHandlers reefEventHandlers;
+
+  @Inject
+  YarnDriverRestartManager(@Parameter(YarnEvaluatorPreserver.class)
+                           final EvaluatorPreserver evaluatorPreserver,
+                           final REEFEventHandlers reefEventHandlers,
+                           final ApplicationMasterRegistration registration,
+                           final DriverStatusManager driverStatusManager){
+    this.registration = registration;
+    this.evaluatorPreserver = evaluatorPreserver;
+    this.driverStatusManager = driverStatusManager;
+    this.reefEventHandlers = reefEventHandlers;
+  }
+
+  @Override
+  public boolean isRestart() {
+    Map<String, String> envs = System.getenv();
+    String containerIdString = envs.get(ApplicationConstants.Environment.CONTAINER_ID.key());
+    if (containerIdString == null) {
+      // container id should always be set in the env by the framework
+      LOG.log(Level.WARNING, "Unable to get the container ID from the environment. Treating as a non-restart.");
+      return false;
+    }
+    ContainerId containerId = ConverterUtils.toContainerId(containerIdString);
+    ApplicationAttemptId appAttemptID = containerId.getApplicationAttemptId();
+    if (appAttemptID == null) {
+      LOG.log(Level.WARNING, "Unable to get the applicationAttempt ID from the environment. " +
+          "Treating as a non-restart.");
+      return false;
+    }
+
+    LOG.log(Level.FINE, "Application attempt: " + appAttemptID.getAttemptId());
+
+    return appAttemptID.getAttemptId() > 1;
+  }
+
+  @Override
+  public void onRestartRecoverEvaluators() {
+    // TODO: this is currently being developed on a hacked 2.4.0 bits, should be 2.4.1
+    final String minVersionToGetPreviousContainer = "2.4.0";
+
+    // when supported, obtain the list of the containers previously allocated, and write info to driver folder
+    if (YarnTypes.isAtOrAfterVersion(minVersionToGetPreviousContainer)) {
+      LOG.log(Level.FINEST, "Hadoop version is {0} or after with support to retain previous containers, " +
+          "processing previous containers.", minVersionToGetPreviousContainer);
+      processPreviousContainers();
+    }
+  }
+
+  @Override
+  public void recordAllocatedEvaluator(final String id) {
+    this.evaluatorPreserver.recordAllocatedEvaluator(id);
+  }
+
+  @Override
+  public void recordRemovedEvaluator(final String id) {
+    this.evaluatorPreserver.recordRemovedEvaluator(id);
+  }
+
+  private void processPreviousContainers() {
+    final List<Container> previousContainers = this.registration.getRegistration().getContainersFromPreviousAttempts();
+    if (previousContainers != null && !previousContainers.isEmpty()) {
+      LOG.log(Level.INFO, "Driver restarted, with {0} previous containers", previousContainers.size());
+      this.driverStatusManager.setNumPreviousContainers(previousContainers.size());
+
+      final Set<String> expectedContainers = this.evaluatorPreserver.recoverEvaluators();
+
+      final int numExpectedContainers = expectedContainers.size();
+      final int numPreviousContainers = previousContainers.size();
+      if (numExpectedContainers > numPreviousContainers) {
+        // we expected more containers to be alive, some containers must have died during driver restart
+        LOG.log(Level.WARNING, "Expected {0} containers while only {1} are still alive",
+            new Object[]{numExpectedContainers, numPreviousContainers});
+        final Set<String> previousContainersIds = new HashSet<>();
+        for (final Container container : previousContainers) {
+          previousContainersIds.add(container.getId().toString());
+        }
+        for (final String expectedContainerId : expectedContainers) {
+          if (!previousContainersIds.contains(expectedContainerId)) {
+            this.evaluatorPreserver.recordRemovedEvaluator(expectedContainerId);
+            LOG.log(Level.WARNING, "Expected container [{0}] not alive, must have failed during driver restart.",
+                expectedContainerId);
+            informAboutContainerFailureDuringRestart(expectedContainerId);
+          }
+        }
+      }
+      if (numExpectedContainers < numPreviousContainers) {
+        // somehow we have more alive evaluators, this should not happen
+        throw new RuntimeException("Expected only [" + numExpectedContainers + "] containers " +
+            "but resource manager believe that [" + numPreviousContainers + "] are outstanding for driver.");
+      }
+
+      //  numExpectedContainers == numPreviousContainers
+      for (final Container container : previousContainers) {
+        LOG.log(Level.FINE, "Previous container: [{0}]", container.toString());
+        if (!expectedContainers.contains(container.getId().toString())) {
+          throw new RuntimeException("Not expecting container " + container.getId().toString());
+        }
+
+        handleRestartedContainer(container);
+      }
+    }
+  }
+
+  private void informAboutContainerFailureDuringRestart(final String containerId) {
+    LOG.log(Level.WARNING, "Container [" + containerId +
+        "] has failed during driver restart process, FailedEvaluatorHandler will be triggered, but " +
+        "no additional evaluator can be requested due to YARN-2433.");
+    // trigger a failed evaluator event
+    this.reefEventHandlers.onResourceStatus(ResourceStatusEventImpl.newBuilder()
+        .setIdentifier(containerId)
+        .setState(ReefServiceProtos.State.FAILED)
+        .setExitCode(1)
+        .setDiagnostics("Container [" + containerId + "] failed during driver restart process.")
+        .setIsFromPreviousDriver(true)
+        .build());
+  }
+
+  private void handleRestartedContainer(Container container) {
+    // TODO: implement logic
+  }
+}

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/parameters/YarnEvaluatorPreserver.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/parameters/YarnEvaluatorPreserver.java
@@ -16,19 +16,19 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.driver.parameters;
+package org.apache.reef.runtime.yarn.driver.parameters;
 
+import org.apache.reef.runtime.common.driver.EvaluatorPreserver;
+import org.apache.reef.runtime.yarn.driver.DFSEvaluatorPreserver;
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
-import org.apache.reef.wake.EventHandler;
-import org.apache.reef.wake.time.event.StartTime;
-
-import java.util.Set;
 
 /**
- * The StartTime event is routed to this EventHandler if there is a restart, instead of to DriverStartHandler.
+ * The Evaluator Preserver to use on YARN, defaults to DFS.
  */
-@NamedParameter(doc = "The StartTime event is routed to this EventHandler if there is a restart, " +
-    "instead of to DriverStartHandler.")
-public final class DriverRestartHandler implements Name<Set<EventHandler<StartTime>>> {
+@NamedParameter(doc = "The Evaluator Preserver to use on YARN, defaults to DFS.",
+    default_class = DFSEvaluatorPreserver.class)
+public final class YarnEvaluatorPreserver implements Name<EvaluatorPreserver> {
+  private YarnEvaluatorPreserver() {
+  }
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/Clock.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/Clock.java
@@ -71,6 +71,12 @@ public interface Clock extends Runnable, AutoCloseable {
   boolean isIdle();
 
   /**
+   * The exception clock has failed on when it calls .run().
+   * @return
+   */
+  Throwable runFailedOnException();
+
+  /**
    * Bind this to an event handler to statically subscribe to the StartTime Event.
    */
   @NamedParameter(default_class = MissingStartHandlerHandler.class, doc = "Will be called upon the start event")

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RuntimeClock.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RuntimeClock.java
@@ -52,6 +52,7 @@ public final class RuntimeClock implements Clock {
   private final InjectionFuture<Set<EventHandler<IdleClock>>> idleHandler;
 
   private boolean closed = false;
+  private Throwable failedOnException = null;
 
   @Inject
   RuntimeClock(final Timer timer,
@@ -158,6 +159,11 @@ public final class RuntimeClock implements Clock {
     }
   }
 
+  @Override
+  public Throwable runFailedOnException() {
+    return this.failedOnException;
+  }
+
   @SuppressWarnings("checkstyle:hiddenfield")
   private <T extends Time> void subscribe(final Class<T> eventClass, final Set<EventHandler<T>> handlers) {
     for (final EventHandler<T> handler : handlers) {
@@ -244,6 +250,7 @@ public final class RuntimeClock implements Clock {
       this.handlers.onNext(new RuntimeStop(this.timer.getCurrent()));
     } catch (Exception e) {
       e.printStackTrace();
+      this.failedOnException = e;
       this.handlers.onNext(new RuntimeStop(this.timer.getCurrent(), e));
     } finally {
       logThreads(Level.FINE, "Threads running after exiting the clock main loop: ");

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/ReefEventStateManager.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/ReefEventStateManager.java
@@ -227,6 +227,17 @@ public final class ReefEventStateManager {
   }
 
   /**
+   * Job Driver has been restarted.
+   */
+  public final class DriverRestartHandler implements EventHandler<StartTime> {
+    @Override
+    @SuppressWarnings("checkstyle:hiddenfield")
+    public void onNext(final StartTime restartTime) {
+      LOG.log(Level.INFO, "DriverRestartHandler called. StartTime: {0}", restartTime);
+    }
+  }
+
+  /**
    * Job driver stopped, log the stop time.
    */
   public final class StopStateHandler implements EventHandler<StopTime> {
@@ -286,7 +297,7 @@ public final class ReefEventStateManager {
   /**
    * Receive notification that a new Context is available.
    */
-  public final class DrivrRestartActiveContextStateHandler implements EventHandler<ActiveContext> {
+  public final class DriverRestartActiveContextStateHandler implements EventHandler<ActiveContext> {
     @Override
     public void onNext(final ActiveContext context) {
       synchronized (ReefEventStateManager.this) {


### PR DESCRIPTION
This addressed the issue by
  * Adding the EvaluatorPreserver interface.
  * Refactoring YARN evaluator preservation to DFSEvaluatorPreserver and using DFSEvaluatorPreserver as default for YARN.
  * Making EvaluatorPreserver a OptionalImplementation in YarnDriverConfiguration.

JIRA:
  [REEF-483](https://issues.apache.org/jira/browse/REEF-483)