### PR TITLE
[REEF-495]Add SolutionDir in HelloREEF project

### DIFF
--- a/lang/cs/Org.Apache.REEF.Examples.HelloREEF/Org.Apache.REEF.Examples.HelloREEF.csproj
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloREEF/Org.Apache.REEF.Examples.HelloREEF.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>Org.Apache.REEF.Examples.HelloREEF</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..</SolutionDir>
   </PropertyGroup>
   <PropertyGroup>
     <BuildPackage>false</BuildPackage>


### PR DESCRIPTION
SolutionDir is not defined in HelloREEF project, when execute copy jar target at build.prop level, the folder is wrong. The build randomly fail because of it. The PR just simply adds it.

JIRA: REEF-495(https://issues.apache.org/jira/browse/REEF-495)

This closes #

Author: Julia Wang  Email: juliaw@apache.org