### PR TITLE
[REEF-312] Fail_Alarm fails with assumed state RUNNING but reported state FAILED

### DIFF
--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/driver/FailDriver.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/driver/FailDriver.java
@@ -203,7 +203,7 @@ public final class FailDriver {
     public void onNext(final FailedEvaluator eval) {
       LOG.log(Level.WARNING, "Evaluator failed: " + eval.getId(), eval.getEvaluatorException());
       checkMsgOrder(eval);
-      throw new RuntimeException(eval.getEvaluatorException());
+
     }
   }
 


### PR DESCRIPTION
This addressed the issue by changing FailDriver.FailedEvaluatorHandler not to throw a RuntimeException.

JIRA:
  [REEF-312] (https://issues.apache.org/jira/browse/REEF-312)

Author:
  Geon Woo Kim (gwsshs22@gmail.com)