### PR TITLE
[REEF-509]  Remove Java ExecutorServiceConstructor from EvaluatorConf…

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/AllocatedEvaluatorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/AllocatedEvaluatorImpl.java
@@ -27,6 +27,7 @@ import org.apache.reef.driver.evaluator.EvaluatorDescriptor;
 import org.apache.reef.driver.evaluator.EvaluatorType;
 import org.apache.reef.driver.evaluator.EvaluatorProcess;
 import org.apache.reef.driver.evaluator.JVMProcessFactory;
+import org.apache.reef.driver.evaluator.CLRProcess;
 import org.apache.reef.runtime.common.driver.api.ResourceLaunchEventImpl;
 import org.apache.reef.runtime.common.evaluator.EvaluatorConfiguration;
 import org.apache.reef.tang.Configuration;
@@ -194,7 +195,13 @@ final class AllocatedEvaluatorImpl implements AllocatedEvaluator {
                                                    final Optional<Configuration> taskConfiguration) {
 
     final String contextConfigurationString = this.configurationSerializer.toString(contextConfiguration);
-    ConfigurationModule evaluatorConfigurationModule = EvaluatorConfiguration.CONF
+    final ConfigurationModule evaluatorConfigModule;
+    if (this.evaluatorManager.getEvaluatorDescriptor().getProcess() instanceof CLRProcess) {
+      evaluatorConfigModule = EvaluatorConfiguration.CONFCLR;
+    } else {
+      evaluatorConfigModule = EvaluatorConfiguration.CONF;
+    }
+    ConfigurationModule evaluatorConfigurationModule = evaluatorConfigModule
         .set(EvaluatorConfiguration.APPLICATION_IDENTIFIER, this.jobIdentifier)
         .set(EvaluatorConfiguration.DRIVER_REMOTE_IDENTIFIER, this.remoteID)
         .set(EvaluatorConfiguration.EVALUATOR_IDENTIFIER, this.getId())

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/EvaluatorConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/EvaluatorConfiguration.java
@@ -43,10 +43,10 @@ public final class EvaluatorConfiguration extends ConfigurationModuleBuilder {
   public static final OptionalParameter<String> TASK_CONFIGURATION = new OptionalParameter<>();
   public static final OptionalParameter<Integer> HEARTBEAT_PERIOD = new OptionalParameter<>();
   public static final OptionalParameter<String> APPLICATION_IDENTIFIER = new OptionalParameter<>();
-  public static final ConfigurationModule CONF = new EvaluatorConfiguration()
+
+  private static final ConfigurationModuleBuilder EvaluatorConfigModuleBuilder = new EvaluatorConfiguration()
       .bindSetEntry(Clock.RuntimeStartHandler.class, EvaluatorRuntime.RuntimeStartHandler.class)
       .bindSetEntry(Clock.RuntimeStopHandler.class, EvaluatorRuntime.RuntimeStopHandler.class)
-      .bindConstructor(ExecutorService.class, ExecutorServiceConstructor.class)
       .bindNamedParameter(DriverRemoteIdentifier.class, DRIVER_REMOTE_IDENTIFIER)
       .bindNamedParameter(ErrorHandlerRID.class, DRIVER_REMOTE_IDENTIFIER)
       .bindNamedParameter(EvaluatorIdentifier.class, EVALUATOR_IDENTIFIER)
@@ -55,7 +55,12 @@ public final class EvaluatorConfiguration extends ConfigurationModuleBuilder {
       .bindNamedParameter(InitialTaskConfiguration.class, TASK_CONFIGURATION)
       .bindNamedParameter(RootServiceConfiguration.class, ROOT_SERVICE_CONFIGURATION)
       .bindNamedParameter(ApplicationIdentifier.class, APPLICATION_IDENTIFIER)
-      .bindNamedParameter(LaunchID.class, APPLICATION_IDENTIFIER)
+      .bindNamedParameter(LaunchID.class, APPLICATION_IDENTIFIER);
+
+  public static final ConfigurationModule CONFCLR = EvaluatorConfigModuleBuilder.build();
+
+  public static final ConfigurationModule CONF = EvaluatorConfigModuleBuilder
+      .bindConstructor(ExecutorService.class, ExecutorServiceConstructor.class)
       .build();
 
   private static final class ExecutorServiceConstructor implements ExternalConstructor<ExecutorService> {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/EvaluatorConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/EvaluatorConfiguration.java
@@ -44,6 +44,9 @@ public final class EvaluatorConfiguration extends ConfigurationModuleBuilder {
   public static final OptionalParameter<Integer> HEARTBEAT_PERIOD = new OptionalParameter<>();
   public static final OptionalParameter<String> APPLICATION_IDENTIFIER = new OptionalParameter<>();
 
+  /**
+   * The EvaluatorConfigModuleBuilder which contains bindings shared for all kinds of Evaluators.
+   */
   private static final ConfigurationModuleBuilder EvaluatorConfigModuleBuilder = new EvaluatorConfiguration()
       .bindSetEntry(Clock.RuntimeStartHandler.class, EvaluatorRuntime.RuntimeStartHandler.class)
       .bindSetEntry(Clock.RuntimeStopHandler.class, EvaluatorRuntime.RuntimeStopHandler.class)
@@ -57,8 +60,15 @@ public final class EvaluatorConfiguration extends ConfigurationModuleBuilder {
       .bindNamedParameter(ApplicationIdentifier.class, APPLICATION_IDENTIFIER)
       .bindNamedParameter(LaunchID.class, APPLICATION_IDENTIFIER);
 
+  /**
+   * This is ConfigurationModule for CLR Evaluator where ExecutorServiceConstructor is not needed and
+   * C# code won't be able to understand Java class ExecutorServiceConstructor
+   */
   public static final ConfigurationModule CONFCLR = EvaluatorConfigModuleBuilder.build();
 
+  /**
+   * This is ConfigurationModule for Java Evaluator
+   */
   public static final ConfigurationModule CONF = EvaluatorConfigModuleBuilder
       .bindConstructor(ExecutorService.class, ExecutorServiceConstructor.class)
       .build();

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/EvaluatorConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/EvaluatorConfiguration.java
@@ -61,13 +61,12 @@ public final class EvaluatorConfiguration extends ConfigurationModuleBuilder {
       .bindNamedParameter(LaunchID.class, APPLICATION_IDENTIFIER);
 
   /**
-   * This is ConfigurationModule for CLR Evaluator where ExecutorServiceConstructor is not needed and
-   * C# code won't be able to understand Java class ExecutorServiceConstructor
+   * This is ConfigurationModule for CLR Evaluator.
    */
   public static final ConfigurationModule CONFCLR = EvaluatorConfigModuleBuilder.build();
 
   /**
-   * This is ConfigurationModule for Java Evaluator
+   * This is ConfigurationModule for Java Evaluator.
    */
   public static final ConfigurationModule CONF = EvaluatorConfigModuleBuilder
       .bindConstructor(ExecutorService.class, ExecutorServiceConstructor.class)


### PR DESCRIPTION
…iguration for .Net Evaluator

Currently the Evaluator configuration contains ExecutorServiceConstructor which is not used in .Net evaluator and .Net Tang will be not able to understand this class. This PR created separate code path for EvaluatorConfiguration in java based on the Evaluator Process.

JIRA: REEF-509(https://issues.apache.org/jira/browse/REEF-509)

This closes #

Author: Julia Wang  Email: juliaw@apache.org