### PR TITLE
[REEF-478] Introduce caching in NameClient LookUp function

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Io/INameClient.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Io/INameClient.cs
@@ -53,6 +53,15 @@ namespace Org.Apache.REEF.Common.Io
         IPEndPoint Lookup(string id);
 
         /// <summary>
+        /// Looks up the IPEndpoint for the registered identifier.
+        /// Use cache if it has entry
+        /// </summary>
+        /// <param name="id">The identifier to look up</param>
+        /// <returns>The mapped IPEndpoint for the identifier, or null if
+        /// the identifier has not been registered with the NameService</returns>
+        IPEndPoint CacheLookup(string id);
+
+        /// <summary>
         /// Looks up the IPEndpoint for each of the registered identifiers in the list.
         /// </summary>
         /// <param name="ids">The list of identifiers to look up</param>

--- a/lang/cs/Org.Apache.REEF.Network.Tests/NamingService/NameServerTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/NamingService/NameServerTests.cs
@@ -239,7 +239,7 @@ namespace Org.Apache.REEF.Network.Tests.NamingService
         [TestMethod]
         public void TestNameCache()
         {
-            double interval = 1000;
+            double interval = 50;
             var config =
                 TangFactory.GetTang()
                     .NewConfigurationBuilder()
@@ -252,7 +252,7 @@ namespace Org.Apache.REEF.Network.Tests.NamingService
             var cache = injector.GetInstance<NameCache>();
 
             cache.Set("dst1", new IPEndPoint(IPAddress.Any, 0));
-            Thread.Sleep(2000);
+            Thread.Sleep(100);
             var value = cache.Get("dst1");
             Assert.IsNull(value);
 

--- a/lang/cs/Org.Apache.REEF.Network.Tests/NamingService/NameServerTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/NamingService/NameServerTests.cs
@@ -19,11 +19,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Net;
 using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Common.Io;
+using Org.Apache.REEF.Examples.Tasks.StreamingTasks;
 using Org.Apache.REEF.Network.Naming;
+using Org.Apache.REEF.Network.Naming.Parameters;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
@@ -48,8 +51,8 @@ namespace Org.Apache.REEF.Network.Tests.NamingService
         {
            using (var server = BuildNameServer())
            {
-               var nameClient = new NameClient(server.LocalEndpoint);
-               var nameClient2 = new NameClient(server.LocalEndpoint);
+               var nameClient = GetNameClientInstance(server.LocalEndpoint);
+               var nameClient2 = GetNameClientInstance(server.LocalEndpoint);
                nameClient2.Register("1", new IPEndPoint(IPAddress.Any, 8080));
                nameClient.Lookup("1");
            }
@@ -60,8 +63,8 @@ namespace Org.Apache.REEF.Network.Tests.NamingService
         {
            using (var server = BuildNameServer())
            {
-               var nameClient = new NameClient(server.LocalEndpoint);
-               var nameClient2 = new NameClient(server.LocalEndpoint);
+               var nameClient = GetNameClientInstance(server.LocalEndpoint);
+               var nameClient2 = GetNameClientInstance(server.LocalEndpoint);
                nameClient2.Register("1", new IPEndPoint(IPAddress.Any, 8080));
                nameClient.Lookup("1");
            }
@@ -72,8 +75,8 @@ namespace Org.Apache.REEF.Network.Tests.NamingService
         {
            using (var server = BuildNameServer())
            {
-               var nameClient = new NameClient(server.LocalEndpoint);
-               var nameClient2 = new NameClient(server.LocalEndpoint);
+               var nameClient = GetNameClientInstance(server.LocalEndpoint);
+               var nameClient2 = GetNameClientInstance(server.LocalEndpoint);
                nameClient.Register("1", new IPEndPoint(IPAddress.Any, 8080));
                nameClient2.Lookup("1");
            }
@@ -233,6 +236,33 @@ namespace Org.Apache.REEF.Network.Tests.NamingService
             }
         }
 
+        [TestMethod]
+        public void TestNameCache()
+        {
+            double interval = 1000;
+            var config =
+                TangFactory.GetTang()
+                    .NewConfigurationBuilder()
+                    .BindNamedParameter<NameCacheConfiguration.CacheEntryExpiryTime, double>(
+                        GenericType<NameCacheConfiguration.CacheEntryExpiryTime>.Class,
+                        interval.ToString(CultureInfo.InvariantCulture))
+                    .Build();
+            
+            var injector = TangFactory.GetTang().NewInjector(config);
+            var cache = injector.GetInstance<NameCache>();
+
+            cache.Set("dst1", new IPEndPoint(IPAddress.Any, 0));
+            Thread.Sleep(2000);
+            var value = cache.Get("dst1");
+            Assert.IsNull(value);
+
+            IPAddress address = new IPAddress(1234);
+            cache.Set("dst1", new IPEndPoint(address, 0));
+            value = cache.Get("dst1");
+            Assert.IsNotNull(value);
+            Assert.AreEqual(address, value.Address);
+        }
+
         public static INameServer BuildNameServer(int listenPort = 0)
         {
             var builder = TangFactory.GetTang()
@@ -252,6 +282,20 @@ namespace Org.Apache.REEF.Network.Tests.NamingService
                 .Build();
 
             return TangFactory.GetTang().NewInjector(nameClientConfiguration).GetInstance<NameClient>();
+        }
+
+        private NameClient GetNameClientInstance(IPEndPoint endPoint)
+        {
+            var config1 = TangFactory.GetTang().NewConfigurationBuilder()
+                   .BindNamedParameter<NamingConfigurationOptions.NameServerAddress, string>(
+                       GenericType<NamingConfigurationOptions.NameServerAddress>.Class,
+                       endPoint.Address.ToString())
+                   .BindNamedParameter<NamingConfigurationOptions.NameServerPort, int>(
+                       GenericType<NamingConfigurationOptions.NameServerPort>.Class,
+                       endPoint.Port.ToString())
+                   .Build();
+
+            return TangFactory.GetTang().NewInjector(config1).GetInstance<NameClient>();
         }
 
         private class ConstructorInjection

--- a/lang/cs/Org.Apache.REEF.Network/Naming/NameCache.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Naming/NameCache.cs
@@ -1,0 +1,105 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System;
+using System.Collections.Specialized;
+using System.Net;
+using System.Runtime.Caching;
+using Org.Apache.REEF.Network.Naming.Parameters;
+using Org.Apache.REEF.Tang.Annotations;
+
+namespace Org.Apache.REEF.Network.Naming
+{
+    /// <summary>
+    /// Cache class for caching IpEndPoint Lookups
+    /// </summary>
+    internal class NameCache
+    {
+        private readonly MemoryCache _cache;
+
+        /// <summary>
+        /// Duration in milli seconds after which cache entry expires
+        /// Usage in cache requires it to be double than int or long
+        /// </summary>
+        private readonly double _expirationDuration;
+
+        [Inject]
+        private NameCache(
+            [Parameter(typeof (NameCacheConfiguration.CacheEntryExpiryTime))] double expirationDuration,
+            [Parameter(typeof (NameCacheConfiguration.CacheMemoryLimit))] string memoryLimit,
+            [Parameter(typeof (NameCacheConfiguration.PollingInterval))] string pollingInterval)
+        {
+            var config = new NameValueCollection
+            {
+                {"pollingInterval", pollingInterval},
+                {"physicalMemoryLimitPercentage", "0"},
+                {"cacheMemoryLimitMegabytes", memoryLimit}
+            };
+
+            _cache = new MemoryCache("NameClientCache", config);
+            _expirationDuration = expirationDuration;
+        }
+
+        /// <summary>
+        /// Add an entry to cache if it does not exist or replace if it already ecists
+        /// </summary>
+        /// <param name="identifier">remote destination Id</param>
+        /// <param name="value">IPEndPoint of remote destination</param>
+        internal void Set(string identifier, IPEndPoint value)
+        {
+            _cache.Set(identifier, value, DateTimeOffset.Now.AddMilliseconds(_expirationDuration));
+        }
+
+        /// <summary>
+        /// Gets the cached remote IpEndPoint given the name
+        /// </summary>
+        /// <param name="identifier">Remote destination name/Id</param>
+        /// <returns>IPEndPoint of remote destination if it is cached, null otherwise</returns>
+        internal IPEndPoint Get(string identifier)
+        {
+            var entry = _cache.Get(identifier);
+            return entry as IPEndPoint;
+        }
+
+        /// <summary>
+        /// Removes the entry from the cache
+        /// </summary>
+        /// <param name="identifier"></param>
+        internal void RemoveEntry(string identifier)
+        {
+            _cache.Remove(identifier);
+        }
+
+        /// <summary>
+        /// returns physical memory of the cache in MB
+        /// </summary>
+        internal long PhysicalMemoryLimit
+        {
+            get { return _cache.CacheMemoryLimit; }
+        }
+
+        /// <summary>
+        /// returns the interval after which Cache checks its memory usage
+        /// </summary>
+        internal TimeSpan PollingInterval
+        {
+            get { return _cache.PollingInterval; }
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Network/Naming/Parameters/NameCacheConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Naming/Parameters/NameCacheConfiguration.cs
@@ -1,0 +1,41 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using Org.Apache.REEF.Tang.Annotations;
+
+namespace Org.Apache.REEF.Network.Naming.Parameters
+{
+    public static class NameCacheConfiguration
+    {
+        [NamedParameter("Time interval in milliseconds before the cache entry expires", "timeinterval", "300000")]
+        public class CacheEntryExpiryTime : Name<double>
+        {
+        }
+
+        [NamedParameter("Maximum cache memory in MB", "cachememorylimit", "20")]
+        public class CacheMemoryLimit : Name<string>
+        {
+        }
+
+        [NamedParameter("Polling interval for checking cache memory", "cachepollinginterval", "00:20:00")]
+        public class PollingInterval : Name<string>
+        {
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Network/NetworkService/NsConnection.cs
+++ b/lang/cs/Org.Apache.REEF.Network/NetworkService/NsConnection.cs
@@ -76,7 +76,7 @@ namespace Org.Apache.REEF.Network.NetworkService
             string destStr = _destId.ToString();
             LOGGER.Log(Level.Verbose, "Network service opening connection to {0}...", destStr);
 
-            IPEndPoint destAddr = _nameClient.Lookup(_destId.ToString());
+            IPEndPoint destAddr = _nameClient.CacheLookup(_destId.ToString());
             if (destAddr == null)
             {
                 throw new RemotingException("Cannot register Identifier with NameService");

--- a/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
+++ b/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
@@ -46,6 +46,7 @@ under the License.
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -129,6 +130,8 @@ under the License.
     <Compile Include="Naming\Events\NamingUnregisterRequest.cs" />
     <Compile Include="Naming\Events\NamingUnregisterResponse.cs" />
     <Compile Include="Naming\INameServer.cs" />
+    <Compile Include="Naming\NameCache.cs" />
+    <Compile Include="Naming\Parameters\NameCacheConfiguration.cs" />
     <Compile Include="Naming\NameClient.cs" />
     <Compile Include="Naming\NameLookupClient.cs" />
     <Compile Include="Naming\NameRegisterClient.cs" />


### PR DESCRIPTION
[REEF-478] Introduce caching in NameClient LookUp function

This addressed the issue by
  * introducing NameCache that caches IPEndPoint and internally used .Net Memory Cache
  * introducing another function in NameClient CacheLookUp() that looks from cache.

JIRA:
  [REEF-478](https://issues.apache.org/jira/browse/REEF-478)
