### PR TITLE
[REEF-539] Tasks cannot be restarted with multiple comm groups

### DIFF
--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CommunicationGroupDriverImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CommunicationGroupDriverImpl.java
@@ -317,6 +317,14 @@ public class CommunicationGroupDriverImpl implements CommunicationGroupDriver {
     LOG.fine(getQualifiedName() + "Got failed Task: " + id);
     synchronized (yetToRunLock) {
       LOG.finest(getQualifiedName() + "Acquired yetToRunLock");
+      // maybe the task does not belong to this communication group.
+      // if it doesn't, we return, it should belong to other group
+      // which will handle its failure
+      if (!perTaskState.containsKey(id)) {
+        LOG.fine(getQualifiedName()
+            + " does not have this task, another communicationGroup must have it");
+        return;
+      }
       while (cantFailTask(id)) {
         LOG.finest(getQualifiedName() + "Need to wait for it run");
         try {


### PR DESCRIPTION
A NullPointerException is thrown when the wrong communication group tries to handle a task. This change allows to ignore an unknown task. The corresponding communication group will be in charge of handling it.

JIRA:
  [REEF-539](https://issues.apache.org/jira/browse/REEF-539)

Pull Request:
  This closes 