### PR TITLE
[REEF-312] Fail_Alarm fails with assumed state RUNNING but reported state FAILED

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeStartHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeStartHandler.java
@@ -20,6 +20,7 @@ package org.apache.reef.runtime.common.driver;
 
 import org.apache.reef.proto.EvaluatorRuntimeProtocol;
 import org.apache.reef.proto.ReefServiceProtos;
+import org.apache.reef.runtime.common.driver.api.ResourceManagerStartHandler;
 import org.apache.reef.runtime.common.driver.evaluator.EvaluatorHeartbeatHandler;
 import org.apache.reef.runtime.common.driver.evaluator.EvaluatorResourceManagerErrorHandler;
 import org.apache.reef.runtime.common.driver.resourcemanager.ResourceManagerStatus;
@@ -43,6 +44,7 @@ final class DriverRuntimeStartHandler implements EventHandler<RuntimeStart> {
   private final EvaluatorResourceManagerErrorHandler evaluatorResourceManagerErrorHandler;
   private final EvaluatorHeartbeatHandler evaluatorHeartbeatHandler;
   private final ResourceManagerStatus resourceManagerStatus;
+  private final ResourceManagerStartHandler resourceManagerStartHandler;
   private final DriverStatusManager driverStatusManager;
 
   /**
@@ -50,6 +52,7 @@ final class DriverRuntimeStartHandler implements EventHandler<RuntimeStart> {
    * @param remoteManager                        the remoteManager in the Driver.
    * @param evaluatorResourceManagerErrorHandler This will be wired up to the remoteManager on onNext()
    * @param evaluatorHeartbeatHandler            This will be wired up to the remoteManager on onNext()
+   * @param resourceManagerStartHandler          This will initialize the resource manager
    * @param resourceManagerStatus                will be set to RUNNING in onNext()
    * @param driverStatusManager                  will be set to RUNNING in onNext()
    */
@@ -59,11 +62,13 @@ final class DriverRuntimeStartHandler implements EventHandler<RuntimeStart> {
                             final EvaluatorResourceManagerErrorHandler evaluatorResourceManagerErrorHandler,
                             final EvaluatorHeartbeatHandler evaluatorHeartbeatHandler,
                             final ResourceManagerStatus resourceManagerStatus,
+                            final ResourceManagerStartHandler resourceManagerStartHandler,
                             final DriverStatusManager driverStatusManager) {
     this.remoteManager = remoteManager;
     this.evaluatorResourceManagerErrorHandler = evaluatorResourceManagerErrorHandler;
     this.evaluatorHeartbeatHandler = evaluatorHeartbeatHandler;
     this.resourceManagerStatus = resourceManagerStatus;
+    this.resourceManagerStartHandler = resourceManagerStartHandler;
     this.driverStatusManager = driverStatusManager;
   }
 
@@ -76,6 +81,7 @@ final class DriverRuntimeStartHandler implements EventHandler<RuntimeStart> {
     this.remoteManager.registerHandler(ReefServiceProtos.RuntimeErrorProto.class, evaluatorResourceManagerErrorHandler);
     this.resourceManagerStatus.setRunning();
     this.driverStatusManager.onRunning();
+    this.resourceManagerStartHandler.onNext(runtimeStart);
     LOG.log(Level.FINEST, "DriverRuntimeStartHandler complete.");
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeStopHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeStopHandler.java
@@ -20,6 +20,7 @@ package org.apache.reef.runtime.common.driver;
 
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.runtime.common.driver.api.ResourceManagerStopHandler;
 import org.apache.reef.runtime.common.driver.evaluator.Evaluators;
 import org.apache.reef.runtime.common.utils.RemoteManager;
 import org.apache.reef.util.Optional;
@@ -40,14 +41,17 @@ final class DriverRuntimeStopHandler implements EventHandler<RuntimeStop> {
   private static final Logger LOG = Logger.getLogger(DriverRuntimeStopHandler.class.getName());
 
   private final DriverStatusManager driverStatusManager;
+  private final ResourceManagerStopHandler resourceManagerStopHandler;
   private final RemoteManager remoteManager;
   private final Evaluators evaluators;
 
   @Inject
   DriverRuntimeStopHandler(final DriverStatusManager driverStatusManager,
+                           final ResourceManagerStopHandler resourceManagerStopHandler,
                            final RemoteManager remoteManager,
                            final Evaluators evaluators) {
     this.driverStatusManager = driverStatusManager;
+    this.resourceManagerStopHandler = resourceManagerStopHandler;
     this.remoteManager = remoteManager;
     this.evaluators = evaluators;
   }
@@ -57,6 +61,7 @@ final class DriverRuntimeStopHandler implements EventHandler<RuntimeStop> {
     LOG.log(Level.FINEST, "RuntimeStop: {0}", runtimeStop);
     // Shutdown the Evaluators.
     this.evaluators.close();
+    this.resourceManagerStopHandler.onNext(runtimeStop);
     // Inform the client of the shutdown.
     final Optional<Throwable> exception = Optional.<Throwable>ofNullable(runtimeStop.getException());
     this.driverStatusManager.sendJobEndingMessageToClient(exception);

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceManagerStartHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceManagerStartHandler.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,23 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.runtime.mesos.driver;
+package org.apache.reef.runtime.common.driver.api;
 
-import org.apache.reef.runtime.common.driver.api.ResourceManagerStartHandler;
+import org.apache.reef.annotations.audience.RuntimeAuthor;
+import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.time.runtime.event.RuntimeStart;
 
-import javax.inject.Inject;
-
-final class MesosRuntimeStartHandler implements ResourceManagerStartHandler {
-  private final REEFScheduler reefScheduler;
-
-  @Inject
-  MesosRuntimeStartHandler(final REEFScheduler reefScheduler) {
-    this.reefScheduler = reefScheduler;
-  }
-
-  @Override
-  public void onNext(final RuntimeStart runtimeStart){
-    this.reefScheduler.onStart();
-  }
+/**
+ * Initialize the resource manager.
+ */
+@RuntimeAuthor
+public interface ResourceManagerStartHandler extends EventHandler<RuntimeStart> {
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceManagerStopHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceManagerStopHandler.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,23 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.runtime.mesos.driver;
+package org.apache.reef.runtime.common.driver.api;
 
-import org.apache.reef.runtime.common.driver.api.ResourceManagerStartHandler;
-import org.apache.reef.wake.time.runtime.event.RuntimeStart;
+import org.apache.reef.annotations.audience.RuntimeAuthor;
+import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.time.runtime.event.RuntimeStop;
 
-import javax.inject.Inject;
-
-final class MesosRuntimeStartHandler implements ResourceManagerStartHandler {
-  private final REEFScheduler reefScheduler;
-
-  @Inject
-  MesosRuntimeStartHandler(final REEFScheduler reefScheduler) {
-    this.reefScheduler = reefScheduler;
-  }
-
-  @Override
-  public void onNext(final RuntimeStart runtimeStart){
-    this.reefScheduler.onStart();
-  }
+/**
+ * Shutdown the resource manager.
+ */
+@RuntimeAuthor
+public interface ResourceManagerStopHandler extends EventHandler<RuntimeStop> {
 }

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/HDInsightDriverConfiguration.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/HDInsightDriverConfiguration.java
@@ -23,9 +23,7 @@ import org.apache.reef.annotations.audience.ClientSide;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.io.TempFileCreator;
 import org.apache.reef.io.WorkingDirectoryTempFileCreator;
-import org.apache.reef.runtime.common.driver.api.ResourceLaunchHandler;
-import org.apache.reef.runtime.common.driver.api.ResourceReleaseHandler;
-import org.apache.reef.runtime.common.driver.api.ResourceRequestHandler;
+import org.apache.reef.runtime.common.driver.api.*;
 import org.apache.reef.runtime.common.driver.parameters.ClientRemoteIdentifier;
 import org.apache.reef.runtime.common.driver.parameters.EvaluatorTimeout;
 import org.apache.reef.runtime.common.driver.parameters.JobIdentifier;
@@ -44,7 +42,6 @@ import org.apache.reef.tang.formats.ConfigurationModule;
 import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
 import org.apache.reef.tang.formats.OptionalParameter;
 import org.apache.reef.tang.formats.RequiredParameter;
-import org.apache.reef.wake.time.Clock;
 
 /**
  * ConfigurationModule to create a Driver configuration.
@@ -88,9 +85,9 @@ public final class HDInsightDriverConfiguration extends ConfigurationModuleBuild
       .bindImplementation(ResourceLaunchHandler.class, YARNResourceLaunchHandler.class)
       .bindImplementation(ResourceReleaseHandler.class, YARNResourceReleaseHandler.class)
       .bindImplementation(ResourceRequestHandler.class, YarnResourceRequestHandler.class)
+      .bindImplementation(ResourceManagerStartHandler.class, YARNRuntimeStartHandler.class)
+      .bindImplementation(ResourceManagerStopHandler.class, YARNRuntimeStopHandler.class)
       .bindConstructor(YarnConfiguration.class, YarnConfigurationConstructor.class)
-      .bindSetEntry(Clock.RuntimeStartHandler.class, YARNRuntimeStartHandler.class)
-      .bindSetEntry(Clock.RuntimeStopHandler.class, YARNRuntimeStopHandler.class)
       .bindImplementation(TempFileCreator.class, WorkingDirectoryTempFileCreator.class)
 
           // Bind the YARN Configuration parameters

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
@@ -195,7 +195,7 @@ final class ContainerManager implements AutoCloseable {
     }
   }
 
-  void start() {
+  synchronized void start() {
     sendNodeDescriptors();
   }
 
@@ -392,7 +392,7 @@ final class ContainerManager implements AutoCloseable {
   }
 
   @Override
-  public void close() {
+  public synchronized void close() {
     synchronized (this.containers) {
       if (this.containers.isEmpty()) {
         LOG.log(Level.FINEST, "Clean shutdown with no outstanding containers.");

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
@@ -195,7 +195,7 @@ final class ContainerManager implements AutoCloseable {
     }
   }
 
-  public void startContainerManager() {
+  void startContainerManager() {
     sendNodeDescriptors();
   }
 

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
@@ -195,7 +195,7 @@ final class ContainerManager implements AutoCloseable {
     }
   }
 
-  void startContainerManager() {
+  void start() {
     sendNodeDescriptors();
   }
 

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalDriverConfiguration.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalDriverConfiguration.java
@@ -18,9 +18,7 @@
  */
 package org.apache.reef.runtime.local.driver;
 
-import org.apache.reef.runtime.common.driver.api.ResourceLaunchHandler;
-import org.apache.reef.runtime.common.driver.api.ResourceReleaseHandler;
-import org.apache.reef.runtime.common.driver.api.ResourceRequestHandler;
+import org.apache.reef.runtime.common.driver.api.*;
 import org.apache.reef.runtime.common.driver.parameters.ClientRemoteIdentifier;
 import org.apache.reef.runtime.common.driver.parameters.JobIdentifier;
 import org.apache.reef.runtime.common.files.RuntimeClasspathProvider;
@@ -73,6 +71,8 @@ public class LocalDriverConfiguration extends ConfigurationModuleBuilder {
       .bindImplementation(ResourceLaunchHandler.class, LocalResourceLaunchHandler.class)
       .bindImplementation(ResourceRequestHandler.class, LocalResourceRequestHandler.class)
       .bindImplementation(ResourceReleaseHandler.class, LocalResourceReleaseHandler.class)
+      .bindImplementation(ResourceManagerStartHandler.class, LocalResourceManagerStartHandler.class)
+      .bindImplementation(ResourceManagerStopHandler.class, LocalResourceManagerStopHandler.class)
       .bindNamedParameter(ClientRemoteIdentifier.class, CLIENT_REMOTE_IDENTIFIER)
       .bindNamedParameter(ErrorHandlerRID.class, CLIENT_REMOTE_IDENTIFIER)
       .bindNamedParameter(JobIdentifier.class, JOB_IDENTIFIER)

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalResourceManagerStartHandler.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalResourceManagerStartHandler.java
@@ -34,6 +34,6 @@ final class LocalResourceManagerStartHandler implements ResourceManagerStartHand
 
   @Override
   public void onNext(final RuntimeStart value) {
-    this.containerManager.startContainerManager();
+    this.containerManager.start();
   }
 }

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalResourceManagerStartHandler.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalResourceManagerStartHandler.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,23 +16,24 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.runtime.mesos.driver;
+package org.apache.reef.runtime.local.driver;
 
 import org.apache.reef.runtime.common.driver.api.ResourceManagerStartHandler;
 import org.apache.reef.wake.time.runtime.event.RuntimeStart;
 
 import javax.inject.Inject;
 
-final class MesosRuntimeStartHandler implements ResourceManagerStartHandler {
-  private final REEFScheduler reefScheduler;
+final class LocalResourceManagerStartHandler implements ResourceManagerStartHandler {
+
+  private final ContainerManager containerManager;
 
   @Inject
-  MesosRuntimeStartHandler(final REEFScheduler reefScheduler) {
-    this.reefScheduler = reefScheduler;
+  public LocalResourceManagerStartHandler(final ContainerManager containerManager) {
+    this.containerManager = containerManager;
   }
 
   @Override
-  public void onNext(final RuntimeStart runtimeStart){
-    this.reefScheduler.onStart();
+   public void onNext(final RuntimeStart value) {
+    containerManager.startContainerManager();
   }
 }

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalResourceManagerStartHandler.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalResourceManagerStartHandler.java
@@ -28,12 +28,12 @@ final class LocalResourceManagerStartHandler implements ResourceManagerStartHand
   private final ContainerManager containerManager;
 
   @Inject
-  public LocalResourceManagerStartHandler(final ContainerManager containerManager) {
+  private LocalResourceManagerStartHandler(final ContainerManager containerManager) {
     this.containerManager = containerManager;
   }
 
   @Override
-   public void onNext(final RuntimeStart value) {
-    containerManager.startContainerManager();
+  public void onNext(final RuntimeStart value) {
+    this.containerManager.startContainerManager();
   }
 }

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalResourceManagerStopHandler.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalResourceManagerStopHandler.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,23 +16,24 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.runtime.mesos.driver;
+package org.apache.reef.runtime.local.driver;
 
-import org.apache.reef.runtime.common.driver.api.ResourceManagerStartHandler;
-import org.apache.reef.wake.time.runtime.event.RuntimeStart;
+import org.apache.reef.runtime.common.driver.api.ResourceManagerStopHandler;
+import org.apache.reef.wake.time.runtime.event.RuntimeStop;
 
 import javax.inject.Inject;
 
-final class MesosRuntimeStartHandler implements ResourceManagerStartHandler {
-  private final REEFScheduler reefScheduler;
+final class LocalResourceManagerStopHandler implements ResourceManagerStopHandler {
+
+  private final ContainerManager containerManager;
 
   @Inject
-  MesosRuntimeStartHandler(final REEFScheduler reefScheduler) {
-    this.reefScheduler = reefScheduler;
+  public LocalResourceManagerStopHandler(final ContainerManager containerManager) {
+    this.containerManager = containerManager;
   }
 
   @Override
-  public void onNext(final RuntimeStart runtimeStart){
-    this.reefScheduler.onStart();
+  public void onNext(final RuntimeStop value) {
+    containerManager.close();
   }
 }

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalResourceManagerStopHandler.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/LocalResourceManagerStopHandler.java
@@ -28,12 +28,12 @@ final class LocalResourceManagerStopHandler implements ResourceManagerStopHandle
   private final ContainerManager containerManager;
 
   @Inject
-  public LocalResourceManagerStopHandler(final ContainerManager containerManager) {
+  private LocalResourceManagerStopHandler(final ContainerManager containerManager) {
     this.containerManager = containerManager;
   }
 
   @Override
   public void onNext(final RuntimeStop value) {
-    containerManager.close();
+    this.containerManager.close();
   }
 }

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosDriverConfiguration.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosDriverConfiguration.java
@@ -21,9 +21,7 @@ package org.apache.reef.runtime.mesos.driver;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.reef.io.TempFileCreator;
 import org.apache.reef.io.WorkingDirectoryTempFileCreator;
-import org.apache.reef.runtime.common.driver.api.ResourceLaunchHandler;
-import org.apache.reef.runtime.common.driver.api.ResourceReleaseHandler;
-import org.apache.reef.runtime.common.driver.api.ResourceRequestHandler;
+import org.apache.reef.runtime.common.driver.api.*;
 import org.apache.reef.runtime.common.driver.parameters.ClientRemoteIdentifier;
 import org.apache.reef.runtime.common.driver.parameters.EvaluatorTimeout;
 import org.apache.reef.runtime.common.driver.parameters.JobIdentifier;
@@ -41,7 +39,6 @@ import org.apache.reef.tang.formats.RequiredParameter;
 import org.apache.reef.wake.EStage;
 import org.apache.reef.wake.StageConfiguration;
 import org.apache.reef.wake.impl.SingleThreadStage;
-import org.apache.reef.wake.time.Clock;
 
 /**
  * Binds Driver's runtime event handlers.
@@ -81,8 +78,8 @@ public final class MesosDriverConfiguration extends ConfigurationModuleBuilder {
       .bindImplementation(ResourceLaunchHandler.class, MesosResourceLaunchHandler.class)
       .bindImplementation(ResourceReleaseHandler.class, MesosResourceReleaseHandler.class)
       .bindImplementation(ResourceRequestHandler.class, MesosResourceRequestHandler.class)
-      .bindSetEntry(Clock.RuntimeStartHandler.class, MesosRuntimeStartHandler.class)
-      .bindSetEntry(Clock.RuntimeStopHandler.class, MesosRuntimeStopHandler.class)
+      .bindImplementation(ResourceManagerStartHandler.class, MesosRuntimeStartHandler.class)
+      .bindImplementation(ResourceManagerStopHandler.class, MesosRuntimeStopHandler.class)
       .bindImplementation(TempFileCreator.class, WorkingDirectoryTempFileCreator.class)
 
       .bindNamedParameter(MesosMasterIp.class, MESOS_MASTER_IP)

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosRuntimeStopHandler.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosRuntimeStopHandler.java
@@ -18,12 +18,12 @@
  */
 package org.apache.reef.runtime.mesos.driver;
 
-import org.apache.reef.wake.EventHandler;
+import org.apache.reef.runtime.common.driver.api.ResourceManagerStopHandler;
 import org.apache.reef.wake.time.runtime.event.RuntimeStop;
 
 import javax.inject.Inject;
 
-final class MesosRuntimeStopHandler implements EventHandler<RuntimeStop> {
+final class MesosRuntimeStopHandler implements ResourceManagerStopHandler {
   private final REEFScheduler reefScheduler;
 
   @Inject

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YARNRuntimeStartHandler.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YARNRuntimeStartHandler.java
@@ -18,7 +18,7 @@
  */
 package org.apache.reef.runtime.yarn.driver;
 
-import org.apache.reef.wake.EventHandler;
+import org.apache.reef.runtime.common.driver.api.ResourceManagerStartHandler;
 import org.apache.reef.wake.time.runtime.event.RuntimeStart;
 
 import javax.inject.Inject;
@@ -26,7 +26,7 @@ import javax.inject.Inject;
 /**
  * Handler of RuntimeStart for the YARN Runtime.
  */
-public final class YARNRuntimeStartHandler implements EventHandler<RuntimeStart> {
+public final class YARNRuntimeStartHandler implements ResourceManagerStartHandler {
 
   private final YarnContainerManager yarnContainerManager;
 

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YARNRuntimeStopHandler.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YARNRuntimeStopHandler.java
@@ -18,7 +18,7 @@
  */
 package org.apache.reef.runtime.yarn.driver;
 
-import org.apache.reef.wake.EventHandler;
+import org.apache.reef.runtime.common.driver.api.ResourceManagerStopHandler;
 import org.apache.reef.wake.time.runtime.event.RuntimeStop;
 
 import javax.inject.Inject;
@@ -26,7 +26,7 @@ import javax.inject.Inject;
 /**
  * Shuts down the YARN resource manager.
  */
-public final class YARNRuntimeStopHandler implements EventHandler<RuntimeStop> {
+public final class YARNRuntimeStopHandler implements ResourceManagerStopHandler {
 
   private final YarnContainerManager yarnContainerManager;
 

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverConfiguration.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverConfiguration.java
@@ -21,9 +21,7 @@ package org.apache.reef.runtime.yarn.driver;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.reef.io.TempFileCreator;
 import org.apache.reef.io.WorkingDirectoryTempFileCreator;
-import org.apache.reef.runtime.common.driver.api.ResourceLaunchHandler;
-import org.apache.reef.runtime.common.driver.api.ResourceReleaseHandler;
-import org.apache.reef.runtime.common.driver.api.ResourceRequestHandler;
+import org.apache.reef.runtime.common.driver.api.*;
 import org.apache.reef.runtime.common.driver.parameters.ClientRemoteIdentifier;
 import org.apache.reef.runtime.common.driver.parameters.EvaluatorTimeout;
 import org.apache.reef.runtime.common.driver.parameters.JobIdentifier;
@@ -39,7 +37,6 @@ import org.apache.reef.tang.formats.ConfigurationModule;
 import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
 import org.apache.reef.tang.formats.OptionalParameter;
 import org.apache.reef.tang.formats.RequiredParameter;
-import org.apache.reef.wake.time.Clock;
 
 /**
  * Created by marku_000 on 2014-07-07.
@@ -80,9 +77,9 @@ public class YarnDriverConfiguration extends ConfigurationModuleBuilder {
       .bindImplementation(ResourceLaunchHandler.class, YARNResourceLaunchHandler.class)
       .bindImplementation(ResourceReleaseHandler.class, YARNResourceReleaseHandler.class)
       .bindImplementation(ResourceRequestHandler.class, YarnResourceRequestHandler.class)
+      .bindImplementation(ResourceManagerStartHandler.class, YARNRuntimeStartHandler.class)
+      .bindImplementation(ResourceManagerStopHandler.class, YARNRuntimeStopHandler.class)
       .bindConstructor(YarnConfiguration.class, YarnConfigurationConstructor.class)
-      .bindSetEntry(Clock.RuntimeStartHandler.class, YARNRuntimeStartHandler.class)
-      .bindSetEntry(Clock.RuntimeStopHandler.class, YARNRuntimeStopHandler.class)
       .bindImplementation(TempFileCreator.class, WorkingDirectoryTempFileCreator.class)
 
           // Bind the YARN Configuration parameters


### PR DESCRIPTION
The root cause of the sporadic exception was a race condition between DriverRuntimeStopHandler
and ContainerManager.close(). DriverRuntimeStopHandler#onNext sets all evaluators' states as KILLED.
If evaluators are closed by the ContainerManager before the evaluator status is set to KILLED, an
unexpected FailedEvaluatorException arises and breaks the FailDriverTest.

JIRA:
    [REEF-312] (https://issues.apache.org/jira/browse/REEF-312)