### PR TITLE
[REEF-544] DriverStatusManager onError does not propagate exception to RuntimeStop

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/REEFLauncher.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/REEFLauncher.java
@@ -22,6 +22,7 @@ import org.apache.reef.runtime.common.evaluator.PIDStoreStartHandler;
 import org.apache.reef.runtime.common.launch.ProfilingStopHandler;
 import org.apache.reef.runtime.common.launch.REEFErrorHandler;
 import org.apache.reef.runtime.common.launch.REEFMessageCodec;
+import org.apache.reef.runtime.common.launch.REEFUncaughtExceptionHandler;
 import org.apache.reef.runtime.common.launch.parameters.ClockConfigurationPath;
 import org.apache.reef.tang.*;
 import org.apache.reef.tang.annotations.Name;
@@ -162,6 +163,8 @@ public final class REEFLauncher {
     }
 
     final REEFLauncher launcher = getREEFLauncher(args[0]);
+
+    Thread.setDefaultUncaughtExceptionHandler(new REEFUncaughtExceptionHandler(launcher.clockConfig));
     launcher.logVersion();
 
     try (final Clock clock = launcher.getClockFromConfig()) {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverStatusManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverStatusManager.java
@@ -143,7 +143,7 @@ public final class DriverStatusManager {
     } else {
       LOG.log(Level.WARNING, "Shutting down the Driver with an exception: ", exception);
       this.shutdownCause = Optional.of(exception);
-      this.clock.stop();
+      this.clock.stop(exception);
       this.setStatus(DriverStatus.FAILING);
     }
     LOG.exiting(DriverStatusManager.class.getCanonicalName(), "onError", new Object[]{exception});

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
@@ -264,7 +264,7 @@ final class YarnContainerManager
     }
   }
 
-  void onStop(final Exception exception) {
+  void onStop(final Throwable exception) {
 
     LOG.log(Level.FINE, "Stop Runtime: RM status {0}", this.resourceManager.getServiceState());
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/Clock.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/Clock.java
@@ -64,6 +64,13 @@ public interface Clock extends Runnable, AutoCloseable {
   void stop();
 
   /**
+   * This stops the clock immediately, without waiting for
+   * client alarms to finish. Stops with an exception that
+   * is propagated to RuntimeStopHandlers.
+   */
+  void stop(final Throwable exception);
+
+  /**
    * Clock is idle if it has no future Alarms set.
    *
    * @return true if idle, otherwise false

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/RuntimeStop.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/RuntimeStop.java
@@ -20,21 +20,20 @@ package org.apache.reef.wake.time.runtime.event;
 
 import org.apache.reef.wake.time.Time;
 
-
 public class RuntimeStop extends Time {
 
-  private final Exception exception;
+  private final Throwable exception;
 
   public RuntimeStop(final long timestamp) {
     this(timestamp, null);
   }
 
-  public RuntimeStop(final long timestamp, final Exception exception) {
+  public RuntimeStop(final long timestamp, final Throwable exception) {
     super(timestamp);
     this.exception = exception;
   }
 
-  public final Exception getException() {
+  public final Throwable getException() {
     return this.exception;
   }
 }


### PR DESCRIPTION
This addressed the issue by
  * Propagating exceptions to RuntimeStopHandlers by adding a Throwable parameter to Clock.onStop().
  * Adding an UncaughtREEFExceptionHandler to REEFLauncher.

JIRA:
  [REEF-544](https://issues.apache.org/jira/browse/REEF-544)