### PR TITLE
[REEF-545]: Create a Configuration Helper for NetworkConnectionService

### DIFF
--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/BindNetworkConnectionServiceToDriver.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/BindNetworkConnectionServiceToDriver.java
@@ -18,34 +18,38 @@
  */
 package org.apache.reef.io.network.impl;
 
+import org.apache.reef.driver.parameters.DriverIdentifier;
 import org.apache.reef.io.network.NetworkConnectionService;
 import org.apache.reef.io.network.impl.config.NetworkConnectionServiceIdFactory;
 import org.apache.reef.tang.annotations.Parameter;
-import org.apache.reef.task.events.TaskStart;
 import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.IdentifierFactory;
+import org.apache.reef.wake.time.event.StartTime;
 
 import javax.inject.Inject;
 
 /**
- * TaskStart event handler for registering NetworkConnectionService.
- * This class registers taskId to network connection service.
+ * Driver start event handler for registering NetworkConnectionService.
+ * This class registers driverId to network connection service.
  */
-public final class BindNetworkConnectionServiceToTask implements EventHandler<TaskStart> {
+public final class BindNetworkConnectionServiceToDriver implements EventHandler<StartTime> {
 
+  private final String driverId;
   private final NetworkConnectionService ncs;
   private final IdentifierFactory idFac;
 
   @Inject
-  private BindNetworkConnectionServiceToTask(
+  private BindNetworkConnectionServiceToDriver(
+      @Parameter(DriverIdentifier.class) final String driverId,
       final NetworkConnectionService ncs,
       @Parameter(NetworkConnectionServiceIdFactory.class) final IdentifierFactory idFac) {
+    this.driverId = driverId;
     this.ncs = ncs;
     this.idFac = idFac;
   }
 
   @Override
-  public void onNext(final TaskStart task) {
-    this.ncs.registerId(this.idFac.getNewInstance(task.getId()));
+  public void onNext(final StartTime task) {
+    this.ncs.registerId(this.idFac.getNewInstance(driverId));
   }
 }

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/UnbindNetworkConnectionServiceFromTask.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/UnbindNetworkConnectionServiceFromTask.java
@@ -28,7 +28,7 @@ import org.apache.reef.wake.IdentifierFactory;
 import javax.inject.Inject;
 /**
  * TaskStop event handler for unregistering NetworkConnectionService.
- * Users have to bind this handler into ServiceConfiguration.ON_TASK_STOP.
+ * This class unregisters driverId from network connection service.
  */
 public final class UnbindNetworkConnectionServiceFromTask implements EventHandler<TaskStop> {
 
@@ -36,7 +36,7 @@ public final class UnbindNetworkConnectionServiceFromTask implements EventHandle
   private final IdentifierFactory idFac;
 
   @Inject
-  public UnbindNetworkConnectionServiceFromTask(
+  private UnbindNetworkConnectionServiceFromTask(
       final NetworkConnectionService ncs,
       @Parameter(NetworkConnectionServiceIdFactory.class) final IdentifierFactory idFac) {
     this.ncs = ncs;

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/UnbindNetworkConnectionServiceFromTask.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/UnbindNetworkConnectionServiceFromTask.java
@@ -28,7 +28,7 @@ import org.apache.reef.wake.IdentifierFactory;
 import javax.inject.Inject;
 /**
  * TaskStop event handler for unregistering NetworkConnectionService.
- * This class unregisters driverId from network connection service.
+ * This class unregisters taskId from network connection service.
  */
 public final class UnbindNetworkConnectionServiceFromTask implements EventHandler<TaskStop> {
 

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/config/NetworkConnectionServiceConfiguration.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/config/NetworkConnectionServiceConfiguration.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.io.network.impl.config;
+
+import org.apache.reef.driver.context.ServiceConfiguration;
+import org.apache.reef.driver.parameters.DriverStartHandler;
+import org.apache.reef.io.network.impl.BindNetworkConnectionServiceToDriver;
+import org.apache.reef.io.network.impl.BindNetworkConnectionServiceToTask;
+import org.apache.reef.io.network.impl.NetworkConnectionServiceImpl;
+import org.apache.reef.io.network.impl.UnbindNetworkConnectionServiceFromTask;
+import org.apache.reef.io.network.naming.LocalNameResolverImpl;
+import org.apache.reef.io.network.naming.NameResolver;
+import org.apache.reef.io.network.naming.parameters.NameResolverNameServerAddr;
+import org.apache.reef.io.network.naming.parameters.NameResolverNameServerPort;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.Configurations;
+import org.apache.reef.tang.JavaConfigurationBuilder;
+import org.apache.reef.tang.Tang;
+
+/**
+ * Configuration for NetworkConnectionService.
+ */
+public final class NetworkConnectionServiceConfiguration {
+
+  private NetworkConnectionServiceConfiguration() {
+    //not called
+  }
+
+  /**
+   * Get a network connection configuration for driver.
+   * @return network service configuration
+   */
+  public static Configuration getDriverConfiguration() {
+    final JavaConfigurationBuilder jcb = Tang.Factory.getTang().newConfigurationBuilder();
+    jcb.bindImplementation(NameResolver.class, LocalNameResolverImpl.class);
+    jcb.bindSetEntry(DriverStartHandler.class, BindNetworkConnectionServiceToDriver.class);
+    return jcb.build();
+  }
+
+  /**
+   * Get a network service configuration for registering network service to a task.
+   * @param nameServerAddr name server address
+   * @param nameServerPort namer server port
+   * @return network service configuration
+   */
+  public static Configuration getServiceConfiguration(final String nameServerAddr, final int nameServerPort) {
+    final JavaConfigurationBuilder jcb = Tang.Factory.getTang().newConfigurationBuilder();
+    jcb.bindNamedParameter(NameResolverNameServerAddr.class, nameServerAddr);
+    jcb.bindNamedParameter(NameResolverNameServerPort.class, Integer.toString(nameServerPort));
+    return Configurations.merge(jcb.build(), ServiceConfiguration.CONF
+        .set(ServiceConfiguration.SERVICES, NetworkConnectionServiceImpl.class)
+        .set(ServiceConfiguration.ON_TASK_STARTED, BindNetworkConnectionServiceToTask.class)
+        .set(ServiceConfiguration.ON_TASK_STOP, UnbindNetworkConnectionServiceFromTask.class)
+        .build());
+  }
+}


### PR DESCRIPTION
This pull request addressed the issue by
* creating `BindNetworkConnectionServiceToDriver` which registers driver id to `NetworkConnectionService`.
* creating `NetworkConnectionServiceConfiguration` which provides driver configuration and service configuration.

JIRA: [REEF-545](https://issues.apache.org/jira/browse/REEF-545)