### PR TITLE
[REEF-549] Remove APIs deprecated since 0.11 from REEF Runtime Common

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Files/REEFFileNames.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Files/REEFFileNames.cs
@@ -42,8 +42,6 @@ namespace Org.Apache.REEF.Common.Files
         private const string EVALUATOR_STDERR = "evaluator.stderr";
         private const string EVALUATOR_STDOUT = "evaluator.stdout";
         private const string CPP_BRIDGE = "JavaClrBridge";
-        private const string REEF_DRIVER_APPDLL_DIR = "/ReefDriverAppDlls/";
-        private const string TMP_LOAD_DIR = "/reef/CLRLoadingDirectory";
         private const string REEF_BASE_FOLDER = "reef";
         private const string GLOBAL_FOLDER = "global";
         private const string LOCAL_FOLDER = "local";
@@ -213,28 +211,12 @@ namespace Org.Apache.REEF.Common.Files
         }
 
         /// <summary>
-        /// </summary>
-        /// <returns>reef driver app dll directory</returns>
-        public string GetReefDriverAppDllDir()
-        {
-            return REEF_DRIVER_APPDLL_DIR;
-        }
-
-        /// <summary>
         /// The name of the Bridge DLL.
         /// </summary>
         /// <returns>The name of the Bridge DLL.</returns>
         public string GetBridgeDLLName()
         {
             return BRIDGE_DLL_NAME;
-        }
-
-        /// <summary>
-        /// </summary>
-        /// <returns>temp load directory</returns>
-        public string GetLoadDir()
-        {
-            return TMP_LOAD_DIR;
         }
 
         private static readonly string GLOBAL_FOLDER_PATH = Path.Combine(REEF_BASE_FOLDER, GLOBAL_FOLDER);

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/REEFFileNames.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/REEFFileNames.java
@@ -47,10 +47,6 @@ public final class REEFFileNames {
   private static final String DRIVER_STDOUT = "driver.stdout";
   private static final String EVALUATOR_STDERR = "evaluator.stderr";
   private static final String EVALUATOR_STDOUT = "evaluator.stdout";
-  @Deprecated
-  private static final String REEF_DRIVER_APPDLL_DIR = "/ReefDriverAppDlls/";
-  @Deprecated
-  private static final String TMP_LOAD_DIR = "/reef/CLRLoadingDirectory";
   private static final String BRIDGE_DLL_NAME = "Org.Apache.REEF.Bridge.dll";
 
 
@@ -219,22 +215,5 @@ public final class REEFFileNames {
    */
   public String getEvaluatorStdoutFileName() {
     return EVALUATOR_STDOUT;
-  }
-
-
-  /**
-   * @return reef driver app dll directory
-   */
-  @Deprecated
-  public String getReefDriverAppDllDir() {
-    return REEF_DRIVER_APPDLL_DIR;
-  }
-
-  /**
-   * @return temp load directory
-   */
-  @Deprecated
-  public String getLoadDir() {
-    return TMP_LOAD_DIR;
   }
 }


### PR DESCRIPTION
This addressed the issue by
  * removing REEF_DRIVER_APPDLL_DIR and TMP_LOAD_DIR

JIRA:
  [REEF-549](https://issues.apache.org/jira/browse/REEF-549)