### PR TITLE
[REEF-508] Determine restarts on YARN by using a runtime environment Determine restarts on YARN by using a runtime environment variable

### DIFF
--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRestartManager.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRestartManager.java
@@ -18,7 +18,11 @@
  */
 package org.apache.reef.runtime.yarn.driver;
 
+import org.apache.hadoop.yarn.api.ApplicationConstants;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.Container;
+import org.apache.hadoop.yarn.api.records.ContainerId;
+import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.reef.annotations.Unstable;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
@@ -52,7 +56,7 @@ public final class YarnDriverRestartManager implements DriverRestartManager {
   private final ApplicationMasterRegistration registration;
   private final DriverStatusManager driverStatusManager;
   private final REEFEventHandlers reefEventHandlers;
-  private List<Container> previousContainers;
+  private Set<Container> previousContainers;
 
   @Inject
   private YarnDriverRestartManager(@Parameter(YarnEvaluatorPreserver.class)
@@ -67,25 +71,81 @@ public final class YarnDriverRestartManager implements DriverRestartManager {
     this.previousContainers = null;
   }
 
+  /**
+   * Determines whether the application master has been restarted based on the container ID environment
+   * variable provided by YARN. If that fails, determine whether the application master is a restart
+   * based on the number of previous containers reported by YARN.
+   * @return true if the application master is a restarted instance, false otherwise.
+   */
   @Override
   public boolean isRestart() {
-    // TODO [REEF-508]: Determine restart based on environment variable as provided by YARN.
+    String containerIdString;
+
+    try {
+      containerIdString = System.getenv(ApplicationConstants.Environment.CONTAINER_ID.key());
+    } catch (Exception e) {
+      LOG.log(Level.WARNING, "Unable to get the container ID from the environment, exception " +
+          e + " was thrown.");
+      containerIdString = null;
+    }
+
+    if (containerIdString == null) {
+      // container id should always be set in the env by the framework
+      LOG.log(Level.WARNING, "Container ID is null, determining restart based on previous containers.");
+      return this.isRestartByPreviousContainers();
+    }
+
+    ApplicationAttemptId appAttemptID;
+
+    try {
+      final ContainerId containerId = ConverterUtils.toContainerId(containerIdString);
+      appAttemptID = containerId.getApplicationAttemptId();
+    } catch (Exception e) {
+      LOG.log(Level.WARNING, "Unable to get the applicationAttempt ID from the environment, exception " +
+          e + " was thrown.");
+      appAttemptID = null;
+    }
+
+    if (appAttemptID == null) {
+      LOG.log(Level.WARNING, "applicationAttempt ID is null, determining restart based on previous containers.");
+      return this.isRestartByPreviousContainers();
+    }
+
+    LOG.log(Level.FINE, "Application attempt: " + appAttemptID.getAttemptId());
+
+    return appAttemptID.getAttemptId() > 1;
+  }
+
+  /**
+   * Initializes the list of previous containers and determine whether or not this is an instance of restart
+   * based on information reported by the RM.
+   * @return true if previous containers is not empty.
+   */
+  private boolean isRestartByPreviousContainers() {
+    this.initializeListOfPreviousContainers();
+    return !this.previousContainers.isEmpty();
+  }
+
+  /**
+   * Initializes the list of previous containers as reported by YARN.
+   */
+  private synchronized void initializeListOfPreviousContainers() {
     if (this.previousContainers == null) {
-      this.previousContainers = this.registration.getRegistration().getContainersFromPreviousAttempts();
+      this.previousContainers = new HashSet<>(this.registration.getRegistration().getContainersFromPreviousAttempts());
 
       // If it's still null, create an empty list to indicate that it's not a restart.
       if (this.previousContainers == null) {
-        this.previousContainers = new ArrayList<>();
+        this.previousContainers = new HashSet<>();
       }
     }
-
-    return !this.previousContainers.isEmpty();
   }
 
   @Override
   public void onRestart() {
     final Set<String> recoveredEvaluators = new HashSet<>();
     final Set<String> failedEvaluators = new HashSet<>();
+
+    this.initializeListOfPreviousContainers();
 
     if (this.previousContainers != null && !this.previousContainers.isEmpty()) {
       LOG.log(Level.INFO, "Driver restarted, with {0} previous containers", this.previousContainers.size());
@@ -131,11 +191,21 @@ public final class YarnDriverRestartManager implements DriverRestartManager {
     this.informAboutEvaluatorFailures(failedEvaluators);
   }
 
+  /**
+   * Informs the driver status manager about the number of evaluators to wait for to reinitiate contact
+   * with the driver.
+   * TODO [REEF-559]: Tighten previous evaluator ID checks by using entire set of evaluator IDs.
+   * @param evaluatorIds The set of evaluator IDs of evaluators expected to be alive.
+   */
   private void informAboutEvaluatorAlive(final Set<String> evaluatorIds) {
     // We will wait for these evaluators to contact us, so we do not need to record the entire container information.
     this.driverStatusManager.setNumPreviousContainers(evaluatorIds.size());
   }
 
+  /**
+   * Generate failure events for evaluators that cannot be recovered.
+   * @param evaluatorIds The set of evaluator IDs of evaluators that have failed on restart.
+   */
   private void informAboutEvaluatorFailures(final Set<String> evaluatorIds) {
     for (String evaluatorId : evaluatorIds) {
       LOG.log(Level.WARNING, "Container [" + evaluatorId +


### PR DESCRIPTION
This addressed the issue by
  * Using the environment variable to determine whether or not the job driver has restarted.
  * Falling back to previous containers reported by RM if using the environment variable fails.

JIRA:
  [REEF-508](https://issues.apache.org/jira/browse/REEF-508)