### PR TITLE
[REEF-557] Move EnvironmentUtils.addAll to ConfigurationModule.set and delete EnvironmentUtils.addClasspath

### DIFF
--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobClient.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobClient.java
@@ -103,7 +103,8 @@ public class JobClient {
   }
 
   public static ConfigurationModule getDriverConfiguration() {
-    return EnvironmentUtils.addClasspath(DriverConfiguration.CONF, DriverConfiguration.GLOBAL_LIBRARIES)
+    return DriverConfiguration.CONF
+        .setMultiple(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getAllClasspathJars())
         .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, JobDriver.AllocatedEvaluatorHandler.class)
         .set(DriverConfiguration.ON_EVALUATOR_FAILED, JobDriver.FailedEvaluatorHandler.class)
         .set(DriverConfiguration.ON_CONTEXT_ACTIVE, JobDriver.ActiveContextHandler.class)

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/EnvironmentUtils.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/EnvironmentUtils.java
@@ -18,10 +18,6 @@
  */
 package org.apache.reef.util;
 
-import org.apache.reef.tang.formats.ConfigurationModule;
-import org.apache.reef.tang.formats.OptionalParameter;
-import org.apache.reef.tang.formats.Param;
-
 import java.io.File;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
@@ -95,37 +91,6 @@ public final class EnvironmentUtils {
     }
 
     return jars;
-  }
-
-  /**
-   * @param config
-   * @param param
-   * @param values
-   * @param <P>
-   * @return
-   * @deprecated in 0.2 this really should be in Tang.
-   */
-  @Deprecated
-  public static <P extends Param> ConfigurationModule addAll(
-      final ConfigurationModule config, final P param, final Iterable<String> values) {
-    ConfigurationModule conf = config;
-    for (final String val : values) {
-      conf = conf.set(param, val);
-    }
-    return conf;
-  }
-
-  /**
-   * @param config
-   * @param param
-   * @return
-   * @deprecated Using this method is inherently non-deterministic as it depends on environment variables on your local
-   * machine.
-   */
-  @Deprecated
-  public static ConfigurationModule addClasspath(
-      final ConfigurationModule config, final OptionalParameter<String> param) {
-    return addAll(config, param, getAllClasspathJars());
   }
 
   /**

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/BGDClient.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/BGDClient.java
@@ -107,8 +107,8 @@ public class BGDClient {
         .setNumberOfDesiredSplits(numSplits)
         .setComputeRequest(computeRequest)
         .renewFailedEvaluators(false)
-        .setDriverConfigurationModule(EnvironmentUtils
-            .addClasspath(DriverConfiguration.CONF, DriverConfiguration.GLOBAL_LIBRARIES)
+        .setDriverConfigurationModule(DriverConfiguration.CONF
+            .setMultiple(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getAllClasspathJars())
             .set(DriverConfiguration.DRIVER_MEMORY, Integer.toString(memory))
             .set(DriverConfiguration.ON_CONTEXT_ACTIVE, BGDDriver.ContextActiveHandler.class)
             .set(DriverConfiguration.ON_TASK_RUNNING, BGDDriver.TaskRunningHandler.class)

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/BroadcastREEF.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/BroadcastREEF.java
@@ -115,8 +115,8 @@ public final class BroadcastREEF {
   public static LauncherStatus runBGDReef(
       final Configuration runtimeConfiguration) throws InjectionException {
 
-    final Configuration driverConfiguration = EnvironmentUtils
-        .addClasspath(DriverConfiguration.CONF, DriverConfiguration.GLOBAL_LIBRARIES)
+    final Configuration driverConfiguration = DriverConfiguration.CONF
+        .setMultiple(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getAllClasspathJars())
         .set(DriverConfiguration.ON_DRIVER_STARTED, BroadcastDriver.StartHandler.class)
         .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, BroadcastDriver.EvaluatorAllocatedHandler.class)
         .set(DriverConfiguration.ON_CONTEXT_ACTIVE, BroadcastDriver.ContextActiveHandler.class)

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationModule.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationModule.java
@@ -144,7 +144,39 @@ public class ConfigurationModule {
   }
 
   /**
-   * Binds a list to a specfici optional/required Param using ConfigurationModule.
+   * Binds a set of values to a Param using ConfigurationModule.
+   *
+   * @param opt    Target Param
+   * @param values Values to bind to the Param
+   * @param <T>
+   * @return
+   */
+  public final <T> ConfigurationModule setMultiple(final Param<T> opt, final Iterable<String> values) {
+    ConfigurationModule c = deepCopy();
+    for (final String val : values) {
+      c = c.set(opt, val);
+    }
+    return c;
+  }
+
+  /**
+   * Binds a set of values to a Param using ConfigurationModule.
+   *
+   * @param opt    Target Param
+   * @param values Values to bind to the Param
+   * @param <T>
+   * @return
+   */
+  public final <T> ConfigurationModule setMultiple(final Param<T> opt, final String... values) {
+    ConfigurationModule c = deepCopy();
+    for (final String val : values) {
+      c = c.set(opt, val);
+    }
+    return c;
+  }
+
+  /**
+   * Binds a list to a specific optional/required Param using ConfigurationModule.
    *
    * @param opt      target optional/required Param
    * @param implList List object to be injected


### PR DESCRIPTION
This addressed the issue by
  * Creating ConfigurationModule.setMultipleValues method
  * Replacing use of addClassPath with setMultipleValues
  * Deprecating EnvironmentUtils.addAll and addClassPath

JIRA:
  [REEF-557](https://issues.apache.org/jira/browse/REEF-557)