### PR TITLE
[REEF-541] Notifying evaluator restart failure entails calling AllocatedEvaluatorHandler

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManagerFactory.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManagerFactory.java
@@ -83,11 +83,13 @@ public final class EvaluatorManagerFactory {
 
   /**
    * Instantiates a new EvaluatorManager based on a resource allocation.
+   * Fires the EvaluatorAllocatedEvent.
    *
    * @param resourceAllocationEvent
-   * @return
+   * @return an EvaluatorManager for the newly allocated Evaluator.
    */
-  public EvaluatorManager getNewEvaluatorManager(final ResourceAllocationEvent resourceAllocationEvent) {
+  public EvaluatorManager getNewEvaluatorManagerForNewlyAllocatedEvaluator(
+      final ResourceAllocationEvent resourceAllocationEvent) {
     final NodeDescriptor nodeDescriptor = this.resourceCatalog.getNode(resourceAllocationEvent.getNodeId());
 
     if (nodeDescriptor == null) {
@@ -98,9 +100,19 @@ public final class EvaluatorManagerFactory {
         processFactory.newEvaluatorProcess());
 
     LOG.log(Level.FINEST, "Resource allocation: new evaluator id[{0}]", resourceAllocationEvent.getIdentifier());
-    return this.getNewEvaluatorManagerInstance(resourceAllocationEvent.getIdentifier(), evaluatorDescriptor);
+    final EvaluatorManager evaluatorManager =
+        getNewEvaluatorManagerInstance(resourceAllocationEvent.getIdentifier(), evaluatorDescriptor);
+    evaluatorManager.fireEvaluatorAllocatedEvent();
+
+    return evaluatorManager;
   }
 
+  /**
+   * Instantiates a new EvaluatorManager for a failed evaluator during driver restart.
+   * Does not fire an EvaluatorAllocatedEvent.
+   * @param resourceStatusEvent
+   * @return an EvaluatorManager for the user to call fail on.
+   */
   public EvaluatorManager createForEvaluatorFailedDuringDriverRestart(final ResourceStatusEvent resourceStatusEvent) {
     if (!resourceStatusEvent.getIsFromPreviousDriver().get()) {
       throw new RuntimeException("Invalid resourceStatusEvent, must be status for resource from previous Driver.");

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/Evaluators.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/Evaluators.java
@@ -107,7 +107,7 @@ public final class Evaluators implements AutoCloseable {
   public synchronized void put(
       final EvaluatorManagerFactory evaluatorManagerFactory,
       final ResourceAllocationEvent evaluatorMsg) {
-    this.put(evaluatorManagerFactory.getNewEvaluatorManager(evaluatorMsg));
+    this.put(evaluatorManagerFactory.getNewEvaluatorManagerForNewlyAllocatedEvaluator(evaluatorMsg));
   }
 
   /**


### PR DESCRIPTION
This addressed the issue by
  * Avoids calling AllocatedEvaluatorHandler on restart by adding a parameter to EvaluatorManager.

JIRA:
  [REEF-541](https://issues.apache.org/jira/browse/REEF-541)