### PR TITLE
[REEF-561] Move restart functions from DriverStatusManager to DriverRestartManager

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartManager.java
@@ -21,43 +21,67 @@ package org.apache.reef.driver.restart;
 import org.apache.reef.annotations.Unstable;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
-import org.apache.reef.annotations.audience.RuntimeAuthor;
 
 /**
- * Classes implementing this interface are in charge of recording evaluator
- * changes as they are allocated as well as recovering Evaluators and
- * discovering which evaluators are lost on the event of a driver restart.
+ * The manager that handles aspects of driver restart such as determining whether the driver is in
+ * restart mode, what to do on restart, whether restart is completed, and others.
  */
 @DriverSide
 @Private
-@RuntimeAuthor
 @Unstable
 public interface DriverRestartManager {
 
   /**
-   * Determines whether or not the driver has been restarted.
+   * @return Whether or not the driver instance is a restarted instance.
    */
   boolean isRestart();
 
   /**
-   * This function has a few jobs crucial jobs to enable restart:
-   * 1. Recover the list of evaluators that are reported to be alive by the Resource Manager.
-   * 2. Make necessary operations to inform relevant runtime components about evaluators that are alive
-   * with the set of evaluator IDs recovered in step 1.
-   * 3. Make necessary operations to inform relevant runtime components about evaluators that have failed
-   * during the driver restart period.
+   * Recovers the list of alive and failed evaluators and inform about evaluator failures
+   * based on the specific runtime. Also sets the expected amount of evaluators to report back
+   * as alive to the job driver.
    */
   void onRestart();
 
   /**
-   * Records the evaluators when it is allocated.
+   * Indicate that the Driver restart is complete. It is meant to be called exactly once during a restart and never
+   * during the ininital launch of a Driver.
+   */
+  void setRestartCompleted();
+
+  /**
+   * @return the number of Evaluators expected to check in from a previous run.
+   */
+  int getNumPreviousContainers();
+
+
+  /**
+   * Set the number of containers to expect still active from a previous execution of the Driver in a restart situation.
+   * To be called exactly once during a driver restart.
+   *
+   * @param num
+   */
+  void setNumPreviousContainers(final int num);
+
+  /**
+   * @return the number of Evaluators from a previous Driver that have checked in with the Driver
+   * in a restart situation.
+   */
+  int getNumRecoveredContainers();
+
+  /**
+   * Indicate that this Driver has re-established the connection with one more Evaluator of a previous run.
+   */
+  void oneContainerRecovered();
+
+  /**
+   * Records the evaluators when it is allocated. The implementation depends on the runtime.
    * @param id The evaluator ID of the allocated evaluator.
    */
   void recordAllocatedEvaluator(final String id);
 
-
   /**
-   * Records a removed evaluator into the evaluator log.
+   * Records a removed evaluator into the evaluator log. The implementation depends on the runtime.
    * @param id The evaluator ID of the removed evaluator.
    */
   void recordRemovedEvaluator(final String id);

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartManagerImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartManagerImpl.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.driver.restart;
+
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Private;
+
+import javax.inject.Inject;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * The implementation of DriverRestartManager. A few methods here are proxy methods for
+ * the DriverRuntimeRestartManager that depends on the runtime implementation.
+ */
+@DriverSide
+@Private
+@Unstable
+public final class DriverRestartManagerImpl implements DriverRestartManager {
+  private static final Logger LOG = Logger.getLogger(DriverRestartManagerImpl.class.getName());
+  private final DriverRuntimeRestartManager driverRuntimeRestartManager;
+
+  private boolean restartCompleted;
+  private int numPreviousContainers;
+  private int numRecoveredContainers;
+
+  @Inject
+  private DriverRestartManagerImpl(final DriverRuntimeRestartManager driverRuntimeRestartManager) {
+    this.driverRuntimeRestartManager = driverRuntimeRestartManager;
+    this.restartCompleted = false;
+    this.numPreviousContainers = -1;
+    this.numRecoveredContainers = 0;
+  }
+
+  @Override
+  public boolean isRestart() {
+    return driverRuntimeRestartManager.isRestart();
+  }
+
+  @Override
+  public void onRestart() {
+    final EvaluatorRestartInfo evaluatorRestartInfo = driverRuntimeRestartManager.getAliveAndFailedEvaluators();
+    setNumPreviousContainers(evaluatorRestartInfo.getAliveEvaluators().size());
+    driverRuntimeRestartManager.informAboutEvaluatorFailures(evaluatorRestartInfo.getFailedEvaluators());
+  }
+
+  @Override
+  public synchronized void setRestartCompleted() {
+    if (this.restartCompleted) {
+      LOG.log(Level.WARNING, "Calling setRestartCompleted more than once.");
+    } else {
+      this.restartCompleted = true;
+    }
+  }
+
+  @Override
+  public synchronized int getNumPreviousContainers() {
+    return this.numPreviousContainers;
+  }
+
+  @Override
+  public synchronized void setNumPreviousContainers(final int num) {
+    if (this.numPreviousContainers >= 0) {
+      throw new IllegalStateException("Attempting to set the number of expected containers left " +
+          "from a previous container more than once.");
+    } else {
+      this.numPreviousContainers = num;
+    }
+  }
+
+  @Override
+  public synchronized int getNumRecoveredContainers() {
+    return this.numRecoveredContainers;
+  }
+
+  @Override
+  public synchronized void oneContainerRecovered() {
+    this.numRecoveredContainers += 1;
+    if (this.numRecoveredContainers > this.numPreviousContainers) {
+      throw new IllegalStateException("Reconnected to" +
+          this.numRecoveredContainers + "Evaluators while only expecting " + this.numPreviousContainers);
+    }
+  }
+
+  @Override
+  public void recordAllocatedEvaluator(final String id) {
+    driverRuntimeRestartManager.recordAllocatedEvaluator(id);
+  }
+
+  @Override
+  public void recordRemovedEvaluator(final String id) {
+    driverRuntimeRestartManager.recordRemovedEvaluator(id);
+  }
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRuntimeRestartManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRuntimeRestartManager.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.driver.restart;
+
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.annotations.audience.RuntimeAuthor;
+
+import java.util.Set;
+
+/**
+ * Classes implementing this interface are in charge of recording evaluator
+ * changes as they are allocated as well as recovering Evaluators and
+ * discovering which evaluators are lost on the event of a driver restart.
+ */
+@DriverSide
+@Private
+@RuntimeAuthor
+@Unstable
+public interface DriverRuntimeRestartManager {
+  /**
+   * Determines whether or not the driver has been restarted.
+   */
+  boolean isRestart();
+
+  /**
+   * Records the evaluators when it is allocated.
+   * @param id The evaluator ID of the allocated evaluator.
+   */
+  void recordAllocatedEvaluator(final String id);
+
+  /**
+   * Records a removed evaluator into the evaluator log.
+   * @param id The evaluator ID of the removed evaluator.
+   */
+  void recordRemovedEvaluator(final String id);
+
+  /**
+   * Gets the sets of alive and failed evaluators based on the runtime implementation.
+   * @return EvaluatorRestartInfo, which encapsulates the alive and failed set of evaluator IDs.
+   */
+  EvaluatorRestartInfo getAliveAndFailedEvaluators();
+
+  /**
+   * Informs the necessary components about failed evaluators. The implementation is runtime dependent.
+   * @param failedEvaluatorIds The set of evaluator IDs of evaluators that failed during restart.
+   */
+  void informAboutEvaluatorFailures(final Set<String> failedEvaluatorIds);
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/EvaluatorPreservingEvaluatorAllocatedHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/EvaluatorPreservingEvaluatorAllocatedHandler.java
@@ -24,7 +24,7 @@ import org.apache.reef.wake.EventHandler;
 import javax.inject.Inject;
 
 /**
- * Records allocated evaluators for recovery on driver restart by using a DriverRestartManager.
+ * Records allocated evaluators for recovery on driver restart by using a DriverRuntimeRestartManager.
  */
 public final class EvaluatorPreservingEvaluatorAllocatedHandler implements EventHandler<AllocatedEvaluator> {
   private final DriverRestartManager driverRestartManager;
@@ -35,7 +35,7 @@ public final class EvaluatorPreservingEvaluatorAllocatedHandler implements Event
   }
 
   /**
-   * Records the allocatedEvaluator ID with the DriverRestartManager.
+   * Records the allocatedEvaluator ID with the DriverRuntimeRestartManager.
    * @param value the allocated evaluator event.
    */
   @Override

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/EvaluatorRestartInfo.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/EvaluatorRestartInfo.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.driver.restart;
+
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Private;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * The encapsulating class for alive and failed evaluators on driver restart.
+ */
+@Private
+@DriverSide
+@Unstable
+public final class EvaluatorRestartInfo {
+  private final Set<String> aliveEvaluators;
+  private final Set<String> failedEvaluators;
+
+  public EvaluatorRestartInfo(final Set<String> aliveEvaluators, final Set<String> failedEvaluators) {
+    this.aliveEvaluators = Collections.unmodifiableSet(aliveEvaluators);
+    this.failedEvaluators = Collections.unmodifiableSet(failedEvaluators);
+  }
+
+  /**
+   * @return the set of evaluator IDs for alive evaluators on driver restart. The returned set is unmodifiable.
+   */
+  public Set<String> getAliveEvaluators() {
+    return this.aliveEvaluators;
+  }
+
+  /**
+   * @return the set of evaluator IDs for faiuled evaluators on driver restart. The returned set is unmodifiable.
+   */
+  public Set<String> getFailedEvaluators() {
+    return this.failedEvaluators;
+  }
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeRestartConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeRestartConfiguration.java
@@ -23,9 +23,7 @@ import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.parameters.ServiceEvaluatorAllocatedHandlers;
 import org.apache.reef.driver.parameters.ServiceEvaluatorCompletedHandlers;
 import org.apache.reef.driver.parameters.ServiceEvaluatorFailedHandlers;
-import org.apache.reef.driver.restart.EvaluatorPreservingEvaluatorAllocatedHandler;
-import org.apache.reef.driver.restart.EvaluatorPreservingEvaluatorCompletedHandler;
-import org.apache.reef.driver.restart.EvaluatorPreservingEvaluatorFailedHandler;
+import org.apache.reef.driver.restart.*;
 import org.apache.reef.tang.formats.*;
 
 /**
@@ -40,6 +38,7 @@ public final class DriverRuntimeRestartConfiguration extends ConfigurationModule
   }
 
   public static final ConfigurationModule CONF = new DriverRuntimeRestartConfiguration()
+      .bindImplementation(DriverRestartManager.class, DriverRestartManagerImpl.class)
       .bindSetEntry(ServiceEvaluatorAllocatedHandlers.class, EvaluatorPreservingEvaluatorAllocatedHandler.class)
       .bindSetEntry(ServiceEvaluatorFailedHandlers.class, EvaluatorPreservingEvaluatorFailedHandler.class)
       .bindSetEntry(ServiceEvaluatorCompletedHandlers.class, EvaluatorPreservingEvaluatorCompletedHandler.class)

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverStartHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverStartHandler.java
@@ -50,10 +50,9 @@ public final class DriverStartHandler implements EventHandler<StartTime> {
                      final Set<EventHandler<StartTime>> restartHandlers,
                      @Parameter(ServiceDriverRestartedHandlers.class)
                      final Set<EventHandler<StartTime>> serviceRestartHandlers,
-                     final DriverRestartManager driverRestartManager,
-                     final DriverStatusManager driverStatusManager) {
+                     final DriverRestartManager driverRestartManager) {
     this(startHandler, Optional.of(restartHandlers), Optional.of(serviceRestartHandlers),
-        Optional.of(driverRestartManager), driverStatusManager);
+        Optional.of(driverRestartManager));
     LOG.log(Level.FINE, "Instantiated `DriverStartHandler with StartHandlers [{0}], RestartHandlers [{1}]," +
             "and ServiceRestartHandlers [{2}], with a restart manager.",
         new String[] {this.startHandlers.toString(), this.restartHandlers.toString(),
@@ -62,10 +61,9 @@ public final class DriverStartHandler implements EventHandler<StartTime> {
 
   @Inject
   DriverStartHandler(@Parameter(org.apache.reef.driver.parameters.DriverStartHandler.class)
-                     final Set<EventHandler<StartTime>> startHandlers,
-                     final DriverStatusManager driverStatusManager) {
+                     final Set<EventHandler<StartTime>> startHandlers) {
     this(startHandlers, Optional.<Set<EventHandler<StartTime>>>empty(),
-        Optional.<Set<EventHandler<StartTime>>>empty(), Optional.<DriverRestartManager>empty(), driverStatusManager);
+        Optional.<Set<EventHandler<StartTime>>>empty(), Optional.<DriverRestartManager>empty());
     LOG.log(Level.FINE, "Instantiated `DriverStartHandler with StartHandlers [{0}] and no restart.",
         this.startHandlers.toString());
   }
@@ -73,8 +71,7 @@ public final class DriverStartHandler implements EventHandler<StartTime> {
   private DriverStartHandler(final Set<EventHandler<StartTime>> startHandler,
                              final Optional<Set<EventHandler<StartTime>>> restartHandlers,
                              final Optional<Set<EventHandler<StartTime>>> serviceRestartHandlers,
-                             final Optional<DriverRestartManager> driverRestartManager,
-                             final DriverStatusManager driverStatusManager) {
+                             final Optional<DriverRestartManager> driverRestartManager) {
     this.startHandlers = startHandler;
     this.restartHandlers = restartHandlers;
     this.serviceRestartHandlers = serviceRestartHandlers;

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRestartConfiguration.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRestartConfiguration.java
@@ -22,7 +22,7 @@ import org.apache.reef.annotations.Provided;
 import org.apache.reef.annotations.Unstable;
 import org.apache.reef.annotations.audience.ClientSide;
 import org.apache.reef.annotations.audience.Public;
-import org.apache.reef.driver.restart.DriverRestartManager;
+import org.apache.reef.driver.restart.DriverRuntimeRestartManager;
 import org.apache.reef.runtime.common.driver.DriverRuntimeRestartConfiguration;
 import org.apache.reef.runtime.common.driver.EvaluatorPreserver;
 import org.apache.reef.runtime.yarn.driver.parameters.YarnEvaluatorPreserver;
@@ -49,7 +49,7 @@ public final class YarnDriverRestartConfiguration extends ConfigurationModuleBui
    */
   public static final ConfigurationModule CONF = new YarnDriverRestartConfiguration()
       .bindNamedParameter(YarnEvaluatorPreserver.class, EVALUATOR_PRESERVER)
-      .bindImplementation(DriverRestartManager.class, YarnDriverRestartManager.class)
+      .bindImplementation(DriverRuntimeRestartManager.class, YarnDriverRuntimeRestartManager.class)
       .merge(DriverRuntimeRestartConfiguration.CONF)
       .build();
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RuntimeClock.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RuntimeClock.java
@@ -251,7 +251,11 @@ public final class RuntimeClock implements Clock {
           // waiting interrupted - return to loop
         }
       }
-      this.handlers.onNext(new RuntimeStop(this.timer.getCurrent()));
+      if (this.stoppedOnException == null) {
+        this.handlers.onNext(new RuntimeStop(this.timer.getCurrent()));
+      } else {
+        this.handlers.onNext(new RuntimeStop(this.timer.getCurrent(), this.stoppedOnException));
+      }
     } catch (final Exception e) {
       e.printStackTrace();
       this.handlers.onNext(new RuntimeStop(this.timer.getCurrent(), e));


### PR DESCRIPTION
This addressed the issue by
  * Refactoring DriverRestartManager to an abstract class that centralizes runtime independent code.
  * Moving restart related funcitonality from the DriverStatusManager to the DriverRestartManager and made the functionality runtime independent.
  * Additionally corrected the behavior to RuntimeClock on failure to propagate the exception.

JIRA:
  [REEF-561](https://issues.apache.org/jira/browse/REEF-561)