### PR TITLE
[REEF-564] Add deprecated annotations and TODO comments to Wake

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/RemoteManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/RemoteManager.java
@@ -65,6 +65,7 @@ public class RemoteManager {
     return this.raw.registerHandler(messageType, theHandler);
   }
 
+  // TODO[REEF-547]: This method uses deprecated raw.registerErrorHandler.
   public AutoCloseable registerErrorHandler(final EventHandler<Exception> theHandler) {
     return this.raw.registerErrorHandler(theHandler);
   }

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameLookupClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameLookupClient.java
@@ -91,7 +91,9 @@ public class NameLookupClient implements Stage, NamingLookup {
    * @param serverPort a server port number
    * @param factory    an identifier factory
    * @param cache      an cache
+   * @deprecated in 0.12 use the constructor that takes a LocalAddressProvider instead.
    */
+  @Deprecated
   public NameLookupClient(final String serverAddr,
                           final int serverPort,
                           final IdentifierFactory factory,

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteManagerFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteManagerFactory.java
@@ -61,6 +61,7 @@ public final class DefaultRemoteManagerFactory implements RemoteManagerFactory {
     this.tpFactory = tpFactory;
   }
 
+  // TODO[REEF-547]: This method uses deprecated DefaultRemoteManagerImplementation constructor.
   @Override
   public RemoteManager getInstance(final String name) {
     return new DefaultRemoteManagerImplementation(name,
@@ -75,7 +76,7 @@ public final class DefaultRemoteManagerFactory implements RemoteManagerFactory {
         this.tpFactory);
   }
 
-
+  // TODO[REEF-547]: This method uses deprecated DefaultRemoteManagerImplementation constructor.
   @Override
   @SuppressWarnings("checkstyle:hiddenfield")
   public <T> RemoteManager getInstance(final String name,
@@ -100,6 +101,7 @@ public final class DefaultRemoteManagerFactory implements RemoteManagerFactory {
         tpFactory);
   }
 
+  // TODO[REEF-547]: This method uses deprecated DefaultRemoteManagerImplementation constructor.
   @Override
   @SuppressWarnings("checkstyle:hiddenfield")
   public <T> RemoteManager getInstance(final String name,
@@ -123,6 +125,7 @@ public final class DefaultRemoteManagerFactory implements RemoteManagerFactory {
 
   }
 
+  // TODO[REEF-547]: This method uses deprecated DefaultRemoteManagerImplementation constructor.
   @Override
   @SuppressWarnings("checkstyle:hiddenfield")
   public <T> RemoteManager getInstance(
@@ -139,6 +142,7 @@ public final class DefaultRemoteManagerFactory implements RemoteManagerFactory {
         this.tpFactory);
   }
 
+  // TODO[REEF-547]: This method uses deprecated DefaultRemoteManagerImplementation constructor.
   @Override
   @SuppressWarnings("checkstyle:hiddenfield")
   public <T> RemoteManager getInstance(final String name,

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/MessagingTransportFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/MessagingTransportFactory.java
@@ -89,6 +89,7 @@ public class MessagingTransportFactory implements TransportFactory {
     }
   }
 
+  // TODO[REEF-547]: This method uses deprecated RangeTcpPortProvider.Default. Must remove usages and deprecate.
   @Override
   public Transport newInstance(final String hostAddress, final int port,
                                final EStage<TransportEvent> clientStage,

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyMessagingTransport.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyMessagingTransport.java
@@ -109,7 +109,7 @@ public class NettyMessagingTransport implements Transport {
    * @param numberOfTries the number of tries of connection
    * @param retryTimeout  the timeout of reconnection
    * @param tcpPortProvider  gives an iterator that produces random tcp ports in a range
-   * @deprecated use the constructor that takes a LocalAddressProvider instead.
+   * @deprecated in 0.12 use the constructor that takes a LocalAddressProvider instead.
    */
   @Deprecated
   public NettyMessagingTransport(
@@ -234,7 +234,7 @@ public class NettyMessagingTransport implements Transport {
    * @param serverStage   the server-side stage that handles transport events
    * @param numberOfTries the number of tries of connection
    * @param retryTimeout  the timeout of reconnection
-   * @deprecated use the constructor that takes a TcpProvider and LocalAddressProvider instead.
+   * @deprecated in 0.11 use the constructor that takes a TcpProvider and LocalAddressProvider instead.
    */
   @Deprecated
   public NettyMessagingTransport(final String hostAddress, final int port,


### PR DESCRIPTION
- Add a missing deprecated annotation that prevented called deprecated methods
  from being removed, where it is obvious that it should be removed.
- Add TODO comments to code that prevents called deprecated methods from being
  removed. These will have to be addressed in a clean-up of Wake (REEF-547).

JIRA:
  [REEF-564](https://issues.apache.org/jira/browse/REEF-564)
