### PR TITLE
[REEF-558] Check and set the environment varible for Mesos native library in runmesostests.sh

### DIFF
--- a/bin/runmesostests.sh
+++ b/bin/runmesostests.sh
@@ -26,6 +26,7 @@ fi
 if [ -z ${MESOS_NATIVE_LIBRARY+x} ]
 then
   search_paths='/usr/lib /usr/local/lib'
+  echo "MESOS_NATIVE_LIBRARY is not set. Searching in $search_paths.."
   mesos_native_library=$(find -L $search_paths -name libmesos.dylib -or -name libmesos.so | head -n1)
 
   if [ -z $mesos_native_library ]

--- a/bin/runmesostests.sh
+++ b/bin/runmesostests.sh
@@ -23,6 +23,21 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
+if [ -z ${MESOS_NATIVE_LIBRARY+x} ]
+then
+  search_paths='/usr/lib /usr/local/lib'
+  mesos_native_library=$(find -L $search_paths -name libmesos.dylib -or -name libmesos.so | head -n1)
+
+  if [ -z $mesos_native_library ]
+  then
+    echo "MESOS_NATIVE_LIBRARY not found"
+	exit 1
+  else
+    export MESOS_NATIVE_LIBRARY=$mesos_native_library
+    echo "MESOS_NATIVE_LIBRARY set to '$mesos_native_library'"
+  fi
+fi
+
 export REEF_TEST_MESOS=true
 export REEF_TEST_MESOS_MASTER_IP=$1
 


### PR DESCRIPTION
This pull request addressed the issue by
* Check whether $MESOS_NATIVE_LIBRARY exists or not.
* If the path of MESOS NATIVE LIBRARY is found, set the environent variable.
* If not, give error message.

JIRA: [REEF-558](https://issues.apache.org/jira/browse/REEF-558)