### PR TITLE
[REEF-565] Remove APIs with no dependencies deprecated since 0.11 fro…

### DIFF
--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/GroupCommDriverImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/GroupCommDriverImpl.java
@@ -60,9 +60,7 @@ import org.apache.reef.wake.impl.SingleThreadStage;
 import org.apache.reef.wake.impl.SyncStage;
 import org.apache.reef.wake.impl.ThreadPoolStage;
 import org.apache.reef.wake.remote.address.LocalAddressProvider;
-import org.apache.reef.wake.remote.address.LocalAddressProviderFactory;
 import org.apache.reef.wake.remote.transport.TransportFactory;
-import org.apache.reef.wake.remote.transport.netty.MessagingTransportFactory;
 
 import javax.inject.Inject;
 import java.util.HashMap;
@@ -110,29 +108,6 @@ public class GroupCommDriverImpl implements GroupCommServiceDriver {
   private final GroupCommMessageHandler groupCommMessageHandler;
   private final EStage<GroupCommunicationMessage> groupCommMessageStage;
   private final int fanOut;
-
-  /**
-   * @deprecated Have an instance injected instead.
-   */
-  @Deprecated
-  @Inject
-  public GroupCommDriverImpl(final ConfigurationSerializer confSerializer,
-                             @Parameter(DriverIdentifier.class) final String driverId,
-                             @Parameter(TreeTopologyFanOut.class) final int fanOut) {
-    this(confSerializer, driverId, fanOut, LocalAddressProviderFactory.getInstance());
-  }
-
-  /**
-   * @deprecated Have an instance injected instead.
-   */
-  @Deprecated
-  @Inject
-  public GroupCommDriverImpl(final ConfigurationSerializer confSerializer,
-                             @Parameter(DriverIdentifier.class) final String driverId,
-                             @Parameter(TreeTopologyFanOut.class) final int fanOut,
-                             final LocalAddressProvider localAddressProvider) {
-    this(confSerializer, driverId, fanOut, localAddressProvider, new MessagingTransportFactory());
-  }
 
   /**
    * @deprecated Have an instance injected instead.

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameClient.java
@@ -31,7 +31,6 @@ import org.apache.reef.wake.IdentifierFactory;
 import org.apache.reef.wake.impl.SyncStage;
 import org.apache.reef.wake.remote.Codec;
 import org.apache.reef.wake.remote.address.LocalAddressProvider;
-import org.apache.reef.wake.remote.address.LocalAddressProviderFactory;
 import org.apache.reef.wake.remote.impl.TransportEvent;
 import org.apache.reef.wake.remote.transport.Transport;
 import org.apache.reef.wake.remote.transport.TransportFactory;
@@ -55,17 +54,6 @@ public final class NameClient implements NameResolver {
   private NameRegistryClient registryClient;
   private Transport transport;
 
-  @Deprecated
-  public NameClient(final String serverAddr,
-                    final int serverPort,
-                    final IdentifierFactory factory,
-                    final int retryCount,
-                    final int retryTimeout,
-                    final Cache<Identifier, InetSocketAddress> cache) {
-    this(serverAddr, serverPort, 10000, factory, retryCount, retryTimeout, cache,
-         LocalAddressProviderFactory.getInstance());
-  }
-
   /**
    * Constructs a naming client.
    *
@@ -83,24 +71,6 @@ public final class NameClient implements NameResolver {
                     final Cache<Identifier, InetSocketAddress> cache,
                     final LocalAddressProvider localAddressProvider) {
     this(serverAddr, serverPort, 10000, factory, retryCount, retryTimeout, cache, localAddressProvider);
-  }
-
-  @Deprecated
-  public NameClient(final String serverAddr,
-                    final int serverPort,
-                    final long timeout,
-                    final IdentifierFactory factory,
-                    final int retryCount,
-                    final int retryTimeout,
-                    final Cache<Identifier, InetSocketAddress> cache) {
-    this(serverAddr,
-        serverPort,
-        timeout,
-        factory,
-        retryCount,
-        retryTimeout,
-        cache,
-        LocalAddressProviderFactory.getInstance());
   }
 
   /**

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameLookupClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameLookupClient.java
@@ -102,25 +102,6 @@ public class NameLookupClient implements Stage, NamingLookup {
          LocalAddressProviderFactory.getInstance());
   }
 
-  @Deprecated
-  public NameLookupClient(final String serverAddr,
-                          final int serverPort,
-                          final long timeout,
-                          final IdentifierFactory factory,
-                          final int retryCount,
-                          final int retryTimeout,
-                          final Cache<Identifier, InetSocketAddress> cache) {
-    this(serverAddr,
-        serverPort,
-        timeout,
-        factory,
-        retryCount,
-        retryTimeout,
-        cache,
-        LocalAddressProviderFactory.getInstance());
-
-  }
-
   /**
    * Constructs a naming lookup client.
    *

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameRegistryClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameRegistryClient.java
@@ -35,7 +35,6 @@ import org.apache.reef.wake.impl.SyncStage;
 import org.apache.reef.wake.remote.Codec;
 import org.apache.reef.wake.remote.RemoteConfiguration;
 import org.apache.reef.wake.remote.address.LocalAddressProvider;
-import org.apache.reef.wake.remote.address.LocalAddressProviderFactory;
 import org.apache.reef.wake.remote.impl.TransportEvent;
 import org.apache.reef.wake.remote.transport.Link;
 import org.apache.reef.wake.remote.transport.Transport;
@@ -106,19 +105,6 @@ public class NameRegistryClient implements Stage, NamingRegistry {
     } catch (final InjectionException e) {
       throw new RuntimeException(e);
     }
-  }
-
-  @Deprecated
-  public NameRegistryClient(final String serverAddr,
-                            final int serverPort,
-                            final long timeout,
-                            final IdentifierFactory factory) {
-
-    this(serverAddr,
-        serverPort,
-        timeout,
-        factory,
-        LocalAddressProviderFactory.getInstance());
   }
 
   public NameRegistryClient(final String serverAddr, final int serverPort,

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameServerImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameServerImpl.java
@@ -107,17 +107,6 @@ public final class NameServerImpl implements NameServer {
   }
 
   /**
-   * @deprecated have an instance injected instead
-   */
-  @Deprecated
-  public NameServerImpl(
-      final int port,
-      final IdentifierFactory factory,
-      final ReefEventStateManager reefEventStateManager) {
-    this(port, factory, reefEventStateManager, LocalAddressProviderFactory.getInstance());
-  }
-
-  /**
    * Constructs a name server.
    *
    * @param port                  a listening port number


### PR DESCRIPTION
…m REEF-IO

Remove deprecated methods from REEF-IO that are not called at all and thus can be trivially removed.

JIRA:
  [REEF-565](https://issues.apache.org/jira/browse/REEF-565)

Pull Request:
  This closes #