### PR TITLE
[REEF-546] Update method signature for deprecated Configuration.getBoundSets

### DIFF
--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Configuration.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Configuration.java
@@ -23,7 +23,6 @@ import org.apache.reef.tang.types.ConstructorDef;
 import org.apache.reef.tang.types.NamedParameterNode;
 
 import java.util.List;
-import java.util.Map.Entry;
 import java.util.Set;
 
 /**
@@ -151,17 +150,9 @@ public interface Configuration {
   ClassHierarchy getClassHierarchy();
 
   /**
-   * Get the set bindings from set-valued NamedParameters to the values they were bound to.
-   * <p/>
-   * TODO: This API seems wonky.
-   * Why not return a Set<NamedParameterNode<Set<?>>> instead, and let the caller invoke getBoundSet() above?
-   *
-   * @return a flattened set with one entry for each binding
-   * (the same NamedParameterNode may be a key for multiple bindings.
-   * @deprecated
+   * @return the set of all NamedParameterNodes explicitly bound to sets.
    */
-  @Deprecated
-  Iterable<Entry<NamedParameterNode<Set<?>>, Object>> getBoundSets();
+  Set<NamedParameterNode<Set<?>>> getBoundSets();
 
   /**
    * @return the set of all NamedParameterNodes explicitly bound to lists.

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/AvroConfigurationSerializer.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/AvroConfigurationSerializer.java
@@ -165,19 +165,21 @@ public final class AvroConfigurationSerializer implements ConfigurationSerialize
           .setValue("" + ConfigurationBuilderImpl.INIT + "(" + legacyConstructors + ")")
           .build());
     }
-    for (final Map.Entry<NamedParameterNode<Set<?>>, Object> e : configuration.getBoundSets()) {
-      final String val;
-      if (e.getValue() instanceof String) {
-        val = (String) e.getValue();
-      } else if (e.getValue() instanceof Node) {
-        val = ((Node) e.getValue()).getFullName();
-      } else {
-        throw new IllegalStateException();
+    for (final NamedParameterNode<Set<?>> key : configuration.getBoundSets()) {
+      for (final Object value : configuration.getBoundSet(key)) {
+        final String val;
+        if (value instanceof String) {
+          val = (String) value;
+        } else if (value instanceof Node) {
+          val = ((Node) value).getFullName();
+        } else {
+          throw new IllegalStateException();
+        }
+        configurationEntries.add(new ConfigurationEntry().newBuilder()
+            .setKey(key.getFullName())
+            .setValue(val)
+            .build());
       }
-      configurationEntries.add(new ConfigurationEntry().newBuilder()
-          .setKey(e.getKey().getFullName())
-          .setValue(val)
-          .build());
     }
     // TODO[JIRA REEF-402]: Implement list serialization
     if (configuration.getBoundLists() != null && !configuration.getBoundLists().isEmpty()) {

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationModule.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationModule.java
@@ -332,16 +332,18 @@ public class ConfigurationModule {
               + ')'
       ));
     }
-    for (final Entry<NamedParameterNode<Set<?>>, Object> e : conf.getBoundSets()) {
-      final String val;
-      if (e.getValue() instanceof String) {
-        val = (String) e.getValue();
-      } else if (e.getValue() instanceof Node) {
-        val = ((Node) e.getValue()).getFullName();
-      } else {
-        throw new IllegalStateException();
+    for (final NamedParameterNode<Set<?>> key : conf.getBoundSets()) {
+      for (final Object value : conf.getBoundSet(key)) {
+        final String val;
+        if (value instanceof String) {
+          val = (String) value;
+        } else if (value instanceof Node) {
+          val = ((Node) value).getFullName();
+        } else {
+          throw new IllegalStateException();
+        }
+        l.add(key.getFullName() + '=' + escape(val));
       }
-      l.add(e.getKey().getFullName() + '=' + escape(val));
     }
     return l;
   }

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/ConfigurationImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/ConfigurationImpl.java
@@ -26,9 +26,7 @@ import org.apache.reef.tang.types.ClassNode;
 import org.apache.reef.tang.types.ConstructorDef;
 import org.apache.reef.tang.types.NamedParameterNode;
 
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map.Entry;
 import java.util.Set;
 
 public class ConfigurationImpl implements Configuration {
@@ -103,14 +101,8 @@ public class ConfigurationImpl implements Configuration {
   }
 
   @Override
-  public Iterable<Entry<NamedParameterNode<Set<?>>, Object>> getBoundSets() {
-    return new Iterable<Entry<NamedParameterNode<Set<?>>, Object>>() {
-
-      @Override
-      public Iterator<Entry<NamedParameterNode<Set<?>>, Object>> iterator() {
-        return builder.boundSetEntries.iterator();
-      }
-    };
+  public Set<NamedParameterNode<Set<?>>> getBoundSets() {
+    return builder.boundSetEntries.keySet();
   }
 
   @Override


### PR DESCRIPTION
This addressed the issue by
  * updating the method to return list of parameters bound to sets
  * updating usages of the method in code

JIRA:
  [REEF-546](https://issues.apache.org/jira/browse/REEF-546)