### PR TITLE
[REEF-569] Add RAT excludes for JVM error logs and Mesos runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,9 @@ under the License.
                             <exclude>**/*.md</exclude>
                             <!-- The below are sometimes created during tests -->
                             <exclude>REEF_LOCAL_RUNTIME/**</exclude>
+                            <exclude>REEF_MESOS_RUNTIME/**</exclude>
+                            <!-- JVM error logs, especially troublesome on CI servers -->
+                            <exclude>**/hs_err_*.log</exclude>
                             <!-- The Visual Studio and Nuget build files -->
                             <exclude>**/*.sln*</exclude>
                             <exclude>**/*.vcxproj*</exclude>


### PR DESCRIPTION
  - hs_error*.log that JVM can produce on fatal errors (e.g, REEF-89).
  - directory that mesos runtime creates, during tests.

JIRA:
  [REEF-569](https://issues.apache.org/jira/browse/REEF-569)

Pull Request:
  This closes #