### PR TITLE
[REEF-540] DriverRestartHandler is not bound correctly to its C# equivalent

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/Common/ClrClient2JavaClientCuratedParameters.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/ClrClient2JavaClientCuratedParameters.cs
@@ -18,6 +18,8 @@
  */
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Org.Apache.REEF.Driver;
 using Org.Apache.REEF.Driver.Bridge;
 using Org.Apache.REEF.Tang.Annotations;
@@ -47,36 +49,14 @@ namespace Org.Apache.REEF.Client.Common
             [Parameter(typeof(TcpPortRangeTryCount))] int tcpPortRangeTryCount,
             [Parameter(typeof(TcpPortRangeSeed))] int tcpPortRangeSeed,
             [Parameter(typeof(DriverBridgeConfigurationOptions.MaxApplicationSubmissions))] int maxApplicationSubmissions,
-            [Parameter(typeof(DriverBridgeConfigurationOptions.DriverRestartedHandler))] IObserver<IDriverRestarted> restartHandler)
-            : this(tcpPortRangeStart, tcpPortRangeCount, tcpPortRangeTryCount, tcpPortRangeSeed, maxApplicationSubmissions, true)
-        {
-        }
-
-        [Inject]
-        private ClrClient2JavaClientCuratedParameters(
-            [Parameter(typeof(TcpPortRangeStart))] int tcpPortRangeStart,
-            [Parameter(typeof(TcpPortRangeCount))] int tcpPortRangeCount,
-            [Parameter(typeof(TcpPortRangeTryCount))] int tcpPortRangeTryCount,
-            [Parameter(typeof(TcpPortRangeSeed))] int tcpPortRangeSeed,
-            [Parameter(typeof(DriverBridgeConfigurationOptions.MaxApplicationSubmissions))] int maxApplicationSubmissions)
-            : this(tcpPortRangeStart, tcpPortRangeCount, tcpPortRangeTryCount, tcpPortRangeSeed, maxApplicationSubmissions, false)
-        {
-        }
-
-        private ClrClient2JavaClientCuratedParameters(
-            int tcpPortRangeStart,
-            int tcpPortRangeCount,
-            int tcpPortRangeTryCount,
-            int tcpPortRangeSeed,
-            int maxApplicationSubmissions,
-            bool enableRestart)
+            [Parameter(typeof(DriverBridgeConfigurationOptions.DriverRestartedHandlers))] ISet<IObserver<IDriverRestarted>> restartHandlers)
         {
             TcpPortRangeStart = tcpPortRangeStart;
             TcpPortRangeCount = tcpPortRangeCount;
             TcpPortRangeTryCount = tcpPortRangeTryCount;
             TcpPortRangeSeed = tcpPortRangeSeed;
             MaxApplicationSubmissions = maxApplicationSubmissions;
-            EnableRestart = enableRestart;
+            EnableRestart = restartHandlers.Any();
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverBridgeConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverBridgeConfiguration.cs
@@ -31,7 +31,6 @@ using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Formats;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Logging;
-using Org.Apache.REEF.Wake.Time.Event;
 
 [module: SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1401:FieldsMustBePrivate", Justification = "static field, typical usage in configurations")]
 
@@ -48,10 +47,10 @@ namespace Org.Apache.REEF.Driver.Bridge
         public static readonly OptionalImpl<IStartHandler> OnDriverStarted = new OptionalImpl<IStartHandler>();
 
         /// <summary>
-        ///  The event handler invoked when driver restarts
+        /// The event handler invoked when driver restarts
         /// </summary>
         [SuppressMessage("Microsoft.Security", "CA2104:Do not declare read only mutable reference types", Justification = "not applicable")]
-        public static readonly OptionalImpl<IObserver<StartTime>> OnDriverRestarted = new OptionalImpl<IObserver<StartTime>>();
+        public static readonly OptionalImpl<IObserver<IDriverRestarted>> OnDriverRestarted = new OptionalImpl<IObserver<IDriverRestarted>>();
 
         /// <summary>
         /// The event handler for requesting evaluator
@@ -131,7 +130,7 @@ namespace Org.Apache.REEF.Driver.Bridge
         /// Event handler for active context received during driver restart. Defaults to closing the context if not bound.
         /// </summary>
         [SuppressMessage("Microsoft.Security", "CA2104:Do not declare read only mutable reference types", Justification = "not applicable")]
-        public static readonly OptionalImpl<IObserver<IActiveContext>> OnDirverRestartContextActive = new OptionalImpl<IObserver<IActiveContext>>();
+        public static readonly OptionalImpl<IObserver<IActiveContext>> OnDriverRestartContextActive = new OptionalImpl<IObserver<IActiveContext>>();
 
         /// <summary>
         /// Event handler for closed context. Defaults to logging if not bound.
@@ -175,6 +174,12 @@ namespace Org.Apache.REEF.Driver.Bridge
         [SuppressMessage("Microsoft.Security", "CA2104:Do not declare read only mutable reference types", Justification = "not applicable")]
         public static readonly OptionalImpl<IDriverConnection> OnDriverReconnect = new OptionalImpl<IDriverConnection>();
 
+        ///// <summary>
+        ///// Event handler for driver restart completed event received during driver restart. Defaults to logging if not bound.
+        ///// </summary>
+        [SuppressMessage("Microsoft.Security", "CA2104:Do not declare read only mutable reference types", Justification = "not applicable")]
+        public static readonly OptionalImpl<IObserver<IDriverRestartCompleted>> OnDriverRestartCompleted = new OptionalImpl<IObserver<IDriverRestartCompleted>>();
+
         // This is currently not needed in Bridge/Driver model
         ///// <summary>
         ///// The event handler invoked right before the driver shuts down. Defaults to ignore.
@@ -206,7 +211,7 @@ namespace Org.Apache.REEF.Driver.Bridge
             {
                 return new DriverBridgeConfiguration()
                 .BindImplementation(GenericType<IStartHandler>.Class, OnDriverStarted)
-                .BindNamedParameter(GenericType<DriverBridgeConfigurationOptions.DriverRestartHandler>.Class, OnDriverRestarted)
+                .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.DriverRestartedHandlers>.Class, OnDriverRestarted)
                 .BindImplementation(GenericType<IDriverConnection>.Class, OnDriverReconnect)
                 .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.EvaluatorRequestHandlers>.Class, OnEvaluatorRequested)
                 .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.AllocatedEvaluatorHandlers>.Class, OnEvaluatorAllocated)
@@ -224,8 +229,9 @@ namespace Org.Apache.REEF.Driver.Bridge
                 .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.ArgumentSets>.Class, CommandLineArguments)
                 .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.HttpEventHandlers>.Class, OnHttpEvent)
                 .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.TraceListenersSet>.Class, CustomTraceListeners)
-                .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.DriverRestartActiveContextHandlers>.Class, OnDirverRestartContextActive)
+                .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.DriverRestartActiveContextHandlers>.Class, OnDriverRestartContextActive)
                 .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.DriverRestartRunningTaskHandlers>.Class, OnDriverRestartTaskRunning)
+                .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.DriverRestartCompletedHandlers>.Class, OnDriverRestartCompleted)
                 .BindNamedParameter(GenericType<DriverBridgeConfigurationOptions.TraceLevel>.Class, CustomTraceLevel)
                 .Build();
             }

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverBridgeConfigurationOptions.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverBridgeConfigurationOptions.cs
@@ -47,14 +47,13 @@ namespace Org.Apache.REEF.Driver.Bridge
         {
         }
 
-        [Obsolete(message:"Since 0.12, Removed in 0.13. Use DriverRestartedHandler instead.")]
-        [NamedParameter(documentation: "Called when driver is restarted, after CLR bridge is set up.", defaultClasses: new[] { typeof(DefaultDriverRestartHandler) })]
-        public class DriverRestartHandler : Name<IObserver<StartTime>>
+        [NamedParameter(documentation: "Called when driver is restarted, after CLR bridge is set up.")]
+        public class DriverRestartedHandlers : Name<ISet<IObserver<IDriverRestarted>>>
         {
         }
 
-        [NamedParameter(documentation: "Called when driver is restarted, after CLR bridge is set up.", defaultClasses: new[] { typeof(DefaultDriverRestartedHandler) })]
-        public class DriverRestartedHandler : Name<IObserver<IDriverRestarted>>
+        [NamedParameter(documentation: "Called when driver restart is completed.", defaultClasses: new[] { typeof (DefaultDriverRestartCompletedHandler) })]
+        public class DriverRestartCompletedHandlers : Name<ISet<IObserver<IDriverRestartCompleted>>>
         {
         }
 

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/DriverRestartCompleted.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/DriverRestartCompleted.cs
@@ -18,39 +18,24 @@
  */
 
 using System;
-using Org.Apache.REEF.Driver;
-using Org.Apache.REEF.Tang.Annotations;
-using Org.Apache.REEF.Wake.Time.Event;
 
-namespace Org.Apache.REEF.Examples.AllHandlers
+namespace Org.Apache.REEF.Driver.Bridge.Events
 {
     /// <summary>
-    /// A sample implementation of driver restart handler
+    /// Implementation of IDriverStarted.
     /// </summary>
-    public class HelloRestartHandler : IObserver<IDriverRestarted>
+    internal sealed class DriverRestartCompleted : IDriverRestartCompleted
     {
-        [Inject]
-        private HelloRestartHandler()
+        private readonly DateTime _completedTime;
+
+        internal DriverRestartCompleted(DateTime completedTime)
         {
+            this._completedTime = completedTime;
         }
 
-        /// <summary>
-        /// It is called when the driver is restarted
-        /// </summary>
-        /// <param name="value"></param>
-        public void OnNext(IDriverRestarted value)
+        public DateTime CompletedTime
         {
-            Console.WriteLine("Hello from CLR: we are informed that Driver has restarted at " + new DateTime(value.StartTime.Ticks));
-        }
-
-        public void OnError(Exception error)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void OnCompleted()
-        {
-            throw new NotImplementedException();
+            get { return this._completedTime; }
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/Constants.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Constants.cs
@@ -24,55 +24,127 @@ namespace Org.Apache.REEF.Driver
 {
     public class Constants
     {
+        /// <summary>
+        /// Null handler that is not used on Java side.
+        /// </summary>
         public const ulong NullHandler = 0;
 
+        /// <summary>
+        /// The class hierarchy file from .NET.
+        /// </summary>
         public const string ClassHierarachyBin = "clrClassHierarchy.bin";
 
+        /// <summary>
+        /// The file containing user supplied libaries.
+        /// </summary>
         public const string GlobalUserSuppliedJavaLibraries = "userSuppliedGlobalLibraries.txt";
 
+        /// <summary>
+        /// The default memory granularity for evaluators.
+        /// </summary>
         public const int DefaultMemoryGranularity = 1024;
 
+        /// <summary>
+        /// The number of handlers total. Tightly coupled with Java.
+        /// </summary>
         public const int HandlersNumber = 17;
 
+        /// <summary>
+        /// The name for EvaluatorRequestorHandler. Tightly coupled with Java.
+        /// </summary>
         public const string EvaluatorRequestorHandler = "EvaluatorRequestor";
 
+        /// <summary>
+        /// The name for AllocatedEvaluatorHandler. Tightly coupled with Java.
+        /// </summary>
         public const string AllocatedEvaluatorHandler = "AllocatedEvaluator";
 
+        /// <summary>
+        /// The name for CompletedEvaluatorHandler. Tightly coupled with Java.
+        /// </summary>
         public const string CompletedEvaluatorHandler = "CompletedEvaluator";
 
+        /// <summary>
+        /// The name for ActiveContextHandler. Tightly coupled with Java.
+        /// </summary>
         public const string ActiveContextHandler = "ActiveContext";
 
+        /// <summary>
+        /// The name for ClosedContextHandler. Tightly coupled with Java.
+        /// </summary>
         public const string ClosedContextHandler = "ClosedContext";
 
+        /// <summary>
+        /// The name for FailedContextHandler. Tightly coupled with Java.
+        /// </summary>
         public const string FailedContextHandler = "FailedContext";
-
+        
+        /// <summary>
+        /// The name for ContextMessageHandler. Tightly coupled with Java.
+        /// </summary>
         public const string ContextMessageHandler = "ContextMessage";
 
+        /// <summary>
+        /// The name for TaskMessageHandler. Tightly coupled with Java.
+        /// </summary>
         public const string TaskMessageHandler = "TaskMessage";
 
+        /// <summary>
+        /// The name for FailedTaskHandler. Tightly coupled with Java.
+        /// </summary>
         public const string FailedTaskHandler = "FailedTask";
 
+        /// <summary>
+        /// The name for RunningTaskHandler. Tightly coupled with Java.
+        /// </summary>
         public const string RunningTaskHandler = "RunningTask";
 
+        /// <summary>
+        /// The name for FailedEvaluatorHandler. Tightly coupled with Java.
+        /// </summary>
         public const string FailedEvaluatorHandler = "FailedEvaluator";
 
+        /// <summary>
+        /// The name for CompletedTaskHandler. Tightly coupled with Java.
+        /// </summary>
         public const string CompletedTaskHandler = "CompletedTask";
 
+        /// <summary>
+        /// The name for SuspendedTaskHandler. Tightly coupled with Java.
+        /// </summary>
         public const string SuspendedTaskHandler = "SuspendedTask";
 
+        /// <summary>
+        /// The name for HttpServerHandler. Tightly coupled with Java.
+        /// </summary>
         public const string HttpServerHandler = "HttpServerHandler";
 
-        public const string DriverRestartHandler = "DriverRestart";
-
+        /// <summary>
+        /// The name for DriverRestartActiveContextHandler. Tightly coupled with Java.
+        /// </summary>
         public const string DriverRestartActiveContextHandler = "DriverRestartActiveContext";
 
+        /// <summary>
+        /// The name for DriverRestartRunningTaskHandler. Tightly coupled with Java.
+        /// </summary>
         public const string DriverRestartRunningTaskHandler = "DriverRestartRunningTask";
+
+        /// <summary>
+        /// The name for DriverRestartCompletedHandler. Tightly coupled with Java.
+        /// </summary>
+        public const string DriverRestartCompletedHandler = "DriverRestartCompleted";
 
         [Obsolete(message:"Use REEFFileNames instead.")]
         public const string DriverBridgeConfiguration = Common.Constants.ClrBridgeRuntimeConfiguration;
 
+        /// <summary>
+        /// The directory to load driver DLLs.
+        /// </summary>
         public const string DriverAppDirectory = "ReefDriverAppDlls";
-
+        
+        /// <summary>
+        /// The bridge JAR name.
+        /// </summary>
         public const string JavaBridgeJarFileName = "reef-bridge-java-0.13.0-incubating-SNAPSHOT-shaded.jar";
 
         public const string BridgeLaunchClass = "org.apache.reef.javabridge.generic.Launch";
@@ -80,12 +152,30 @@ namespace Org.Apache.REEF.Driver
         [Obsolete(message: "Deprecated in 0.13. Use BridgeLaunchClass instead.")]
         public const string BridgeLaunchHeadlessClass = "org.apache.reef.javabridge.generic.LaunchHeadless";
 
+        /// <summary>
+        /// The direct launcher class, deprecated in 0.13, please use DirectREEFLauncherClass instead.
+        /// </summary>
+        [Obsolete("Deprecated in 0.13, please use DirectREEFLauncherClass instead.")]
         public const string DirectLauncherClass = "org.apache.reef.runtime.common.Launcher";
 
+        /// <summary>
+        /// The direct launcher class.
+        /// </summary>
+        public const string DirectREEFLauncherClass = "org.apache.reef.runtime.common.REEFLauncher";
+
+        /// <summary>
+        /// Configuration for Java CLR logging.
+        /// </summary>
         public const string JavaToCLRLoggingConfig = "-Djava.util.logging.config.class=org.apache.reef.util.logging.CLRLoggingConfig";
 
+        /// <summary>
+        /// Configuration for Java verbose logging.
+        /// </summary>
         public const string JavaVerboseLoggingConfig = "-Djava.util.logging.config.class=org.apache.reef.util.logging.Config";
 
+        /// <summary>
+        /// A dictionary of handler constants to handler descriptors.
+        /// </summary>
         public static Dictionary<string, int> Handlers
         {
             get
@@ -107,9 +197,9 @@ namespace Org.Apache.REEF.Driver
                         { ClosedContextHandler, 11 },
                         { FailedContextHandler, 12 },
                         { ContextMessageHandler, 13 },
-                        { DriverRestartHandler, 14 },
-                        { DriverRestartActiveContextHandler, 15 },
-                        { DriverRestartRunningTaskHandler, 16 },
+                        { DriverRestartActiveContextHandler, 14 },
+                        { DriverRestartRunningTaskHandler, 15 },
+                        { DriverRestartCompletedHandler, 16 }
                     };
             }
         }

--- a/lang/cs/Org.Apache.REEF.Driver/Defaults/DefaultDriverRestartCompletedHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Defaults/DefaultDriverRestartCompletedHandler.cs
@@ -18,33 +18,28 @@
  */
 
 using System;
-using Org.Apache.REEF.Driver.Bridge.Events;
-using Org.Apache.REEF.Wake.Time.Event;
+using System.Globalization;
+using Org.Apache.REEF.Driver.Context;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Utilities.Logging;
 
-namespace Org.Apache.REEF.Driver.Bridge
+namespace Org.Apache.REEF.Driver.Defaults
 {
     /// <summary>
-    /// Wrapper of the new Observers of DriverRestarted with and into an Observer of StartTime.
+    /// The default driver restart completed handler. Prints the time when restart is completed.
     /// </summary>
-    /// <remarks>
-    /// Rationale: This way, we don't have to change the C++ code in the same change as the API.
-    /// </remarks>
-    internal sealed class DriverRestartHandlerWrapper : IObserver<StartTime>
+    public sealed class DefaultDriverRestartCompletedHandler : IObserver<IDriverRestartCompleted>
     {
-        private readonly IObserver<IDriverRestarted> _driverRestartedObserver;
-        private readonly IObserver<StartTime> _startTimeObserver;
-
-        internal DriverRestartHandlerWrapper(IObserver<StartTime> startTimeObserver,
-            IObserver<IDriverRestarted> driverRestartedObserver)
+        private static readonly Logger LOGGER = Logger.GetLogger(typeof(DefaultDriverRestartCompletedHandler));
+        
+        [Inject]
+        public DefaultDriverRestartCompletedHandler()
         {
-            _startTimeObserver = startTimeObserver;
-            _driverRestartedObserver = driverRestartedObserver;
         }
 
-        public void OnNext(StartTime startTime)
+        public void OnNext(IDriverRestartCompleted value)
         {
-            _driverRestartedObserver.OnNext(new DriverRestarted(new DateTime(startTime.TimeStamp)));
-            _startTimeObserver.OnNext(startTime);
+            LOGGER.Log(Level.Info, string.Format(CultureInfo.InvariantCulture, "Driver restart completed at " + value.CompletedTime));
         }
 
         public void OnError(Exception error)

--- a/lang/cs/Org.Apache.REEF.Driver/DriverConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/DriverConfiguration.cs
@@ -27,7 +27,6 @@ using Org.Apache.REEF.Driver.Evaluator;
 using Org.Apache.REEF.Driver.Task;
 using Org.Apache.REEF.Tang.Formats;
 using Org.Apache.REEF.Tang.Util;
-using Org.Apache.REEF.Wake.Time.Event;
 
 namespace Org.Apache.REEF.Driver
 {
@@ -45,8 +44,8 @@ namespace Org.Apache.REEF.Driver
         /// <summary>
         /// The event handler invoked when driver restarts
         /// </summary>
-        public static readonly OptionalImpl<IObserver<StartTime>> OnDriverRestarted =
-            new OptionalImpl<IObserver<StartTime>>();
+        public static readonly OptionalImpl<IObserver<IDriverRestarted>> OnDriverRestarted =
+            new OptionalImpl<IObserver<IDriverRestarted>>();
 
         /// <summary>
         /// Event handler for allocated evaluators. Defaults to returning the evaluator if not bound.
@@ -120,7 +119,7 @@ namespace Org.Apache.REEF.Driver
         /// <summary>
         /// Event handler for active context received during driver restart. Defaults to closing the context if not bound.
         /// </summary>
-        public static readonly OptionalImpl<IObserver<IActiveContext>> OnDirverRestartContextActive =
+        public static readonly OptionalImpl<IObserver<IActiveContext>> OnDriverRestartContextActive =
             new OptionalImpl<IObserver<IActiveContext>>();
 
         /// <summary>
@@ -140,6 +139,12 @@ namespace Org.Apache.REEF.Driver
         /// </summary>
         public static readonly OptionalImpl<IObserver<IContextMessage>> OnContextMessage =
             new OptionalImpl<IObserver<IContextMessage>>();
+
+        /// <summary>
+        /// Event handler for driver restart completed. Defaults to logging if not bound.
+        /// </summary>
+        public static readonly OptionalImpl<IObserver<IDriverRestartCompleted>> OnDriverRestartCompleted =
+            new OptionalImpl<IObserver<IDriverRestartCompleted>>();
 
         /// <summary>
         /// Additional set of string arguments that can be pssed to handlers through client
@@ -175,7 +180,7 @@ namespace Org.Apache.REEF.Driver
                 return new DriverConfiguration()
                     .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.DriverStartedHandlers>.Class,
                         OnDriverStarted)
-                    .BindNamedParameter(GenericType<DriverBridgeConfigurationOptions.DriverRestartHandler>.Class,
+                    .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.DriverRestartedHandlers>.Class,
                         OnDriverRestarted)
                     .BindImplementation(GenericType<IDriverConnection>.Class, OnDriverReconnect)
                     .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.AllocatedEvaluatorHandlers>.Class,
@@ -199,13 +204,15 @@ namespace Org.Apache.REEF.Driver
                         OnContextFailed)
                     .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.ContextMessageHandlers>.Class,
                         OnContextMessage)
+                    .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.DriverRestartCompletedHandlers>.Class,
+                        OnDriverRestartCompleted)
                     .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.ArgumentSets>.Class, CommandLineArguments)
                     .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.HttpEventHandlers>.Class, OnHttpEvent)
                     .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.TraceListenersSet>.Class,
                         CustomTraceListeners)
                     .BindSetEntry(
                         GenericType<DriverBridgeConfigurationOptions.DriverRestartActiveContextHandlers>.Class,
-                        OnDirverRestartContextActive)
+                        OnDriverRestartContextActive)
                     .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.DriverRestartRunningTaskHandlers>.Class,
                         OnDriverRestartTaskRunning)
                     .BindNamedParameter(GenericType<DriverBridgeConfigurationOptions.TraceLevel>.Class, CustomTraceLevel)

--- a/lang/cs/Org.Apache.REEF.Driver/IDriverRestartCompleted.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/IDriverRestartCompleted.cs
@@ -1,0 +1,31 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System;
+
+namespace Org.Apache.REEF.Driver
+{
+    /// <summary>
+    /// Event fired on Driver restart completed
+    /// </summary>
+    public interface IDriverRestartCompleted
+    {
+        DateTime CompletedTime { get; }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Driver/Org.Apache.REEF.Driver.csproj
+++ b/lang/cs/Org.Apache.REEF.Driver/Org.Apache.REEF.Driver.csproj
@@ -62,13 +62,13 @@ under the License.
     <Compile Include="Bridge\DriverBridge.cs" />
     <Compile Include="Bridge\DriverBridgeConfiguration.cs" />
     <Compile Include="Bridge\DriverBridgeConfigurationOptions.cs" />
-    <Compile Include="Bridge\DriverRestartHandlerWrapper.cs" />
     <Compile Include="Bridge\Events\ActiveContext.cs" />
     <Compile Include="Bridge\Events\AllocatedEvaluator.cs" />
     <Compile Include="Bridge\Events\ClosedContext.cs" />
     <Compile Include="Bridge\Events\CompletedEvaluator.cs" />
     <Compile Include="Bridge\Events\CompletedTask.cs" />
     <Compile Include="Bridge\Events\ContextMessage.cs" />
+    <Compile Include="Bridge\Events\DriverRestartCompleted.cs" />
     <Compile Include="Bridge\Events\DriverRestarted.cs" />
     <Compile Include="Bridge\Events\DriverStarted.cs" />
     <Compile Include="Bridge\Events\EvaluatorRequstor.cs" />
@@ -107,6 +107,7 @@ under the License.
     <Compile Include="Defaults\DefaultContextFailureHandler.cs" />
     <Compile Include="Defaults\DefaultContextMessageHandler.cs" />
     <Compile Include="Defaults\DefaultCustomTraceListener.cs" />
+    <Compile Include="Defaults\DefaultDriverRestartCompletedHandler.cs" />
     <Compile Include="Defaults\DefaultDriverRestartContextActiveHandler.cs" />
     <Compile Include="Defaults\DefaultDriverRestartedHandler.cs" />
     <Compile Include="Defaults\DefaultDriverRestartHandler.cs" />
@@ -140,6 +141,7 @@ under the License.
     <Compile Include="IDriver.cs" />
     <Compile Include="IDriverRestarted.cs" />
     <Compile Include="IDriverStarted.cs" />
+    <Compile Include="IDriverRestartCompleted.cs" />
     <Compile Include="IStartHandler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Task\ICompletedTask.cs" />

--- a/lang/cs/Org.Apache.REEF.Examples.AllHandlers/AllHandlers.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.AllHandlers/AllHandlers.cs
@@ -67,7 +67,7 @@ namespace Org.Apache.REEF.Examples.AllHandlers
                 .Set(DriverConfiguration.CustomTraceLevel, Level.Info.ToString())
                 .Set(DriverConfiguration.OnDriverRestarted, GenericType<HelloRestartHandler>.Class)
                 .Set(DriverConfiguration.OnDriverReconnect, GenericType<DefaultLocalHttpDriverConnection>.Class)
-                .Set(DriverConfiguration.OnDirverRestartContextActive, GenericType<HelloDriverRestartActiveContextHandler>.Class)
+                .Set(DriverConfiguration.OnDriverRestartContextActive, GenericType<HelloDriverRestartActiveContextHandler>.Class)
                 .Set(DriverConfiguration.OnDriverRestartTaskRunning, GenericType<HelloDriverRestartRunningTaskHandler>.Class)
                 .Build();
 

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/NativeInterop.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/NativeInterop.java
@@ -36,9 +36,9 @@ public final class NativeInterop {
   public static final String CLOSED_CONTEXT_KEY = "ClosedContext";
   public static final String FAILED_CONTEXT_KEY = "FailedContext";
   public static final String CONTEXT_MESSAGE_KEY = "ContextMessage";
-  public static final String DRIVER_RESTART_KEY = "DriverRestart";
   public static final String DRIVER_RESTART_ACTIVE_CONTEXT_KEY = "DriverRestartActiveContext";
   public static final String DRIVER_RESTART_RUNNING_TASK_KEY = "DriverRestartRunningTask";
+  public static final String DRIVER_RESTART_COMPLETED_KEY = "DriverRestartCompleted";
   public static final HashMap<String, Integer> HANDLERS = new HashMap<String, Integer>() {
     {
       put(ALLOCATED_EVALUATOR_KEY, 1);
@@ -54,9 +54,9 @@ public final class NativeInterop {
       put(CLOSED_CONTEXT_KEY, 11);
       put(FAILED_CONTEXT_KEY, 12);
       put(CONTEXT_MESSAGE_KEY, 13);
-      put(DRIVER_RESTART_KEY, 14);
-      put(DRIVER_RESTART_ACTIVE_CONTEXT_KEY, 15);
-      put(DRIVER_RESTART_RUNNING_TASK_KEY, 16);
+      put(DRIVER_RESTART_ACTIVE_CONTEXT_KEY, 14);
+      put(DRIVER_RESTART_RUNNING_TASK_KEY, 15);
+      put(DRIVER_RESTART_COMPLETED_KEY, 16);
     }
   };
 
@@ -145,8 +145,10 @@ public final class NativeInterop {
       final ContextMessageBridge contextMessageBridge
   );
 
-  public static native void clrSystemDriverRestartHandlerOnNext(
-      final long handle
+  public static native long[] callClrSystemOnRestartHandlerOnNext(
+      final String dateTime,
+      final String httpServerPortNumber,
+      final EvaluatorRequestorBridge javaEvaluatorRequestorBridge
   );
 
   public static native void clrSystemDriverRestartActiveContextHandlerOnNext(
@@ -157,6 +159,10 @@ public final class NativeInterop {
   public static native void clrSystemDriverRestartRunningTaskHandlerOnNext(
       final long handle,
       final RunningTaskBridge runningTaskBridge
+  );
+
+  public static native void clrSystemDriverRestartCompletedHandlerOnNext(
+      final long handle
   );
 
   /**


### PR DESCRIPTION
This addressed the issue by
  * Adding InterOp functions for restart-related (DriverRestarted, DriverRestartCompleted) operations.
  * Adding missing restart configurations to DriverConfiguration and DriverBridgeConfiguration.
  * Calling the restart handler on driver restart instead of calling the start handler.

JIRA:
  [REEF-540](https://issues.apache.org/jira/browse/REEF-540)