### PR TITLE
[REEF-574]  Eliminate Task Configuration deserialization/serializatio…

### DIFF
--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ActiveContextBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ActiveContextBridge.java
@@ -20,8 +20,8 @@ package org.apache.reef.javabridge;
 
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.io.naming.Identifiable;
+import org.apache.reef.runtime.common.driver.context.EvaluatorContext;
 import org.apache.reef.tang.ClassHierarchy;
-import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.formats.AvroConfigurationSerializer;
 
 import java.util.logging.Level;
@@ -51,15 +51,9 @@ public final class ActiveContextBridge extends NativeBridge implements Identifia
       throw new RuntimeException("empty taskConfigurationString provided.");
     }
 
-    final Configuration taskConfiguration;
-    try {
-      taskConfiguration = serializer.fromString(taskConfigurationString, clrClassHierarchy);
-    } catch (final Exception e) {
-      final String message = "Unable to de-serialize CLR  task configurations using class hierarchy.";
-      LOG.log(Level.SEVERE, message, e);
-      throw new RuntimeException(message, e);
-    }
-    jactiveContext.submitTask(taskConfiguration);
+    //when submit over the bridge, we would keep the task configuration as a serialized string
+    //submitTask(String taskConfig) is not exposed in the interface. Therefore cast is necessary.
+    ((EvaluatorContext)jactiveContext).submitTask(taskConfigurationString);
   }
 
   public String getEvaluatorDescriptorSring() {

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/AllocatedEvaluatorBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/AllocatedEvaluatorBridge.java
@@ -18,6 +18,7 @@
  */
 package org.apache.reef.javabridge;
 
+import org.apache.reef.runtime.common.driver.evaluator.AllocatedEvaluatorImpl;
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
 import org.apache.reef.tang.ClassHierarchy;
 import org.apache.reef.tang.Configuration;
@@ -70,13 +71,16 @@ public final class AllocatedEvaluatorBridge extends NativeBridge {
     final Configuration taskConfiguration;
     try {
       contextConfiguration = serializer.fromString(contextConfigurationString, clrClassHierarchy);
-      taskConfiguration = serializer.fromString(taskConfigurationString, clrClassHierarchy);
     } catch (final Exception e) {
       final String message = "Unable to de-serialize CLR context or task configurations using class hierarchy.";
       LOG.log(Level.SEVERE, message, e);
       throw new RuntimeException(message, e);
     }
-    jallocatedEvaluator.submitContextAndTask(contextConfiguration, taskConfiguration);
+
+    //When submit over the bridge, we would keep the task configuration as a serialized string.
+    //submitContextAndTask(final Configuration contextConfiguration,
+    //final String taskConfiguration) is not exposed in the interface. Therefore cast is necessary.
+    ((AllocatedEvaluatorImpl)jallocatedEvaluator).submitContextAndTask(contextConfiguration, taskConfigurationString);
   }
 
   /**
@@ -150,14 +154,18 @@ public final class AllocatedEvaluatorBridge extends NativeBridge {
     try {
       contextConfiguration = serializer.fromString(contextConfigurationString, clrClassHierarchy);
       servicetConfiguration = serializer.fromString(serviceConfigurationString, clrClassHierarchy);
-      taskConfiguration = serializer.fromString(taskConfigurationString, clrClassHierarchy);
     } catch (final Exception e) {
       final String message =
           "Unable to de-serialize CLR context or service or task configurations using class hierarchy.";
       LOG.log(Level.SEVERE, message, e);
       throw new RuntimeException(message, e);
     }
-    jallocatedEvaluator.submitContextAndServiceAndTask(contextConfiguration, servicetConfiguration, taskConfiguration);
+
+    //When submit over the bridge, we would keep the task configuration as a serialized string.
+    //submitContextAndServiceAndTask(final Configuration contextConfiguration, final Configuration serviceConfiguration,
+    //final String taskConfiguration) is not exposed in the interface. Therefore cast is necessary.
+    ((AllocatedEvaluatorImpl)jallocatedEvaluator)
+        .submitContextAndServiceAndTask(contextConfiguration, servicetConfiguration, taskConfigurationString);
   }
 
   /**

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/ContextAndTaskSubmittable.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/ContextAndTaskSubmittable.java
@@ -60,5 +60,4 @@ public interface ContextAndTaskSubmittable {
   void submitContextAndServiceAndTask(final Configuration contextConfiguration,
                                       final Configuration serviceConfiguration,
                                       final Configuration taskConfiguration);
-
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/EvaluatorContext.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/EvaluatorContext.java
@@ -124,7 +124,10 @@ public final class EvaluatorContext implements ActiveContext {
 
   @Override
   public synchronized void submitTask(final Configuration taskConf) {
+    submitTask(this.configurationSerializer.toString(taskConf));
+  }
 
+  public synchronized void submitTask(final String taskConf) {
     if (this.isClosed) {
       throw new RuntimeException("Active context already closed");
     }
@@ -137,7 +140,7 @@ public final class EvaluatorContext implements ActiveContext {
             .setStartTask(
                 EvaluatorRuntimeProtocol.StartTaskProto.newBuilder()
                     .setContextId(this.contextIdentifier)
-                    .setConfiguration(this.configurationSerializer.toString(taskConf))
+                    .setConfiguration(taskConf)
                     .build())
             .build();
 


### PR DESCRIPTION
…n at Java side

Currently Task configuration is passed over the bridge as a string. At Java side, it is deserialized into a Configuration object with C# class hierarchy. Before it is passed over to Evaluator, it is serialized again into a string.
This PR added overloading methods to allow the task configuration passing around as a string without deserialization. And then set it directly to evaluator configuration.

JIRA: REEF-574(https://issues.apache.org/jira/browse/REEF-574)

This closes #

Author: Julia Wang  Email: juliaw@apache.org