### PR TITLE
[REEF-321] AllocatedEvaluatorBridge constructor needlessly loads the class hierarchy

### DIFF
--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/AllocatedEvaluatorBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/AllocatedEvaluatorBridge.java
@@ -26,7 +26,10 @@ import org.apache.reef.tang.formats.AvroConfigurationSerializer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-public class AllocatedEvaluatorBridge extends NativeBridge {
+/**
+ * The AllocatedEvaluatorBridge object to bridge operations between REEF .NET and Java allocated evaluator operations.
+ */
+public final class AllocatedEvaluatorBridge extends NativeBridge {
 
   private static final Logger LOG = Logger.getLogger(AllocatedEvaluatorBridge.class.getName());
 
@@ -36,14 +39,25 @@ public class AllocatedEvaluatorBridge extends NativeBridge {
   private final String evaluatorId;
   private final String nameServerInfo;
 
-  public AllocatedEvaluatorBridge(final AllocatedEvaluator allocatedEvaluator, final String serverInfo) {
-    jallocatedEvaluator = allocatedEvaluator;
-    serializer = new AvroConfigurationSerializer();
-    clrClassHierarchy = Utilities.loadClassHierarchy(NativeInterop.CLASS_HIERARCHY_FILENAME);
-    evaluatorId = allocatedEvaluator.getId();
-    nameServerInfo = serverInfo;
+  /**
+   * This constructor should only be called by the AllocatedEvaluatorBridgeFactory.
+   */
+  AllocatedEvaluatorBridge(final AllocatedEvaluator allocatedEvaluator,
+                           final ClassHierarchy clrClassHierarchy,
+                           final String serverInfo,
+                           final AvroConfigurationSerializer serializer) {
+    this.jallocatedEvaluator = allocatedEvaluator;
+    this.serializer = serializer;
+    this.clrClassHierarchy = clrClassHierarchy;
+    this.evaluatorId = allocatedEvaluator.getId();
+    this.nameServerInfo = serverInfo;
   }
 
+  /**
+   * Bridge function for REEF .NET to submit context and task configurations for the allocated evaluator.
+   * @param contextConfigurationString the context configuration from .NET.
+   * @param taskConfigurationString the task configuration from .NET.
+   */
   public void submitContextAndTaskString(final String contextConfigurationString,
                                          final String taskConfigurationString) {
     if (contextConfigurationString.isEmpty()) {
@@ -65,6 +79,10 @@ public class AllocatedEvaluatorBridge extends NativeBridge {
     jallocatedEvaluator.submitContextAndTask(contextConfiguration, taskConfiguration);
   }
 
+  /**
+   * Bridge function for REEF .NET to submit context configuration for the allocated evaluator.
+   * @param contextConfigurationString the context configuration from .NET.
+   */
   public void submitContextString(final String contextConfigurationString) {
     if (contextConfigurationString.isEmpty()) {
       throw new RuntimeException("empty contextConfigurationString provided.");
@@ -80,6 +98,11 @@ public class AllocatedEvaluatorBridge extends NativeBridge {
     jallocatedEvaluator.submitContext(contextConfiguration);
   }
 
+  /**
+   * Bridge function for REEF .NET to submit context and service configurations for the allocated evaluator.
+   * @param contextConfigurationString the context configuration from .NET.
+   * @param serviceConfigurationString the service configuration from .NET.
+   */
   public void submitContextAndServiceString(final String contextConfigurationString,
                                             final String serviceConfigurationString) {
     if (contextConfigurationString.isEmpty()) {
@@ -102,6 +125,12 @@ public class AllocatedEvaluatorBridge extends NativeBridge {
     jallocatedEvaluator.submitContextAndService(contextConfiguration, servicetConfiguration);
   }
 
+  /**
+   * Bridge function for REEF .NET to submit context, service. and task configurations for the allocated evaluator.
+   * @param contextConfigurationString the context configuration from .NET.
+   * @param serviceConfigurationString the service configuration from .NET.
+   * @param taskConfigurationString the task configuration from .NET.
+   */
   public void submitContextAndServiceAndTaskString(
       final String contextConfigurationString,
       final String serviceConfigurationString,
@@ -131,6 +160,10 @@ public class AllocatedEvaluatorBridge extends NativeBridge {
     jallocatedEvaluator.submitContextAndServiceAndTask(contextConfiguration, servicetConfiguration, taskConfiguration);
   }
 
+  /**
+   * Gets the serialized evaluator descriptor from the Java allocated evaluator.
+   * @return the serialized evaluator descriptor.
+   */
   public String getEvaluatorDescriptorSring() {
     final String descriptorString =
         Utilities.getEvaluatorDescriptorString(jallocatedEvaluator.getEvaluatorDescriptor());
@@ -138,6 +171,9 @@ public class AllocatedEvaluatorBridge extends NativeBridge {
     return descriptorString;
   }
 
+  /**
+   * Closes the Java AllocatedEvaluator.
+   */
   @Override
   public void close() {
     jallocatedEvaluator.close();

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/AllocatedEvaluatorBridgeFactory.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/AllocatedEvaluatorBridgeFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.javabridge;
+
+import net.jcip.annotations.GuardedBy;
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.driver.evaluator.AllocatedEvaluator;
+import org.apache.reef.tang.ClassHierarchy;
+import org.apache.reef.tang.formats.AvroConfigurationSerializer;
+
+import javax.inject.Inject;
+
+/**
+ * The Factory object used to create AllocatedEvaluatorBridge objects.
+ * AllocatedEvaluatorBridge objects should not be instantiated directly.
+ */
+@DriverSide
+@Private
+public final class AllocatedEvaluatorBridgeFactory {
+  @GuardedBy("this")
+  private ClassHierarchy clrClassHierarchy;
+  private AvroConfigurationSerializer serializer;
+
+  /**
+   * This is always instantiated via Tang.
+   */
+  @Inject
+  private AllocatedEvaluatorBridgeFactory(final AvroConfigurationSerializer serializer) {
+    this.serializer = serializer;
+  }
+
+
+  /**
+   * Instantiates a new AllocatedEvaluatorBridge.
+   * @param allocatedEvaluator the AllocatedEvaluator object.
+   * @param serverInfo the name server String.
+   * @return the allocatedEvaluatorBridge.
+   */
+  public AllocatedEvaluatorBridge getAllocatedEvaluatorBridge(final AllocatedEvaluator allocatedEvaluator,
+                                                              final String serverInfo) {
+    return new AllocatedEvaluatorBridge(allocatedEvaluator, getClrClassHierarchy(), serverInfo, serializer);
+  }
+
+  /**
+   * Returns the clr ClassHierarchy. Loads it if needed.
+   *
+   * @return the clr ClassHierarchy.
+   */
+  private synchronized ClassHierarchy getClrClassHierarchy() {
+    if (null == this.clrClassHierarchy) {
+      this.clrClassHierarchy = Utilities.loadClassHierarchy(NativeInterop.CLASS_HIERARCHY_FILENAME);
+    }
+    return this.clrClassHierarchy;
+  }
+}

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
@@ -73,6 +73,8 @@ public final class JobDriver {
   private final String nameServerInfo;
   private final HttpServer httpServer;
   private final ActiveContextBridgeFactory activeContextBridgeFactory;
+  private final AllocatedEvaluatorBridgeFactory allocatedEvaluatorBridgeFactory;
+
   /**
    * Wake clock is used to schedule periodical job check-ups.
    */
@@ -156,6 +158,7 @@ public final class JobDriver {
             final LibLoader libLoader,
             final LocalAddressProvider localAddressProvider,
             final ActiveContextBridgeFactory activeContextBridgeFactory,
+            final AllocatedEvaluatorBridgeFactory allocatedEvaluatorBridgeFactory,
             final CLRProcessFactory clrProcessFactory) {
     this.clock = clock;
     this.httpServer = httpServer;
@@ -164,6 +167,7 @@ public final class JobDriver {
     this.nameServer = nameServer;
     this.driverStatusManager = driverStatusManager;
     this.activeContextBridgeFactory = activeContextBridgeFactory;
+    this.allocatedEvaluatorBridgeFactory = allocatedEvaluatorBridgeFactory;
     this.nameServerInfo = localAddressProvider.getLocalAddress() + ":" + this.nameServer.getPort();
     this.loggingScopeFactory = loggingScopeFactory;
     this.libLoader = libLoader;
@@ -262,7 +266,7 @@ public final class JobDriver {
         throw new RuntimeException("Allocated Evaluator Handler not initialized by CLR.");
       }
       final AllocatedEvaluatorBridge allocatedEvaluatorBridge =
-          new AllocatedEvaluatorBridge(eval, JobDriver.this.nameServerInfo);
+          this.allocatedEvaluatorBridgeFactory.getAllocatedEvaluatorBridge(eval, this.nameServerInfo);
       NativeInterop.clrSystemAllocatedEvaluatorHandlerOnNext(JobDriver.this.allocatedEvaluatorHandler,
           allocatedEvaluatorBridge, this.interopLogger);
     }


### PR DESCRIPTION
This addressed the issue by
  * Caching class hierarchy via the AllocatedEvaluatorBridgeFactory.
  * Adding missing JavaDocs for AllocatedEvaluatorBridge.

JIRA:
  [REEF-321](https://issues.apache.org/jira/browse/REEF-321)