### PR TITLE
[REEF-579] All .NET files should be checked out as CRLF from git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,7 @@
-# Commit text files using LF endings
+# Note that settings for text files below are overridden
+# within /lang/*/ directories by local .gitattributes
+
+# Files to checkout with LF
 *.java text eol=lf whitespace=trailing-space,space-before-tab,tab-in-indent,blank-at-eof
 *.sh text eol=lf
 *.js text eol=lf
@@ -10,6 +13,8 @@ LICENSE text eol=lf
 NOTICE text eol=lf
 *.md text eol=lf
 pom.xml text eol=lf
+
+# Files to checkout with CRLF
 *.h text eol=crlf
 *.cpp text eol=crlf
 *.rc text eol=crlf
@@ -19,7 +24,14 @@ pom.xml text eol=lf
 *.cs text eol=crlf
 *.cmd text eol=crlf
 *.ps1 text eol=crlf
-*.psm1 eol=crlf
+*.psm1 text eol=crlf
+
+# Binary files
 *.png binary
 *.jpg binary
+*.snk binary
+*.ico binary
+*.bin binary
+
+# Commit text files using LF endings
 * text=auto

--- a/lang/cs/.gitattributes
+++ b/lang/cs/.gitattributes
@@ -1,0 +1,9 @@
+# Checkout all files with CRLF
+* text eol=crlf
+
+# Except binary files
+*.png binary
+*.jpg binary
+*.snk binary
+*.ico binary
+*.bin binary

--- a/lang/java/.gitattributes
+++ b/lang/java/.gitattributes
@@ -1,0 +1,9 @@
+# Checkout all files with LF
+* text eol=lf
+
+# Except binary files
+*.png binary
+*.jpg binary
+*.snk binary
+*.ico binary
+*.bin binary

--- a/lang/java/reef-tang/.gitattributes
+++ b/lang/java/reef-tang/.gitattributes
@@ -1,3 +1,0 @@
-# Commit text files using LF endings
-*.java text eol=lf whitespace=trailing-space,space-before-tab,tab-in-indent,blank-at-eof
-* text=auto

--- a/lang/java/reef-wake/.gitattributes
+++ b/lang/java/reef-wake/.gitattributes
@@ -1,3 +1,0 @@
-# Commit text files using LF endings
-*.java text eol=lf whitespace=trailing-space,space-before-tab,tab-in-indent,blank-at-eof
-* text=auto


### PR DESCRIPTION
  Address the problem by creating .gitattributes in /lang/cs and
  /lang/java. Also remove local .gitattributes from java Wake and Tang.

JIRA:
  [REEF-579](https://issues.apache.org/jira/browse/REEF-579)

Pull Request:
  This closes #

===

NOTE: To actually get the EOL changes locally, it's not enough to checkout/pull. The entire index has to be removed from the local filesystem. One way to do this is:

```
git rm --cached -r .
git reset --hard
```

The first line makes sure only those files in git are removed (so your local IDE files survive), but it has the side-effect of marking files in git for removal. The next line tells git to forget you marked these files for removal.