### PR TITLE
[REEF-506] Make Driver call DriverRestartActiveContextHandler instead of have the Evaluator decide when to call it

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartState.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartState.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.driver.restart;
+
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Private;
+
+/**
+ * Represents the current driver restart progress.
+ */
+@Private
+@DriverSide
+@Unstable
+public enum DriverRestartState {
+  /**
+   *  Driver restart is not implemented.
+   */
+  NotImplemented,
+
+  /**
+   *  Driver has not begun the restart progress yet.
+   */
+  NotRestarted,
+
+  /**
+   * Driver has been notified of the restart by the runtime, but has not yet
+   * received its set of evaluator IDs to recover yet.
+   */
+  RestartBegan,
+
+  /**
+   * Driver has received its set of evaluator IDs to recover.
+   */
+  RestartInProgress,
+
+  /**
+   * Driver has recovered all the evaluator IDs that it can, and the restart process is completed.
+   */
+  RestartCompleted;
+
+  /**
+   * Returns true if the restart process has began.
+   */
+  public boolean isRestart() {
+    switch (this) {
+    case RestartBegan:
+    case RestartInProgress:
+    case RestartCompleted:
+      return true;
+    default:
+      return false;
+    }
+  }
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartUtilities.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartUtilities.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.driver.restart;
+
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.util.Optional;
+
+/**
+ * A static utilities class for simplifying calls to driver restart manager.
+ */
+@Private
+@DriverSide
+@Unstable
+public final class DriverRestartUtilities {
+
+  /**
+   * Helper function for driver restart to determine whether an evaluator ID is from an evaluator from the
+   * previous application attempt. DriverRestartManager is optional here.
+   */
+  public static boolean isRestartAndIsPreviousEvaluator(final Optional<DriverRestartManager> driverRestartManager,
+                                                        final String evaluatorId) {
+    if (!driverRestartManager.isPresent()) {
+      return false;
+    }
+
+    return isRestartAndIsPreviousEvaluator(driverRestartManager.get(), evaluatorId);
+  }
+
+  /**
+   * Helper function for driver restart to determine whether an evaluator ID is from an evaluator from the
+   * previous application attempt.
+   */
+  public static boolean isRestartAndIsPreviousEvaluator(final DriverRestartManager driverRestartManager,
+                                                        final String evaluatorId) {
+    return driverRestartManager.isRestart() && driverRestartManager.getPreviousEvaluatorIds().contains(evaluatorId);
+  }
+
+  private DriverRestartUtilities() {
+  }
+}


### PR DESCRIPTION
This addressed the issue by
  * Call restart handlers by checking the restart status based on DriverRestartManager instead of using the protobuf message from the recovered evaluator.

JIRA:
  [REEF-506](https://issues.apache.org/jira/browse/REEF-506)