### PR TITLE
[REEF-586] Deprecate org.apache.reef.javabridge.generic.LaunchHeadless

### DIFF
--- a/lang/cs/Org.Apache.REEF.Driver/Constants.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Constants.cs
@@ -77,6 +77,7 @@ namespace Org.Apache.REEF.Driver
 
         public const string BridgeLaunchClass = "org.apache.reef.javabridge.generic.Launch";
 
+        [Obsolete(message: "Deprecated in 0.13. Use BridgeLaunchClass instead.")]
         public const string BridgeLaunchHeadlessClass = "org.apache.reef.javabridge.generic.LaunchHeadless";
 
         public const string DirectLauncherClass = "org.apache.reef.runtime.common.Launcher";

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/LaunchHeadless.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/LaunchHeadless.java
@@ -35,7 +35,9 @@ import java.util.logging.Logger;
 
 /**
  * Clr Bridge example - main class.
+ * @deprecated in 0.13, please use {@link org.apache.reef.javabridge.generic.Launch instead}
  */
+@Deprecated
 public final class LaunchHeadless {
 
   /**


### PR DESCRIPTION
This addressed the issue by
  * Deprecating the org.apache.reef.javabridge.generic.LaunchHeadless and its usage in .NET.

JIRA:
  [REEF-586](https://issues.apache.org/jira/browse/REEF-586)