### PR TITLE
[REEF-568] Work around the federated YARN node reports problem

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManagerFactory.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManagerFactory.java
@@ -18,11 +18,15 @@
  */
 package org.apache.reef.runtime.common.driver.evaluator;
 
+import org.apache.commons.lang.Validate;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.catalog.NodeDescriptor;
 import org.apache.reef.driver.catalog.ResourceCatalog;
 import org.apache.reef.driver.evaluator.EvaluatorProcessFactory;
+import org.apache.reef.runtime.common.driver.catalog.ResourceCatalogImpl;
+import org.apache.reef.runtime.common.driver.resourcemanager.NodeDescriptorEvent;
+import org.apache.reef.runtime.common.driver.resourcemanager.NodeDescriptorEventImpl;
 import org.apache.reef.runtime.common.driver.resourcemanager.ResourceAllocationEvent;
 import org.apache.reef.runtime.common.driver.resourcemanager.ResourceStatusEvent;
 import org.apache.reef.tang.Injector;
@@ -90,10 +94,41 @@ public final class EvaluatorManagerFactory {
    */
   public EvaluatorManager getNewEvaluatorManagerForNewlyAllocatedEvaluator(
       final ResourceAllocationEvent resourceAllocationEvent) {
-    final NodeDescriptor nodeDescriptor = this.resourceCatalog.getNode(resourceAllocationEvent.getNodeId());
+    NodeDescriptor nodeDescriptor = this.resourceCatalog.getNode(resourceAllocationEvent.getNodeId());
 
     if (nodeDescriptor == null) {
-      throw new RuntimeException("Unknown resource: " + resourceAllocationEvent.getNodeId());
+      LOG.log(Level.WARNING, "Node descriptor not found for node {0}", resourceAllocationEvent.getNodeId());
+
+      // HOT FIX for YARN with FEDERATION
+      // See JIRA https://issues.apache.org/jira/browse/REEF-568
+      // Should be removed once the corresponding YARN issue is fixed
+      if (resourceAllocationEvent.getRackName().isPresent()) {
+        final String federationAsStr = resourceAllocationEvent.getRackName().get();
+        final boolean federation = Boolean.valueOf(federationAsStr);
+        // if a true value came here, means that we are using federation
+        if (federation) {
+          LOG.log(Level.WARNING, "Adding node {0}, hack to make it work with Federation",
+              resourceAllocationEvent.getNodeId());
+          final String nodeId = resourceAllocationEvent.getNodeId();
+          final String[] hostNameAndPort = nodeId.split(":");
+          Validate.isTrue(hostNameAndPort.length == 2);
+          final String[] rackAndNumber = hostNameAndPort[0].split("-");
+          Validate.isTrue(rackAndNumber.length == 2);
+          final NodeDescriptorEvent event = NodeDescriptorEventImpl.newBuilder().setIdentifier(nodeId)
+              .setHostName(hostNameAndPort[0]).setPort(Integer.parseInt(hostNameAndPort[1]))
+              .setMemorySize(resourceAllocationEvent.getResourceMemory()).setRackName(rackAndNumber[0]).build();
+          // downcast not to change the API
+          Validate.isTrue(this.resourceCatalog instanceof ResourceCatalogImpl);
+          // add the nodeDescriptor
+          ((ResourceCatalogImpl) this.resourceCatalog).handle(event);
+          // request it again
+          nodeDescriptor = this.resourceCatalog.getNode(resourceAllocationEvent.getNodeId());
+        } else {
+          throw new RuntimeException("Unknown resource: " + resourceAllocationEvent.getNodeId());
+        }
+      } else {
+        throw new RuntimeException("Unknown resource: " + resourceAllocationEvent.getNodeId());
+      }
     }
     final EvaluatorDescriptorImpl evaluatorDescriptor = new EvaluatorDescriptorImpl(nodeDescriptor,
         resourceAllocationEvent.getResourceMemory(), resourceAllocationEvent.getVirtualCores().get(),

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/YarnClientConfiguration.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/YarnClientConfiguration.java
@@ -28,6 +28,7 @@ import org.apache.reef.runtime.common.parameters.JVMHeapSlack;
 import org.apache.reef.runtime.yarn.YarnClasspathProvider;
 import org.apache.reef.runtime.yarn.client.parameters.JobPriority;
 import org.apache.reef.runtime.yarn.client.parameters.JobQueue;
+import org.apache.reef.runtime.yarn.driver.parameters.YarnFederation;
 import org.apache.reef.runtime.yarn.util.YarnConfigurationConstructor;
 import org.apache.reef.tang.ConfigurationProvider;
 import org.apache.reef.tang.formats.ConfigurationModule;
@@ -50,6 +51,7 @@ public class YarnClientConfiguration extends ConfigurationModuleBuilder {
   public static final OptionalParameter<Integer> YARN_PRIORITY = new OptionalParameter<>();
 
   public static final OptionalParameter<Double> JVM_HEAP_SLACK = new OptionalParameter<>();
+  public static final OptionalParameter<Boolean> YARN_FEDERATION = new OptionalParameter<>();
 
   /**
    * Configuration provides whose Configuration will be merged into all Driver Configuration.
@@ -64,6 +66,7 @@ public class YarnClientConfiguration extends ConfigurationModuleBuilder {
       .bindNamedParameter(JobQueue.class, YARN_QUEUE_NAME)
       .bindNamedParameter(JobPriority.class, YARN_PRIORITY)
       .bindNamedParameter(JVMHeapSlack.class, JVM_HEAP_SLACK)
+      .bindNamedParameter(YarnFederation.class, YARN_FEDERATION)
       .bindImplementation(RuntimeClasspathProvider.class, YarnClasspathProvider.class)
           // Bind external constructors. Taken from  YarnExternalConstructors.registerClientConstructors
       .bindConstructor(org.apache.hadoop.yarn.conf.YarnConfiguration.class, YarnConfigurationConstructor.class)

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/YarnJobSubmissionHandler.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/YarnJobSubmissionHandler.java
@@ -35,6 +35,7 @@ import org.apache.reef.runtime.yarn.client.parameters.JobQueue;
 import org.apache.reef.runtime.yarn.client.uploader.JobFolder;
 import org.apache.reef.runtime.yarn.client.uploader.JobUploader;
 import org.apache.reef.runtime.yarn.driver.YarnDriverConfiguration;
+import org.apache.reef.runtime.yarn.driver.parameters.YarnFederation;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Configurations;
 import org.apache.reef.tang.Tang;
@@ -61,6 +62,7 @@ final class YarnJobSubmissionHandler implements JobSubmissionHandler {
   private final JobUploader uploader;
   private final double jvmSlack;
   private final String defaultQueueName;
+  private final boolean yarnFederation;
 
   @Inject
   YarnJobSubmissionHandler(
@@ -70,7 +72,8 @@ final class YarnJobSubmissionHandler implements JobSubmissionHandler {
       final ClasspathProvider classpath,
       final JobUploader uploader,
       @Parameter(JVMHeapSlack.class) final double jvmSlack,
-      @Parameter(JobQueue.class) final String defaultQueueName) throws IOException {
+      @Parameter(JobQueue.class) final String defaultQueueName,
+      @Parameter(YarnFederation.class) final boolean yarnFederation) throws IOException {
 
     this.yarnConfiguration = yarnConfiguration;
     this.jobJarMaker = jobJarMaker;
@@ -79,6 +82,7 @@ final class YarnJobSubmissionHandler implements JobSubmissionHandler {
     this.uploader = uploader;
     this.jvmSlack = jvmSlack;
     this.defaultQueueName = defaultQueueName;
+    this.yarnFederation = yarnFederation;
   }
 
   @Override
@@ -131,6 +135,7 @@ final class YarnJobSubmissionHandler implements JobSubmissionHandler {
             .set(YarnDriverConfiguration.JOB_IDENTIFIER, jobSubmissionEvent.getIdentifier())
             .set(YarnDriverConfiguration.CLIENT_REMOTE_IDENTIFIER, jobSubmissionEvent.getRemoteId())
             .set(YarnDriverConfiguration.JVM_HEAP_SLACK, this.jvmSlack)
+            .set(YarnDriverConfiguration.YARN_FEDERATION, this.yarnFederation)
             .build(),
         jobSubmissionEvent.getConfiguration());
   }

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
@@ -36,6 +36,7 @@ import org.apache.reef.runtime.common.driver.resourcemanager.NodeDescriptorEvent
 import org.apache.reef.runtime.common.driver.resourcemanager.ResourceAllocationEventImpl;
 import org.apache.reef.runtime.common.driver.resourcemanager.ResourceStatusEventImpl;
 import org.apache.reef.runtime.common.driver.resourcemanager.RuntimeStatusEventImpl;
+import org.apache.reef.runtime.yarn.driver.parameters.YarnFederation;
 import org.apache.reef.runtime.yarn.driver.parameters.YarnHeartbeatPeriod;
 import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.util.Optional;
@@ -75,11 +76,13 @@ final class YarnContainerManager
   private final ContainerRequestCounter containerRequestCounter;
   private final DriverStatusManager driverStatusManager;
   private final TrackingURLProvider trackingURLProvider;
+  private final boolean yarnFederation;
 
   @Inject
   YarnContainerManager(
       final YarnConfiguration yarnConf,
       @Parameter(YarnHeartbeatPeriod.class) final int yarnRMHeartbeatPeriod,
+      @Parameter(YarnFederation.class) final boolean yarnFederation,
       final REEFEventHandlers reefEventHandlers,
       final Containers containers,
       final ApplicationMasterRegistration registration,
@@ -89,6 +92,7 @@ final class YarnContainerManager
 
     this.reefEventHandlers = reefEventHandlers;
     this.driverStatusManager = driverStatusManager;
+    this.yarnFederation = yarnFederation;
 
     this.containers = containers;
     this.registration = registration;
@@ -399,6 +403,10 @@ final class YarnContainerManager
             .setNodeId(container.getNodeId().toString())
             .setResourceMemory(container.getResource().getMemory())
             .setVirtualCores(container.getResource().getVirtualCores())
+            // send the flag of federation here, not to change any
+            // APIs, dirty fix for JIRA https://issues.apache.org/jira/browse/REEF-568
+            // until the linked YARN issue is fixed
+            .setRackName(Boolean.toString(yarnFederation))
             .build());
         this.updateRuntimeStatus();
       } else {

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverConfiguration.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverConfiguration.java
@@ -31,6 +31,7 @@ import org.apache.reef.runtime.common.launch.parameters.LaunchID;
 import org.apache.reef.runtime.common.parameters.JVMHeapSlack;
 import org.apache.reef.runtime.yarn.YarnClasspathProvider;
 import org.apache.reef.runtime.yarn.driver.parameters.JobSubmissionDirectory;
+import org.apache.reef.runtime.yarn.driver.parameters.YarnFederation;
 import org.apache.reef.runtime.yarn.driver.parameters.YarnHeartbeatPeriod;
 import org.apache.reef.runtime.yarn.util.YarnConfigurationConstructor;
 import org.apache.reef.tang.formats.ConfigurationModule;
@@ -50,6 +51,10 @@ public class YarnDriverConfiguration extends ConfigurationModuleBuilder {
    * @see org.apache.reef.runtime.yarn.driver.parameters.YarnHeartbeatPeriod.class
    */
   public static final OptionalParameter<Integer> YARN_HEARTBEAT_INTERVAL = new OptionalParameter<>();
+  /**
+   * @see org.apache.reef.runtime.yarn.driver.parameters.YarnFederation.class
+   */
+  public static final OptionalParameter<Boolean> YARN_FEDERATION = new OptionalParameter<>();
 
   /**
    * @see JobIdentifier.class
@@ -85,6 +90,7 @@ public class YarnDriverConfiguration extends ConfigurationModuleBuilder {
           // Bind the YARN Configuration parameters
       .bindNamedParameter(JobSubmissionDirectory.class, JOB_SUBMISSION_DIRECTORY)
       .bindNamedParameter(YarnHeartbeatPeriod.class, YARN_HEARTBEAT_INTERVAL)
+      .bindNamedParameter(YarnFederation.class, YARN_FEDERATION)
 
           // Bind the fields bound in AbstractDriverRuntimeConfiguration
       .bindNamedParameter(JobIdentifier.class, JOB_IDENTIFIER)

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/parameters/YarnFederation.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/parameters/YarnFederation.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runtime.yarn.driver.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+/**
+ * Flag to check if we are using YARN with Federation.
+ */
+@NamedParameter(doc = "If we are using a federated yarn", default_value = "false")
+public final class YarnFederation implements Name<Boolean> {
+}


### PR DESCRIPTION
This change is a work around for a federated YARN problem. Once the corresponding JIRA is fixed, it should be reverted.
The issue is the following:
Just after initializing our yarn client library, we ask for the RUNNING nodes in the cluster to populate our own Resource Catalog.
YARN replies with the nodes that belong to a 'random' sub-cluster; sometimes with the nodes in the correct sub-cluster (where the containers will be placed), but sometimes with other ones.
That causes the application to randomly fail.

This hot fix adds the information of the allocated containers to the resource catalog if they are not there, when using using a federated YARN environment. This last check is done by the "YarnFederation" configuration parameter.