### PR TITLE
[REEF-591]:Use TcpPortProvider in HttpServerImpl

### DIFF
--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpServerImpl.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpServerImpl.java
@@ -92,7 +92,7 @@ public final class HttpServerImpl implements HttpServer {
         }
       } else {
         // new TcpPortProvider path
-        Iterator<Integer> ports = tcpPortProvider.iterator();
+        final Iterator<Integer> ports = tcpPortProvider.iterator();
         while (ports.hasNext() && srv  == null) {
           availablePort = ports.next();
           srv = tryPort(availablePort);

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/MaxPortNumber.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/MaxPortNumber.java
@@ -23,7 +23,7 @@ import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
  * max port number range when generating a port number for the Http Server.
- * @deprecated "Use TcpPortRangeCount and TcpPortProvider instead."
+ * @deprecated in 0.13, use TcpPortRangeCount and TcpPortProvider instead.
  */
 @NamedParameter(doc = "Max port number for Jetty Server", default_value = "49151")
 @Deprecated

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/MaxPortNumber.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/MaxPortNumber.java
@@ -23,7 +23,9 @@ import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
  * max port number range when generating a port number for the Http Server.
+ * @deprecated "Use TcpPortRangeCount and TcpPortProvider instead."
  */
 @NamedParameter(doc = "Max port number for Jetty Server", default_value = "49151")
+@Deprecated
 public class MaxPortNumber implements Name<Integer> {
 }

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/MaxRetryAttempts.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/MaxRetryAttempts.java
@@ -23,7 +23,7 @@ import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
  * Max retry times when generating a port number for the Http Server.
- * @deprecated "Use TcpPortRangeTryCount and TcpPortProvider instead."
+ * @deprecated in 0.13, use TcpPortRangeTryCount and TcpPortProvider instead.
  */
 @NamedParameter(doc = "Maximum retry attempts for port number of Jetty Server", default_value = "100")
 @Deprecated

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/MaxRetryAttempts.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/MaxRetryAttempts.java
@@ -23,7 +23,9 @@ import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
  * Max retry times when generating a port number for the Http Server.
+ * @deprecated "Use TcpPortRangeTryCount and TcpPortProvider instead."
  */
 @NamedParameter(doc = "Maximum retry attempts for port number of Jetty Server", default_value = "100")
+@Deprecated
 public class MaxRetryAttempts implements Name<Integer> {
 }

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/MinPortNumber.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/MinPortNumber.java
@@ -23,7 +23,9 @@ import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
  * minimum port number range when generating a port number for the Http Server.
+ * @deprecated "Use TcpPortRangeStart and TcpPortProvider instead."
  */
 @NamedParameter(doc = "Minimum port number for Jetty Server", default_value = "1024")
+@Deprecated
 public class MinPortNumber implements Name<Integer> {
 }

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/MinPortNumber.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/MinPortNumber.java
@@ -23,7 +23,7 @@ import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
  * minimum port number range when generating a port number for the Http Server.
- * @deprecated "Use TcpPortRangeStart and TcpPortProvider instead."
+ * @deprecated in 0.13, use TcpPortRangeStart and TcpPortProvider instead.
  */
 @NamedParameter(doc = "Minimum port number for Jetty Server", default_value = "1024")
 @Deprecated

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/PortNumber.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/PortNumber.java
@@ -25,7 +25,7 @@ import org.apache.reef.tang.annotations.NamedParameter;
  * port number for the Http Server
  * Clients can set a preferred port number. However, Reef will detect if the given port number has been used
  * in the machine. If yes, it will generate another available port number.
- * @deprecated "Use TcpPortRangeStart and TcpPortProvider instead."
+ * @deprecated in 0.13, use TcpPortRangeStart and TcpPortProvider instead.
  */
 @NamedParameter(doc = "Port number for Jetty Server", default_value = PortNumber.DEFAULT_VALUE)
 @Deprecated

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/PortNumber.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/PortNumber.java
@@ -25,7 +25,11 @@ import org.apache.reef.tang.annotations.NamedParameter;
  * port number for the Http Server
  * Clients can set a preferred port number. However, Reef will detect if the given port number has been used
  * in the machine. If yes, it will generate another available port number.
+ * @deprecated "Use TcpPortRangeStart and TcpPortProvider instead."
  */
-@NamedParameter(doc = "Port number for Jetty Server", default_value = "8080")
-public class PortNumber implements Name<Integer> {
+@NamedParameter(doc = "Port number for Jetty Server", default_value = PortNumber.DEFAULT_VALUE)
+@Deprecated
+public final class PortNumber implements Name<Integer> {
+  private PortNumber(){}
+  public static final String DEFAULT_VALUE = "8080";
 }


### PR DESCRIPTION
This addressed the issue adding TcpPortProvider HttpServerImpl.

JIRA: [REEF-591](https://issues.apache.org/jira/browse/REEF-591)

This closes #