### PR TITLE
[REEF-560] Add a configurable timeout for driver to recover evaluators on restart

### DIFF
--- a/lang/cs/Org.Apache.REEF.Driver/ClassHierarchyGeneratingDriverStartObserver.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/ClassHierarchyGeneratingDriverStartObserver.cs
@@ -32,7 +32,7 @@ namespace Org.Apache.REEF.Driver
     /// <summary>
     /// Utility class that generates the class hierarchy for the assemblies in the `global` folder.
     /// </summary>
-    internal sealed class ClassHierarchyGeneratingDriverStartObserver : IObserver<IDriverStarted>
+    internal sealed class ClassHierarchyGeneratingDriverStartObserver : IObserver<IDriverStarted>, IObserver<IDriverRestarted>
     {
         private static readonly Logger Logger = Logger.GetLogger(typeof(ClassHierarchyGeneratingDriverStartObserver));
 
@@ -52,18 +52,16 @@ namespace Org.Apache.REEF.Driver
         /// <param name="value"></param>
         public void OnNext(IDriverStarted value)
         {
-            if (_assemblies != null && _assemblies.Count > 0)
-            {
-                //adding system level assemblies
-                _assemblies.Add(typeof(IDriver).Assembly.GetName().Name);
-                _assemblies.Add(typeof(ITask).Assembly.GetName().Name);
+            GenerateClassHierarchyBin();
+        }
 
-                ClrHandlerHelper.GenerateClassHierarchy(_assemblies);
-            }
-            else
-            {
-                ClrHandlerHelper.GenerateClassHierarchy(GetAssembliesInGlobalFolder());
-            }
+        /// <summary>
+        /// Generates the class hierarchy file
+        /// </summary>
+        /// <param name="value"></param>
+        public void OnNext(IDriverRestarted value)
+        {
+            GenerateClassHierarchyBin();
         }
 
         /// <summary>
@@ -81,6 +79,25 @@ namespace Org.Apache.REEF.Driver
         public void OnCompleted()
         {
             // Silently ignored, assuming that a user-bound Observer will catch it.
+        }
+
+        /// <summary>
+        /// Generates the clr class hierarchy.
+        /// </summary>
+        private void GenerateClassHierarchyBin()
+        {
+            if (_assemblies != null && _assemblies.Count > 0)
+            {
+                //adding system level assemblies
+                _assemblies.Add(typeof(IDriver).Assembly.GetName().Name);
+                _assemblies.Add(typeof(ITask).Assembly.GetName().Name);
+
+                ClrHandlerHelper.GenerateClassHierarchy(_assemblies);
+            }
+            else
+            {
+                ClrHandlerHelper.GenerateClassHierarchy(GetAssembliesInGlobalFolder());
+            }
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Driver/DriverConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/DriverConfiguration.cs
@@ -226,7 +226,8 @@ namespace Org.Apache.REEF.Driver
                     .BindNamedParameter(GenericType<DriverBridgeConfigurationOptions.RestartEnabled>.Class, RestartEnabled)
                     .Build()
                     // TODO: Move this up
-                    .Set(OnDriverStarted, GenericType<ClassHierarchyGeneratingDriverStartObserver>.Class);
+                    .Set(OnDriverStarted, GenericType<ClassHierarchyGeneratingDriverStartObserver>.Class)
+                    .Set(OnDriverRestarted, GenericType<ClassHierarchyGeneratingDriverStartObserver>.Class);
             }
         }
     }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverRestartConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverRestartConfiguration.java
@@ -64,6 +64,12 @@ public final class DriverRestartConfiguration extends ConfigurationModuleBuilder
       new OptionalImpl<>();
 
   /**
+   * The amount of time the driver waits for evaluators to report back on restart. Defaults to 3 minutes. If
+   * the value is set to Integer.MAX_VALUE, the driver will wait forever.
+   */
+  public static final OptionalParameter<Integer> DRIVER_RESTART_EVALUATOR_RECOVERY_MS = new OptionalParameter<>();
+
+  /**
    * Parameter to determine whether the driver should fail or continue if there are evaluator
    * preservation log failures. Defaults to false.
    */
@@ -72,6 +78,7 @@ public final class DriverRestartConfiguration extends ConfigurationModuleBuilder
 
   public static final ConfigurationModule CONF = new DriverRestartConfiguration()
       .bindNamedParameter(FailDriverOnEvaluatorLogErrors.class, FAIL_DRIVER_ON_EVALUATOR_LOG_ERROR)
+      .bindNamedParameter(DriverRestartEvaluatorRecoveryMs.class, DRIVER_RESTART_EVALUATOR_RECOVERY_MS)
       .bindSetEntry(DriverRestartHandler.class, ON_DRIVER_RESTARTED)
       .bindSetEntry(DriverRestartTaskRunningHandlers.class, ON_DRIVER_RESTART_TASK_RUNNING)
       .bindSetEntry(DriverRestartContextActiveHandlers.class, ON_DRIVER_RESTART_CONTEXT_ACTIVE)

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/catalog/EvaluatorInfo.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/catalog/EvaluatorInfo.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.driver.catalog;
+
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Private;
+
+/**
+ * Provides information on an evaluator. Currently primarily used in the case of a recovered evaluator
+ * on driver restart.
+ */
+@Private
+@DriverSide
+public final class EvaluatorInfo {
+  private final String rackName;
+  private final int numberOfCores;
+  private final int memoryInMegaBytes;
+  private final String nodeId;
+
+  public EvaluatorInfo(final String nodeId,
+                       final String rackName,
+                       final int memoryInMegaBytes,
+                       final int numberOfCores) {
+    this.memoryInMegaBytes = memoryInMegaBytes;
+    this.numberOfCores = numberOfCores;
+    this.rackName = rackName;
+    this.nodeId = nodeId;
+  }
+
+  /**
+   * @return the Node ID of the evaluator.
+   */
+  public String getNodeId() {
+    return nodeId;
+  }
+
+  /**
+   * @return the rack name of the evaluator.
+   */
+  public String getRackName() {
+    return rackName;
+  }
+
+  /**
+   * @return the number of cores of the evaluator.
+   */
+  public int getNumberOfCores() {
+    return numberOfCores;
+  }
+
+  /**
+   * @return the memory of an evaluator in megabytes.
+   */
+  public int getMemoryInMegaBytes() {
+    return memoryInMegaBytes;
+  }
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverRestartEvaluatorRecoveryMs.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverRestartEvaluatorRecoveryMs.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.driver.parameters;
+
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+/**
+ * Represents the amount of time in milliseconds that the driver restart waits for evaluators to report back.
+ * Defaults to 3 minutes. If the value is set to Integer.MAX_VALUE, the driver will wait forever until all
+ * expected evaluators report back or fail.
+ */
+@Unstable
+@NamedParameter(doc = "The amount of time in milliseconds that the driver restart waits for" +
+    " evaluators to report back. Defaults to 3 minutes. If the value is set to Integer.MAX_VALUE, " +
+    "the driver will wait forever until all expected evaluators report back or fail.",
+    default_value = DriverRestartEvaluatorRecoveryMs.DEFAULT)
+public final class DriverRestartEvaluatorRecoveryMs implements Name<Integer> {
+
+  /**
+   * The driver waits forever until all expected evaluators report back or fail.
+   */
+  public static final String INFINITE = new Long(Integer.MAX_VALUE).toString();
+
+  /**
+   * Default restart wait for the driver is 3 minutes.
+   */
+  public static final String DEFAULT = "180000";
+
+  private DriverRestartEvaluatorRecoveryMs(){
+  }
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DefaultDriverRuntimeRestartMangerImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DefaultDriverRuntimeRestartMangerImpl.java
@@ -28,8 +28,8 @@ import java.util.Set;
 
 /**
  * The default driver runtime restart manager that is not able to perform any restart actions.
- * Thus, when performing actions pertaining to restart, it is recommended to call static functions in
- * {@link DriverRestartUtilities} or call canRestart() first.
+ * Thus, when performing actions pertaining to restart, it is recommended to call isRestarting()
+ * or hasRestarted() first.
  */
 @Private
 @DriverSide
@@ -40,7 +40,7 @@ final class DefaultDriverRuntimeRestartMangerImpl implements DriverRuntimeRestar
   }
 
   @Override
-  public boolean isRestart() {
+  public boolean hasRestarted() {
     return false;
   }
 
@@ -57,7 +57,7 @@ final class DefaultDriverRuntimeRestartMangerImpl implements DriverRuntimeRestar
   }
 
   @Override
-  public EvaluatorRestartInfo getAliveAndFailedEvaluators() {
+  public EvaluatorRestartCollection getAliveAndFailedEvaluators() {
     throw new DriverFatalRuntimeException(
         "Restart is not enabled. getAliveAndFailedEvaluators should not have been called.");
   }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartManager.java
@@ -21,12 +21,23 @@ package org.apache.reef.driver.restart;
 import org.apache.reef.annotations.Unstable;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.driver.parameters.DriverRestartCompletedHandlers;
+import org.apache.reef.driver.parameters.DriverRestartEvaluatorRecoveryMs;
+import org.apache.reef.driver.parameters.ServiceDriverRestartCompletedHandlers;
 import org.apache.reef.exception.DriverFatalRuntimeException;
+import org.apache.reef.proto.ReefServiceProtos;
+import org.apache.reef.runtime.common.DriverRestartCompleted;
+import org.apache.reef.runtime.common.driver.evaluator.EvaluatorManagerFactory;
+import org.apache.reef.runtime.common.driver.idle.DriverIdlenessSource;
+import org.apache.reef.runtime.common.driver.idle.IdleMessage;
+import org.apache.reef.runtime.common.driver.resourcemanager.ResourceStatusEvent;
+import org.apache.reef.runtime.common.driver.resourcemanager.ResourceStatusEventImpl;
+import org.apache.reef.tang.annotations.Parameter;
+import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.time.Clock;
 
 import javax.inject.Inject;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -37,46 +48,81 @@ import java.util.logging.Logger;
 @DriverSide
 @Private
 @Unstable
-public final class DriverRestartManager {
-  private static final Logger LOG = Logger.getLogger(DriverRestartManager.class.getName());
+public final class DriverRestartManager implements DriverIdlenessSource {
+  private static final String CLASS_NAME = DriverRestartManager.class.getName();
+  private static final Logger LOG = Logger.getLogger(CLASS_NAME);
+
   private final DriverRuntimeRestartManager driverRuntimeRestartManager;
-  private final Set<String> previousEvaluators;
-  private final Set<String> recoveredEvaluators;
+  private final Map<String, EvaluatorRestartInfo> previousEvaluators;
+  private final int driverRestartEvaluatorRecoveryMs;
+  private final EvaluatorManagerFactory evaluatorManagerFactory;
+  private final Set<EventHandler<DriverRestartCompleted>> driverRestartCompletedHandlers;
+  private final Set<EventHandler<DriverRestartCompleted>> serviceDriverRestartCompletedHandlers;
+  private final Clock clock;
+
   private DriverRestartState state;
 
   @Inject
-  private DriverRestartManager(final DriverRuntimeRestartManager driverRuntimeRestartManager) {
+  private DriverRestartManager(@Parameter(DriverRestartEvaluatorRecoveryMs.class)
+                               final int driverRestartEvaluatorRecoveryMs,
+                               final Clock clock,
+                               final DriverRuntimeRestartManager driverRuntimeRestartManager,
+                               final EvaluatorManagerFactory evaluatorManagerFactory,
+                               @Parameter(DriverRestartCompletedHandlers.class)
+                               final Set<EventHandler<DriverRestartCompleted>> driverRestartCompletedHandlers,
+                               @Parameter(ServiceDriverRestartCompletedHandlers.class)
+                               final Set<EventHandler<DriverRestartCompleted>> serviceDriverRestartCompletedHandlers) {
+    this.clock = clock;
     this.driverRuntimeRestartManager = driverRuntimeRestartManager;
     this.state = DriverRestartState.NotRestarted;
-    this.previousEvaluators = new HashSet<>();
-    this.recoveredEvaluators = new HashSet<>();
+    this.driverRestartEvaluatorRecoveryMs = driverRestartEvaluatorRecoveryMs;
+    this.evaluatorManagerFactory = evaluatorManagerFactory;
+    this.driverRestartCompletedHandlers = driverRestartCompletedHandlers;
+    this.serviceDriverRestartCompletedHandlers = serviceDriverRestartCompletedHandlers;
+    this.previousEvaluators = new HashMap<>();
+    if (driverRestartEvaluatorRecoveryMs <= 0) {
+      throw new DriverFatalRuntimeException("The restart wait time for the driver must be greater than 0.");
+    }
   }
 
   /**
-   * @return Whether or not the driver instance is a restarted instance.
+   * Triggers the state machine if the application is a restart instance. Returns true
+   * @return true if the application is a restart instance.
    */
-  public synchronized boolean isRestart() {
-    if (this.state.isRestart()) {
-      return true;
-    }
-
-    if (driverRuntimeRestartManager.isRestart()) {
+  public synchronized boolean detectRestart() {
+    if (!this.state.hasRestarted() && driverRuntimeRestartManager.hasRestarted()) {
       this.state = DriverRestartState.RestartBegan;
-      return true;
     }
 
-    return false;
+    return this.state.hasRestarted();
+  }
+
+  /**
+   * @return true if the driver is undergoing the process of restart.
+   */
+  public synchronized boolean isRestarting() {
+    return this.state.isRestarting();
   }
 
   /**
    * Recovers the list of alive and failed evaluators and inform about evaluator failures
    * based on the specific runtime. Also sets the expected amount of evaluators to report back
-   * as alive to the job driver.
+   * as alive to the job driver and schedules the restart clock.
    */
   public synchronized void onRestart() {
-    final EvaluatorRestartInfo evaluatorRestartInfo = driverRuntimeRestartManager.getAliveAndFailedEvaluators();
-    setPreviousEvaluatorIds(evaluatorRestartInfo.getAliveEvaluators());
+    final EvaluatorRestartCollection evaluatorRestartInfo = driverRuntimeRestartManager.getAliveAndFailedEvaluators();
+    setPreviousEvaluators(evaluatorRestartInfo.getAliveEvaluators());
     driverRuntimeRestartManager.informAboutEvaluatorFailures(evaluatorRestartInfo.getFailedEvaluators());
+    if (driverRestartEvaluatorRecoveryMs != Integer.MAX_VALUE) {
+      // Don't use Clock here because if there is an event scheduled, the driver will not be idle, even if
+      // driver restart has already completed, and we cannot cancel the event.
+      new Timer().schedule(new TimerTask() {
+        @Override
+        public void run() {
+          onDriverRestartCompleted();
+        }
+      }, driverRestartEvaluatorRecoveryMs);
+    }
   }
 
   /**
@@ -87,21 +133,35 @@ public final class DriverRestartManager {
   }
 
   /**
+   * @return the restart state of the evaluator.
+   */
+  public synchronized EvaluatorRestartState getEvaluatorRestartState(final String evaluatorId) {
+    if (!this.state.hasRestarted() ||
+        !this.previousEvaluators.containsKey(evaluatorId)) {
+      return EvaluatorRestartState.NOT_RESTARTED_EVALUATOR;
+    }
+
+    return this.previousEvaluators.get(evaluatorId).getState();
+  }
+
+  /**
    * @return the Evaluators expected to check in from a previous run.
    */
-  public synchronized Set<String> getPreviousEvaluatorIds() {
-    return Collections.unmodifiableSet(this.previousEvaluators);
+  public synchronized Map<String, EvaluatorRestartInfo> getPreviousEvaluators() {
+    return Collections.unmodifiableMap(this.previousEvaluators);
   }
 
   /**
    * Set the Evaluators to expect still active from a previous execution of the Driver in a restart situation.
    * To be called exactly once during a driver restart.
-   *
-   * @param ids the evaluator IDs of the evaluators that are expected to have survived driver restart.
+   * @param evaluatorMap the evaluator IDs of the evaluators that are expected to have survived driver restart.
    */
-  public synchronized void setPreviousEvaluatorIds(final Set<String> ids) {
-    if (this.state != DriverRestartState.RestartInProgress) {
-      previousEvaluators.addAll(ids);
+  public synchronized void setPreviousEvaluators(final Map<String, EvaluatorRestartInfo> evaluatorMap) {
+    if (this.state == DriverRestartState.RestartBegan) {
+      for (final Map.Entry<String, EvaluatorRestartInfo> entry : evaluatorMap.entrySet()) {
+        previousEvaluators.put(entry.getKey(), entry.getValue());
+      }
+
       this.state = DriverRestartState.RestartInProgress;
     } else {
       final String errMsg = "Should not be setting the set of expected alive evaluators more than once.";
@@ -111,34 +171,38 @@ public final class DriverRestartManager {
   }
 
   /**
-   * @return the IDs of the Evaluators from a previous Driver that have checked in with the Driver
-   * in a restart situation.
-   */
-  public synchronized Set<String> getRecoveredEvaluatorIds() {
-    return Collections.unmodifiableSet(this.previousEvaluators);
-  }
-
-  /**
    * Indicate that this Driver has re-established the connection with one more Evaluator of a previous run.
-   * @return true if the driver restart is completed.
+   * @return true if the evaluator has been newly recovered.
    */
-  public synchronized boolean onRecoverEvaluatorIsRestartComplete(final String evaluatorId) {
-    if (!this.previousEvaluators.contains(evaluatorId)) {
+  public synchronized boolean onRecoverEvaluator(final String evaluatorId) {
+    if (!this.previousEvaluators.containsKey(evaluatorId)) {
       final String errMsg = "Evaluator with evaluator ID " + evaluatorId + " not expected to be alive.";
       LOG.log(Level.SEVERE, errMsg);
       throw new DriverFatalRuntimeException(errMsg);
     }
 
-    if (!this.recoveredEvaluators.add(evaluatorId)) {
+    if (this.previousEvaluators.get(evaluatorId).getState() != EvaluatorRestartState.EXPECTED) {
       LOG.log(Level.WARNING, "Evaluator with evaluator ID " + evaluatorId + " added to the set" +
           " of recovered evaluators more than once. Ignoring second add...");
+      return false;
     }
 
-    if (this.recoveredEvaluators.containsAll(this.previousEvaluators)) {
-      this.state = DriverRestartState.RestartCompleted;
+    // set the status for this evaluator ID to be reported.
+    this.previousEvaluators.get(evaluatorId).setState(EvaluatorRestartState.REPORTED);
+
+    boolean restartCompleted = true;
+
+    for (final EvaluatorRestartInfo restartInfo : this.previousEvaluators.values()) {
+      if (!restartInfo.getState().hasReported()) {
+        restartCompleted = false;
+      }
     }
 
-    return this.state == DriverRestartState.RestartCompleted;
+    if (restartCompleted) {
+      onDriverRestartCompleted();
+    }
+
+    return true;
   }
 
   /**
@@ -155,5 +219,71 @@ public final class DriverRestartManager {
    */
   public synchronized void recordRemovedEvaluator(final String id) {
     driverRuntimeRestartManager.recordRemovedEvaluator(id);
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return True if not in process of restart. False otherwise.
+   */
+  @Override
+  public IdleMessage getIdleStatus() {
+    boolean idleState = !this.state.isRestarting();
+    final String idleMessage = idleState ? CLASS_NAME + " currently not in the process of restart." :
+        CLASS_NAME + " currently in the process of restart.";
+    return new IdleMessage(CLASS_NAME, idleMessage, idleState);
+  }
+
+  /**
+   * Sets the driver restart status to be completed if not yet set and notifies the restart completed event handlers.
+   */
+  private synchronized void onDriverRestartCompleted() {
+    if (this.state != DriverRestartState.RestartCompleted) {
+      final Set<String> outstandingEvaluatorIds = getOutstandingEvaluatorsAndMarkExpired();
+      driverRuntimeRestartManager.informAboutEvaluatorFailures(outstandingEvaluatorIds);
+      closeUnrecoverableEvaluators(outstandingEvaluatorIds);
+
+      this.state = DriverRestartState.RestartCompleted;
+      final DriverRestartCompleted driverRestartCompleted = new DriverRestartCompleted(System.currentTimeMillis());
+
+      for (final EventHandler<DriverRestartCompleted> serviceRestartCompletedHandler
+          : this.serviceDriverRestartCompletedHandlers) {
+        serviceRestartCompletedHandler.onNext(driverRestartCompleted);
+      }
+
+      for (final EventHandler<DriverRestartCompleted> restartCompletedHandler : this.driverRestartCompletedHandlers) {
+        restartCompletedHandler.onNext(driverRestartCompleted);
+      }
+
+      LOG.log(Level.FINE, "Restart completed. Evaluators that have not reported back are: " + outstandingEvaluatorIds);
+    }
+  }
+
+  /**
+   * Gets the outstanding evaluators that have not yet reported back and mark them as expired.
+   */
+  private Set<String> getOutstandingEvaluatorsAndMarkExpired() {
+    final Set<String> outstanding = new HashSet<>();
+    for (final Map.Entry<String, EvaluatorRestartInfo> entry : previousEvaluators.entrySet()) {
+      if (!entry.getValue().getState().hasReported()) {
+        outstanding.add(entry.getKey());
+        entry.getValue().setState(EvaluatorRestartState.EXPIRED);
+      }
+    }
+
+    return outstanding;
+  }
+
+  /**
+   * Closes the evaluator properly for unrecoverable evaluators.
+   */
+  private void closeUnrecoverableEvaluators(final Set<String> evaluatorIds) {
+    for (final String evaluatorId : evaluatorIds) {
+      final ResourceStatusEvent recoveredResourceStatusEvent =
+          ResourceStatusEventImpl.newBuilder().setIdentifier(evaluatorId).setIsFromPreviousDriver(true)
+              .setState(ReefServiceProtos.State.FAILED).build();
+
+      evaluatorManagerFactory.getNewEvaluatorManagerForRecoveredEvaluatorDuringDriverRestart(
+          this.previousEvaluators.get(evaluatorId).getEvaluatorInfo(), recoveredResourceStatusEvent).close();
+    }
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartState.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartState.java
@@ -30,11 +30,6 @@ import org.apache.reef.annotations.audience.Private;
 @Unstable
 public enum DriverRestartState {
   /**
-   *  Driver restart is not implemented.
-   */
-  NotImplemented,
-
-  /**
    *  Driver has not begun the restart progress yet.
    */
   NotRestarted,
@@ -56,16 +51,22 @@ public enum DriverRestartState {
   RestartCompleted;
 
   /**
-   * Returns true if the restart process has began.
+   * @return  true if the restart is in process.
    */
-  public boolean isRestart() {
+  public boolean isRestarting() {
     switch (this) {
     case RestartBegan:
     case RestartInProgress:
-    case RestartCompleted:
       return true;
     default:
       return false;
     }
+  }
+
+  /**
+   * @return true if the driver began the restart process.
+   */
+  public boolean hasRestarted() {
+    return this != NotRestarted;
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRuntimeRestartManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRuntimeRestartManager.java
@@ -40,7 +40,7 @@ public interface DriverRuntimeRestartManager {
   /**
    * Determines whether or not the driver has been restarted. The default implementation always returns false.
    */
-  boolean isRestart();
+  boolean hasRestarted();
 
   /**
    * Records the evaluators when it is allocated.
@@ -58,7 +58,7 @@ public interface DriverRuntimeRestartManager {
    * Gets the sets of alive and failed evaluators based on the runtime implementation.
    * @return EvaluatorRestartInfo, which encapsulates the alive and failed set of evaluator IDs.
    */
-  EvaluatorRestartInfo getAliveAndFailedEvaluators();
+  EvaluatorRestartCollection getAliveAndFailedEvaluators();
 
   /**
    * Informs the necessary components about failed evaluators. The implementation is runtime dependent.

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/EvaluatorRestartCollection.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/EvaluatorRestartCollection.java
@@ -21,42 +21,38 @@ package org.apache.reef.driver.restart;
 import org.apache.reef.annotations.Unstable;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
-import org.apache.reef.driver.catalog.EvaluatorInfo;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
 
 /**
- * The restart information on an evaluator. Contains state of the restart progress and
- * the information to reconstruct the EvaluatorManager.
+ * The encapsulating class for alive and failed evaluators on driver restart.
  */
 @Private
 @DriverSide
 @Unstable
-public final class EvaluatorRestartInfo {
-  private final EvaluatorInfo evaluatorInfo;
-  private EvaluatorRestartState state;
+public class EvaluatorRestartCollection {
+  private final Map<String, EvaluatorRestartInfo> aliveEvaluators;
+  private final Set<String> failedEvaluators;
 
-  public EvaluatorRestartInfo(final EvaluatorInfo evaluatorInfo) {
-    this.evaluatorInfo = evaluatorInfo;
-    this.state = EvaluatorRestartState.EXPECTED;
+  public EvaluatorRestartCollection(final Map<String, EvaluatorRestartInfo> aliveEvaluators,
+                                    final Set<String> failedEvaluators) {
+    this.aliveEvaluators = Collections.unmodifiableMap(aliveEvaluators);
+    this.failedEvaluators = Collections.unmodifiableSet(failedEvaluators);
   }
 
   /**
-   * Sets the restart progress state.
+   * @return the unmodifiable map of evaluator IDs to their restart information for alive evaluators on driver restart.
    */
-  public void setState(final EvaluatorRestartState evaluatorRestartState) {
-    this.state = evaluatorRestartState;
+  public Map<String, EvaluatorRestartInfo> getAliveEvaluators() {
+    return this.aliveEvaluators;
   }
 
   /**
-   * @return the restart progress state.
+   * @return the set of evaluator IDs for failed evaluators on driver restart. The returned set is unmodifiable.
    */
-  public EvaluatorRestartState getState() {
-    return this.state;
-  }
-
-  /**
-   * @return the information needed to reconstruct the EvaluatorManager.
-   */
-  public EvaluatorInfo getEvaluatorInfo() {
-    return this.evaluatorInfo;
+  public Set<String> getFailedEvaluators() {
+    return this.failedEvaluators;
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/EvaluatorRestartState.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/EvaluatorRestartState.java
@@ -23,24 +23,53 @@ import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
 
 /**
- * A static utilities class for simplifying calls to driver restart manager.
- * Functions here should always call driverRestartManager.canRestart() before performing any
- * actual options.
- */
+* The state that the evaluator is in in the driver restart process.
+*/
 @Private
 @DriverSide
 @Unstable
-public final class DriverRestartUtilities {
+public enum EvaluatorRestartState {
+  /**
+   * The evaluator is not a restarted instance. Not expecting.
+   */
+  NOT_RESTARTED_EVALUATOR,
 
   /**
-   * Helper function for driver restart to determine whether an evaluator ID is from an evaluator from the
-   * previous application attempt.
+   * Have not yet heard back from an evaluator, but we are expecting it to report back.
    */
-  public static boolean isRestartAndIsPreviousEvaluator(final DriverRestartManager driverRestartManager,
-                                                        final String evaluatorId) {
-    return driverRestartManager.isRestart() && driverRestartManager.getPreviousEvaluatorIds().contains(evaluatorId);
-  }
+  EXPECTED,
 
-  private DriverRestartUtilities() {
+  /**
+   * Received the evaluator heartbeat, but have not yet processed it.
+   */
+  REPORTED,
+
+  /**
+   * The evaluator has had its recovery heartbeat processed.
+   */
+  REREGISTERED,
+
+  /**
+   * The evaluator has had its running task processed.
+   */
+  TASK_RUNNING_FIRED,
+
+  /**
+   * The evaluator has only contacted the driver after the expiration period.
+   */
+  EXPIRED;
+
+  /**
+   * @return true if the evaluator has heartbeated back to the driver.
+   */
+  public boolean hasReported() {
+    switch(this) {
+    case REPORTED:
+    case REREGISTERED:
+    case TASK_RUNNING_FIRED:
+      return true;
+    default:
+      return false;
+    }
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeRestartConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeRestartConfiguration.java
@@ -20,10 +20,7 @@ package org.apache.reef.runtime.common.driver;
 
 import org.apache.reef.annotations.audience.ClientSide;
 import org.apache.reef.annotations.audience.Private;
-import org.apache.reef.driver.parameters.ResourceManagerPreserveEvaluators;
-import org.apache.reef.driver.parameters.ServiceEvaluatorAllocatedHandlers;
-import org.apache.reef.driver.parameters.ServiceEvaluatorCompletedHandlers;
-import org.apache.reef.driver.parameters.ServiceEvaluatorFailedHandlers;
+import org.apache.reef.driver.parameters.*;
 import org.apache.reef.driver.restart.*;
 import org.apache.reef.tang.formats.*;
 
@@ -43,6 +40,7 @@ public final class DriverRuntimeRestartConfiguration extends ConfigurationModule
       // Automatically sets preserve evaluators to true.
       .bindNamedParameter(ResourceManagerPreserveEvaluators.class, Boolean.toString(true))
 
+      .bindSetEntry(DriverIdleSources.class, DriverRestartManager.class)
       .bindSetEntry(ServiceEvaluatorAllocatedHandlers.class, EvaluatorPreservingEvaluatorAllocatedHandler.class)
       .bindSetEntry(ServiceEvaluatorFailedHandlers.class, EvaluatorPreservingEvaluatorFailedHandler.class)
       .bindSetEntry(ServiceEvaluatorCompletedHandlers.class, EvaluatorPreservingEvaluatorCompletedHandler.class)

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverStartHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverStartHandler.java
@@ -62,7 +62,7 @@ public final class DriverStartHandler implements EventHandler<StartTime> {
 
   @Override
   public void onNext(final StartTime startTime) {
-    if (this.driverRestartManager.isRestart()) {
+    if (this.driverRestartManager.detectRestart()) {
       this.onRestart(startTime);
     } else {
       this.onStart(startTime);

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/ContextRepresenters.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/ContextRepresenters.java
@@ -24,7 +24,7 @@ import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.context.FailedContext;
 import org.apache.reef.driver.restart.DriverRestartManager;
-import org.apache.reef.driver.restart.DriverRestartUtilities;
+import org.apache.reef.driver.restart.EvaluatorRestartState;
 import org.apache.reef.proto.ReefServiceProtos;
 import org.apache.reef.runtime.common.driver.evaluator.EvaluatorMessageDispatcher;
 import org.apache.reef.util.Optional;
@@ -215,7 +215,7 @@ public final class ContextRepresenters {
         Optional.of(contextStatusProto.getParentId()) : Optional.<String>empty();
     final EvaluatorContext context = contextFactory.newContext(contextID, parentID);
     this.addContext(context);
-    if (DriverRestartUtilities.isRestartAndIsPreviousEvaluator(driverRestartManager, context.getEvaluatorId())) {
+    if (driverRestartManager.getEvaluatorRestartState(context.getEvaluatorId()) == EvaluatorRestartState.REREGISTERED) {
       // when we get a recovered active context, always notify application
       this.messageDispatcher.onDriverRestartContextActive(context);
     } else {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorControlHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorControlHandler.java
@@ -66,6 +66,7 @@ public final class EvaluatorControlHandler {
    */
   public synchronized void send(final EvaluatorRuntimeProtocol.EvaluatorControlProto evaluatorControlProto) {
     if (!this.wrapped.isPresent()) {
+      LOG.log(Level.WARNING, "ILLEGAL EVALUATOR ID IS: " + evaluatorId);
       throw new IllegalStateException("Trying to send an EvaluatorControlProto before the Evaluator ID is set.");
     }
     if (!this.stateManager.isRunning()) {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorMessageDispatcher.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorMessageDispatcher.java
@@ -27,7 +27,6 @@ import org.apache.reef.driver.evaluator.CompletedEvaluator;
 import org.apache.reef.driver.evaluator.FailedEvaluator;
 import org.apache.reef.driver.parameters.*;
 import org.apache.reef.driver.task.*;
-import org.apache.reef.runtime.common.DriverRestartCompleted;
 import org.apache.reef.runtime.common.driver.DriverExceptionHandler;
 import org.apache.reef.runtime.common.utils.DispatchingEStage;
 import org.apache.reef.tang.annotations.Parameter;
@@ -116,16 +115,12 @@ public final class EvaluatorMessageDispatcher {
       final Set<EventHandler<RunningTask>> driverRestartTaskRunningHandlers,
       @Parameter(DriverRestartContextActiveHandlers.class)
       final Set<EventHandler<ActiveContext>> driverRestartActiveContextHandlers,
-      @Parameter(DriverRestartCompletedHandlers.class)
-      final Set<EventHandler<DriverRestartCompleted>> driverRestartCompletedHandlers,
 
       // Service-provided event handlers specific to a Driver restart
       @Parameter(ServiceDriverRestartTaskRunningHandlers.class)
       final Set<EventHandler<RunningTask>> serviceDriverRestartTaskRunningHandlers,
       @Parameter(ServiceDriverRestartContextActiveHandlers.class)
       final Set<EventHandler<ActiveContext>> serviceDriverRestartActiveContextHandlers,
-      @Parameter(ServiceDriverRestartCompletedHandlers.class)
-      final Set<EventHandler<DriverRestartCompleted>> serviceDriverRestartCompletedHandlers,
 
       @Parameter(EvaluatorDispatcherThreads.class) final int numberOfThreads,
       @Parameter(EvaluatorManager.EvaluatorIdentifier.class) final String evaluatorIdentifier,
@@ -175,12 +170,10 @@ public final class EvaluatorMessageDispatcher {
     // Application event handlers specific to a Driver restart
     this.driverRestartApplicationDispatcher.register(RunningTask.class, driverRestartTaskRunningHandlers);
     this.driverRestartApplicationDispatcher.register(ActiveContext.class, driverRestartActiveContextHandlers);
-    this.driverRestartApplicationDispatcher.register(DriverRestartCompleted.class, driverRestartCompletedHandlers);
 
     // Service event handlers specific to a Driver restart
     this.driverRestartServiceDispatcher.register(RunningTask.class, serviceDriverRestartTaskRunningHandlers);
     this.driverRestartServiceDispatcher.register(ActiveContext.class, serviceDriverRestartActiveContextHandlers);
-    this.driverRestartServiceDispatcher.register(DriverRestartCompleted.class, serviceDriverRestartCompletedHandlers);
 
     final Set<EventHandler<CompletedEvaluator>> evaluatorCompletedCallbackHandlers = new HashSet<>();
     for (final EventHandler<CompletedEvaluator> evaluatorCompletedHandler : evaluatorCompletedHandlers) {
@@ -253,10 +246,6 @@ public final class EvaluatorMessageDispatcher {
 
   public void onDriverRestartContextActive(final ActiveContext activeContext) {
     this.dispatchForRestartedDriver(ActiveContext.class, activeContext);
-  }
-
-  public void onDriverRestartCompleted(final DriverRestartCompleted restartCompleted) {
-    this.dispatchForRestartedDriver(DriverRestartCompleted.class, restartCompleted);
   }
 
   boolean isEmpty() {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceStatusHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceStatusHandler.java
@@ -58,7 +58,8 @@ public final class ResourceStatusHandler implements EventHandler<ResourceStatusE
     } else {
       if (resourceStatusEvent.getIsFromPreviousDriver().get()) {
         final EvaluatorManager previousEvaluatorManager =
-            this.evaluatorManagerFactory.createForEvaluatorFailedDuringDriverRestart(resourceStatusEvent);
+            this.evaluatorManagerFactory
+                .getNewEvaluatorManagerForEvaluatorFailedDuringDriverRestart(resourceStatusEvent);
         previousEvaluatorManager.onResourceStatusMessage(resourceStatusEvent);
       } else {
         throw new RuntimeException(

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/util/YarnUtilities.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/util/YarnUtilities.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runtime.yarn.util;
+
+import org.apache.hadoop.yarn.api.records.Container;
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Private;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Helper functions for YARN.
+ */
+@Private
+@DriverSide
+public final class YarnUtilities {
+  private static final Logger LOG = Logger.getLogger(YarnUtilities.class.getName());
+
+  /**
+   * @return the rack name of a given container.
+   */
+  public static String getRackName(final Container container) {
+    final String hostName = container.getNodeId().getHost();
+
+    // the rack name comes as part of the host name, e.g.
+    // <rackName>-<hostNumber>
+    // we perform some checks just in case it doesn't
+    String rackName = null;
+    if (hostName != null) {
+      final String[] rackNameAndNumber = hostName.split("-");
+      if (rackNameAndNumber.length == 2) {
+        rackName = rackNameAndNumber[0];
+      } else {
+        LOG.log(Level.WARNING, "Could not get information from the rack name, should use the default");
+      }
+    }
+
+    return rackName;
+  }
+
+  private YarnUtilities(){
+  }
+}

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RuntimeClock.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RuntimeClock.java
@@ -114,7 +114,7 @@ public final class RuntimeClock implements Clock {
       this.schedule.add(new StopTime(timer.getCurrent()));
       this.schedule.notifyAll();
       this.closed = true;
-      if (this.stoppedOnException != null) {
+      if (this.stoppedOnException == null) {
         this.stoppedOnException = stopOnException;
       }
     }


### PR DESCRIPTION
This addressed the issue by
  * Moving restart completed handler invocation from evaluator-based to driver-based.
  * Adding the class DriverRestartEvaluatorRecoveryMs.
  * Implementing failure logic as discussed in JIRA link.

JIRA:
  [REEF-560](https://issues.apache.org/jira/browse/REEF-560)