### PR TITLE
[REEF-599]:Move DriverConfigurationProviders from Org.Apache.REEF.Cli…

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/API/JobSubmissionBuilderFactory.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/JobSubmissionBuilderFactory.cs
@@ -18,7 +18,7 @@
  */
 
 using System.Collections.Generic;
-using Org.Apache.REEF.Client.Local.Parameters;
+using Org.Apache.REEF.Client.API.Parameters;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Interface;
 

--- a/lang/cs/Org.Apache.REEF.Client/API/Parameters/DriverConfigurationProviders.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/Parameters/DriverConfigurationProviders.cs
@@ -21,7 +21,7 @@ using System.Collections.Generic;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Interface;
 
-namespace Org.Apache.REEF.Client.Local.Parameters
+namespace Org.Apache.REEF.Client.API.Parameters
 {
     /// <summary>
     // This name parameter is used to target receviers Configuration providers at driver level

--- a/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
+++ b/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
@@ -52,6 +52,7 @@ under the License.
     <Compile Include="API\JobSubmission.cs" />
     <Compile Include="API\JobSubmissionBuilder.cs" />
     <Compile Include="API\JobSubmissionBuilderFactory.cs" />
+    <Compile Include="API\Parameters\DriverConfigurationProviders.cs" />
     <Compile Include="Common\ClientConstants.cs" />
     <Compile Include="Common\ClrClient2JavaClientCuratedParameters.cs" />
     <Compile Include="Common\DriverFolderPreparationHelper.cs" />
@@ -60,7 +61,6 @@ under the License.
     <Compile Include="Common\ResourceHelper.cs" />
     <Compile Include="Local\LocalClient.cs" />
     <Compile Include="Local\LocalRuntimeClientConfiguration.cs" />
-    <Compile Include="Local\Parameters\DriverConfigurationProviders.cs" />
     <Compile Include="Local\Parameters\LocalRuntimeDirectory.cs" />
     <Compile Include="Local\Parameters\NumberOfEvaluators.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
…ent.Local to Org.Apache.REEF.Client.API

This addressed the issue by moving DriverConfigurationProviders from Org.Apache.REEF.Client.Local to Org.Apache.REEF.Client.API

JIRA: [REEF-599](https://issues.apache.org/jira/browse/REEF-599)

This closes #