### PR TITLE
[REEF-563] Evaluators that are kept alive are not able to re-register with the driver

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Evaluator/DefaultYarnClusterHttpDriverConnection.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Evaluator/DefaultYarnClusterHttpDriverConnection.cs
@@ -35,7 +35,7 @@ namespace Org.Apache.REEF.Common.Evaluator
             Uri queryUri = new Uri(
                 string.Concat(
                 Constants.HDInsightClusterHttpEndpointBaseUri,
-                applicationId,
+                applicationId + "/",
                 Constants.HttpReefUriSpecification,
                 Constants.HttpDriverUriTarget));
             return DriverInformation.GetDriverInformationFromHttp(queryUri);


### PR DESCRIPTION
This addressed the issue by
  * Add missing forward slash to driver endpoint URI.
  * Handle redirects in contacting driver endpoint.

JIRA:
  [REEF-563](https://issues.apache.org/jira/browse/REEF-563)