### PR TITLE
[REEF-605] Remove HelloCLRBridge folder in Org.Apache.REEF.Examples

### DIFF
--- a/lang/cs/Org.Apache.REEF.Examples/Org.Apache.REEF.Examples.csproj
+++ b/lang/cs/Org.Apache.REEF.Examples/Org.Apache.REEF.Examples.csproj
@@ -89,9 +89,6 @@ under the License.
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="HelloCLRBridge\Handlers\" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="ConfigFiles\evaluator.conf">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
This deletes `<ItemGroup>` entry for HelloCLRBridge
from `Org.Apache.REEF.Examples.csproj`

JIRA:
[REEF-605] (https://issues.apache.org/jira/browse/REEF-605)