### PR TITLE
[REEF-607] Race condition in TaskDone and EvaluatorDone observed in .NET

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
@@ -222,17 +222,19 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
   @Override
   public void close() {
     synchronized (this.evaluatorDescriptor) {
-      if (this.stateManager.isRunning()) {
+      if (this.stateManager.isAllocatedOrSubmittedOrRunning()) {
         LOG.log(Level.WARNING, "Dirty shutdown of running evaluator id[{0}]", getId());
         try {
-          // Killing the evaluator means that it doesn't need to send a confirmation; it just dies.
-          final EvaluatorRuntimeProtocol.EvaluatorControlProto evaluatorControlProto =
-              EvaluatorRuntimeProtocol.EvaluatorControlProto.newBuilder()
-                  .setTimestamp(System.currentTimeMillis())
-                  .setIdentifier(getId())
-                  .setKillEvaluator(EvaluatorRuntimeProtocol.KillEvaluatorProto.newBuilder().build())
-                  .build();
-          sendEvaluatorControlMessage(evaluatorControlProto);
+          if (this.stateManager.isRunning()){
+            // Killing the evaluator means that it doesn't need to send a confirmation; it just dies.
+            final EvaluatorRuntimeProtocol.EvaluatorControlProto evaluatorControlProto =
+                EvaluatorRuntimeProtocol.EvaluatorControlProto.newBuilder()
+                    .setTimestamp(System.currentTimeMillis())
+                    .setIdentifier(getId())
+                    .setKillEvaluator(EvaluatorRuntimeProtocol.KillEvaluatorProto.newBuilder().build())
+                    .build();
+            sendEvaluatorControlMessage(evaluatorControlProto);
+          }
         } finally {
           this.stateManager.setKilled();
         }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/IdlenessCallbackEventHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/IdlenessCallbackEventHandler.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runtime.common.driver.evaluator;
+
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.runtime.common.driver.idle.EventHandlerIdlenessSource;
+import org.apache.reef.wake.EventHandler;
+
+/**
+ * Checks for idleness after an {@link EventHandler#onNext(Object)} invocation.
+ */
+@Private
+@DriverSide
+final class IdlenessCallbackEventHandler<T> implements EventHandler<T> {
+  private final EventHandler<T> innerHandler;
+  private final EventHandlerIdlenessSource idlenessSource;
+
+  IdlenessCallbackEventHandler(final EventHandler<T> innerHandler,
+                               final EventHandlerIdlenessSource idlenessSource) {
+    this.innerHandler = innerHandler;
+    this.idlenessSource = idlenessSource;
+  }
+
+  /**
+   * Checks idleness as a callback to the innerHandler.
+   */
+  @Override
+  public void onNext(final T value) {
+    innerHandler.onNext(value);
+    idlenessSource.check();
+  }
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/IdlenessCallbackEventHandlerFactory.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/IdlenessCallbackEventHandlerFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runtime.common.driver.evaluator;
+
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.runtime.common.driver.idle.EventHandlerIdlenessSource;
+import org.apache.reef.wake.EventHandler;
+
+import javax.inject.Inject;
+
+/**
+ * Creates {@link IdlenessCallbackEventHandler}, which runs an idleness check after the innerHandler's
+ * {@link EventHandler#onNext(Object)} call is handled.
+ */
+@Private
+@DriverSide
+final class IdlenessCallbackEventHandlerFactory {
+  private final EventHandlerIdlenessSource idlenessSource;
+
+  @Inject
+  private IdlenessCallbackEventHandlerFactory(final EventHandlerIdlenessSource idlenessSource) {
+    this.idlenessSource = idlenessSource;
+  }
+
+  /**
+   * @return a new instance of {@link IdlenessCallbackEventHandler} wrapped with the specified innerHandler
+   */
+  <T> IdlenessCallbackEventHandler<T> createIdlenessCallbackWrapperHandler(
+      final EventHandler<T> innerHandler) {
+    return new IdlenessCallbackEventHandler<>(innerHandler, idlenessSource);
+  }
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/idle/EventHandlerIdlenessSource.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/idle/EventHandlerIdlenessSource.java
@@ -31,7 +31,7 @@ public final class EventHandlerIdlenessSource implements DriverIdlenessSource {
   private static final IdleMessage IDLE_MESSAGE =
       new IdleMessage("EventHandlers", "All events have been processed.", true);
   private static final IdleMessage NOT_IDLE_MESSAGE =
-      new IdleMessage("EventHandlers", "Some events are still in flight.", true);
+      new IdleMessage("EventHandlers", "Some events are still in flight.", false);
 
   private final InjectionFuture<Evaluators> evaluators;
   private final InjectionFuture<DriverIdleManager> driverIdleManager;

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorexit/EvaluatorCompleteTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorexit/EvaluatorCompleteTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.evaluatorexit;
+
+import org.apache.reef.client.DriverConfiguration;
+import org.apache.reef.client.LauncherStatus;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tests.TestEnvironment;
+import org.apache.reef.tests.TestEnvironmentFactory;
+import org.apache.reef.tests.library.driver.OnDriverStartedAllocateOne;
+import org.apache.reef.util.EnvironmentUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests whether we receive both evaluator complete and task complete.
+ */
+public final class EvaluatorCompleteTest {
+  private final TestEnvironment testEnvironment = TestEnvironmentFactory.getNewTestEnvironment();
+
+  @Before
+  public void setUp() throws Exception {
+    testEnvironment.setUp();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    this.testEnvironment.tearDown();
+  }
+
+  @Test
+  public void testEvaluatorCompleted() {
+    final Configuration driverConfiguration = DriverConfiguration.CONF
+        .set(DriverConfiguration.DRIVER_IDENTIFIER, "TEST_EvaluatorComplete")
+        .set(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getClassLocation(EvaluatorCompleteTestDriver.class))
+        .set(DriverConfiguration.ON_DRIVER_STARTED, OnDriverStartedAllocateOne.class)
+        .set(DriverConfiguration.ON_TASK_COMPLETED, EvaluatorCompleteTestDriver.TaskCompletedHandler.class)
+        .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, EvaluatorCompleteTestDriver.EvaluatorAllocatedHandler.class)
+        .set(DriverConfiguration.ON_EVALUATOR_COMPLETED, EvaluatorCompleteTestDriver.EvaluatorCompletedHandler.class)
+        .set(DriverConfiguration.ON_DRIVER_STOP, EvaluatorCompleteTestDriver.StopHandler.class)
+        .build();
+    final LauncherStatus status = this.testEnvironment.run(driverConfiguration);
+    Assert.assertTrue("Job state after execution: " + status, status.isSuccess());
+  }
+
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorexit/EvaluatorCompleteTestDriver.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorexit/EvaluatorCompleteTestDriver.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.evaluatorexit;
+
+import org.apache.reef.driver.evaluator.AllocatedEvaluator;
+import org.apache.reef.driver.evaluator.CompletedEvaluator;
+import org.apache.reef.driver.task.CompletedTask;
+import org.apache.reef.driver.task.TaskConfiguration;
+import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.annotations.Unit;
+import org.apache.reef.tests.library.exceptions.DriverSideFailure;
+import org.apache.reef.wake.EventHandler;
+import org.apache.reef.wake.time.event.StopTime;
+
+import javax.inject.Inject;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Unit
+final class EvaluatorCompleteTestDriver {
+  private static final Logger LOG = Logger.getLogger(EvaluatorCompleteTestDriver.class.getName());
+  private final AtomicBoolean completedEvaluatorReceived = new AtomicBoolean(false);
+  private final AtomicBoolean completedTaskReceived = new AtomicBoolean(false);
+
+  @Inject
+  private EvaluatorCompleteTestDriver() {
+  }
+
+  final class EvaluatorAllocatedHandler implements EventHandler<AllocatedEvaluator> {
+
+    @Override
+    public void onNext(final AllocatedEvaluator allocatedEvaluator) {
+      final Configuration taskConfiguration = TaskConfiguration.CONF
+          .set(TaskConfiguration.IDENTIFIER, "EvaluatorCompleteTestTask")
+          .set(TaskConfiguration.TASK, EvaluatorCompleteTestTask.class)
+          .build();
+      allocatedEvaluator.submitTask(taskConfiguration);
+    }
+  }
+
+  final class EvaluatorCompletedHandler implements EventHandler<CompletedEvaluator> {
+
+    @Override
+    public void onNext(final CompletedEvaluator completedEvaluator) {
+      LOG.log(Level.FINE, "Received a CompletedEvaluator for Evaluator {0}", completedEvaluator.getId());
+      completedEvaluatorReceived.set(true);
+    }
+  }
+
+  final class TaskCompletedHandler implements EventHandler<CompletedTask> {
+
+    @Override
+    public void onNext(final CompletedTask completedTask) {
+      LOG.log(Level.FINE, "Received a CompletedTask for Evaluator {0}", completedTask.getId());
+      completedTaskReceived.set(true);
+      completedTask.getActiveContext().close();
+    }
+  }
+
+  final class StopHandler implements EventHandler<StopTime> {
+
+    @Override
+    public void onNext(final StopTime stopTime) {
+      synchronized (completedEvaluatorReceived) {
+        if (completedEvaluatorReceived.get() && completedTaskReceived.get()) {
+          LOG.log(Level.FINE, "Received an expected CompletedEvaluator and CompletedTask before exit. All good.");
+        } else {
+          throw new DriverSideFailure("Did not receive expected completion events.");
+        }
+      }
+    }
+  }
+
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorexit/EvaluatorCompleteTestTask.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorexit/EvaluatorCompleteTestTask.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.tests.evaluatorexit;
+
+import org.apache.reef.task.Task;
+
+import javax.inject.Inject;
+
+/**
+ * Merely returns null.
+ */
+final class EvaluatorCompleteTestTask implements Task {
+
+  @Inject
+  private EvaluatorCompleteTestTask() {
+  }
+
+  @Override
+  public byte[] call(final byte[] memento) throws Exception {
+    return null;
+  }
+}


### PR DESCRIPTION
This addressed the issue by
  * Fixed EventHandlerIdlenessSource to return not idle properly.
  * Used callback EventHandlers to prevent driver from hanging when the final EvaluatorCompleted call is completed.
  * Added an E2E test to capture.

JIRA:
  [REEF-607](https://issues.apache.org/jira/browse/REEF-607)