### PR TITLE
[REEF-610] Make NetworkConnectionService be able to register multiple identifiers.

### DIFF
--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/ConnectionFactory.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/ConnectionFactory.java
@@ -41,7 +41,11 @@ public interface ConnectionFactory<T> {
   Identifier getConnectionFactoryId();
 
   /**
-   * @return the current node's end point id for the connection.
+   * Each connection factory has own local end point id. If connections
+   * are created by the connection factory, the local end point id is used as
+   * the source id of all the connections. It returns the local end point id.
+   *
+   * @return the local end point id
    */
-  Identifier getEndPointId();
+  Identifier getLocalEndPointId();
 }

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/ConnectionFactory.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/ConnectionFactory.java
@@ -34,4 +34,14 @@ public interface ConnectionFactory<T> {
    * @return a connection
    */
   Connection<T> newConnection(Identifier destId);
+
+  /**
+   * @return the connection factory identifier.
+   */
+  Identifier getConnectionFactoryId();
+
+  /**
+   * @return the current node's end point id for the connection.
+   */
+  Identifier getEndPointId();
 }

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/NetworkConnectionService.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/NetworkConnectionService.java
@@ -70,27 +70,27 @@ public interface NetworkConnectionService extends AutoCloseable {
 
   /**
    * Registers an instance of ConnectionFactory corresponding to the connectionFactoryId.
-   * Binds Codec, EventHandler, LinkListener and endPointId to the ConnectionFactory.
+   * Binds Codec, EventHandler, LinkListener and localEndPointId to the ConnectionFactory.
    * ConnectionFactory can create multiple connections between other NetworkConnectionServices.
-   * The connectionFactoryId is used to distinguish the type of connection and the endPointId
+   * The connectionFactoryId is used to distinguish the type of connection and the localEndPointId
    * is the contact point, which is registered to NameServer through this method.
    *
    * @param connectionFactoryId a connection factory id
    * @param codec a codec for type <T>
    * @param eventHandler an event handler for type <T>
    * @param linkListener a link listener
-   * @param endPointId an end point id
+   * @param localEndPointId a local end point id
    * @return the registered connection factory
    */
   <T> ConnectionFactory<T> registerConnectionFactory(final Identifier connectionFactoryId,
                                      final Codec<T> codec,
                                      final EventHandler<Message<T>> eventHandler,
                                      final LinkListener<Message<T>> linkListener,
-                                     final Identifier endPointId);
+                                     final Identifier localEndPointId);
 
   /**
    * Unregisters a connectionFactory corresponding to the connectionFactoryId
-   * and removes the endPointID from NameServer.
+   * and removes the localEndPointID of the connection factory from NameServer.
    * @param connectionFactoryId a connection factory id
    */
   void unregisterConnectionFactory(final Identifier connectionFactoryId);
@@ -113,7 +113,8 @@ public interface NetworkConnectionService extends AutoCloseable {
    * Registers a network connection service identifier.
    * This can be used for destination identifier
    * @param ncsId network connection service identifier
-   * @deprecated in 0.13.
+   * @deprecated in 0.13. Use registerConnectionFactory(Identifier, Codec, EventHandler, LinkListener, Identifier)
+   * instead.
    */
   @Deprecated
   void registerId(final Identifier ncsId);
@@ -128,7 +129,7 @@ public interface NetworkConnectionService extends AutoCloseable {
 
   /**
    * Gets a network connection service client id which is equal to the registered id.
-   * @deprecated in 0.13. Use ConnectionFactory.getEndPointId instead.
+   * @deprecated in 0.13. Use ConnectionFactory.getLocalEndPointId instead.
    */
   @Deprecated
   Identifier getNetworkConnectionServiceId();

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/NetworkConnectionService.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/NetworkConnectionService.java
@@ -37,7 +37,7 @@ import org.apache.reef.wake.remote.transport.LinkListener;
  * -> src NetworkConnectionService (encode) -> dest NetworkConnectionService.
  * [Upstream]: message -> dest NetworkConnectionService (decode) -> ConnectionFactory -> EventHandler.
  *
- * Users can register a ConnectionFactory by registering their Codec, EventHandler and LinkListener.
+ * Users can register a ConnectionFactory by registering their Codec, EventHandler, LinkListener and end point id.
  * When users send messages via connections created by the ConnectionFactory,
  *
  * NetworkConnectionService encodes the messages according to the Codec
@@ -47,8 +47,7 @@ import org.apache.reef.wake.remote.transport.LinkListener;
  * to the corresponding EventHandler registered in the ConnectionFactory.
  */
 @DefaultImplementation(NetworkConnectionServiceImpl.class)
-public interface
-    NetworkConnectionService extends AutoCloseable {
+public interface NetworkConnectionService extends AutoCloseable {
 
   /**
    * Registers an instance of ConnectionFactory corresponding to the connectionFactoryId.
@@ -60,40 +59,78 @@ public interface
    * @param eventHandler an event handler for type <T>
    * @param linkListener a link listener
    * @throws NetworkException throws a NetworkException when multiple connectionFactoryIds exist.
+   * @deprecated in 0.13. Use registerConnectionFactory(Identifier, Codec, EventHandler, LinkListener, Identifier)
+   * instead.
    */
+  @Deprecated
   <T> void registerConnectionFactory(final Identifier connectionFactoryId,
                                      final Codec<T> codec,
                                      final EventHandler<Message<T>> eventHandler,
                                      final LinkListener<Message<T>> linkListener) throws NetworkException;
 
   /**
-   * Unregisters a connectionFactory corresponding to the connectionFactoryId.
+   * Registers an instance of ConnectionFactory corresponding to the connectionFactoryId.
+   * Binds Codec, EventHandler, LinkListener and endPointId to the ConnectionFactory.
+   * ConnectionFactory can create multiple connections between other NetworkConnectionServices.
+   * The connectionFactoryId is used to distinguish the type of connection and the endPointId
+   * is the contact point, which is registered to NameServer through this method.
+   *
+   * @param connectionFactoryId a connection factory id
+   * @param codec a codec for type <T>
+   * @param eventHandler an event handler for type <T>
+   * @param linkListener a link listener
+   * @param endPointId an end point id
+   * @return the registered connection factory
+   */
+  <T> ConnectionFactory<T> registerConnectionFactory(final Identifier connectionFactoryId,
+                                     final Codec<T> codec,
+                                     final EventHandler<Message<T>> eventHandler,
+                                     final LinkListener<Message<T>> linkListener,
+                                     final Identifier endPointId);
+
+  /**
+   * Unregisters a connectionFactory corresponding to the connectionFactoryId
+   * and removes the endPointID from NameServer.
    * @param connectionFactoryId a connection factory id
    */
   void unregisterConnectionFactory(final Identifier connectionFactoryId);
 
   /**
    * Gets an instance of ConnectionFactory which is registered by the registerConnectionFactory method.
+   *
    * @param connectionFactoryId a connection factory id
    */
   <T> ConnectionFactory<T> getConnectionFactory(final Identifier connectionFactoryId);
 
   /**
+   * Closes all resources and unregisters all registered connection factories.
+   *
+   * @throws Exception if this resource cannot be closed
+   */
+  void close() throws Exception;
+
+  /**
    * Registers a network connection service identifier.
    * This can be used for destination identifier
    * @param ncsId network connection service identifier
+   * @deprecated in 0.13.
    */
+  @Deprecated
   void registerId(final Identifier ncsId);
 
   /**
    * Unregister a network connection service identifier.
    * @param ncsId network connection service identifier
+   * @deprecated in 0.13.
    */
+  @Deprecated
   void unregisterId(final Identifier ncsId);
 
   /**
    * Gets a network connection service client id which is equal to the registered id.
+   * @deprecated in 0.13. Use ConnectionFactory.getEndPointId instead.
    */
+  @Deprecated
   Identifier getNetworkConnectionServiceId();
 
 }

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/BindNetworkConnectionServiceToTask.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/BindNetworkConnectionServiceToTask.java
@@ -30,7 +30,9 @@ import javax.inject.Inject;
 /**
  * TaskStart event handler for registering NetworkConnectionService.
  * Users have to bind this handler into ServiceConfiguration.ON_TASK_STARTED.
+ * @deprecated in 0.13. Users should register/unregister an end point id by themselves.
  */
+@Deprecated
 public final class BindNetworkConnectionServiceToTask implements EventHandler<TaskStart> {
 
   private final NetworkConnectionService ncs;

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkConnection.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkConnection.java
@@ -33,7 +33,7 @@ final class NetworkConnection<T> implements Connection<T> {
 
   private final Identifier destId;
   private final AtomicBoolean closed;
-  private final NetworkConnectionFactory connFactory;
+  private final NetworkConnectionFactory<T> connFactory;
 
   /**
    * Constructs a connection for destination identifier of NetworkConnectionService.
@@ -41,7 +41,7 @@ final class NetworkConnection<T> implements Connection<T> {
    * @param destId a destination identifier of NetworkConnectionService.
    */
   NetworkConnection(
-      final NetworkConnectionFactory connFactory,
+      final NetworkConnectionFactory<T> connFactory,
       final Identifier destId) {
     this.connFactory = connFactory;
     this.destId = destId;
@@ -56,7 +56,7 @@ final class NetworkConnection<T> implements Connection<T> {
   @Override
   public void write(final List<T> messageList) {
     final NetworkConnectionServiceMessage<T> nsMessage = new NetworkConnectionServiceMessage<>(
-        connFactory.getConnectionFactoryId(),
+        connFactory.getConnectionFactoryId().toString(),
         connFactory.getSrcId(),
         destId,
         messageList);

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkConnectionFactory.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkConnectionFactory.java
@@ -37,24 +37,27 @@ import java.util.concurrent.ConcurrentMap;
 final class NetworkConnectionFactory<T> implements ConnectionFactory<T> {
 
   private final ConcurrentMap<Identifier, Connection<T>> connectionMap;
-  private final String connFactoryId;
+  private final Identifier connectionFactoryId;
   private final Codec<T> eventCodec;
   private final EventHandler<Message<T>> eventHandler;
   private final LinkListener<Message<T>> eventListener;
+  private final Identifier endPointId;
   private final NetworkConnectionServiceImpl networkService;
 
   NetworkConnectionFactory(
       final NetworkConnectionServiceImpl networkService,
-      final String connFactoryId,
+      final Identifier connectionFactoryId,
       final Codec<T> eventCodec,
       final EventHandler<Message<T>> eventHandler,
-      final LinkListener<Message<T>> eventListener) {
+      final LinkListener<Message<T>> eventListener,
+      final Identifier endPointId) {
     this.networkService = networkService;
     this.connectionMap = new ConcurrentHashMap<>();
-    this.connFactoryId = connFactoryId;
+    this.connectionFactoryId = connectionFactoryId;
     this.eventCodec = eventCodec;
     this.eventHandler = eventHandler;
     this.eventListener = eventListener;
+    this.endPointId = endPointId;
   }
 
   /**
@@ -73,16 +76,27 @@ final class NetworkConnectionFactory<T> implements ConnectionFactory<T> {
     return connection;
   }
 
-  <T> Link<NetworkConnectionServiceMessage<T>> openLink(final Identifier remoteId) throws NetworkException {
+  Link<NetworkConnectionServiceMessage<T>> openLink(final Identifier remoteId) throws NetworkException {
     return networkService.openLink(remoteId);
   }
 
-  String getConnectionFactoryId() {
-    return this.connFactoryId;
+  @Override
+  public Identifier getConnectionFactoryId() {
+    return connectionFactoryId;
+  }
+
+  @Override
+  public Identifier getEndPointId() {
+    return endPointId;
   }
 
   Identifier getSrcId() {
-    return this.networkService.getNetworkConnectionServiceId();
+    // TODO : Change to always return the endPointId when the deprecated getNetworkConnectionServiceId is removed.
+    if (endPointId == null) {
+      return this.networkService.getNetworkConnectionServiceId();
+    } else {
+      return endPointId;
+    }
   }
 
   EventHandler<Message<T>> getEventHandler() {

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkConnectionFactory.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkConnectionFactory.java
@@ -77,7 +77,7 @@ final class NetworkConnectionFactory<T> implements ConnectionFactory<T> {
   }
 
   Link<NetworkConnectionServiceMessage<T>> openLink(final Identifier remoteId) throws NetworkException {
-    return networkService.openLink(remoteId);
+    return networkService.openLink(connectionFactoryId, remoteId);
   }
 
   @Override
@@ -90,8 +90,11 @@ final class NetworkConnectionFactory<T> implements ConnectionFactory<T> {
     return localEndPointId;
   }
 
+  /**
+   * @deprecated in 0.13. Use getLocalEndPointId() instead.
+   */
+  @Deprecated
   Identifier getSrcId() {
-    // TODO : Change to always return the localEndPointId when the deprecated getNetworkConnectionServiceId is removed.
     if (localEndPointId == null) {
       return this.networkService.getNetworkConnectionServiceId();
     } else {

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkConnectionFactory.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkConnectionFactory.java
@@ -41,7 +41,7 @@ final class NetworkConnectionFactory<T> implements ConnectionFactory<T> {
   private final Codec<T> eventCodec;
   private final EventHandler<Message<T>> eventHandler;
   private final LinkListener<Message<T>> eventListener;
-  private final Identifier endPointId;
+  private final Identifier localEndPointId;
   private final NetworkConnectionServiceImpl networkService;
 
   NetworkConnectionFactory(
@@ -50,14 +50,14 @@ final class NetworkConnectionFactory<T> implements ConnectionFactory<T> {
       final Codec<T> eventCodec,
       final EventHandler<Message<T>> eventHandler,
       final LinkListener<Message<T>> eventListener,
-      final Identifier endPointId) {
+      final Identifier localEndPointId) {
     this.networkService = networkService;
     this.connectionMap = new ConcurrentHashMap<>();
     this.connectionFactoryId = connectionFactoryId;
     this.eventCodec = eventCodec;
     this.eventHandler = eventHandler;
     this.eventListener = eventListener;
-    this.endPointId = endPointId;
+    this.localEndPointId = localEndPointId;
   }
 
   /**
@@ -86,16 +86,16 @@ final class NetworkConnectionFactory<T> implements ConnectionFactory<T> {
   }
 
   @Override
-  public Identifier getEndPointId() {
-    return endPointId;
+  public Identifier getLocalEndPointId() {
+    return localEndPointId;
   }
 
   Identifier getSrcId() {
-    // TODO : Change to always return the endPointId when the deprecated getNetworkConnectionServiceId is removed.
-    if (endPointId == null) {
+    // TODO : Change to always return the localEndPointId when the deprecated getNetworkConnectionServiceId is removed.
+    if (localEndPointId == null) {
       return this.networkService.getNetworkConnectionServiceId();
     } else {
-      return endPointId;
+      return localEndPointId;
     }
   }
 

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkService.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkService.java
@@ -185,7 +185,7 @@ public final class NetworkService<T> implements Stage, ConnectionFactory<T> {
   }
 
   @Override
-  public Identifier getEndPointId() {
+  public Identifier getLocalEndPointId() {
     throw new UnsupportedOperationException();
   }
 }

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkService.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/NetworkService.java
@@ -178,6 +178,16 @@ public final class NetworkService<T> implements Stage, ConnectionFactory<T> {
     final Connection<T> existing = this.idToConnMap.putIfAbsent(destId, newConnection);
     return existing == null ? newConnection : existing;
   }
+
+  @Override
+  public Identifier getConnectionFactoryId() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Identifier getEndPointId() {
+    throw new UnsupportedOperationException();
+  }
 }
 
 class MessageHandler<T> implements EventHandler<TransportEvent> {

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/UnbindNetworkConnectionServiceFromTask.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/impl/UnbindNetworkConnectionServiceFromTask.java
@@ -29,7 +29,9 @@ import javax.inject.Inject;
 /**
  * TaskStop event handler for unregistering NetworkConnectionService.
  * Users have to bind this handler into ServiceConfiguration.ON_TASK_STOP.
+ * @deprecated in 0.13. Users should register/unregister an end point id by themselves.
  */
+@Deprecated
 public final class UnbindNetworkConnectionServiceFromTask implements EventHandler<TaskStop> {
 
   private final NetworkConnectionService ncs;

--- a/lang/java/reef-io/src/test/java/org/apache/reef/services/network/util/NetworkMessagingTestService.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/services/network/util/NetworkMessagingTestService.java
@@ -80,8 +80,8 @@ public final class NetworkMessagingTestService implements AutoCloseable {
   public <T> void registerTestConnectionFactory(final Identifier connFactoryId,
                                                 final int numMessages, final Monitor monitor,
                                                 final Codec<T> codec) throws NetworkException {
-    final Identifier receiverEndPointId = factory.getNewInstance(connFactoryId.toString() + "-receiver");
-    final Identifier senderEndPointId = factory.getNewInstance(connFactoryId.toString() + "-sender");
+    final Identifier receiverEndPointId = factory.getNewInstance("receiver");
+    final Identifier senderEndPointId = factory.getNewInstance("sender");
     receiverNetworkConnService.registerConnectionFactory(connFactoryId, codec,
         new MessageHandler<T>(monitor, numMessages, senderEndPointId, receiverEndPointId),
         new TestListener<T>(), receiverEndPointId);
@@ -91,7 +91,7 @@ public final class NetworkMessagingTestService implements AutoCloseable {
   }
 
   public <T> Connection<T> getConnectionFromSenderToReceiver(final Identifier connFactoryId) {
-    final Identifier receiverEndPointId = factory.getNewInstance(connFactoryId.toString() + "-receiver");
+    final Identifier receiverEndPointId = factory.getNewInstance("receiver");
     return (Connection<T>)senderNetworkConnService
         .getConnectionFactory(connFactoryId)
         .newConnection(receiverEndPointId);

--- a/lang/java/reef-io/src/test/java/org/apache/reef/services/network/util/NetworkMessagingTestService.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/services/network/util/NetworkMessagingTestService.java
@@ -50,8 +50,6 @@ public final class NetworkMessagingTestService implements AutoCloseable {
   private final IdentifierFactory factory;
   private final NetworkConnectionService receiverNetworkConnService;
   private final NetworkConnectionService senderNetworkConnService;
-  private final String receiver;
-  private final String sender;
   private final NameServer nameServer;
   private final NameResolver receiverResolver;
   private final NameResolver senderResolver;
@@ -67,34 +65,36 @@ public final class NetworkMessagingTestService implements AutoCloseable {
 
     LOG.log(Level.FINEST, "=== Test network connection service receiver start");
     // network service for receiver
-    this.receiver = "receiver";
     final Injector injectorReceiver = injector.forkInjector(netConf);
     this.receiverNetworkConnService = injectorReceiver.getInstance(NetworkConnectionService.class);
     this.receiverResolver = injectorReceiver.getInstance(NameResolver.class);
     this.factory = injectorReceiver.getNamedInstance(NetworkConnectionServiceIdFactory.class);
-    this.receiverNetworkConnService.registerId(this.factory.getNewInstance(receiver));
 
     // network service for sender
-    this.sender = "sender";
     LOG.log(Level.FINEST, "=== Test network connection service sender start");
     final Injector injectorSender = injector.forkInjector(netConf);
     senderNetworkConnService = injectorSender.getInstance(NetworkConnectionService.class);
-    senderNetworkConnService.registerId(this.factory.getNewInstance(this.sender));
     this.senderResolver = injectorSender.getInstance(NameResolver.class);
   }
 
   public <T> void registerTestConnectionFactory(final Identifier connFactoryId,
                                                 final int numMessages, final Monitor monitor,
                                                 final Codec<T> codec) throws NetworkException {
+    final Identifier receiverEndPointId = factory.getNewInstance(connFactoryId.toString() + "-receiver");
+    final Identifier senderEndPointId = factory.getNewInstance(connFactoryId.toString() + "-sender");
     receiverNetworkConnService.registerConnectionFactory(connFactoryId, codec,
-        new MessageHandler<T>(monitor, numMessages), new TestListener<T>());
+        new MessageHandler<T>(monitor, numMessages, senderEndPointId, receiverEndPointId),
+        new TestListener<T>(), receiverEndPointId);
     senderNetworkConnService.registerConnectionFactory(connFactoryId, codec,
-        new MessageHandler<T>(monitor, numMessages), new TestListener<T>());
+        new MessageHandler<T>(monitor, numMessages, receiverEndPointId, senderEndPointId),
+        new TestListener<T>(), senderEndPointId);
   }
 
   public <T> Connection<T> getConnectionFromSenderToReceiver(final Identifier connFactoryId) {
-    final Identifier destId = factory.getNewInstance(receiver);
-    return (Connection<T>)senderNetworkConnService.getConnectionFactory(connFactoryId).newConnection(destId);
+    final Identifier receiverEndPointId = factory.getNewInstance(connFactoryId.toString() + "-receiver");
+    return (Connection<T>)senderNetworkConnService
+        .getConnectionFactory(connFactoryId)
+        .newConnection(receiverEndPointId);
   }
 
   public void close() throws Exception {
@@ -108,12 +108,18 @@ public final class NetworkMessagingTestService implements AutoCloseable {
   public static final class MessageHandler<T> implements EventHandler<Message<T>> {
     private final int expected;
     private final Monitor monitor;
+    private final Identifier expectedSrcId;
+    private final Identifier expectedDestId;
     private AtomicInteger count = new AtomicInteger(0);
 
     public MessageHandler(final Monitor monitor,
-                          final int expected) {
+                          final int expected,
+                          final Identifier expectedSrcId,
+                          final Identifier expectedDestId) {
       this.monitor = monitor;
       this.expected = expected;
+      this.expectedSrcId = expectedSrcId;
+      this.expectedDestId = expectedDestId;
     }
 
     @Override
@@ -127,6 +133,9 @@ public final class NetworkMessagingTestService implements AutoCloseable {
       for (final T obj : value.getData()) {
         LOG.log(Level.FINE, "OUT: data: {0}", obj);
       }
+
+      assert value.getSrcId().equals(expectedSrcId);
+      assert value.getDestId().equals(expectedDestId);
 
       if (count.get() == expected) {
         monitor.mnotify();


### PR DESCRIPTION
This addressed the issue by
 * Deprecated registerId/unregisterId/getNetworkConnectionServiceId methods of NCS.
 * Deprecated [Unbind|Bind]NetworkConnectionServiceFromTask classes.
 * Changed tests not to use deprecated methods.
 * Made each NetworkConnectionFacory has own end point identifier.