### PR TITLE
[REEF-618] Change the way restart is represented in DriverRestartManager

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DefaultDriverRuntimeRestartMangerImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DefaultDriverRuntimeRestartMangerImpl.java
@@ -28,8 +28,8 @@ import java.util.Set;
 
 /**
  * The default driver runtime restart manager that is not able to perform any restart actions.
- * Thus, when performing actions pertaining to restart, it is recommended to call static functions in
- * {@link DriverRestartUtilities} or call canRestart() first.
+ * Thus, when performing actions pertaining to restart, it is recommended to call
+ * {@link DriverRuntimeRestartManager#hasRestarted()} first or use static functions in {@link DriverRestartUtilities}.
  */
 @Private
 @DriverSide
@@ -40,7 +40,7 @@ final class DefaultDriverRuntimeRestartMangerImpl implements DriverRuntimeRestar
   }
 
   @Override
-  public boolean isRestart() {
+  public boolean hasRestarted() {
     return false;
   }
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartManager.java
@@ -53,19 +53,31 @@ public final class DriverRestartManager {
   }
 
   /**
-   * @return Whether or not the driver instance is a restarted instance.
+   * Triggers the state machine if the application is a restart instance. Returns true
+   * @return true if the application is a restart instance.
+   * Can be already done with restart or in the process of restart.
    */
-  public synchronized boolean isRestart() {
-    if (this.state.isRestart()) {
-      return true;
-    }
-
-    if (driverRuntimeRestartManager.isRestart()) {
+  public synchronized boolean detectRestart() {
+    if (!this.state.hasRestarted() && driverRuntimeRestartManager.hasRestarted()) {
       this.state = DriverRestartState.RestartBegan;
-      return true;
     }
 
-    return false;
+    return this.state.hasRestarted();
+  }
+
+  /**
+   * @return true if the application is a restart instance.
+   * Can be already done with restart or in the process of restart.
+   */
+  public synchronized boolean hasRestarted() {
+    return this.state.hasRestarted();
+  }
+
+  /**
+   * @return true if the driver is undergoing the process of restart.
+   */
+  public synchronized boolean isRestarting() {
+    return this.state.isRestarting();
   }
 
   /**

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartState.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartState.java
@@ -30,11 +30,6 @@ import org.apache.reef.annotations.audience.Private;
 @Unstable
 public enum DriverRestartState {
   /**
-   *  Driver restart is not implemented.
-   */
-  NotImplemented,
-
-  /**
    *  Driver has not begun the restart progress yet.
    */
   NotRestarted,
@@ -56,16 +51,22 @@ public enum DriverRestartState {
   RestartCompleted;
 
   /**
-   * Returns true if the restart process has began.
+   * @return  true if the restart is in process.
    */
-  public boolean isRestart() {
+  public boolean isRestarting() {
     switch (this) {
     case RestartBegan:
     case RestartInProgress:
-    case RestartCompleted:
       return true;
     default:
       return false;
     }
+  }
+
+  /**
+   * @return true if the driver began the restart process. Can be already done with the restart process.
+   */
+  public boolean hasRestarted() {
+    return this != NotRestarted;
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartUtilities.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartUtilities.java
@@ -24,8 +24,6 @@ import org.apache.reef.annotations.audience.Private;
 
 /**
  * A static utilities class for simplifying calls to driver restart manager.
- * Functions here should always call driverRestartManager.canRestart() before performing any
- * actual options.
  */
 @Private
 @DriverSide
@@ -38,7 +36,7 @@ public final class DriverRestartUtilities {
    */
   public static boolean isRestartAndIsPreviousEvaluator(final DriverRestartManager driverRestartManager,
                                                         final String evaluatorId) {
-    return driverRestartManager.isRestart() && driverRestartManager.getPreviousEvaluatorIds().contains(evaluatorId);
+    return driverRestartManager.hasRestarted() && driverRestartManager.getPreviousEvaluatorIds().contains(evaluatorId);
   }
 
   private DriverRestartUtilities() {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRuntimeRestartManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRuntimeRestartManager.java
@@ -38,9 +38,11 @@ import java.util.Set;
 @DefaultImplementation(DefaultDriverRuntimeRestartMangerImpl.class)
 public interface DriverRuntimeRestartManager {
   /**
-   * Determines whether or not the driver has been restarted. The default implementation always returns false.
+   * @return true if the driver has been restarted. Note that this is different from whether
+   * the driver is in the process of restarting. This returns true both on when the driver is in the
+   * restart process or has already finished restarting. The default implementation always returns false.
    */
-  boolean isRestart();
+  boolean hasRestarted();
 
   /**
    * Records the evaluators when it is allocated.

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverStartHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverStartHandler.java
@@ -62,7 +62,7 @@ public final class DriverStartHandler implements EventHandler<StartTime> {
 
   @Override
   public void onNext(final StartTime startTime) {
-    if (this.driverRestartManager.isRestart()) {
+    if (this.driverRestartManager.detectRestart()) {
       this.onRestart(startTime);
     } else {
       this.onStart(startTime);

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRuntimeRestartManager.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRuntimeRestartManager.java
@@ -75,7 +75,7 @@ public final class YarnDriverRuntimeRestartManager implements DriverRuntimeResta
    * @return true if the application master is a restarted instance, false otherwise.
    */
   @Override
-  public boolean isRestart() {
+  public boolean hasRestarted() {
     final String containerIdString = getContainerIdString();
 
     if (containerIdString == null) {


### PR DESCRIPTION
This addressed the issue by
  * Adding methods to DriverRestartManager and DriverRuntimeRestartManager to differentiate between restart in progress and driver has been restarted.

JIRA:
  [REEF-618](https://issues.apache.org/jira/browse/REEF-618)