### PR TITLE
[REEF-619]  Remove unused bindings from ConfigurationModuleBuilder for Evaluator for CLR

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/EvaluatorConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/EvaluatorConfiguration.java
@@ -48,8 +48,6 @@ public final class EvaluatorConfiguration extends ConfigurationModuleBuilder {
    * The EVALUATOR_CONFIG_MODULE_BUILDER which contains bindings shared for all kinds of Evaluators.
    */
   private static final ConfigurationModuleBuilder EVALUATOR_CONFIG_MODULE_BUILDER = new EvaluatorConfiguration()
-      .bindSetEntry(Clock.RuntimeStartHandler.class, EvaluatorRuntime.RuntimeStartHandler.class)
-      .bindSetEntry(Clock.RuntimeStopHandler.class, EvaluatorRuntime.RuntimeStopHandler.class)
       .bindNamedParameter(DriverRemoteIdentifier.class, DRIVER_REMOTE_IDENTIFIER)
       .bindNamedParameter(ErrorHandlerRID.class, DRIVER_REMOTE_IDENTIFIER)
       .bindNamedParameter(EvaluatorIdentifier.class, EVALUATOR_IDENTIFIER)
@@ -69,6 +67,8 @@ public final class EvaluatorConfiguration extends ConfigurationModuleBuilder {
    * This is ConfigurationModule for Java Evaluator.
    */
   public static final ConfigurationModule CONF = EVALUATOR_CONFIG_MODULE_BUILDER
+      .bindSetEntry(Clock.RuntimeStartHandler.class, EvaluatorRuntime.RuntimeStartHandler.class)
+      .bindSetEntry(Clock.RuntimeStopHandler.class, EvaluatorRuntime.RuntimeStopHandler.class)
       .bindConstructor(ExecutorService.class, ExecutorServiceConstructor.class)
       .build();
 


### PR DESCRIPTION
The two start/stop handler bindings will remain for Java only. C# doesn't need it. This PR is to remove it from the ConfigurationModuleBuilder for Evaluator

JIRA: REEF-619(https://issues.apache.org/jira/browse/REEF-619)

This closes #

Author: Julia Wang  Email: juliaw@apache.org