### PR TITLE
[REEF-616] Keep state of previous evaluators with a state machine

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DefaultDriverRuntimeRestartMangerImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DefaultDriverRuntimeRestartMangerImpl.java
@@ -29,7 +29,7 @@ import java.util.Set;
 /**
  * The default driver runtime restart manager that is not able to perform any restart actions.
  * Thus, when performing actions pertaining to restart, it is recommended to call
- * {@link DriverRuntimeRestartManager#hasRestarted()} first or use static functions in {@link DriverRestartUtilities}.
+ * {@link DriverRuntimeRestartManager#hasRestarted()} first.
  */
 @Private
 @DriverSide

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartState.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartState.java
@@ -69,4 +69,11 @@ public enum DriverRestartState {
   public boolean hasRestarted() {
     return this != NotRestarted;
   }
+
+  /**
+   * the negation of {@link #hasRestarted()}.
+   */
+  public boolean hasNotRestarted() {
+    return !this.hasRestarted();
+  }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/EvaluatorRestartState.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/EvaluatorRestartState.java
@@ -32,7 +32,7 @@ public enum EvaluatorRestartState {
   /**
    * The evaluator is not a restarted instance. Not expecting.
    */
-  NOT_RESTARTED_EVALUATOR,
+  NOT_EXPECTED,
 
   /**
    * Have not yet heard back from an evaluator, but we are expecting it to report back.
@@ -50,14 +50,45 @@ public enum EvaluatorRestartState {
   REREGISTERED,
 
   /**
-   * The evaluator has had its running task processed.
+   * The evaluator has had its context/running task processed.
    */
-  TASK_RUNNING_FIRED,
+  PROCESSED,
 
   /**
    * The evaluator has only contacted the driver after the expiration period.
    */
   EXPIRED;
+
+  /**
+   * @return true if the transition of {@link EvaluatorRestartState} is legal.
+   */
+  public static boolean isLegalTransition(final EvaluatorRestartState from, final EvaluatorRestartState to) {
+    switch(from) {
+    case EXPECTED:
+      switch(to) {
+      case REPORTED:
+        return true;
+      default:
+        return false;
+      }
+    case REPORTED:
+      switch(to) {
+      case REREGISTERED:
+        return true;
+      default:
+        return false;
+      }
+    case REREGISTERED:
+      switch(to) {
+      case PROCESSED:
+        return true;
+      default:
+        return false;
+      }
+    default:
+      return false;
+    }
+  }
 
   /**
    * @return true if the evaluator has heartbeated back to the driver.
@@ -66,7 +97,7 @@ public enum EvaluatorRestartState {
     switch(this) {
     case REPORTED:
     case REREGISTERED:
-    case TASK_RUNNING_FIRED:
+    case PROCESSED:
       return true;
     default:
       return false;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/EvaluatorRestartState.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/EvaluatorRestartState.java
@@ -23,22 +23,53 @@ import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
 
 /**
- * A static utilities class for simplifying calls to driver restart manager.
+ * The state that the evaluator is in in the driver restart process.
  */
 @Private
 @DriverSide
 @Unstable
-public final class DriverRestartUtilities {
+public enum EvaluatorRestartState {
+  /**
+   * The evaluator is not a restarted instance. Not expecting.
+   */
+  NOT_RESTARTED_EVALUATOR,
 
   /**
-   * Helper function for driver restart to determine whether an evaluator ID is from an evaluator from the
-   * previous application attempt.
+   * Have not yet heard back from an evaluator, but we are expecting it to report back.
    */
-  public static boolean isRestartAndIsPreviousEvaluator(final DriverRestartManager driverRestartManager,
-                                                        final String evaluatorId) {
-    return driverRestartManager.hasRestarted() && driverRestartManager.getPreviousEvaluatorIds().contains(evaluatorId);
-  }
+  EXPECTED,
 
-  private DriverRestartUtilities() {
+  /**
+   * Received the evaluator heartbeat, but have not yet processed it.
+   */
+  REPORTED,
+
+  /**
+   * The evaluator has had its recovery heartbeat processed.
+   */
+  REREGISTERED,
+
+  /**
+   * The evaluator has had its running task processed.
+   */
+  TASK_RUNNING_FIRED,
+
+  /**
+   * The evaluator has only contacted the driver after the expiration period.
+   */
+  EXPIRED;
+
+  /**
+   * @return true if the evaluator has heartbeated back to the driver.
+   */
+  public boolean hasReported() {
+    switch(this) {
+    case REPORTED:
+    case REREGISTERED:
+    case TASK_RUNNING_FIRED:
+      return true;
+    default:
+      return false;
+    }
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/ContextRepresenters.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/context/ContextRepresenters.java
@@ -24,7 +24,7 @@ import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.context.FailedContext;
 import org.apache.reef.driver.restart.DriverRestartManager;
-import org.apache.reef.driver.restart.DriverRestartUtilities;
+import org.apache.reef.driver.restart.EvaluatorRestartState;
 import org.apache.reef.proto.ReefServiceProtos;
 import org.apache.reef.runtime.common.driver.evaluator.EvaluatorMessageDispatcher;
 import org.apache.reef.util.Optional;
@@ -215,7 +215,7 @@ public final class ContextRepresenters {
         Optional.of(contextStatusProto.getParentId()) : Optional.<String>empty();
     final EvaluatorContext context = contextFactory.newContext(contextID, parentID);
     this.addContext(context);
-    if (DriverRestartUtilities.isRestartAndIsPreviousEvaluator(driverRestartManager, context.getEvaluatorId())) {
+    if (driverRestartManager.getEvaluatorRestartState(context.getEvaluatorId()) == EvaluatorRestartState.REREGISTERED) {
       // when we get a recovered active context, always notify application
       this.messageDispatcher.onDriverRestartContextActive(context);
     } else {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/TaskRepresenter.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/TaskRepresenter.java
@@ -22,7 +22,7 @@ import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.restart.DriverRestartManager;
-import org.apache.reef.driver.restart.DriverRestartUtilities;
+import org.apache.reef.driver.restart.EvaluatorRestartState;
 import org.apache.reef.driver.task.FailedTask;
 import org.apache.reef.driver.task.RunningTask;
 import org.apache.reef.proto.ReefServiceProtos;
@@ -88,7 +88,7 @@ public final class TaskRepresenter {
       throw new RuntimeException("Received a message for task " + taskStatusProto.getTaskId() +
           " in the TaskRepresenter for Task " + this.taskId);
     }
-    if (taskStatusProto.getRecovery()) {
+    if (driverRestartManager.getEvaluatorRestartState(evaluatorManager.getId()) == EvaluatorRestartState.REREGISTERED) {
       // when a recovered heartbeat is received, we will take its word for it
       LOG.log(Level.INFO, "Received task status {0} for RECOVERED task {1}.",
           new Object[]{taskStatusProto.getState(), this.taskId});
@@ -139,9 +139,10 @@ public final class TaskRepresenter {
     }
 
     // fire driver restart task running handler if this is a recovery heartbeat
-    if (DriverRestartUtilities.isRestartAndIsPreviousEvaluator(driverRestartManager, evaluatorManager.getId())) {
+    if (driverRestartManager.getEvaluatorRestartState(evaluatorManager.getId()) == EvaluatorRestartState.REREGISTERED) {
       final RunningTask runningTask = new RunningTaskImpl(
           this.evaluatorManager, this.taskId, this.context, this);
+      this.driverRestartManager.setEvaluatorRunningTask(evaluatorManager.getId());
       this.messageDispatcher.onDriverRestartTaskRunning(runningTask);
     }
 


### PR DESCRIPTION
This addressed the issue by
  * Switching to a state machine model for evaluator statuses for driver restart.

JIRA:
  [REEF-616](https://issues.apache.org/jira/browse/REEF-616)