### PR TITLE
[REEF-633] Add a static function to share the getRackName() function …

### DIFF
--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/DefaultRackNameFormatter.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/DefaultRackNameFormatter.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.runtime.yarn.util;
+package org.apache.reef.runtime.yarn.driver;
 
 import org.apache.hadoop.yarn.api.records.Container;
 import org.apache.reef.annotations.audience.DriverSide;
@@ -25,18 +25,17 @@ import org.apache.reef.annotations.audience.Private;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * Helper functions for YARN.
- */
 @Private
 @DriverSide
-public final class ContainerUtilities {
-  private static final Logger LOG = Logger.getLogger(ContainerUtilities.class.getName());
+public class DefaultRackNameFormatter implements RackNameFormatter {
+
+  private static final Logger LOG = Logger.getLogger(DefaultRackNameFormatter.class.getName());
 
   /**
-   * @return the rack name of a given container.
+   * @see {@link RackNameFormatter#getRackName(Container)}.
    */
-  public static String getRackName(final Container container) {
+  @Override
+  public String getRackName(final Container container) {
     final String hostName = container.getNodeId().getHost();
 
     // the rack name comes as part of the host name, e.g.
@@ -53,8 +52,5 @@ public final class ContainerUtilities {
     }
 
     return rackName;
-  }
-
-  private ContainerUtilities(){
   }
 }

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/RackNameFormatter.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/RackNameFormatter.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runtime.yarn.driver;
+
+import org.apache.hadoop.yarn.api.records.Container;
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Public;
+import org.apache.reef.annotations.audience.RuntimeAuthor;
+import org.apache.reef.tang.annotations.DefaultImplementation;
+
+/**
+ * Provides a method to retrieve the rack name from a container, which
+ * may be dependent on the Hadoop distribution.
+ */
+@Public
+@RuntimeAuthor
+@DriverSide
+@DefaultImplementation(DefaultRackNameFormatter.class)
+public interface RackNameFormatter {
+
+  /**
+   * The rack name of the Container.
+   */
+  String getRackName(final Container container);
+}

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
@@ -37,7 +37,6 @@ import org.apache.reef.runtime.common.driver.resourcemanager.ResourceAllocationE
 import org.apache.reef.runtime.common.driver.resourcemanager.ResourceStatusEventImpl;
 import org.apache.reef.runtime.common.driver.resourcemanager.RuntimeStatusEventImpl;
 import org.apache.reef.runtime.yarn.driver.parameters.YarnHeartbeatPeriod;
-import org.apache.reef.runtime.yarn.util.ContainerUtilities;
 import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.util.Optional;
 import org.apache.reef.wake.remote.Encoder;
@@ -76,6 +75,7 @@ final class YarnContainerManager
   private final ContainerRequestCounter containerRequestCounter;
   private final DriverStatusManager driverStatusManager;
   private final TrackingURLProvider trackingURLProvider;
+  private final RackNameFormatter rackNameFormatter;
 
   @Inject
   YarnContainerManager(
@@ -86,7 +86,8 @@ final class YarnContainerManager
       final ApplicationMasterRegistration registration,
       final ContainerRequestCounter containerRequestCounter,
       final DriverStatusManager driverStatusManager,
-      final TrackingURLProvider trackingURLProvider) throws IOException {
+      final TrackingURLProvider trackingURLProvider,
+      final RackNameFormatter rackNameFormatter) throws IOException {
 
     this.reefEventHandlers = reefEventHandlers;
     this.driverStatusManager = driverStatusManager;
@@ -96,6 +97,7 @@ final class YarnContainerManager
     this.containerRequestCounter = containerRequestCounter;
     this.yarnConf = yarnConf;
     this.trackingURLProvider = trackingURLProvider;
+    this.rackNameFormatter = rackNameFormatter;
 
 
     this.yarnClient.init(this.yarnConf);
@@ -401,7 +403,7 @@ final class YarnContainerManager
             .setNodeId(container.getNodeId().toString())
             .setResourceMemory(container.getResource().getMemory())
             .setVirtualCores(container.getResource().getVirtualCores())
-            .setRackName(ContainerUtilities.getRackName(container))
+            .setRackName(rackNameFormatter.getRackName(container))
             .build());
         this.updateRuntimeStatus();
       } else {

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
@@ -37,6 +37,7 @@ import org.apache.reef.runtime.common.driver.resourcemanager.ResourceAllocationE
 import org.apache.reef.runtime.common.driver.resourcemanager.ResourceStatusEventImpl;
 import org.apache.reef.runtime.common.driver.resourcemanager.RuntimeStatusEventImpl;
 import org.apache.reef.runtime.yarn.driver.parameters.YarnHeartbeatPeriod;
+import org.apache.reef.runtime.yarn.util.ContainerUtilities;
 import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.util.Optional;
 import org.apache.reef.wake.remote.Encoder;
@@ -103,6 +104,7 @@ final class YarnContainerManager
     this.nodeManager = new NMClientAsyncImpl(this);
     LOG.log(Level.FINEST, "Instantiated YarnContainerManager");
   }
+
 
   @Override
   public void onContainersCompleted(final List<ContainerStatus> containerStatuses) {
@@ -392,20 +394,6 @@ final class YarnContainerManager
         this.requestsAfterSentToRM.remove();
         doHomogeneousRequests();
 
-        // the rack name comes as part of the host name, e.g.
-        // <rackName>-<hostNumber>
-        // we perform some checks just in case it doesn't
-        final String hostName = container.getNodeId().getHost();
-        String rackName = null;
-        if (hostName != null) {
-          final String[] rackNameAndNumber = hostName.split("-");
-          if (rackNameAndNumber.length == 2) {
-            rackName = rackNameAndNumber[0];
-          } else {
-            LOG.log(Level.WARNING, "Could not get information from the rack name, should use the default");
-          }
-        }
-
         LOG.log(Level.FINEST, "Allocated Container: memory = {0}, core number = {1}",
             new Object[]{container.getResource().getMemory(), container.getResource().getVirtualCores()});
         this.reefEventHandlers.onResourceAllocation(ResourceAllocationEventImpl.newBuilder()
@@ -413,7 +401,7 @@ final class YarnContainerManager
             .setNodeId(container.getNodeId().toString())
             .setResourceMemory(container.getResource().getMemory())
             .setVirtualCores(container.getResource().getVirtualCores())
-            .setRackName(rackName)
+            .setRackName(ContainerUtilities.getRackName(container))
             .build());
         this.updateRuntimeStatus();
       } else {

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverConfiguration.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverConfiguration.java
@@ -33,10 +33,7 @@ import org.apache.reef.runtime.yarn.YarnClasspathProvider;
 import org.apache.reef.runtime.yarn.driver.parameters.JobSubmissionDirectory;
 import org.apache.reef.runtime.yarn.driver.parameters.YarnHeartbeatPeriod;
 import org.apache.reef.runtime.yarn.util.YarnConfigurationConstructor;
-import org.apache.reef.tang.formats.ConfigurationModule;
-import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
-import org.apache.reef.tang.formats.OptionalParameter;
-import org.apache.reef.tang.formats.RequiredParameter;
+import org.apache.reef.tang.formats.*;
 
 /**
  * Created by marku_000 on 2014-07-07.
@@ -55,6 +52,11 @@ public class YarnDriverConfiguration extends ConfigurationModuleBuilder {
    * @see JobIdentifier.class
    */
   public static final RequiredParameter<String> JOB_IDENTIFIER = new RequiredParameter<>();
+
+  /**
+   * @see {@link RackNameFormatter}
+   */
+  public static final OptionalImpl<RackNameFormatter> RACK_NAME_FORMATTER = new OptionalImpl<>();
 
   /**
    * @see EvaluatorTimeout
@@ -93,6 +95,7 @@ public class YarnDriverConfiguration extends ConfigurationModuleBuilder {
       .bindNamedParameter(ClientRemoteIdentifier.class, CLIENT_REMOTE_IDENTIFIER)
       .bindNamedParameter(ErrorHandlerRID.class, CLIENT_REMOTE_IDENTIFIER)
       .bindNamedParameter(JVMHeapSlack.class, JVM_HEAP_SLACK)
+      .bindImplementation(RackNameFormatter.class, RACK_NAME_FORMATTER)
       .bindImplementation(RuntimeClasspathProvider.class, YarnClasspathProvider.class)
       .build();
 }

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/util/ContainerUtilities.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/util/ContainerUtilities.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runtime.yarn.util;
+
+import org.apache.hadoop.yarn.api.records.Container;
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Private;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Helper functions for YARN.
+ */
+@Private
+@DriverSide
+public final class ContainerUtilities {
+  private static final Logger LOG = Logger.getLogger(ContainerUtilities.class.getName());
+
+  /**
+   * @return the rack name of a given container.
+   */
+  public static String getRackName(final Container container) {
+    final String hostName = container.getNodeId().getHost();
+
+    // the rack name comes as part of the host name, e.g.
+    // <rackName>-<hostNumber>
+    // we perform some checks just in case it doesn't
+    String rackName = null;
+    if (hostName != null) {
+      final String[] rackNameAndNumber = hostName.split("-");
+      if (rackNameAndNumber.length == 2) {
+        rackName = rackNameAndNumber[0];
+      } else {
+        LOG.log(Level.WARNING, "Could not get information from the rack name, should use the default");
+      }
+    }
+
+    return rackName;
+  }
+
+  private ContainerUtilities(){
+  }
+}


### PR DESCRIPTION
…in YARN

This addressed the issue by
  * Adding ContainerUtilities.getRackName() and replacing original logic with the function call in YarnContainerManager.

JIRA:
  [REEF-633](https://issues.apache.org/jira/browse/REEF-633)