### PR TITLE
[REEF-632] Add container to the set of containers on restart such that YarnContainerManager will know how to release it

### DIFF
--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
@@ -199,6 +199,16 @@ final class YarnContainerManager
   }
 
   /**
+   * Called by {@link YarnDriverRuntimeRestartManager} to record recovered containers
+   * such that containers can be released properly on unrecoverable containers.
+   */
+  public void onContainersRecovered(final Set<Container> recoveredContainers) {
+    for (final Container container : recoveredContainers) {
+      containers.add(container);
+    }
+  }
+
+  /**
    * Submit the given launchContext to the given container.
    */
   void submit(final Container container, final ContainerLaunchContext launchContext) {

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRuntimeRestartManager.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRuntimeRestartManager.java
@@ -55,16 +55,20 @@ public final class YarnDriverRuntimeRestartManager implements DriverRuntimeResta
   private final EvaluatorPreserver evaluatorPreserver;
   private final ApplicationMasterRegistration registration;
   private final REEFEventHandlers reefEventHandlers;
+  private final YarnContainerManager yarnContainerManager;
+
   private Set<Container> previousContainers;
 
   @Inject
   private YarnDriverRuntimeRestartManager(@Parameter(YarnEvaluatorPreserver.class)
                                           final EvaluatorPreserver evaluatorPreserver,
                                           final REEFEventHandlers reefEventHandlers,
-                                          final ApplicationMasterRegistration registration){
+                                          final ApplicationMasterRegistration registration,
+                                          final YarnContainerManager yarnContainerManager) {
     this.registration = registration;
     this.evaluatorPreserver = evaluatorPreserver;
     this.reefEventHandlers = reefEventHandlers;
+    this.yarnContainerManager = yarnContainerManager;
     this.previousContainers = null;
   }
 
@@ -138,6 +142,8 @@ public final class YarnDriverRuntimeRestartManager implements DriverRuntimeResta
       if (this.previousContainers == null) {
         this.previousContainers = new HashSet<>();
       }
+
+      yarnContainerManager.onContainersRecovered(Collections.unmodifiableSet(this.previousContainers));
     }
   }
 

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRuntimeRestartManager.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRuntimeRestartManager.java
@@ -136,14 +136,17 @@ public final class YarnDriverRuntimeRestartManager implements DriverRuntimeResta
    */
   private synchronized void initializeListOfPreviousContainers() {
     if (this.previousContainers == null) {
-      this.previousContainers = new HashSet<>(this.registration.getRegistration().getContainersFromPreviousAttempts());
+      final List<Container> yarnPrevContainers =
+          this.registration.getRegistration().getContainersFromPreviousAttempts();
 
       // If it's still null, create an empty list to indicate that it's not a restart.
-      if (this.previousContainers == null) {
-        this.previousContainers = new HashSet<>();
+      if (yarnPrevContainers == null) {
+        this.previousContainers = Collections.unmodifiableSet(new HashSet<Container>());
+      } else {
+        this.previousContainers = Collections.unmodifiableSet(new HashSet<>(yarnPrevContainers));
       }
 
-      yarnContainerManager.onContainersRecovered(Collections.unmodifiableSet(this.previousContainers));
+      yarnContainerManager.onContainersRecovered(this.previousContainers);
     }
   }
 


### PR DESCRIPTION
This addressed the issue by
  * Adding onContainersRecovered to YarnContainerManager and calling it on recovering containers in YarnDriverRuntimeRestartManager.

JIRA:
  [REEF-632](https://issues.apache.org/jira/browse/REEF-632)