### PR TITLE
[REEF-635] Evaluator removed twice from evaluator log if an evaluator failed on restart

### DIFF
--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRuntimeRestartManager.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRuntimeRestartManager.java
@@ -180,7 +180,6 @@ public final class YarnDriverRuntimeRestartManager implements DriverRuntimeResta
         }
         for (final String expectedContainerId : expectedContainers) {
           if (!previousContainersIds.contains(expectedContainerId)) {
-            this.evaluatorPreserver.recordRemovedEvaluator(expectedContainerId);
             LOG.log(Level.WARNING, "Expected container [{0}] not alive, must have failed during driver restart.",
                 expectedContainerId);
             failedEvaluators.add(expectedContainerId);


### PR DESCRIPTION
This addressed the issue by
  * Remove evaluator entry in informAboutEvaluatorFailures in YarnDriverRuntimeRestartManager.

JIRA:
  [REEF-635](https://issues.apache.org/jira/browse/REEF-635)