### PR TITLE
[REEF-631] Implement driver restart completion logic

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorHeartbeatHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorHeartbeatHandler.java
@@ -73,13 +73,20 @@ public final class EvaluatorHeartbeatHandler
 
       if (driverRestartManager.isRestarting() &&
           driverRestartManager.getEvaluatorRestartState(evaluatorId) == EvaluatorRestartState.EXPECTED) {
-        // TODO[REEF-617]: Create EvaluatorManager for recovered evaluator and call onEvaluatorHeartbeatMessage().
+
+        if (this.driverRestartManager.onRecoverEvaluator(evaluatorId)) {
+          LOG.log(Level.FINE, "Evaluator [" + evaluatorId + "] has reported back to the driver after restart.");
+          // TODO[REEF-617]: Create EvaluatorManager, add to this.evaluators, and call onEvaluatorHeartbeatMessage().
+
+        } else {
+          LOG.log(Level.FINE, "Evaluator [" + evaluatorId + "] has already been recovered.");
+        }
         return;
       }
 
       if (driverRestartManager.getEvaluatorRestartState(evaluatorId) == EvaluatorRestartState.EXPIRED) {
         LOG.log(Level.FINE, "Expired evaluator " + evaluatorId + " has reported back to the driver after restart.");
-        // TODO[REEF-617]: Create EvaluatorManager for expired evaluator and close it.
+        // TODO[REEF-617]: Create EvaluatorManager, call onEvaluatorHeartbeatMessage, and close it.
         return;
       }
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
@@ -36,7 +36,6 @@ import org.apache.reef.exception.EvaluatorKilledByResourceManagerException;
 import org.apache.reef.io.naming.Identifiable;
 import org.apache.reef.proto.EvaluatorRuntimeProtocol;
 import org.apache.reef.proto.ReefServiceProtos;
-import org.apache.reef.runtime.common.DriverRestartCompleted;
 import org.apache.reef.driver.evaluator.EvaluatorProcess;
 import org.apache.reef.runtime.common.driver.api.ResourceLaunchEvent;
 import org.apache.reef.runtime.common.driver.api.ResourceReleaseEventImpl;
@@ -366,18 +365,7 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
         LOG.log(Level.FINEST, "Evaluator {0} is running", this.evaluatorId);
 
         if (evaluatorRestartState == EvaluatorRestartState.REPORTED) {
-
-          // TODO[REEF-617]: Move evaluator recovery to EvaluatorHeartbeatHandler and reregister evaluator here.
-          final boolean restartCompleted =
-              this.driverRestartManager.onRecoverEvaluatorIsRestartComplete(this.evaluatorId);
-
-          LOG.log(Level.FINE, "Received recovery heartbeat from evaluator {0}.", this.evaluatorId);
-
-          // TODO[REEF-617]: Move restart completion logic to DriverRestartManager.
-          if (restartCompleted) {
-            this.messageDispatcher.onDriverRestartCompleted(new DriverRestartCompleted(System.currentTimeMillis()));
-            LOG.log(Level.INFO, "All expected evaluators checked in.");
-          }
+          driverRestartManager.setEvaluatorReregistered(evaluatorId);
         }
       }
 


### PR DESCRIPTION
This addressed the issue by
  * Change restart completion logic to be in ``DriverRestartManager.onRecoverEvaluator`` instead of being in ``EvaluatorManager``.
  * Implement the actual restart completion logic to call ``EvaluatorFailedHandler`` and to mark Evaluators as expired.

JIRA:
  [REEF-631](https://issues.apache.org/jira/browse/REEF-631)