### PR TITLE
[REEF-638] Passing Mapper Specific configuration in IMRU

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU/API/IMRUJobDefinition.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/API/IMRUJobDefinition.cs
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+using System.Collections.Generic;
 using Org.Apache.REEF.Tang.Interface;
 
 namespace Org.Apache.REEF.IMRU.API
@@ -39,6 +40,7 @@ namespace Org.Apache.REEF.IMRU.API
         private readonly int _numberOfMappers;
         private readonly int _memoryPerMapper;
         private readonly int _updateTaskMemory;
+        private readonly ISet<IConfiguration> _perMapConfigGeneratorConfig;
 
         /// <summary>
         /// Constructor
@@ -55,6 +57,7 @@ namespace Org.Apache.REEF.IMRU.API
         /// PipelineDataConverter for TMapInput</param>
         /// <param name="partitionedDatasetConfiguration">Configuration of partitioned 
         /// dataset</param>
+        /// <param name="perMapConfigGeneratorConfig">Per mapper configuration</param>
         /// <param name="numberOfMappers">Number of mappers</param>
         /// <param name="memoryPerMapper">Per Mapper memory.</param>
         /// <param name="jobName">Job name</param>
@@ -67,6 +70,7 @@ namespace Org.Apache.REEF.IMRU.API
             IConfiguration mapOutputPipelineDataConverterConfiguration,
             IConfiguration mapInputPipelineDataConverterConfiguration,
             IConfiguration partitionedDatasetConfiguration,
+            ISet<IConfiguration> perMapConfigGeneratorConfig,
             int numberOfMappers,
             int memoryPerMapper,
             int updateTaskMemory,
@@ -84,6 +88,7 @@ namespace Org.Apache.REEF.IMRU.API
             _jobName = jobName;
             _memoryPerMapper = memoryPerMapper;
             _updateTaskMemory = updateTaskMemory;
+            _perMapConfigGeneratorConfig = perMapConfigGeneratorConfig;
         }
 
         /// <summary>
@@ -183,6 +188,14 @@ namespace Org.Apache.REEF.IMRU.API
         internal int UpdateTaskMemory
         {
             get { return _updateTaskMemory; }
+        }
+
+        /// <summary>
+        /// Per mapper configuration
+        /// </summary>
+        internal ISet<IConfiguration> PerMapConfigGeneratorConfig
+        {
+            get { return _perMapConfigGeneratorConfig; }
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IMRU/API/IMRUJobDefinitionBuilder.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/API/IMRUJobDefinitionBuilder.cs
@@ -18,9 +18,13 @@
  */
 
 using System;
+using System.Collections.Generic;
+using Org.Apache.REEF.IMRU.OnREEF.Parameters;
 using Org.Apache.REEF.Network.Group.Driver.Impl;
+using Org.Apache.REEF.Tang.Formats;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Implementations.Tang;
+using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Diagnostics;
 using Org.Apache.REEF.Utilities.Logging;
 
@@ -46,6 +50,7 @@ namespace Org.Apache.REEF.IMRU.API
         private IConfiguration _mapOutputPipelineDataConverterConfiguration;
         private IConfiguration _mapInputPipelineDataConverterConfiguration;
         private IConfiguration _partitionedDatasetConfiguration;
+        private readonly ISet<IConfiguration> _perMapConfigGeneratorConfig;
 
         private static readonly IConfiguration EmptyConfiguration =
             TangFactory.GetTang().NewConfigurationBuilder().Build();
@@ -60,6 +65,7 @@ namespace Org.Apache.REEF.IMRU.API
             _partitionedDatasetConfiguration = EmptyConfiguration;
             _memoryPerMapper = 512;
             _updateTaskMemory = 512;
+            _perMapConfigGeneratorConfig = new HashSet<IConfiguration>();
         }
 
         /// <summary>
@@ -203,6 +209,17 @@ namespace Org.Apache.REEF.IMRU.API
         }
 
         /// <summary>
+        /// Sets Per Map Configuration
+        /// </summary>
+        /// <param name="perMapperConfig">Mapper configs</param>
+        /// <returns></returns>
+        public IMRUJobDefinitionBuilder SetPerMapConfigurations(IConfiguration perMapperConfig)
+        {
+            _perMapConfigGeneratorConfig.Add(perMapperConfig);
+            return this;
+        }
+
+        /// <summary>
         /// Instantiate the IMRUJobDefinition.
         /// </summary>
         /// <returns>The IMRUJobDefintion configured.</returns>
@@ -250,6 +267,7 @@ namespace Org.Apache.REEF.IMRU.API
                 _mapOutputPipelineDataConverterConfiguration,
                 _mapInputPipelineDataConverterConfiguration,
                 _partitionedDatasetConfiguration,
+                _perMapConfigGeneratorConfig,
                 _numberOfMappers,
                 _memoryPerMapper,
                 _updateTaskMemory,

--- a/lang/cs/Org.Apache.REEF.IMRU/API/IMRUPerMapperConfigGeneratorConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/API/IMRUPerMapperConfigGeneratorConfiguration.cs
@@ -1,0 +1,45 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using Org.Apache.REEF.IMRU.OnREEF.Parameters;
+using Org.Apache.REEF.Tang.Formats;
+using Org.Apache.REEF.Tang.Util;
+
+namespace Org.Apache.REEF.IMRU.API
+{
+    /// <summary>
+    /// A configuration module for per mapper configuration.
+    /// </summary>
+    public sealed class IMRUPerMapperConfigGeneratorConfiguration : ConfigurationModuleBuilder
+    {
+        /// <summary>
+        /// The IPerMapperConfigs to use.
+        /// </summary>
+        public static readonly RequiredImpl<IPerMapperConfigGenerator> PerMapperConfigGenerator =
+            new RequiredImpl<IPerMapperConfigGenerator>();
+
+        /// <summary>
+        /// Configuration module
+        /// </summary>
+        public static ConfigurationModule ConfigurationModule =
+            new IMRUPerMapperConfigGeneratorConfiguration()
+                .BindSetEntry(GenericType<PerMapConfigGeneratorSet>.Class, PerMapperConfigGenerator)
+                .Build();
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IMRU/API/IPerMapperConfigGenerator.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/API/IPerMapperConfigGenerator.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using Org.Apache.REEF.Tang.Interface;
+
+namespace Org.Apache.REEF.IMRU.API
+{
+    /// <summary>
+    /// Class returning mapper specific configuration
+    /// </summary>
+    public interface IPerMapperConfigGenerator
+    {
+        /// <summary>
+        /// returns per mapper configuration
+        /// </summary>
+        /// <param name="currentPartitionNumber">current partition number</param>
+        /// <param name="totalMappers">total number of mappers</param>
+        /// <returns>mapper configuration</returns>
+        IConfiguration GetMapperConfiguration(int currentPartitionNumber, int totalMappers);
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IMRU/API/PerMapConfigGeneratorSet.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/API/PerMapConfigGeneratorSet.cs
@@ -1,0 +1,31 @@
+﻿#region LICENSE
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#endregion
+
+using System.Collections.Generic;
+using Org.Apache.REEF.Tang.Annotations;
+
+namespace Org.Apache.REEF.IMRU.API
+{
+    [NamedParameter("Set of mapper specfic configuration generators", "setofmapconfig")]
+    internal sealed class PerMapConfigGeneratorSet : Name<ISet<IPerMapperConfigGenerator>>
+    {
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IMRU/Org.Apache.REEF.IMRU.csproj
+++ b/lang/cs/Org.Apache.REEF.IMRU/Org.Apache.REEF.IMRU.csproj
@@ -49,8 +49,11 @@ under the License.
     <Compile Include="API\IMRUJobDefinitionBuilder.cs" />
     <Compile Include="API\IMRUMapConfiguration.cs" />
     <Compile Include="API\IMRUReduceFunctionConfiguration.cs" />
+    <Compile Include="API\IMRUPerMapperConfigGeneratorConfiguration.cs" />
     <Compile Include="API\IMRUUpdateConfiguration.cs" />
     <Compile Include="API\IUpdateFunction.cs" />
+    <Compile Include="API\IPerMapperConfigGenerator.cs" />
+    <Compile Include="API\PerMapConfigGeneratorSet.cs" />
     <Compile Include="API\UpdateResult.cs" />
     <Compile Include="InProcess\IMRURunner.cs" />
     <Compile Include="InProcess\InProcessIMRUClient.cs" />


### PR DESCRIPTION
This addressed the issue by
* introducing interface IPerMapperConfigs that allowes user to specify a list of configurations, one for each mapper.
* implementing EmptyPerMapperConfigs that is default for IPerMapperConfigs in case user has no mapper specfic configs
* making appropriate changes in IMRUDriver, IMRUClient, JobDefinition and JobDefinitionBuilder
JIRA:
[REEF-638](https://issues.apache.org/jira/browse/REEF-638)