### PR TITLE
[REEF-643] Remove APIs deprecated since 0.12 from reef-common: AllocatedEvaluator

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/AllocatedEvaluator.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/AllocatedEvaluator.java
@@ -60,15 +60,6 @@ public interface AllocatedEvaluator
   EvaluatorDescriptor getEvaluatorDescriptor();
 
   /**
-   * Set the type of Evaluator to be instantiated. Defaults to EvaluatorType.JVM.
-   *
-   * @param type
-   * @deprecated Replace with #setProcess
-   */
-  @Deprecated
-  void setType(final EvaluatorType type);
-
-  /**
    * Specify the process to be instantiated for the Evaluator.
    * Defaults to an EvaluatorProcess instantiated by the binded ProcessFactory.
    *

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/AllocatedEvaluatorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/AllocatedEvaluatorImpl.java
@@ -56,9 +56,6 @@ public final class AllocatedEvaluatorImpl implements AllocatedEvaluator {
   private final String jobIdentifier;
   private final LoggingScopeFactory loggingScopeFactory;
   private final Set<ConfigurationProvider> evaluatorConfigurationProviders;
-  // TODO: The factories should be removed when deprecated setType is removed, as the process should not be created here
-  private final JVMProcessFactory jvmProcessFactory;
-  private final CLRProcessFactory clrProcessFactory;
 
   /**
    * The set of files to be places on the Evaluator.
@@ -74,17 +71,13 @@ public final class AllocatedEvaluatorImpl implements AllocatedEvaluator {
                          final ConfigurationSerializer configurationSerializer,
                          final String jobIdentifier,
                          final LoggingScopeFactory loggingScopeFactory,
-                         final Set<ConfigurationProvider> evaluatorConfigurationProviders,
-                         final JVMProcessFactory jvmProcessFactory,
-                         final CLRProcessFactory clrProcessFactory) {
+                         final Set<ConfigurationProvider> evaluatorConfigurationProviders) {
     this.evaluatorManager = evaluatorManager;
     this.remoteID = remoteID;
     this.configurationSerializer = configurationSerializer;
     this.jobIdentifier = jobIdentifier;
     this.loggingScopeFactory = loggingScopeFactory;
     this.evaluatorConfigurationProviders = evaluatorConfigurationProviders;
-    this.jvmProcessFactory = jvmProcessFactory;
-    this.clrProcessFactory = clrProcessFactory;
   }
 
   @Override
@@ -153,19 +146,6 @@ public final class AllocatedEvaluatorImpl implements AllocatedEvaluator {
                                              final Configuration serviceConfiguration,
                                              final String taskConfiguration) {
     launchWithTaskString(contextConfiguration, Optional.of(serviceConfiguration), Optional.of(taskConfiguration));
-  }
-
-  @Override
-  @Deprecated
-  public void setType(final EvaluatorType type) {
-    switch (type) {
-    case CLR:
-      setProcess(clrProcessFactory.newEvaluatorProcess());
-      break;
-    default:
-      setProcess(jvmProcessFactory.newEvaluatorProcess());
-      break;
-    }
   }
 
   @Override

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
@@ -20,7 +20,6 @@ package org.apache.reef.runtime.common.driver.evaluator;
 
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
-import org.apache.reef.driver.evaluator.CLRProcessFactory;
 import org.apache.reef.driver.parameters.EvaluatorConfigurationProviders;
 import org.apache.reef.driver.restart.DriverRestartManager;
 import org.apache.reef.driver.restart.EvaluatorRestartState;
@@ -29,7 +28,6 @@ import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.context.FailedContext;
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
 import org.apache.reef.driver.evaluator.EvaluatorDescriptor;
-import org.apache.reef.driver.evaluator.JVMProcessFactory;
 import org.apache.reef.driver.task.FailedTask;
 import org.apache.reef.exception.EvaluatorException;
 import org.apache.reef.exception.EvaluatorKilledByResourceManagerException;
@@ -102,8 +100,6 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
   private final ConfigurationSerializer configurationSerializer;
   private final LoggingScopeFactory loggingScopeFactory;
   private final Set<ConfigurationProvider> evaluatorConfigurationProviders;
-  private final JVMProcessFactory jvmProcessFactory;
-  private final CLRProcessFactory clrProcessFactory;
   private final DriverRestartManager driverRestartManager;
 
   // Mutable fields
@@ -130,9 +126,6 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
       final LoggingScopeFactory loggingScopeFactory,
       @Parameter(EvaluatorConfigurationProviders.class)
       final Set<ConfigurationProvider> evaluatorConfigurationProviders,
-      // TODO: Eventually remove the factories when they are removed from AllocatedEvaluatorImpl
-      final JVMProcessFactory jvmProcessFactory,
-      final CLRProcessFactory clrProcessFactory,
       final DriverRestartManager driverRestartManager) {
     this.contextRepresenters = contextRepresenters;
     this.idlenessSource = idlenessSource;
@@ -153,8 +146,6 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
     this.configurationSerializer = configurationSerializer;
     this.loggingScopeFactory = loggingScopeFactory;
     this.evaluatorConfigurationProviders = evaluatorConfigurationProviders;
-    this.jvmProcessFactory = jvmProcessFactory;
-    this.clrProcessFactory = clrProcessFactory;
     this.driverRestartManager = driverRestartManager;
 
     LOG.log(Level.FINEST, "Instantiated 'EvaluatorManager' for evaluator: [{0}]", this.getId());
@@ -189,9 +180,7 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
               configurationSerializer,
               getJobIdentifier(),
               loggingScopeFactory,
-              evaluatorConfigurationProviders,
-              jvmProcessFactory,
-              clrProcessFactory);
+              evaluatorConfigurationProviders);
       LOG.log(Level.FINEST, "Firing AllocatedEvaluator event for Evaluator with ID [{0}]", evaluatorId);
       messageDispatcher.onEvaluatorAllocated(allocatedEvaluator);
       allocationFired = true;


### PR DESCRIPTION
This removes deprecated setType methods and related process factories.

JIRA:
  [REEF-643](https://issues.apache.org/jira/browse/REEF-643)

Pull Request:
  Closes #