### PR TITLE
[REEF-644] Remove APIs deprecated since 0.12 from reef-common: EvaluatorRequest

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequest.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequest.java
@@ -21,7 +21,6 @@ package org.apache.reef.driver.evaluator;
 import org.apache.reef.annotations.Provided;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Public;
-import org.apache.reef.driver.catalog.ResourceCatalog;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -37,31 +36,8 @@ public final class EvaluatorRequest {
   private final int megaBytes;
   private final int number;
   private final int cores;
-  /**
-   * @deprecated since 0.12.0, should use instead
-   *             {@link EvaluatorRequest#nodeNames} and
-   *             {@link EvaluatorRequest#rackNames}
-   */
-  @Deprecated
-  private final ResourceCatalog.Descriptor descriptor;
   private final List<String> nodeNames;
   private final List<String> rackNames;
-
-  /**
-   * Deprecated constructor. ResourceCatalog.Descriptor should not be used
-   * anymore. In order to specify the rack names and node names where evaluators
-   * should run on, you should use nodeNames and rackNames lists
-   *
-   * @deprecated since 0.12.0, use constructor with node
-   *             names and rack names as parameters
-   */
-  @Deprecated
-  EvaluatorRequest(final int number,
-                   final int megaBytes,
-                   final int cores,
-                   final ResourceCatalog.Descriptor descriptor) {
-    this(number, megaBytes, cores, new ArrayList<String>(), new ArrayList<String>());
-  }
 
   EvaluatorRequest(final int number,
       final int megaBytes,
@@ -73,7 +49,6 @@ public final class EvaluatorRequest {
     this.cores = cores;
     this.nodeNames = nodeNames;
     this.rackNames = rackNames;
-    this.descriptor = null;
   }
 
   /**
@@ -110,21 +85,6 @@ public final class EvaluatorRequest {
   }
 
   /**
-   * Access the {@link org.apache.reef.driver.catalog.NodeDescriptor} used as
-   * the template for this {@link EvaluatorRequest}.
-   *
-   * @return the {@link org.apache.reef.driver.catalog.NodeDescriptor} used as
-   *         the template for this {@link EvaluatorRequest}.
-   * @deprecated since 0.12.0. Should use instead
-   *             {@link EvaluatorRequest#getNodeNames()} and
-   *             {@link EvaluatorRequest#getRackNames()}
-   */
-  @Deprecated
-  public ResourceCatalog.Descriptor getDescriptor() {
-    return this.descriptor;
-  }
-
-  /**
    * @return the minimum size of Evaluator requested.
    */
   public int getMegaBytes() {
@@ -151,13 +111,6 @@ public final class EvaluatorRequest {
   public static final class Builder implements org.apache.reef.util.Builder<EvaluatorRequest> {
 
     private int n = 1;
-    /**
-     * @deprecated since 0.12.0, should use instead
-     *             {@link EvaluatorRequest.Builder#nodeNames} and
-     *             {@link EvaluatorRequest.Builder#rackNames}
-     */
-    @Deprecated
-    private ResourceCatalog.Descriptor descriptor = null;
     private int megaBytes = -1;
     private int cores = 1; //if not set, default to 1
     private final List<String> nodeNames = new ArrayList<>();
@@ -174,7 +127,6 @@ public final class EvaluatorRequest {
      */
     private Builder(final EvaluatorRequest request) {
       setNumber(request.getNumber());
-      fromDescriptor(request.getDescriptor());
       setMemory(request.getMegaBytes());
       setNumberOfCores(request.getNumberOfCores());
       for (final String nodeName : request.getNodeNames()) {
@@ -246,25 +198,6 @@ public final class EvaluatorRequest {
     @Override
     public EvaluatorRequest build() {
       return new EvaluatorRequest(this.n, this.megaBytes, this.cores, this.nodeNames, this.rackNames);
-    }
-
-    /**
-     * Pre-fill this {@link EvaluatorRequest} from the given
-     * {@link org.apache.reef.driver.catalog.NodeDescriptor}. Any value not
-     * changed in subsequent calls to this Builder will be taken from the given
-     * descriptor.
-     *
-     * @param rd
-     *          the descriptor used to pre-fill this request.
-     * @deprecated since 0.12.0. Replace with
-     *             {@link EvaluatorRequest.Builder#addRackName} and
-     *             {@link EvaluatorRequest.Builder#addNodeName}
-     * @return this
-     */
-    @Deprecated
-    public Builder fromDescriptor(final ResourceCatalog.Descriptor rd) {
-      this.descriptor = rd;
-      return this;
     }
   }
 }


### PR DESCRIPTION
This removed EvaluatorRequest.descriptor and related methods.

JIRA:
  [REEF-664](https://issues.apache.org/jira/browse/REEF-644)

Pull Request:
  Closes #