### PR TITLE
[REEF-617] Enable creation of EvaluatorManager on restarted evaluators

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/Evaluators.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/Evaluators.java
@@ -107,7 +107,7 @@ public final class Evaluators implements AutoCloseable {
   public synchronized void put(
       final EvaluatorManagerFactory evaluatorManagerFactory,
       final ResourceAllocationEvent evaluatorMsg) {
-    this.put(evaluatorManagerFactory.getNewEvaluatorManagerForNewlyAllocatedEvaluator(evaluatorMsg));
+    this.put(evaluatorManagerFactory.getNewEvaluatorManagerForNewEvaluator(evaluatorMsg));
   }
 
   /**

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceStatusHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceStatusHandler.java
@@ -57,8 +57,9 @@ public final class ResourceStatusHandler implements EventHandler<ResourceStatusE
       evaluatorManager.get().onResourceStatusMessage(resourceStatusEvent);
     } else {
       if (resourceStatusEvent.getIsFromPreviousDriver().get()) {
-        final EvaluatorManager previousEvaluatorManager =
-            this.evaluatorManagerFactory.createForEvaluatorFailedDuringDriverRestart(resourceStatusEvent);
+        final EvaluatorManager previousEvaluatorManager = this.evaluatorManagerFactory
+            .getNewEvaluatorManagerForEvaluatorFailedDuringDriverRestart(resourceStatusEvent);
+
         previousEvaluatorManager.onResourceStatusMessage(resourceStatusEvent);
       } else {
         throw new RuntimeException(

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/TaskRepresenter.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/TaskRepresenter.java
@@ -88,6 +88,7 @@ public final class TaskRepresenter {
       throw new RuntimeException("Received a message for task " + taskStatusProto.getTaskId() +
           " in the TaskRepresenter for Task " + this.taskId);
     }
+
     if (driverRestartManager.getEvaluatorRestartState(evaluatorManager.getId()) == EvaluatorRestartState.REREGISTERED) {
       // when a recovered heartbeat is received, we will take its word for it
       LOG.log(Level.INFO, "Received task status {0} for RECOVERED task {1}.",
@@ -142,7 +143,7 @@ public final class TaskRepresenter {
     if (driverRestartManager.getEvaluatorRestartState(evaluatorManager.getId()) == EvaluatorRestartState.REREGISTERED) {
       final RunningTask runningTask = new RunningTaskImpl(
           this.evaluatorManager, this.taskId, this.context, this);
-      this.driverRestartManager.setEvaluatorRunningTask(evaluatorManager.getId());
+      this.driverRestartManager.setEvaluatorProcessed(evaluatorManager.getId());
       this.messageDispatcher.onDriverRestartTaskRunning(runningTask);
     }
 

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRuntimeRestartManager.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRuntimeRestartManager.java
@@ -243,6 +243,7 @@ public final class YarnDriverRuntimeRestartManager implements DriverRuntimeResta
           .setState(ReefServiceProtos.State.FAILED)
           .setExitCode(1)
           .setDiagnostics("Container [" + evaluatorId + "] failed during driver restart process.")
+          .setIsFromPreviousDriver(true)
           .build());
     }
   }


### PR DESCRIPTION
This addressed the issue by
  * Adding helper functions for ``EvaluatorManagerFactory`` to create EvaluatorManagers for recovered evaluators.
  * Recover ``EvaluatorManager`` on first heartbeat of an expected Evaluator on restart.
  * Fix a bug in ``DriverRestartManager`` where the boolean check is reversed.

JIRA:
  [REEF-617](https://issues.apache.org/jira/browse/REEF-617)