### PR TITLE
[REEF-629] Treat warnings as errors in REEF .NET build

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
@@ -292,7 +292,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
                             GenericType<MapInputwithControlMessagePipelineDataConverter<TMapInput>>.Class)
                         .Build();
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 mapInputPipelineDataConverterConfig = TangFactory.GetTang()
                     .NewConfigurationBuilder()
@@ -308,7 +308,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
                     .NewInjector(mapInputPipelineDataConverterConfig)
                     .GetInstance<IPipelineDataConverter<TMapOutput>>();
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 mapOutputPipelineDataConverterConfig =
                     TangFactory.GetTang()

--- a/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommuDriverTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommuDriverTests.cs
@@ -37,8 +37,6 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
         public void TestServiceConfiguration()
         {
             string groupName = "group1";
-            string broadcastOperatorName = "broadcast";
-            string reduceOperatorName = "reduce";
             string masterTaskId = "task0";
             string driverId = "Driver Id";
             int numTasks = 3;

--- a/lang/cs/Org.Apache.REEF.Network/NetworkService/Codec/NsMessageStreamingCodec.cs
+++ b/lang/cs/Org.Apache.REEF.Network/NetworkService/Codec/NsMessageStreamingCodec.cs
@@ -143,7 +143,7 @@ namespace Org.Apache.REEF.Network.NetworkService.Codec
             foreach (var data in obj.Data)
             {
                 var asyncResult = codecWriteFunc.BeginInvoke(data, writer, token, null, null);
-                codecWriteFunc.EndInvoke(asyncResult);
+                await codecWriteFunc.EndInvoke(asyncResult);
             }
         }
 

--- a/lang/cs/build.props
+++ b/lang/cs/build.props
@@ -37,6 +37,8 @@ under the License.
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>612,618</WarningsNotAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <BuildPackage>true</BuildPackage>
@@ -48,6 +50,8 @@ under the License.
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>612,618</WarningsNotAsErrors>
   </PropertyGroup>
 
   <!-- REEF NuGet properties -->


### PR DESCRIPTION
This addressed the issue by
 * Treating warnings as errors
 * Treating Obsolete attribute warnings (612 & 618) as warnings
 * Fix trivial warnings to make the build succeed

JIRA:
 [REEF-629](https://issues.apache.org/jira/browse/REEF-629)