### PR TITLE
[REEF-606] Generalize IPartitionedDataset

### DIFF
--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestRandomDataSet.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestRandomDataSet.cs
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.IO.PartitionedData;
 using Org.Apache.REEF.IO.PartitionedData.Random;
@@ -79,11 +80,11 @@ namespace Org.Apache.REEF.IO.Tests
                 var partition =
                     TangFactory.GetTang()
                         .NewInjector(partitionDescriptor.GetPartitionConfiguration())
-                        .GetInstance<IPartition>();
+                        .GetInstance<IPartition<Stream>>();
                 Assert.IsNotNull(partition);
                 Assert.IsNotNull(partition.Id);
 
-                using (var partitionStream = partition.Open())
+                using (var partitionStream = partition.GetPartitionHandle())
                 {
                     Assert.IsNotNull(partitionStream);
                     Assert.IsTrue(partitionStream.CanRead);

--- a/lang/cs/Org.Apache.REEF.IO/PartitionedData/IPartition.cs
+++ b/lang/cs/Org.Apache.REEF.IO/PartitionedData/IPartition.cs
@@ -24,7 +24,9 @@ namespace Org.Apache.REEF.IO.PartitionedData
     /// <summary>
     /// Evaluator-Side representation of a data set partition.
     /// </summary>
-    public interface IPartition
+    /// <typeparam name="T">Generic Type representing data pointer.
+    /// For example, for data in local file it can be file pointer </typeparam>
+    public interface IPartition<T>
     {
         /// <summary>
         /// The id of the partition.
@@ -32,9 +34,9 @@ namespace Org.Apache.REEF.IO.PartitionedData
         string Id { get; }
 
         /// <summary>
-        /// Opens the stream to the underlying partition.
+        /// Gives a pointer to the underlying partition.
         /// </summary>
-        /// <returns>A read-only stream.</returns>
-        Stream Open();
+        /// <returns>The pointer to the underlying partition</returns>
+        T GetPartitionHandle();
     }
 }

--- a/lang/cs/Org.Apache.REEF.IO/PartitionedData/Random/RandomPartition.cs
+++ b/lang/cs/Org.Apache.REEF.IO/PartitionedData/Random/RandomPartition.cs
@@ -28,7 +28,7 @@ namespace Org.Apache.REEF.IO.PartitionedData.Random
     /// <summary>
     /// An implementation of IPartition that returns a configurable number of random doubles.
     /// </summary>
-    internal sealed class RandomPartition : IPartition
+    internal sealed class RandomPartition : IPartition<Stream>
     {
         private readonly string _id;
         private readonly byte[] _randomData;
@@ -60,7 +60,7 @@ namespace Org.Apache.REEF.IO.PartitionedData.Random
             get { return _id; }
         }
 
-        public Stream Open()
+        public Stream GetPartitionHandle()
         {
             return new MemoryStream(_randomData, false);
         }

--- a/lang/cs/Org.Apache.REEF.IO/PartitionedData/Random/RandomPartitionDescriptor.cs
+++ b/lang/cs/Org.Apache.REEF.IO/PartitionedData/Random/RandomPartitionDescriptor.cs
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+using System.IO;
 using Org.Apache.REEF.IO.PartitionedData.Random.Parameters;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
@@ -42,7 +43,7 @@ namespace Org.Apache.REEF.IO.PartitionedData.Random
         public IConfiguration GetPartitionConfiguration()
         {
             return TangFactory.GetTang().NewConfigurationBuilder()
-                .BindImplementation(typeof(IPartition), typeof(RandomPartition))
+                .BindImplementation(typeof(IPartition<Stream>), typeof(RandomPartition))
                 .BindNamedParameter(typeof(PartitionId), _id)
                 .BindNamedParameter(typeof(NumberOfDoublesPerPartition), _numberOfDoubles.ToString())
                 .Build();


### PR DESCRIPTION
This addressed the issue by
* Making interface IPartition generic
* Open function is renamed to GetPartitionPointer and return pointer of generic type.
JIRA:
[REEF-606](https://issues.apache.org/jira/browse/REEF-606)