### PR TITLE
[REEF-655] Jar File path of run.sh doesn't exist

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -22,7 +22,7 @@
 # ./run.sh org.apache.reef.examples.hello.HelloREEF
 
 # RUNTIME
-SELF_JAR=`echo $REEF_HOME/reef-examples/target/reef-examples-*-shaded.jar`
+SELF_JAR=`echo $REEF_HOME/lang/java/reef-examples/target/reef-examples-*-shaded.jar`
 
 LOGGING_CONFIG='-Djava.util.logging.config.class=org.apache.reef.util.logging.Config'
 


### PR DESCRIPTION
This addressed the issue by
  * Fixed the jar file path of run.sh

JIRA: [REEF-655](https://issues.apache.org/jira/browse/REEF-655)