### PR TITLE
[REEF-518] Smarter VortexWorker-Tasklet scheduling

### DIFF
--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/DefaultVortexMaster.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/DefaultVortexMaster.java
@@ -20,6 +20,7 @@ package org.apache.reef.vortex.driver;
 
 import net.jcip.annotations.ThreadSafe;
 import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.util.Optional;
 import org.apache.reef.vortex.api.VortexFunction;
 import org.apache.reef.vortex.api.VortexFuture;
 
@@ -74,9 +75,11 @@ final class DefaultVortexMaster implements VortexMaster {
    */
   @Override
   public void workerPreempted(final String id) {
-    final Collection<Tasklet> preemptedTasklets = runningWorkers.removeWorker(id);
-    for (final Tasklet tasklet : preemptedTasklets) {
-      pendingTasklets.addFirst(tasklet);
+    final Optional<Collection<Tasklet>> preemptedTasklets = runningWorkers.removeWorker(id);
+    if (preemptedTasklets.isPresent()) {
+      for (final Tasklet tasklet : preemptedTasklets.get()) {
+        pendingTasklets.addFirst(tasklet);
+      }
     }
   }
 

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/FirstFitSchedulingPolicy.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/FirstFitSchedulingPolicy.java
@@ -85,7 +85,7 @@ class FirstFitSchedulingPolicy implements SchedulingPolicy {
     final String workerId = vortexWorker.getId();
     if (!idLoadMap.containsKey(workerId)) { // Ignore duplicate add.
       idLoadMap.put(workerId, 0);
-      idList.add(nextIndex, workerId); // prefer to schedule the new worker ASAP
+      idList.add(nextIndex, workerId); // Prefer to schedule the new worker ASAP.
     }
   }
 
@@ -96,7 +96,7 @@ class FirstFitSchedulingPolicy implements SchedulingPolicy {
   public void workerRemoved(final VortexWorkerManager vortexWorker) {
     final String workerId = vortexWorker.getId();
     if (idLoadMap.remove(workerId) != null) { // Ignore invalid removal.
-      for (int i = 0; i < idList.size(); i++) {
+      for (int i = 0; i < idList.size(); i++) { // This looping operation might degrade performance.
         if (idList.get(i).equals(workerId)) {
           idList.remove(i);
           

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/FirstFitSchedulingPolicy.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/FirstFitSchedulingPolicy.java
@@ -85,10 +85,7 @@ class FirstFitSchedulingPolicy implements SchedulingPolicy {
     final String workerId = vortexWorker.getId();
     if (!idLoadMap.containsKey(workerId)) { // Ignore duplicate add.
       idLoadMap.put(workerId, 0);
-      
-      // Insert before the next index, so that newly added worker will be searched for at last.
-      idList.add(nextIndex, workerId);
-      nextIndex = (nextIndex + 1) % idList.size();
+      idList.add(nextIndex, workerId); // prefer to schedule the new worker ASAP
     }
   }
 

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/FirstFitSchedulingPolicy.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/FirstFitSchedulingPolicy.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.vortex.driver;
+
+import org.apache.reef.tang.annotations.Parameter;
+
+import javax.inject.Inject;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+
+/**
+ * Always select the next worker that has enough resource in a round-robin fashion
+ * based on the worker capacity configured.
+ *
+ * Concurrency: shares the lock with `RunningWorkers'.
+ */
+class FirstFitSchedulingPolicy implements SchedulingPolicy {
+
+  private final int workerCapacity;
+
+  /**
+   * A linked list for a circular buffer of <worker-id, load> pairs.
+   */
+  private final List<Map.Entry<String, Integer>> loadList = new ArrayList<>();
+
+  /**
+   * A list isn't very efficient for fast lookup of worker ids, and so we keep a separate index.
+   */
+  private final HashMap<String, Integer> indexMap = new HashMap<>();
+
+  /**
+   * Invariant: the worker at [lastIndex + 1] in the circular buffer will be selected
+   * if the index is valid and the worker has enough resource.
+   */
+  private int lastIndex = -1;
+
+  @Inject
+  FirstFitSchedulingPolicy(@Parameter(VortexMasterConf.WorkerCapacity.class) final int capacity) {
+    this.workerCapacity = capacity;
+  }
+
+  /**
+   * @param tasklet to schedule
+   * @return the next worker that has enough resources for the tasklet.
+   */
+  @Override
+  public String trySchedule(final Tasklet tasklet) {
+    final int index = loadList.isEmpty() ? 0 : (lastIndex + 1) % loadList.size();
+    final String workerId = search(index, loadList.size());
+    if (index == 0 || workerId != null) {
+      return workerId;
+    } else {
+      return search(0, index);
+    }
+  }
+
+  /**
+   * @param vortexWorker added
+   */
+  @Override
+  public void workerAdded(final VortexWorkerManager vortexWorker) {
+    final String workerId = vortexWorker.getId();
+    if (indexMap.containsKey(workerId)) {
+      final int index = indexMap.get(workerId);
+      loadList.get(index).setValue(0);
+    } else {
+      loadList.add(new AbstractMap.SimpleEntry<>(workerId, 0));
+      indexMap.put(workerId, loadList.size() - 1);
+    }
+  }
+
+  /**
+   * @param vortexWorker removed
+   */
+  @Override
+  public void workerRemoved(final VortexWorkerManager vortexWorker) {
+    final String workerId = vortexWorker.getId();
+    if (indexMap.containsKey(workerId)) {
+      final Map.Entry<String, Integer> worker = loadList.get(indexMap.get(workerId));
+      // We simply mark a removal with worker capacity
+      // for that it is often transient
+      worker.setValue(workerCapacity);
+    }
+  }
+
+  /**
+   * @param vortexWorker that the tasklet was launched onto
+   * @param tasklet launched
+   */
+  @Override
+  public void taskletLaunched(final VortexWorkerManager vortexWorker, final Tasklet tasklet) {
+    final String workerId = vortexWorker.getId();
+    if (indexMap.containsKey(workerId)) {
+      final Map.Entry<String, Integer> worker = loadList.get(indexMap.get(workerId));
+      worker.setValue(Math.min(workerCapacity, worker.getValue() + 1));
+    }
+  }
+
+  /**
+   * @param vortexWorker that the tasklet completed in
+   * @param tasklet completed
+   */
+  @Override
+  public void taskletCompleted(final VortexWorkerManager vortexWorker, final Tasklet tasklet) {
+    final String workerId = vortexWorker.getId();
+    removeTasklet(workerId);
+  }
+
+  /**
+   * @param vortexWorker that the tasklet failed in
+   * @param tasklet failed
+   */
+  @Override
+  public void taskletFailed(final VortexWorkerManager vortexWorker, final Tasklet tasklet) {
+    final String workerId = vortexWorker.getId();
+    removeTasklet(workerId);
+  }
+
+  private String search(final int start, final int end) {
+    final ListIterator<Map.Entry<String, Integer>> iter = loadList.listIterator(start);
+    int index = start;
+    while (iter.hasNext() && index < end) {
+      final Map.Entry<String, Integer> worker = iter.next();
+      if (worker.getValue() < workerCapacity) {
+        lastIndex = index;
+        return worker.getKey();
+      }
+      index++;
+    }
+    return null;
+  }
+
+  private void removeTasklet(final String workerId) {
+    if (indexMap.containsKey(workerId)) {
+      final Map.Entry<String, Integer> worker = loadList.get(indexMap.get(workerId));
+      worker.setValue(Math.max(0, worker.getValue() - 1));
+    }
+  }
+
+}

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/PendingTaskletLauncher.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/PendingTaskletLauncher.java
@@ -26,24 +26,24 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Pending Tasklet Scheduler.
+ * Pending Tasklet Launcher.
  */
 @DriverSide
-final class PendingTaskletScheduler implements EventHandler<Integer> {
-  private static final Logger LOG = Logger.getLogger(PendingTaskletScheduler.class.getName());
+final class PendingTaskletLauncher implements EventHandler<Integer> {
+  private static final Logger LOG = Logger.getLogger(PendingTaskletLauncher.class.getName());
 
   private final RunningWorkers runningWorkers;
   private final PendingTasklets pendingTasklets;
 
   @Inject
-  private PendingTaskletScheduler(final RunningWorkers runningWorkers,
-                                  final PendingTasklets pendingTasklets) {
+  private PendingTaskletLauncher(final RunningWorkers runningWorkers,
+                                 final PendingTasklets pendingTasklets) {
     this.runningWorkers = runningWorkers;
     this.pendingTasklets = pendingTasklets;
   }
 
   /**
-   * Repeatedly take a tasklet from the pending queue and schedule/launch it via RunningWorkers.
+   * Repeatedly take a tasklet from the pending queue and launch it via RunningWorkers.
    */
   @Override
   public void onNext(final Integer integer) {

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/RandomSchedulingPolicy.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/RandomSchedulingPolicy.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.vortex.driver;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Randomly select a running worker for scheduling a tasklet,
+ * without considering worker load or capacity.
+ *
+ * Concurrency: shares the lock with `RunningWorkers'.
+ */
+class RandomSchedulingPolicy implements SchedulingPolicy {
+  private final Random rand = new Random();
+
+  /**
+   * Maintain a list of worker ids using array for random access/selection.
+   *
+   * Removal from an array might be costly; so instead, we keep removed worker ids in the list,
+   * for that the failure/preemption that causes removal is often transient.
+   */
+  private final List<String> idList = new ArrayList<>();
+
+  /**
+   * Set of running worker ids for fast lookup.
+   */
+  private final HashSet<String> runningSet = new HashSet<>();
+
+  /**
+   * Set of preempted (= removed) worker ids for fast lookup.
+   */
+  private final HashSet<String> preemptedSet = new HashSet<>();
+
+  @Inject
+  RandomSchedulingPolicy() {
+  }
+
+  /**
+   * @param tasklet to schedule
+   * @return a random worker
+   */
+  @Override
+  public String trySchedule(final Tasklet tasklet) {
+    if (runningSet.size() - preemptedSet.size() == 0) {
+      return null;
+    }
+    int index;
+    String workerId;
+    do {
+      index = rand.nextInt(idList.size());
+      workerId = idList.get(index);
+    } while (preemptedSet.contains(workerId));
+    return workerId;
+  }
+
+  /**
+   * @param vortexWorker added
+   */
+  @Override
+  public void workerAdded(final VortexWorkerManager vortexWorker) {
+    final String workerId = vortexWorker.getId();
+    if (!runningSet.contains(workerId)) {
+      if (!preemptedSet.remove(workerId)) {
+        idList.add(workerId);
+        runningSet.add(workerId);
+      }
+    }
+  }
+
+  /**
+   * @param vortexWorker removed
+   */
+  @Override
+  public void workerRemoved(final VortexWorkerManager vortexWorker) {
+    final String workerId = vortexWorker.getId();
+    if (!runningSet.contains(workerId)) {
+      throw new IllegalArgumentException();
+    }
+    preemptedSet.add(workerId);
+  }
+
+  /**
+   * Do nothing.
+   */
+  @Override
+  public void taskletLaunched(final VortexWorkerManager vortexWorker, final Tasklet tasklet) {
+    // Do nothing
+  }
+
+  /**
+   * Do nothing.
+   */
+  @Override
+  public void taskletCompleted(final VortexWorkerManager vortexWorker, final Tasklet tasklet) {
+    // Do nothing
+  }
+
+  /**
+   * Do nothing.
+   */
+  @Override
+  public void taskletFailed(final VortexWorkerManager vortexWorker, final Tasklet tasklet) {
+    // Do nothing
+  }
+
+}

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/RunningWorkers.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/RunningWorkers.java
@@ -19,14 +19,16 @@
 package org.apache.reef.vortex.driver;
 
 import net.jcip.annotations.ThreadSafe;
+
 import org.apache.reef.annotations.audience.DriverSide;
 
 import javax.inject.Inject;
+
 import java.io.Serializable;
 import java.util.*;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Keeps track of all running VortexWorkers and Tasklets.
@@ -37,22 +39,25 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 final class RunningWorkers {
   // RunningWorkers and its locks
   private final HashMap<String, VortexWorkerManager> runningWorkers = new HashMap<>(); // Running workers/tasklets
-  private final ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock();
-  private final Lock readLock = rwLock.readLock(); // Need to acquire this to launch/complete tasklets
-  private final Lock writeLock = rwLock.writeLock(); // Need to acquire this to add/remove worker
-  private final Condition noRunningWorker = writeLock.newCondition(); // When there's no running worker
+  private final Lock lock = new ReentrantLock();
+  private final Condition noWorkerOrResource = lock.newCondition();
 
   // To keep track of workers that are preempted before acknowledged
   private final Set<String> removedBeforeAddedWorkers = new HashSet<>();
 
   // Terminated
-  private volatile boolean terminated = false;
+  private boolean terminated = false;
+
+  // Scheduling policy
+  private final SchedulingPolicy schedulingPolicy;
+
 
   /**
    * RunningWorkers constructor.
    */
   @Inject
-  RunningWorkers() {
+  RunningWorkers(final SchedulingPolicy schedulingPolicy) {
+    this.schedulingPolicy = schedulingPolicy;
   }
 
   /**
@@ -60,23 +65,20 @@ final class RunningWorkers {
    * Parameter: Called exactly once per vortexWorkerManager.
    */
   void addWorker(final VortexWorkerManager vortexWorkerManager) {
-    if (!terminated) {
-      writeLock.lock();
-      try {
-        if (!terminated) { // Make sure it is really terminated
-          if (!removedBeforeAddedWorkers.contains(vortexWorkerManager.getId())) {
-            this.runningWorkers.put(vortexWorkerManager.getId(), vortexWorkerManager);
+    lock.lock();
+    try {
+      if (!terminated) {
+        if (!removedBeforeAddedWorkers.contains(vortexWorkerManager.getId())) {
+          this.runningWorkers.put(vortexWorkerManager.getId(), vortexWorkerManager);
+          this.schedulingPolicy.workerAdded(vortexWorkerManager);
 
-            // Notify (possibly) waiting scheduler
-            if (runningWorkers.size() == 1) {
-              noRunningWorker.signalAll();
-            }
-          }
-          return;
+          // Notify (possibly) waiting scheduler
+          noWorkerOrResource.signal();
         }
-      } finally {
-        writeLock.unlock();
+        return;
       }
+    } finally {
+      lock.unlock();
     }
 
     // Terminate the worker
@@ -88,22 +90,21 @@ final class RunningWorkers {
    * Parameter: Called exactly once per id.
    */
   Collection<Tasklet> removeWorker(final String id) {
-    if (!terminated) {
-      writeLock.lock();
-      try {
-        if (!terminated) { // Make sure it is really terminated
-          final VortexWorkerManager vortexWorkerManager = this.runningWorkers.remove(id);
-          if (vortexWorkerManager != null) {
-            return vortexWorkerManager.removed();
-          } else {
-            // Called before addWorker (e.g. RM preempted the resource before the Evaluator started)
-            removedBeforeAddedWorkers.add(id);
-            return new ArrayList<>(0);
-          }
+    lock.lock();
+    try {
+      if (!terminated) {
+        final VortexWorkerManager vortexWorkerManager = this.runningWorkers.remove(id);
+        if (vortexWorkerManager != null) {
+          this.schedulingPolicy.workerRemoved(vortexWorkerManager);
+          return vortexWorkerManager.removed();
+        } else {
+          // Called before addWorker (e.g. RM preempted the resource before the Evaluator started)
+          removedBeforeAddedWorkers.add(id);
+          return new ArrayList<>(0);
         }
-      } finally {
-        writeLock.unlock();
       }
+    } finally {
+      lock.unlock();
     }
 
     // No need to return anything since it is terminated
@@ -115,35 +116,24 @@ final class RunningWorkers {
    * Parameter: Same tasklet can be launched multiple times.
    */
   void launchTasklet(final Tasklet tasklet) {
-    if (!terminated) {
-      readLock.lock();
-      try {
-        if (!terminated) { // Make sure it is really terminated
-          // Wait until there is a running worker
-          if (runningWorkers.isEmpty()) {
-            readLock.unlock();
-            writeLock.lock();
-            try {
-              while (runningWorkers.isEmpty()) {
-                try {
-                  noRunningWorker.await();
-                } catch (InterruptedException e) {
-                  throw new RuntimeException(e);
-                }
-              }
-              readLock.lock();
-            } finally {
-              writeLock.unlock();
-            }
+    lock.lock();
+    try {
+      if (!terminated) {
+        String workerId;
+        while ((workerId = schedulingPolicy.trySchedule(tasklet)) == null) {
+          try {
+            noWorkerOrResource.await();
+          } catch (InterruptedException e) {
+            throw new RuntimeException(e);
           }
-
-          final VortexWorkerManager vortexWorkerManager = randomlyChooseWorker();
-          vortexWorkerManager.launchTasklet(tasklet);
-          return;
         }
-      } finally {
-        readLock.unlock();
+        final VortexWorkerManager vortexWorkerManager = runningWorkers.get(workerId);
+        vortexWorkerManager.launchTasklet(tasklet);
+        schedulingPolicy.taskletLaunched(vortexWorkerManager, tasklet);
+        return;
       }
+    } finally {
+      lock.unlock();
     }
   }
 
@@ -153,20 +143,23 @@ final class RunningWorkers {
    * (e.g. preemption message coming before tasklet completion message multiple times)
    */
   void completeTasklet(final String workerId,
-                              final int taskletId,
-                              final Serializable result) {
-    if (!terminated) {
-      readLock.lock();
-      try {
-        if (!terminated) { // Make sure it is really terminated
-          if (runningWorkers.containsKey(workerId)) { // Preemption can come before
-            this.runningWorkers.get(workerId).taskletCompleted(taskletId, result);
-          }
-          return;
+                       final int taskletId,
+                       final Serializable result) {
+    lock.lock();
+    try {
+      if (!terminated) {
+        if (runningWorkers.containsKey(workerId)) { // Preemption can come before
+          final VortexWorkerManager worker = this.runningWorkers.get(workerId);
+          final Tasklet tasklet = worker.taskletCompleted(taskletId, result);
+          this.schedulingPolicy.taskletCompleted(worker, tasklet);
+
+          // Notify (possibly) waiting scheduler
+          noWorkerOrResource.signal();
         }
-      } finally {
-        readLock.unlock();
+        return;
       }
+    } finally {
+      lock.unlock();
     }
   }
 
@@ -178,56 +171,45 @@ final class RunningWorkers {
   void errorTasklet(final String workerId,
                            final int taskletId,
                            final Exception exception) {
-    if (!terminated) {
-      readLock.lock();
-      try {
-        if (!terminated) { // Make sure it is really terminated
-          if (runningWorkers.containsKey(workerId)) { // Preemption can come before
-            this.runningWorkers.get(workerId).taskletThrewException(taskletId, exception);
-          }
-          return;
+    lock.lock();
+    try {
+      if (!terminated) {
+        if (runningWorkers.containsKey(workerId)) { // Preemption can come before
+          final VortexWorkerManager worker = this.runningWorkers.get(workerId);
+          final Tasklet tasklet = worker.taskletThrewException(taskletId, exception);
+          this.schedulingPolicy.taskletFailed(worker, tasklet);
+
+          // Notify (possibly) waiting scheduler
+          noWorkerOrResource.signal();
         }
-      } finally {
-        readLock.unlock();
+        return;
       }
+    } finally {
+      lock.unlock();
     }
   }
 
   void terminate() {
-    if (!terminated) {
-      writeLock.lock();
-      try {
-        if (!terminated) { // Make sure it is really terminated
-          terminated = true;
-          for (final VortexWorkerManager vortexWorkerManager : runningWorkers.values()) {
-            vortexWorkerManager.terminate();
-          }
-          runningWorkers.clear();
-          return;
+    lock.lock();
+    try {
+      if (!terminated) {
+        terminated = true;
+        for (final VortexWorkerManager vortexWorkerManager : runningWorkers.values()) {
+          vortexWorkerManager.terminate();
+          schedulingPolicy.workerRemoved(vortexWorkerManager);
         }
-      } finally {
-        writeLock.unlock();
+        runningWorkers.clear();
+        return;
       }
+    } finally {
+      lock.unlock();
     }
+
     throw new RuntimeException("Attempting to terminate an already terminated RunningWorkers");
   }
 
   boolean isTerminated() {
     return terminated;
-  }
-
-  private VortexWorkerManager randomlyChooseWorker() {
-    final Collection<VortexWorkerManager> workers = runningWorkers.values();
-    final int index = new Random().nextInt(workers.size());
-    int i = 0;
-    for (final VortexWorkerManager vortexWorkerManager : workers) {
-      if (i == index) {
-        return vortexWorkerManager;
-      } else {
-        i++;
-      }
-    }
-    throw new RuntimeException("Bad Index");
   }
 
   ///////////////////////////////////////// For Tests Only

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/RunningWorkers.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/RunningWorkers.java
@@ -88,22 +88,22 @@ final class RunningWorkers {
    * Concurrency: Called by multiple threads.
    * Parameter: Called exactly once per id.
    */
-  Collection<Tasklet> removeWorker(final String id) {
+  Optional<Collection<Tasklet>> removeWorker(final String id) {
     lock.lock();
     try {
       if (!terminated) {
         final VortexWorkerManager vortexWorkerManager = this.runningWorkers.remove(id);
         if (vortexWorkerManager != null) {
           this.schedulingPolicy.workerRemoved(vortexWorkerManager);
-          return vortexWorkerManager.removed();
+          return Optional.ofNullable(vortexWorkerManager.removed());
         } else {
           // Called before addWorker (e.g. RM preempted the resource before the Evaluator started)
           removedBeforeAddedWorkers.add(id);
-          return new ArrayList<>(0);
+          return Optional.empty();
         }
       } else {
         // No need to return anything since it is terminated
-        return new ArrayList<>(0);
+        return Optional.empty();
       }
     } finally {
       lock.unlock();

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/SchedulingPolicy.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/SchedulingPolicy.java
@@ -19,6 +19,7 @@
 package org.apache.reef.vortex.driver;
 
 import org.apache.reef.tang.annotations.DefaultImplementation;
+import org.apache.reef.util.Optional;
 
 /**
  * For choosing which worker to schedule the tasklet onto.
@@ -30,7 +31,7 @@ interface SchedulingPolicy {
    * @param tasklet to schedule
    * @return the worker onto which the tasklet should be scheduled, null if there's none
    */
-  String trySchedule(final Tasklet tasklet);
+  Optional<String> trySchedule(final Tasklet tasklet);
 
   /**
    * Worker added.

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/SchedulingPolicy.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/SchedulingPolicy.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.vortex.driver;
+
+import org.apache.reef.tang.annotations.DefaultImplementation;
+
+/**
+ * For choosing which worker to schedule the tasklet onto.
+ */
+@DefaultImplementation(FirstFitSchedulingPolicy.class)
+interface SchedulingPolicy {
+  /**
+   * Implementation of this method is expected to be fast.
+   * @param tasklet to schedule
+   * @return the worker onto which the tasklet should be scheduled, null if there's none
+   */
+  String trySchedule(final Tasklet tasklet);
+
+  /**
+   * Worker added.
+   */
+  void workerAdded(final VortexWorkerManager vortexWorker);
+
+  /**
+   * Worker removed.
+   */
+  void workerRemoved(final VortexWorkerManager vortexWorker);
+
+  /**
+   * Tasklet launched.
+   */
+  void taskletLaunched(final VortexWorkerManager vortexWorker, final Tasklet tasklet);
+
+  /**
+   * Tasklet completed.
+   */
+  void taskletCompleted(final VortexWorkerManager vortexWorker, final Tasklet tasklet);
+
+  /**
+   * Tasklet failed.
+   */
+  void taskletFailed(final VortexWorkerManager vortexWorker, final Tasklet tasklet);
+}

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexConfHelper.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexConfHelper.java
@@ -42,7 +42,8 @@ public final class VortexConfHelper {
                                             final Class<? extends VortexStart> vortexStart,
                                             final int numOfWorkers,
                                             final int workerMemory,
-                                            final int workerCores) {
+                                            final int workerCores,
+                                            final int workerCapacity) {
     final Configuration vortexDriverConf = DriverConfiguration.CONF
         .set(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getClassLocation(VortexDriver.class))
         .set(DriverConfiguration.ON_DRIVER_STARTED, VortexDriver.StartHandler.class)
@@ -57,6 +58,7 @@ public final class VortexConfHelper {
         .set(VortexMasterConf.WORKER_NUM, numOfWorkers)
         .set(VortexMasterConf.WORKER_MEM, workerMemory)
         .set(VortexMasterConf.WORKER_CORES, workerCores)
+        .set(VortexMasterConf.WORKER_CAPACITY, workerCapacity)
         .set(VortexMasterConf.VORTEX_START, vortexStart)
         .set(VortexMasterConf.NUM_OF_VORTEX_START_THERAD, DEFAULT_NUM_OF_VORTEX_START_THERAD) // fixed to 1 for now
         .build();

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexDriver.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexDriver.java
@@ -74,14 +74,14 @@ final class VortexDriver {
                        final VortexMaster vortexMaster,
                        final VortexStart vortexStart,
                        final VortexStartExecutor vortexStartExecutor,
-                       final PendingTaskletScheduler pendingTaskletScheduler,
+                       final PendingTaskletLauncher pendingTaskletLauncher,
                        @Parameter(VortexMasterConf.WorkerMem.class) final int workerMem,
                        @Parameter(VortexMasterConf.WorkerNum.class) final int workerNum,
                        @Parameter(VortexMasterConf.WorkerCores.class) final int workerCores,
                        @Parameter(VortexMasterConf.NumberOfVortexStartThreads.class) final int numOfStartThreads) {
     this.vortexStartEStage = new ThreadPoolStage<>(vortexStartExecutor, numOfStartThreads);
     this.vortexStart = vortexStart;
-    this.pendingTaskletSchedulerEStage = new SingleThreadStage<>(pendingTaskletScheduler, 1);
+    this.pendingTaskletSchedulerEStage = new SingleThreadStage<>(pendingTaskletLauncher, 1);
     this.evaluatorRequestor = evaluatorRequestor;
     this.vortexMaster = vortexMaster;
     this.vortexRequestor = vortexRequestor;

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexLauncher.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexLauncher.java
@@ -43,12 +43,18 @@ public final class VortexLauncher {
                                            final Class<? extends VortexStart> vortexUserCode,
                                            final int numOfWorkers,
                                            final int workerMemory,
-                                           final int workerCores) {
+                                           final int workerCores,
+                                           final int workerCapacity) {
     final Configuration runtimeConf = LocalRuntimeConfiguration.CONF
         .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, MAX_NUMBER_OF_EVALUATORS)
         .build();
-    final Configuration vortexConf =
-        VortexConfHelper.getVortexConf(jobName, vortexUserCode, numOfWorkers, workerMemory, workerCores);
+    final Configuration vortexConf = VortexConfHelper.getVortexConf(
+        jobName,
+        vortexUserCode,
+        numOfWorkers,
+        workerMemory,
+        workerCores,
+        workerCapacity);
     return launch(runtimeConf, vortexConf);
   }
 

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexMasterConf.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexMasterConf.java
@@ -22,10 +22,7 @@ import org.apache.reef.annotations.Unstable;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
-import org.apache.reef.tang.formats.ConfigurationModule;
-import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
-import org.apache.reef.tang.formats.RequiredImpl;
-import org.apache.reef.tang.formats.RequiredParameter;
+import org.apache.reef.tang.formats.*;
 import org.apache.reef.vortex.api.VortexStart;
 
 /**
@@ -56,6 +53,13 @@ public final class VortexMasterConf extends ConfigurationModuleBuilder {
   }
 
   /**
+   * Worker Capacity.
+   */
+  @NamedParameter(doc = "Worker Capacity")
+  final class WorkerCapacity implements Name<Integer> {
+  }
+
+  /**
    * Number of Vortex Start Threads.
    */
   @NamedParameter(doc = "Number of Vortex Start Threads")
@@ -78,6 +82,11 @@ public final class VortexMasterConf extends ConfigurationModuleBuilder {
   public static final RequiredParameter<Integer> WORKER_CORES = new RequiredParameter<>();
 
   /**
+   * Worker Cores.
+   */
+  public static final OptionalParameter<Integer> WORKER_CAPACITY = new OptionalParameter<>();
+
+  /**
    * Vortex Start.
    */
   public static final RequiredImpl<VortexStart> VORTEX_START = new RequiredImpl<>();
@@ -94,6 +103,7 @@ public final class VortexMasterConf extends ConfigurationModuleBuilder {
       .bindNamedParameter(WorkerNum.class, WORKER_NUM)
       .bindNamedParameter(WorkerMem.class, WORKER_MEM)
       .bindNamedParameter(WorkerCores.class, WORKER_CORES)
+      .bindNamedParameter(WorkerCapacity.class, WORKER_CAPACITY)
       .bindImplementation(VortexStart.class, VORTEX_START)
       .bindNamedParameter(NumberOfVortexStartThreads.class, NUM_OF_VORTEX_START_THERAD)
       .build();

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexWorkerManager.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexWorkerManager.java
@@ -25,7 +25,7 @@ import org.apache.reef.vortex.common.TaskletExecutionRequest;
 
 import java.io.Serializable;
 import java.util.Collection;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.HashMap;
 
 /**
  * Representation of a VortexWorkerManager in Driver.
@@ -35,7 +35,7 @@ import java.util.concurrent.ConcurrentHashMap;
 class VortexWorkerManager {
   private final VortexRequestor vortexRequestor;
   private final RunningTask reefTask;
-  private final ConcurrentHashMap<Integer, Tasklet> runningTasklets = new ConcurrentHashMap<>();
+  private final HashMap<Integer, Tasklet> runningTasklets = new HashMap<>();
 
   VortexWorkerManager(final VortexRequestor vortexRequestor, final RunningTask reefTask) {
     this.vortexRequestor = vortexRequestor;
@@ -51,19 +51,18 @@ class VortexWorkerManager {
     vortexRequestor.send(reefTask, taskletExecutionRequest);
   }
 
-  <TOutput extends Serializable>
-      void taskletCompleted(final Integer taskletId, final TOutput result) {
+  <TOutput extends Serializable> Tasklet taskletCompleted(final Integer taskletId, final TOutput result) {
     final Tasklet<?, TOutput> tasklet = runningTasklets.remove(taskletId);
-    if (tasklet != null) { // Tasklet should complete/error only once
-      tasklet.completed(result);
-    }
+    assert(tasklet != null); // Tasklet should complete/error only once
+    tasklet.completed(result);
+    return tasklet;
   }
 
-  void taskletThrewException(final Integer taskletId, final Exception exception) {
+  Tasklet taskletThrewException(final Integer taskletId, final Exception exception) {
     final Tasklet tasklet = runningTasklets.remove(taskletId);
-    if (tasklet != null) { // Tasklet should complete/error only once
-      tasklet.threwException(exception);
-    }
+    assert(tasklet != null); // Tasklet should complete/error only once
+    tasklet.threwException(exception);
+    return tasklet;
   }
 
   Collection<Tasklet> removed() {

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexWorkerManager.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/VortexWorkerManager.java
@@ -18,7 +18,7 @@
  */
 package org.apache.reef.vortex.driver;
 
-import net.jcip.annotations.ThreadSafe;
+import net.jcip.annotations.NotThreadSafe;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.driver.task.RunningTask;
 import org.apache.reef.vortex.common.TaskletExecutionRequest;
@@ -30,7 +30,7 @@ import java.util.HashMap;
 /**
  * Representation of a VortexWorkerManager in Driver.
  */
-@ThreadSafe
+@NotThreadSafe
 @DriverSide
 class VortexWorkerManager {
   private final VortexRequestor vortexRequestor;
@@ -66,7 +66,7 @@ class VortexWorkerManager {
   }
 
   Collection<Tasklet> removed() {
-    return runningTasklets.values();
+    return runningTasklets.isEmpty() ? null : runningTasklets.values();
   }
 
   void terminate() {

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/addone/AddOne.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/addone/AddOne.java
@@ -31,6 +31,6 @@ final class AddOne {
    * Launch the vortex job, passing appropriate arguments.
    */
   public static void main(final String[] args) {
-    VortexLauncher.launchLocal("Vortex_Example_AddOne", AddOneStart.class, 2, 1024, 4);
+    VortexLauncher.launchLocal("Vortex_Example_AddOne", AddOneStart.class, 2, 1024, 4, 2000);
   }
 }

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/hello/HelloVortex.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/examples/hello/HelloVortex.java
@@ -31,6 +31,6 @@ final class HelloVortex {
    * Launch the vortex job, passing appropriate arguments.
    */
   public static void main(final String[] args) {
-    VortexLauncher.launchLocal("Vortex_Example_HelloVortex", HelloVortexStart.class, 1, 1024, 1);
+    VortexLauncher.launchLocal("Vortex_Example_HelloVortex", HelloVortexStart.class, 1, 1024, 1, 2000);
   }
 }

--- a/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/RunningWorkersTest.java
+++ b/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/RunningWorkersTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertTrue;
  * Test Possible Race Conditions.
  */
 public class RunningWorkersTest {
-  private final RunningWorkers runningWorkers = new RunningWorkers();
+  private final RunningWorkers runningWorkers = new RunningWorkers(new RandomSchedulingPolicy());
   private final TestUtil testUtil = new TestUtil();
 
   /**

--- a/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/RunningWorkersTest.java
+++ b/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/RunningWorkersTest.java
@@ -40,7 +40,7 @@ public class RunningWorkersTest {
   @Test
   public void removeExecutorAndAddExecutor() throws Exception {
     final VortexWorkerManager vortexWorkerManager = testUtil.newWorker();
-    assertEquals("Must be no running tasklets", 0, runningWorkers.removeWorker(vortexWorkerManager.getId()).size());
+    assertFalse("Must be no running tasklets", runningWorkers.removeWorker(vortexWorkerManager.getId()).isPresent());
     runningWorkers.addWorker(vortexWorkerManager);
     assertFalse("Executor should not be running", runningWorkers.isWorkerRunning(vortexWorkerManager.getId()));
   }
@@ -55,7 +55,7 @@ public class RunningWorkersTest {
     final Tasklet tasklet = testUtil.newTasklet();
     runningWorkers.addWorker(vortexWorkerManager);
     runningWorkers.launchTasklet(tasklet); // blocks when no worker exists
-    final Collection<Tasklet> tasklets = runningWorkers.removeWorker(vortexWorkerManager.getId());
+    final Collection<Tasklet> tasklets = runningWorkers.removeWorker(vortexWorkerManager.getId()).get();
     assertEquals("Only 1 Tasklet must have been running", 1, tasklets.size());
     assertTrue("This Tasklet must have been running", tasklets.contains(tasklet));
     runningWorkers.completeTasklet(vortexWorkerManager.getId(), tasklet.getId(), null);

--- a/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/SchedulingPolicyTest.java
+++ b/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/SchedulingPolicyTest.java
@@ -19,9 +19,7 @@
 package org.apache.reef.vortex.driver;
 
 import org.junit.Test;
-
 import java.util.ArrayList;
-
 import static org.junit.Assert.*;
 
 /**
@@ -59,12 +57,12 @@ public class SchedulingPolicyTest {
     // Launch 1 tasklet per worker
     for (final VortexWorkerManager worker : workers) {
       final Tasklet tasklet = testUtil.newTasklet();
-      assertEquals("This should be the first fit", worker.getId(), policy.trySchedule(tasklet));
+      assertEquals("This should be the first fit", worker.getId(), policy.trySchedule(tasklet).get());
       policy.taskletLaunched(worker, tasklet);
     }
 
     // When all workers are full...
-    assertNull("Should return null as all workers are now full", policy.trySchedule(testUtil.newTasklet()));
+    assertFalse("All workers should be full", policy.trySchedule(testUtil.newTasklet()).isPresent());
   }
 
   /**
@@ -92,13 +90,13 @@ public class SchedulingPolicyTest {
     for (int i = 0; i < numOfWorkers; i++) {
       if (i % 2 == 0) {
         final Tasklet tasklet = testUtil.newTasklet();
-        assertEquals("This should be the first fit", workers.get(i).getId(), policy.trySchedule(tasklet));
+        assertEquals("This should be the first fit", workers.get(i).getId(), policy.trySchedule(tasklet).get());
         policy.taskletLaunched(workers.get(i), tasklet);
       }
     }
 
     // When all workers are full...
-    assertNull("Should return null as all workers are now full", policy.trySchedule(testUtil.newTasklet()));
+    assertFalse("All workers should be full", policy.trySchedule(testUtil.newTasklet()).isPresent());
   }
 
   /**
@@ -106,15 +104,15 @@ public class SchedulingPolicyTest {
    */
   private void commonPolicyTests(final SchedulingPolicy policy) {
     // Initial state
-    assertNull("No worker added yet", policy.trySchedule(testUtil.newTasklet()));
+    assertFalse("No worker added yet", policy.trySchedule(testUtil.newTasklet()).isPresent());
 
     // One worker added
     final VortexWorkerManager worker = testUtil.newWorker();
     policy.workerAdded(worker);
-    assertEquals("Only one worker exists", worker.getId(), policy.trySchedule(testUtil.newTasklet()));
+    assertEquals("Only one worker exists", worker.getId(), policy.trySchedule(testUtil.newTasklet()).get());
 
     // One worker removed
     policy.workerRemoved(worker);
-    assertNull("No worker exists", policy.trySchedule(testUtil.newTasklet()));
+    assertFalse("No worker exists", policy.trySchedule(testUtil.newTasklet()).isPresent());
   }
 }

--- a/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/SchedulingPolicyTest.java
+++ b/lang/java/reef-applications/reef-vortex/src/test/java/org/apache/reef/vortex/driver/SchedulingPolicyTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.vortex.driver;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test SchedulingPolicy.
+ */
+public class SchedulingPolicyTest {
+  private final TestUtil testUtil = new TestUtil();
+
+  /**
+   * Test common traits of different scheduling policies.
+   */
+  @Test
+  public void testCommon() throws Exception {
+    commonPolicyTests(new RandomSchedulingPolicy());
+    commonPolicyTests(new FirstFitSchedulingPolicy(10));
+  }
+
+  /**
+   * Test FirstFitSchedulingPolicy without preemption events.
+   */
+  @Test
+  public void testFirstFitNoPreemption() throws Exception {
+    final int workerCapacity = 1;
+    final int numOfWorkers = 5;
+    final FirstFitSchedulingPolicy policy = new FirstFitSchedulingPolicy(workerCapacity);
+
+    // Add workers
+    final ArrayList<VortexWorkerManager> workers = new ArrayList<>();
+    for (int i = 0; i < numOfWorkers; i++) {
+      final VortexWorkerManager worker = testUtil.newWorker();
+      workers.add(worker);
+      policy.workerAdded(worker);
+    }
+
+    // Launch 1 tasklet per worker
+    for (final VortexWorkerManager worker : workers) {
+      final Tasklet tasklet = testUtil.newTasklet();
+      assertEquals("This should be the first fit", worker.getId(), policy.trySchedule(tasklet));
+      policy.taskletLaunched(worker, tasklet);
+    }
+
+    // When all workers are full...
+    assertNull("Should return null as all workers are now full", policy.trySchedule(testUtil.newTasklet()));
+  }
+
+  /**
+   * Test FirstFitSchedulingPolicy with preemption events.
+   */
+  @Test
+  public void testFirstFitPreemptions() throws Exception {
+    final int workerCapacity = 1;
+    final int numOfWorkers = 10;
+    final FirstFitSchedulingPolicy policy = new FirstFitSchedulingPolicy(workerCapacity);
+
+    // Add workers and make the odd ones full
+    final ArrayList<VortexWorkerManager> workers = new ArrayList<>();
+    for (int i = 0; i < numOfWorkers; i++) {
+      final VortexWorkerManager worker = testUtil.newWorker();
+      workers.add(worker);
+      policy.workerAdded(worker);
+
+      if (i % 2 == 1) {
+        policy.taskletLaunched(worker, testUtil.newTasklet());
+      }
+    }
+
+    // Check whether the policy returns even ones in order
+    for (int i = 0; i < numOfWorkers; i++) {
+      if (i % 2 == 0) {
+        final Tasklet tasklet = testUtil.newTasklet();
+        assertEquals("This should be the first fit", workers.get(i).getId(), policy.trySchedule(tasklet));
+        policy.taskletLaunched(workers.get(i), tasklet);
+      }
+    }
+
+    // When all workers are full...
+    assertNull("Should return null as all workers are now full", policy.trySchedule(testUtil.newTasklet()));
+  }
+
+  /**
+   * Simple common tests.
+   */
+  private void commonPolicyTests(final SchedulingPolicy policy) {
+    // Initial state
+    assertNull("No worker added yet", policy.trySchedule(testUtil.newTasklet()));
+
+    // One worker added
+    final VortexWorkerManager worker = testUtil.newWorker();
+    policy.workerAdded(worker);
+    assertEquals("Only one worker exists", worker.getId(), policy.trySchedule(testUtil.newTasklet()));
+
+    // One worker removed
+    policy.workerRemoved(worker);
+    assertNull("No worker exists", policy.trySchedule(testUtil.newTasklet()));
+  }
+}

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/applications/vortex/addone/AddOneTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/applications/vortex/addone/AddOneTest.java
@@ -56,7 +56,7 @@ public final class AddOneTest {
   @Test
   public void testVortexAddOne() {
     final Configuration conf =
-        VortexConfHelper.getVortexConf("TEST_Vortex_AddOneTest", AddOneTestStart.class, 2, 1024, 4);
+        VortexConfHelper.getVortexConf("TEST_Vortex_AddOneTest", AddOneTestStart.class, 2, 1024, 4, 2000);
     final LauncherStatus status = this.testEnvironment.run(conf);
     Assert.assertTrue("Job state after execution: " + status, status.isSuccess());
   }


### PR DESCRIPTION
This addressed the issue by
  * Creating pluggable SchedulingPolicy for choosing a worker to launch a tasklet onto.
  * Implementing two types of SchedulingPolicy: FirstFit and Random.
  * Creating unit tests for testing these two policies.
  * Making changes in related classes to configure and use the SchedulingPolicy.

Zhengping Qian implemented the core logic. John Yang wrote tests, code for configurations, and JavaDocs.
Note that we changed the name of the class PendingTaskletScheduler to PendingTaskletLauncher to
make it clearer that the worker-tasklet matching is the responsibility of RunningWorkers.
In the code you can see that SchedulingPolicy is injected into RunningWorkers and used there.

We expect that later the PendingTaskletLauncher will be responsibile for addressing [REEF-500](https://issues.apache.org/jira/browse/REEF-500).

JIRA:
  [REEF-518](https://issues.apache.org/jira/browse/REEF-518)