### PR TITLE
[REEF-646] Remove APIs deprecated since 0.12 from reef-io

### DIFF
--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/data/loading/DataLoadingREEF.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/data/loading/DataLoadingREEF.java
@@ -95,11 +95,10 @@ public final class DataLoadingREEF {
         .build();
 
     final Configuration dataLoadConfiguration = new DataLoadingRequestBuilder()
-        .setMemoryMB(1024)
         .setInputFormatClass(TextInputFormat.class)
         .setInputPath(inputDir)
         .setNumberOfDesiredSplits(NUM_SPLITS)
-        .setComputeRequest(computeRequest)
+        .addComputeRequest(computeRequest)
         .setDriverConfigurationModule(DriverConfiguration.CONF
             .set(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getClassLocation(LineCounter.class))
             .set(DriverConfiguration.ON_CONTEXT_ACTIVE, LineCounter.ContextActiveHandler.class)

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/BGDClient.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/BGDClient.java
@@ -101,11 +101,10 @@ public class BGDClient {
         .setMemory(memory)
         .build();
     final Configuration dataLoadConfiguration = new DataLoadingRequestBuilder()
-        .setMemoryMB(memory)
         .setInputFormatClass(TextInputFormat.class)
         .setInputPath(input)
         .setNumberOfDesiredSplits(numSplits)
-        .setComputeRequest(computeRequest)
+        .addComputeRequest(computeRequest)
         .renewFailedEvaluators(false)
         .setDriverConfigurationModule(DriverConfiguration.CONF
             .setMultiple(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getAllClasspathJars())

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/api/DataLoader.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/api/DataLoader.java
@@ -39,8 +39,6 @@ import org.apache.reef.wake.time.event.StartTime;
 
 import javax.inject.Inject;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -83,27 +81,6 @@ public class DataLoader {
   private int computeEvalMemoryMB;
   private int computeEvalCore;
   private final EvaluatorRequestor requestor;
-
-  /**
-   * @deprecated since 0.12. Should use the other constructor instead, which
-   *             allows to specify different compute requests (i.e. masters) and
-   *             data requests (i.e. slaves), in particular racks
-   */
-  @Deprecated
-  @Inject
-  public DataLoader(
-      final Clock clock,
-      final EvaluatorRequestor requestor,
-      final DataLoadingService dataLoadingService,
-      @Parameter(DataLoadingRequestBuilder.DataLoadingEvaluatorMemoryMB.class) final int dataEvalMemoryMB,
-      @Parameter(DataLoadingRequestBuilder.DataLoadingEvaluatorNumberOfCores.class) final int dataEvalCore,
-      @Parameter(DataLoadingRequestBuilder.DataLoadingComputeRequest.class) final String serializedComputeRequest) {
-    this(clock, requestor, dataLoadingService, new HashSet<String>(
-        Arrays.asList(serializedComputeRequest)), new HashSet<String>(
-        Arrays.asList(AvroEvaluatorRequestSerializer.toString(EvaluatorRequest
-            .newBuilder().setMemory(dataEvalMemoryMB)
-            .setNumberOfCores(dataEvalCore).build()))));
-  }
 
   /**
    * Allows to specify compute and data evaluator requests in particular

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/InputFormatLoadingService.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/InputFormatLoadingService.java
@@ -18,7 +18,6 @@
  */
 package org.apache.reef.io.data.loading.impl;
 
-import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.reef.annotations.audience.DriverSide;
@@ -37,15 +36,13 @@ import org.apache.reef.tang.exceptions.BindException;
 
 import javax.inject.Inject;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Random;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
  * An implementation of {@link DataLoadingService}
- * that uses the Hadoop {@link InputFormat} to find
+ * that uses the Hadoop {@link org.apache.hadoop.mapred.InputFormat} to find
  * partitions of data & request resources.
  * <p/>
  * The InputFormat is taken from the job configurations
@@ -68,27 +65,6 @@ public class InputFormatLoadingService<K, V> implements DataLoadingService {
   private final boolean inMemory;
 
   private final String inputFormatClass;
-
-
-  /**
-   * @deprecated since 0.12. Should use the other constructor instead, which
-   *             allows to specify the strategy on how to assign partitions to
-   *             evaluators. This one by default uses {@link SingleDataCenterEvaluatorToPartitionStrategy}
-   *
-   */
-  @Deprecated
-  @Inject
-  public InputFormatLoadingService(
-      final InputFormat<K, V> inputFormat,
-      final JobConf jobConf,
-      @Parameter(DataLoadingRequestBuilder.NumberOfDesiredSplits.class) final int numberOfDesiredSplits,
-      @Parameter(DataLoadingRequestBuilder.LoadDataIntoMemory.class) final boolean inMemory,
-      @Parameter(JobConfExternalConstructor.InputFormatClass.class) final String inputFormatClass,
-      @Parameter(JobConfExternalConstructor.InputPath.class) final String inputPath) {
-    this(new SingleDataCenterEvaluatorToPartitionStrategy(inputFormatClass, new HashSet<String>(
-        Arrays.asList(DistributedDataSetPartitionSerializer.serialize(new DistributedDataSetPartition(inputPath,
-            DistributedDataSetPartition.LOAD_INTO_ANY_LOCATION, numberOfDesiredSplits))))), inMemory, inputFormatClass);
-  }
 
   @Inject
   public InputFormatLoadingService(


### PR DESCRIPTION
This removes deprecated fields/methods in DataLoader,
DataLoadingRequestBuilder and InputFormatLoadingService.

JIRA:
  [REEF-646](https://issues.apache.org/jira/browse/REEF-646)

Pull Request:
  Closes #