### PR TITLE
[REEF-653] Remove usage of get/setIsFromPreviousDriver()

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/EvaluatorRestartState.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/EvaluatorRestartState.java
@@ -121,4 +121,17 @@ public enum EvaluatorRestartState {
       return false;
     }
   }
+
+  /**
+   * @return true if the evaluator has failed on driver restart or has been expired.
+   */
+  public boolean isFailedOrExpired() {
+    switch(this) {
+    case FAILED:
+    case EXPIRED:
+      return true;
+    default:
+      return false;
+    }
+  }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManagerFactory.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManagerFactory.java
@@ -131,20 +131,6 @@ public final class EvaluatorManagerFactory {
    * @param resourceStatusEvent
    * @return an EvaluatorManager for the user to call fail on.
    */
-  public EvaluatorManager createForEvaluatorFailedDuringDriverRestart(final ResourceStatusEvent resourceStatusEvent) {
-    if (!resourceStatusEvent.getIsFromPreviousDriver().get()) {
-      throw new RuntimeException("Invalid resourceStatusEvent, must be status for resource from previous Driver.");
-    }
-    return getNewEvaluatorManagerInstance(resourceStatusEvent.getIdentifier(),
-        new EvaluatorDescriptorImpl(null, 128, 1, processFactory.newEvaluatorProcess()));
-  }
-
-  /**
-   * Instantiates a new EvaluatorManager for a failed evaluator during driver restart.
-   * Does not fire an EvaluatorAllocatedEvent.
-   * @param resourceStatusEvent
-   * @return an EvaluatorManager for the user to call fail on.
-   */
   public EvaluatorManager getNewEvaluatorManagerForEvaluatorFailedDuringDriverRestart(
       final ResourceStatusEvent resourceStatusEvent) {
     return getNewEvaluatorManagerInstance(resourceStatusEvent.getIdentifier(),

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceStatusEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceStatusEvent.java
@@ -51,9 +51,4 @@ public interface ResourceStatusEvent {
    * @return Exit code of the resource, if it has exited
    */
   Optional<Integer> getExitCode();
-
-  /**
-   * @return If true, this resource is from a previous Driver (the Driver was restarted)
-   */
-  Optional<Boolean> getIsFromPreviousDriver();
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceStatusEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceStatusEventImpl.java
@@ -31,14 +31,12 @@ public final class ResourceStatusEventImpl implements ResourceStatusEvent {
   private final ReefServiceProtos.State state;
   private final Optional<String> diagnostics;
   private final Optional<Integer> exitCode;
-  private final Optional<Boolean> isFromPreviousDriver;
 
   private ResourceStatusEventImpl(final Builder builder) {
     this.identifier = BuilderUtils.notNull(builder.identifier);
     this.state = BuilderUtils.notNull(builder.state);
     this.diagnostics = Optional.ofNullable(builder.diagnostics);
     this.exitCode = Optional.ofNullable(builder.exitCode);
-    this.isFromPreviousDriver = Optional.ofNullable(builder.isFromPreviousDriver);
   }
 
   @Override
@@ -61,11 +59,6 @@ public final class ResourceStatusEventImpl implements ResourceStatusEvent {
     return exitCode;
   }
 
-  @Override
-  public Optional<Boolean> getIsFromPreviousDriver() {
-    return isFromPreviousDriver;
-  }
-
   public static Builder newBuilder() {
     return new Builder();
   }
@@ -78,7 +71,6 @@ public final class ResourceStatusEventImpl implements ResourceStatusEvent {
     private ReefServiceProtos.State state;
     private String diagnostics;
     private Integer exitCode;
-    private Boolean isFromPreviousDriver;
 
     /**
      * @see ResourceStatusEvent#getIdentifier()
@@ -109,14 +101,6 @@ public final class ResourceStatusEventImpl implements ResourceStatusEvent {
      */
     public Builder setExitCode(final int exitCode) {
       this.exitCode = exitCode;
-      return this;
-    }
-
-    /**
-     * @see ResourceStatusEvent#getIsFromPreviousDriver()
-     */
-    public Builder setIsFromPreviousDriver(final boolean isFromPreviousDriver) {
-      this.isFromPreviousDriver = isFromPreviousDriver;
       return this;
     }
 

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRuntimeRestartManager.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRuntimeRestartManager.java
@@ -243,7 +243,6 @@ public final class YarnDriverRuntimeRestartManager implements DriverRuntimeResta
           .setState(ReefServiceProtos.State.FAILED)
           .setExitCode(1)
           .setDiagnostics("Container [" + evaluatorId + "] failed during driver restart process.")
-          .setIsFromPreviousDriver(true)
           .build());
     }
   }


### PR DESCRIPTION
This addressed the issue by
  * Remove ``get/setIsFromPreviousDriver()`` and use the state in ``DriverRestartManager`` instead.

JIRA:
  [REEF-653](https://issues.apache.org/jira/browse/REEF-653)