### PR TITLE
[REEF-663]  Make Http Endpoint available for client

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/API/IREEFClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/IREEFClient.cs
@@ -17,6 +17,9 @@
  * under the License.
  */
 
+using System;
+using Org.Apache.REEF.Client.Common;
+
 namespace Org.Apache.REEF.Client.API
 {
     /// <summary>
@@ -29,6 +32,7 @@ namespace Org.Apache.REEF.Client.API
         /// Submit the job described in jobSubmission to the cluster.
         /// </summary>
         /// <param name="jobSubmission"></param>
-        void Submit(IJobSubmission jobSubmission);
+        /// <returns>IDriverHttpEndpoint</returns>
+        IDriverHttpEndpoint Submit(IJobSubmission jobSubmission);
     }
 }

--- a/lang/cs/Org.Apache.REEF.Client/Common/HttpClientHelper.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/HttpClientHelper.cs
@@ -1,0 +1,344 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Org.Apache.REEF.Utilities.Logging;
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Org.Apache.REEF.Client.Common
+{
+    internal class HttpClientHelper : IDriverHttpEndpoint
+    {
+        private static readonly Logger LOGGER = Logger.GetLogger(typeof (HttpClientHelper));
+        private const int MaxConnectAttemptCount = 20;
+        private const int MilliSecondsToWaitBeforeNextConnectAttempt = 1000;
+        private const int SecondsForHttpClientTimeout = 120;
+        private const string UnAssigned = "UNASSIGNED";
+        private const string TrackingUrlKey = "trackingUrl";
+        private const string AppKey = "app";
+        private const string ThisIsStandbyRm = "This is standby RM";
+        private const string AppJson = "application/json";
+
+        private string _driverUrl;
+
+        private readonly HttpClient _client;
+
+        internal HttpClientHelper()
+        {
+            _client = new HttpClient
+            {
+                Timeout = TimeSpan.FromSeconds(SecondsForHttpClientTimeout),
+            };
+            _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(AppJson));
+        }
+
+        public string DriverUrl { get { return _driverUrl; } }
+
+        public string GetUrlResult(string url)
+        {
+            var task = Task.Run(() => CallUrl(url));
+            task.Wait();
+            return task.Result;
+        }
+
+        enum UrlResultKind
+        {
+            WasNotAbleToTalkToRm,
+            BackupRm,
+            AppIdNotThereYet,
+            UrlNotAssignedYet,
+            GotAppIdUrl,
+        }
+
+        internal static List<string> GetRmUri(string filePath)
+        {
+            using (var sr = new StreamReader(File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.Read)))
+            {
+                sr.ReadLine(); // appid 
+                sr.ReadLine(); // trackingUrl
+                var rmList = new List<string>();
+                var rmUri = sr.ReadLine();
+                while (rmUri != null)
+                {                    
+                    rmList.Add(rmUri);
+                    rmUri = sr.ReadLine();
+                }
+                return rmList;
+            }
+        }
+
+        internal static string GetAppId(string filePath)
+        {
+            using (var sr = new StreamReader(File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.Read)))
+            {
+                var appId = sr.ReadLine();                
+                return appId;
+            }
+        }
+
+        internal static string GetTrackingUrl(string filePath)
+        {
+            using (var sr = new StreamReader(File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.Read)))
+            {
+                sr.ReadLine(); // appid
+                var trackingUrl = sr.ReadLine();
+                return "http://" + trackingUrl + "/";
+            }
+        }
+
+        internal async Task<string> CallUrl (string url)
+        {
+            var result = await TryGetUri(url);
+            if (HasCommandFailed(result))
+            {
+                return null;
+            }
+            LOGGER.Log(Level.Warning, "CallUrl result " + result.Item2);
+            return result.Item2;
+        }
+
+        internal string GetDriverUrlForYarn(String filePath)
+        {
+            _driverUrl = GetTrackingUrl(filePath);
+            return _driverUrl;
+        }
+
+        internal string GetDriverUrlForLocalRuntime(string filePath)
+        {
+            _driverUrl = null;
+            for (int i = 0; i < 10; i++)
+            {
+                var driverUrl = TryReadHttpServerIpAndPortFromFile(filePath);
+                if (!string.IsNullOrEmpty(driverUrl))
+                {
+                    _driverUrl = "http://" + driverUrl + "/";
+                    break;
+                }
+                Thread.Sleep(1000);
+            }
+            return _driverUrl;
+        }
+
+        private string TryReadHttpServerIpAndPortFromFile(String fileName)
+        {
+            string httpServerIpAndPort = null;
+            try
+            {
+                LOGGER.Log(Level.Info, "try open " + fileName);
+                using (var rdr = new StreamReader(File.OpenRead(fileName)))
+                {
+                    httpServerIpAndPort = rdr.ReadLine();
+                    LOGGER.Log(Level.Info, "httpServerIpAndPort is " + httpServerIpAndPort);
+                }
+            }
+            catch (FileNotFoundException)
+            {
+                LOGGER.Log(Level.Info, "File does not exist: " + fileName);
+            }
+            return httpServerIpAndPort;
+        }
+
+        internal async Task<string> GetAppIdTrackingUrl(string url)
+        {
+            var result = await TryGetUri(url);
+            if (HasCommandFailed(result) ||  
+                result.Item2 == null)                
+            {
+                return null;
+            }
+
+            LOGGER.Log(Level.Info, "GetAppIdTrackingUrl: " + result.Item2);
+            return result.Item2;
+        }
+
+        private static bool ShouldRetry(HttpRequestException httpRequestException)
+        {
+            var shouldRetry = false;
+            if (httpRequestException.Message.IndexOf(((int)(HttpStatusCode.NotFound)).ToString(), StringComparison.Ordinal) != -1 ||
+                httpRequestException.Message.IndexOf(((int)(HttpStatusCode.BadGateway)).ToString(), StringComparison.Ordinal) != -1)
+            {
+                shouldRetry = true;
+            }
+            else
+            {
+                var webException = httpRequestException.InnerException as System.Net.WebException;
+                if (webException != null)
+                {
+                    if (webException.Status == System.Net.WebExceptionStatus.ConnectFailure)
+                    {
+                        shouldRetry = true;
+                    }
+                }
+            }
+            return shouldRetry;
+        }
+
+        private static Tuple<bool, string> CommandFailed(String reason)
+        {
+            return new Tuple<bool, string>(false, null);
+        }
+
+        private static Tuple<bool, string> CommandSucceeded(string commandResult)
+        {
+            return new Tuple<bool, string>(true, commandResult);
+        }
+
+        private bool HasCommandFailed(Tuple<bool, string> httpCallResult)
+        {
+            return !httpCallResult.Item1;
+        }
+
+        internal async Task<Tuple<bool, string>> TryGetUri(string commandUri)
+        {
+            var connectAttemptCount = 0;
+            Tuple<bool, string> result;
+
+            while (true)
+            {
+                try
+                {
+                    string strResult = null;
+                    LOGGER.Log(Level.Warning, "Try url [" + commandUri + "] connectAttemptCount " + connectAttemptCount + ".");
+                    strResult = await _client.GetStringAsync(commandUri);
+                    result = CommandSucceeded(strResult);
+                    LOGGER.Log(Level.Warning, "Connection succeeded. connectAttemptCount was " + connectAttemptCount + ".");
+                    break;
+                }
+                catch (HttpRequestException httpRequestException)
+                {
+                    if (!ShouldRetry(httpRequestException))
+                    {
+                        LOGGER.Log(Level.Error,
+                            commandUri + " exception " + httpRequestException.Message + "\n" +
+                            httpRequestException.StackTrace);
+                        result = CommandFailed(httpRequestException.Message);
+                        LOGGER.Log(Level.Warning, "Connection failed. connectAttemptCount was " + connectAttemptCount + ".");
+                        break;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    LOGGER.Log(Level.Error, commandUri + " exception " + ex.Message + "\n" + ex.StackTrace);
+                    result = CommandFailed(ex.Message);
+                    LOGGER.Log(Level.Warning, "Connection failed. connectAttemptCount was " + connectAttemptCount + ".");
+                    break;
+                }
+
+                ++connectAttemptCount;
+                if (connectAttemptCount >= MaxConnectAttemptCount)
+                {
+                    result = CommandFailed("Could not connect to " + commandUri + " after " + MaxConnectAttemptCount.ToString() + "attempts.");
+                    LOGGER.Log(Level.Warning, "Connection failed. connectAttemptCount was " + connectAttemptCount + ".");
+                    break;
+                }
+
+                Thread.Sleep(MilliSecondsToWaitBeforeNextConnectAttempt);
+            }
+
+            return result;
+        }
+
+        internal async Task<string> TryUntilNoConnection(string commandUri)
+        {
+            var connectAttemptCount = 0;
+            while (true)
+            {
+                try
+                {
+                    var strResult = await _client.GetStringAsync(commandUri);
+                    LOGGER.Log(Level.Info,
+                        "Connection succeeded. connectAttemptCount was " + connectAttemptCount + ".");
+                }
+                catch (HttpRequestException httpRequestException)
+                {
+                    LOGGER.Log(Level.Info, httpRequestException.Message);
+                    break;
+                }
+                catch (Exception e)
+                {
+                    LOGGER.Log(Level.Info, e.Message);
+                    break;
+                }
+
+                ++connectAttemptCount;
+                if (connectAttemptCount >= MaxConnectAttemptCount)
+                {
+                    LOGGER.Log(Level.Info, "Can still connect to " + commandUri + " after " + MaxConnectAttemptCount.ToString() + "attempts.");
+                    break;
+                }
+
+                Thread.Sleep(MilliSecondsToWaitBeforeNextConnectAttempt);
+            }
+
+            return null;
+        }
+
+        private static bool ShouldRetry(HttpStatusCode httpStatusCode)
+        {
+            return httpStatusCode == HttpStatusCode.NotFound;
+        }
+
+        private UrlResultKind CheckUrlAttempt(string result)
+        {
+            UrlResultKind resultKind = UrlResultKind.WasNotAbleToTalkToRm;
+            if (string.IsNullOrEmpty(result))
+            {
+                resultKind = UrlResultKind.WasNotAbleToTalkToRm;
+            }
+            else if (result.StartsWith(ThisIsStandbyRm))
+            {
+                resultKind = UrlResultKind.BackupRm;
+            }
+            else
+            {
+                dynamic deserializedValue = JsonConvert.DeserializeObject(result);
+                var values = deserializedValue[AppKey];
+                if (values == null || values[TrackingUrlKey] == null)
+                {
+                    resultKind = UrlResultKind.AppIdNotThereYet;
+                }
+                else
+                {
+                    _driverUrl = values[TrackingUrlKey].ToString();
+                    LOGGER.Log(Level.Info, "trackingUrl[" + _driverUrl + "]");
+
+                    if (0 == String.Compare(_driverUrl, UnAssigned))
+                    {
+                        resultKind = UrlResultKind.UrlNotAssignedYet;
+                    }
+                    else
+                    {
+                        resultKind = UrlResultKind.GotAppIdUrl;
+                    }
+
+                }
+            }
+
+            LOGGER.Log(Level.Info, "CheckUrlAttempt " + resultKind);
+            return resultKind;
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Client/Common/IDriverHttpEndpoint.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/IDriverHttpEndpoint.cs
@@ -1,4 +1,4 @@
-/*
+﻿/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -17,14 +17,11 @@
  * under the License.
  */
 
-package org.apache.reef.driver.parameters;
-
-import org.apache.reef.tang.annotations.NamedParameter;
-import org.apache.reef.tang.annotations.Name;
-
-/**
- * The job submission directory.
- */
-@NamedParameter(doc = "The job submission directory.")
-public final class JobSubmissionDirectory implements Name<String> {
+namespace Org.Apache.REEF.Client.Common
+{   
+    public interface IDriverHttpEndpoint
+    {
+        string GetUrlResult(string url);
+        string DriverUrl { get; }
+    }
 }

--- a/lang/cs/Org.Apache.REEF.Client/Common/JavaClientLauncher.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/JavaClientLauncher.cs
@@ -100,6 +100,7 @@ namespace Org.Apache.REEF.Client.Common
             IList<string> arguments = new List<string>();
             arguments.Add("-cp");
             arguments.Add(GetClientClasspath());
+            arguments.Add("-Djava.util.logging.config.class=org.apache.reef.util.logging.Config");
             arguments.Add(javaClassName);
             foreach (var parameter in parameters)
             {

--- a/lang/cs/Org.Apache.REEF.Client/Local/LocalClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Local/LocalClient.cs
@@ -20,9 +20,11 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Org.Apache.REEF.Client.API;
 using Org.Apache.REEF.Client.Common;
 using Org.Apache.REEF.Client.Local.Parameters;
+using Org.Apache.REEF.Common.Files;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Utilities.Logging;
@@ -49,16 +51,21 @@ namespace Org.Apache.REEF.Client.Local
         private readonly JavaClientLauncher _javaClientLauncher;
         private readonly int _numberOfEvaluators;
         private readonly string _runtimeFolder;
+        private string _driverUrl;
+        private REEFFileNames _fileNames;
 
         [Inject]
         private LocalClient(DriverFolderPreparationHelper driverFolderPreparationHelper,
             [Parameter(typeof(LocalRuntimeDirectory))] string runtimeFolder,
-            [Parameter(typeof(NumberOfEvaluators))] int numberOfEvaluators, JavaClientLauncher javaClientLauncher)
+            [Parameter(typeof(NumberOfEvaluators))] int numberOfEvaluators,
+            JavaClientLauncher javaClientLauncher,
+            REEFFileNames fileNames)
         {
             _driverFolderPreparationHelper = driverFolderPreparationHelper;
             _runtimeFolder = runtimeFolder;
             _numberOfEvaluators = numberOfEvaluators;
             _javaClientLauncher = javaClientLauncher;
+            _fileNames = fileNames;
         }
 
         /// <summary>
@@ -67,16 +74,20 @@ namespace Org.Apache.REEF.Client.Local
         /// <param name="driverFolderPreparationHelper"></param>
         /// <param name="reefJarPath"></param>
         /// <param name="numberOfEvaluators"></param>
+        /// <param name="javaClientLauncher"></param>
+        /// <param name="fileNames"></param>
         [Inject]
         private LocalClient(
             DriverFolderPreparationHelper driverFolderPreparationHelper,
-            [Parameter(typeof(NumberOfEvaluators))] int numberOfEvaluators, JavaClientLauncher javaClientLauncher)
-            : this(driverFolderPreparationHelper, Path.GetTempPath(), numberOfEvaluators, javaClientLauncher)
+            [Parameter(typeof(NumberOfEvaluators))] int numberOfEvaluators,
+            JavaClientLauncher javaClientLauncher,
+            REEFFileNames fileNames)
+            : this(driverFolderPreparationHelper, Path.GetTempPath(), numberOfEvaluators, javaClientLauncher, fileNames)
         {
             // Intentionally left blank.
         }
 
-        public void Submit(IJobSubmission jobSubmission)
+        public IDriverHttpEndpoint Submit(IJobSubmission jobSubmission)
         {
             // Prepare the job submission folder
             var jobFolder = CreateJobFolder(jobSubmission.JobIdentifier);
@@ -90,13 +101,25 @@ namespace Org.Apache.REEF.Client.Local
                 .NewInjector(jobSubmission.DriverConfigurations.ToArray())
                 .GetInstance<ClrClient2JavaClientCuratedParameters>();
 
+            Task.Run(() =>
             _javaClientLauncher.Launch(JavaClassName, driverFolder, jobSubmission.JobIdentifier,
                 _numberOfEvaluators.ToString(),
                 javaParams.TcpPortRangeStart.ToString(),
                 javaParams.TcpPortRangeCount.ToString(),
                 javaParams.TcpPortRangeTryCount.ToString()
-                );
-            Logger.Log(Level.Info, "Submitted the Driver for execution.");
+                ));
+
+            var fileName = Path.Combine(driverFolder, _fileNames.DriverHttpEndpoint);
+            HttpClientHelper helper = new HttpClientHelper();
+            _driverUrl = helper.GetDriverUrlForLocalRuntime(fileName);
+
+            Logger.Log(Level.Info, "Submitted the Driver for execution. Returned driverUrl is: " + _driverUrl);
+            return helper;
+        }
+
+        public string DriverUrl
+        {
+            get { return _driverUrl; }
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
+++ b/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
@@ -37,10 +37,15 @@ under the License.
     <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="API\ClientFactory.cs" />
@@ -57,6 +62,8 @@ under the License.
     <Compile Include="Common\ClrClient2JavaClientCuratedParameters.cs" />
     <Compile Include="Common\DriverFolderPreparationHelper.cs" />
     <Compile Include="Common\FileSets.cs" />
+    <Compile Include="Common\HttpClientHelper.cs" />
+    <Compile Include="Common\IDriverHttpEndpoint.cs" />
     <Compile Include="Common\JavaClientLauncher.cs" />
     <Compile Include="Common\ResourceHelper.cs" />
     <Compile Include="Local\LocalClient.cs" />

--- a/lang/cs/Org.Apache.REEF.Client/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Properties/AssemblyInfo.cs
@@ -18,6 +18,7 @@
  */
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -52,3 +53,13 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.13.0.0")]
 [assembly: AssemblyFileVersion("0.13.0.0")]
+
+#if DEBUG
+[assembly: InternalsVisibleTo("Org.Apache.REEF.Tests")]
+#else
+[assembly: InternalsVisibleTo("Org.Apache.REEF.IMRU.Tests, publickey=" +
+ "00240000048000009400000006020000002400005253413100040000010001005df3e621d886a9" +
+ "9c03469d0f93a9f5d45aa2c883f50cd158759e93673f759ec4657fd84cc79d2db38ef1a2d914cc" +
+ "b7c717846a897e11dd22eb260a7ce2da2dccf0263ea63e2b3f7dac24f28882aa568ef544341d17" +
+ "618392a1095f4049ad079d4f4f0b429bb535699155fd6a7652ec7d6c1f1ba2b560f11ef3a86b5945d288cf")]
+#endif

--- a/lang/cs/Org.Apache.REEF.Common/Files/REEFFileNames.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Files/REEFFileNames.cs
@@ -49,6 +49,7 @@ namespace Org.Apache.REEF.Common.Files
         private const string EVALUATOR_CONFIGURATION_NAME = "evaluator.conf";
         private const string CLR_DRIVER_CONFIGURATION_NAME = "clrdriver.conf";
         private const string BRIDGE_DLL_NAME = "Org.Apache.REEF.Bridge.dll";
+        private const string DRIVER_HTTP_ENDPOINT_FILE_NAME = "DriverHttpEndpoint.txt";
 
         [Inject]
         public REEFFileNames()
@@ -218,6 +219,11 @@ namespace Org.Apache.REEF.Common.Files
         {
             return BRIDGE_DLL_NAME;
         }
+
+        /// <summary>
+        /// </summary>
+        /// <returns>File name that contains the dfs path for the DriverHttpEndpoint</returns>
+        public string DriverHttpEndpoint { get { return DRIVER_HTTP_ENDPOINT_FILE_NAME; } }
 
         private static readonly string GLOBAL_FOLDER_PATH = Path.Combine(REEF_BASE_FOLDER, GLOBAL_FOLDER);
         private static readonly string LOCAL_FOLDER_PATH = Path.Combine(REEF_BASE_FOLDER, LOCAL_FOLDER);

--- a/lang/cs/Org.Apache.REEF.Examples.AllHandlers/AllHandlers.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.AllHandlers/AllHandlers.cs
@@ -20,6 +20,7 @@
 using System;
 using System.IO;
 using Org.Apache.REEF.Client.API;
+using Org.Apache.REEF.Client.Common;
 using Org.Apache.REEF.Client.Local;
 using Org.Apache.REEF.Client.YARN;
 using Org.Apache.REEF.Common.Evaluator;
@@ -50,7 +51,7 @@ namespace Org.Apache.REEF.Examples.AllHandlers
             _jobSubmissionBuilderFactory = jobSubmissionBuilderFactory;
         }
 
-        private void Run()
+        private IDriverHttpEndpoint Run()
         {
             var helloDriverConfiguration = DriverConfiguration.ConfigurationModule
                 .Set(DriverConfiguration.OnEvaluatorAllocated, GenericType<HelloAllocatedEvaluatorHandler>.Class)
@@ -82,7 +83,8 @@ namespace Org.Apache.REEF.Examples.AllHandlers
                 .SetJobIdentifier("HelloDriver")
                 .Build();
 
-            _reefClient.Submit(helloJobSubmission);
+            IDriverHttpEndpoint driverHttpEndpoint = _reefClient.Submit(helloJobSubmission);
+            return driverHttpEndpoint;
         }
 
         /// <summary></summary>
@@ -122,11 +124,12 @@ namespace Org.Apache.REEF.Examples.AllHandlers
         /// args[0] specify either running local or YARN. Default is local
         /// args[1] specify running folder. Default is REEF_LOCAL_RUNTIME
         /// </remarks>
-        public static void Run(string[] args)
+        public static IDriverHttpEndpoint Run(string[] args)
         {
             string runOnYarn = args.Length > 0 ? args[0] : Local;
             string runtimeFolder = args.Length > 1 ? args[1] : "REEF_LOCAL_RUNTIME";
-            TangFactory.GetTang().NewInjector(GetRuntimeConfiguration(runOnYarn, runtimeFolder)).GetInstance<AllHandlers>().Run();
+            IDriverHttpEndpoint driverEndPoint = TangFactory.GetTang().NewInjector(GetRuntimeConfiguration(runOnYarn, runtimeFolder)).GetInstance<AllHandlers>().Run();
+            return driverEndPoint;
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
@@ -55,6 +55,7 @@ namespace Org.Apache.REEF.Tests.Functional
 
         private const string Local = "local";
         private const string YARN = "yarn";
+        private const int SleppTime = 1000;
 
         private readonly static Logger Logger = Logger.GetLogger(typeof(ReefFunctionalTest));
         private const string StorageAccountKeyEnvironmentVariable = "REEFTestStorageAccountKey";
@@ -152,14 +153,35 @@ namespace Org.Apache.REEF.Tests.Functional
             const string successIndication = "EXIT: ActiveContextClr2Java::Close";
             const string failedTaskIndication = "Java_com_microsoft_reef_javabridge_NativeInterop_clrSystemFailedTaskHandlerOnNext";
             const string failedEvaluatorIndication = "Java_com_microsoft_reef_javabridge_NativeInterop_clrSystemFailedEvaluatorHandlerOnNext";
-            string[] lines = File.ReadAllLines(GetLogFile(_stdout, testFolder));
-            Console.WriteLine("Lines read from log file : " + lines.Count());
-            string[] successIndicators = lines.Where(s => s.Contains(successIndication)).ToArray();
-            string[] failedTaskIndicators = lines.Where(s => s.Contains(failedTaskIndication)).ToArray();
-            string[] failedIndicators = lines.Where(s => s.Contains(failedEvaluatorIndication)).ToArray();
-            Assert.IsTrue(successIndicators.Count() == numberOfEvaluatorsToClose);
-            Assert.IsFalse(failedTaskIndicators.Any());
-            Assert.IsFalse(failedIndicators.Any());
+            string[] lines = null;
+            for (int i = 0; i < 60; i++)
+            {
+                try
+                {
+                    lines = File.ReadAllLines(GetLogFile(_stdout, testFolder));
+                    break;
+                }
+                catch (Exception)
+                {
+                    Thread.Sleep(SleppTime);
+                }
+            }
+
+            if (lines != null)
+            {
+                Console.WriteLine("Lines read from log file : " + lines.Count());
+                string[] successIndicators = lines.Where(s => s.Contains(successIndication)).ToArray();
+                string[] failedTaskIndicators = lines.Where(s => s.Contains(failedTaskIndication)).ToArray();
+                string[] failedIndicators = lines.Where(s => s.Contains(failedEvaluatorIndication)).ToArray();
+                Assert.IsTrue(successIndicators.Count() == numberOfEvaluatorsToClose);
+                Assert.IsFalse(failedTaskIndicators.Any());
+                Assert.IsFalse(failedIndicators.Any());
+            }
+            else
+            {
+                Console.WriteLine("Cannot read from log file");
+                Assert.IsNotNull(null);
+            }
         }
 
         protected void PeriodicUploadLog(object source, ElapsedEventArgs e)

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/LocalClient.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/LocalClient.java
@@ -32,6 +32,7 @@ import org.apache.reef.tang.formats.AvroConfigurationSerializer;
 import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeBegin;
 import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeCount;
 import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeTryCount;
+import org.apache.reef.driver.parameters.JobSubmissionDirectory;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -84,6 +85,8 @@ public class LocalClient {
     final Configuration providedConfigurations =  configurationBuilder.build();
     final Configuration driverConfiguration = Configurations.merge(
         driverConfiguration1,
+        Tang.Factory.getTang().newConfigurationBuilder().
+            bindNamedParameter(JobSubmissionDirectory.class, driverFolder.toString()).build(),
         providedConfigurations);
 
     final File driverConfigurationFile = new File(driverFolder, fileNames.getDriverConfigurationPath());
@@ -123,13 +126,14 @@ public class LocalClient {
       final int tcpRangeCount,
       final int tcpTryCount) {
     final Configuration runtimeConfiguration = getRuntimeConfiguration(numberOfEvaluators, runtimeRootFolder);
-    final Configuration userproviderConfiguration = Tang.Factory.getTang().newConfigurationBuilder()
+    final Configuration userprovidedConfiguration = Tang.Factory.getTang().newConfigurationBuilder()
         .bindSetEntry(DriverConfigurationProviders.class, TcpPortConfigurationProvider.class)
         .bindNamedParameter(TcpPortRangeBegin.class, Integer.toString(tcpBeginPort))
         .bindNamedParameter(TcpPortRangeCount.class, Integer.toString(tcpRangeCount))
         .bindNamedParameter(TcpPortRangeTryCount.class, Integer.toString(tcpTryCount))
+        .bindNamedParameter(JobSubmissionDirectory.class, runtimeRootFolder)
         .build();
-    return Configurations.merge(runtimeConfiguration, userproviderConfiguration);
+    return Configurations.merge(runtimeConfiguration, userprovidedConfiguration);
   }
 
   private static Configuration getRuntimeConfiguration(final int numberOfEvaluators, final String runtimeRootFolder) {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/REEFFileNames.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/REEFFileNames.java
@@ -48,7 +48,7 @@ public final class REEFFileNames {
   private static final String EVALUATOR_STDERR = "evaluator.stderr";
   private static final String EVALUATOR_STDOUT = "evaluator.stdout";
   private static final String BRIDGE_DLL_NAME = "Org.Apache.REEF.Bridge.dll";
-
+  private static final String DRIVER_HTTP_ENDPOINT_FILE_NAME = "DriverHttpEndpoint.txt";
 
   @Inject
   public REEFFileNames() {
@@ -216,4 +216,12 @@ public final class REEFFileNames {
   public String getEvaluatorStdoutFileName() {
     return EVALUATOR_STDOUT;
   }
+
+  /**
+   * @return File name that contains the dfs path for the DriverHttpEndpoint.
+   */
+  public String getDriverHttpEndpoint() {
+    return DRIVER_HTTP_ENDPOINT_FILE_NAME;
+  }
+
 }

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/HDInsightDriverConfiguration.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/HDInsightDriverConfiguration.java
@@ -35,7 +35,7 @@ import org.apache.reef.runtime.common.parameters.JVMHeapSlack;
 import org.apache.reef.runtime.hdinsight.HDInsightClasspathProvider;
 import org.apache.reef.runtime.hdinsight.HDInsightJVMPathProvider;
 import org.apache.reef.runtime.yarn.driver.*;
-import org.apache.reef.runtime.yarn.driver.parameters.JobSubmissionDirectory;
+import org.apache.reef.driver.parameters.JobSubmissionDirectory;
 import org.apache.reef.runtime.yarn.driver.parameters.YarnHeartbeatPeriod;
 import org.apache.reef.runtime.yarn.util.YarnConfigurationConstructor;
 import org.apache.reef.tang.formats.ConfigurationModule;

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/YarnSubmissionHelper.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/YarnSubmissionHelper.java
@@ -90,6 +90,14 @@ public final class YarnSubmissionHelper implements Closeable{
   }
 
   /**
+   *
+   * @return the application ID string representation assigned by YARN.
+   */
+  public String getStringApplicationId() {
+    return this.applicationId.toString();
+  }
+
+  /**
    * Set the name of the application to be submitted.
    * @param applicationName
    * @return

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/UploaderToJobfolder.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/UploaderToJobfolder.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.yarn.api.records.LocalResourceVisibility;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.hadoop.yarn.util.Records;
-import org.apache.reef.runtime.yarn.driver.parameters.JobSubmissionDirectory;
+import org.apache.reef.driver.parameters.JobSubmissionDirectory;
 import org.apache.reef.tang.annotations.Parameter;
 
 import javax.inject.Inject;

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnContainerManager.java
@@ -20,6 +20,7 @@ package org.apache.reef.runtime.yarn.driver;
 
 import com.google.protobuf.ByteString;
 import org.apache.commons.collections.ListUtils;
+import org.apache.hadoop.fs.*;
 import org.apache.hadoop.service.Service;
 import org.apache.hadoop.yarn.api.records.*;
 import org.apache.hadoop.yarn.client.api.AMRMClient;
@@ -29,6 +30,7 @@ import org.apache.hadoop.yarn.client.api.async.NMClientAsync;
 import org.apache.hadoop.yarn.client.api.async.impl.NMClientAsyncImpl;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
+import org.apache.reef.driver.parameters.JobSubmissionDirectory;
 import org.apache.reef.exception.DriverFatalRuntimeException;
 import org.apache.reef.proto.ReefServiceProtos;
 import org.apache.reef.runtime.common.driver.DriverStatusManager;
@@ -36,6 +38,7 @@ import org.apache.reef.runtime.common.driver.resourcemanager.NodeDescriptorEvent
 import org.apache.reef.runtime.common.driver.resourcemanager.ResourceEventImpl;
 import org.apache.reef.runtime.common.driver.resourcemanager.ResourceStatusEventImpl;
 import org.apache.reef.runtime.common.driver.resourcemanager.RuntimeStatusEventImpl;
+import org.apache.reef.runtime.common.files.REEFFileNames;
 import org.apache.reef.runtime.yarn.driver.parameters.YarnHeartbeatPeriod;
 import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.util.Optional;
@@ -75,6 +78,8 @@ final class YarnContainerManager
   private final ContainerRequestCounter containerRequestCounter;
   private final DriverStatusManager driverStatusManager;
   private final TrackingURLProvider trackingURLProvider;
+  private final String jobSubmissionDirectory;
+  private final REEFFileNames reefFileNames;
   private final RackNameFormatter rackNameFormatter;
 
   @Inject
@@ -86,9 +91,10 @@ final class YarnContainerManager
       final ApplicationMasterRegistration registration,
       final ContainerRequestCounter containerRequestCounter,
       final DriverStatusManager driverStatusManager,
+      final REEFFileNames reefFileNames,
+      @Parameter(JobSubmissionDirectory.class) final String jobSubmissionDirectory,
       final TrackingURLProvider trackingURLProvider,
       final RackNameFormatter rackNameFormatter) throws IOException {
-
     this.reefEventHandlers = reefEventHandlers;
     this.driverStatusManager = driverStatusManager;
 
@@ -104,6 +110,8 @@ final class YarnContainerManager
 
     this.resourceManager = AMRMClientAsync.createAMRMClientAsync(yarnRMHeartbeatPeriod, this);
     this.nodeManager = new NMClientAsyncImpl(this);
+    this.jobSubmissionDirectory = jobSubmissionDirectory;
+    this.reefFileNames = reefFileNames;
     LOG.log(Level.FINEST, "Instantiated YarnContainerManager");
   }
 
@@ -250,7 +258,12 @@ final class YarnContainerManager
       this.registration.setRegistration(this.resourceManager.registerApplicationMaster(
           "", 0, this.trackingURLProvider.getTrackingUrl()));
       LOG.log(Level.FINE, "YARN registration: {0}", registration);
-
+      final FileSystem fs = FileSystem.get(this.yarnConf);
+      final Path outputFileName = new Path(this.jobSubmissionDirectory, this.reefFileNames.getDriverHttpEndpoint());
+      final FSDataOutputStream out = fs.create(outputFileName);
+      out.writeBytes(this.trackingURLProvider.getTrackingUrl() + "\n");
+      out.flush();
+      out.close();
     } catch (final YarnException | IOException e) {
       LOG.log(Level.WARNING, "Unable to register application master.", e);
       onRuntimeError(e);

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverConfiguration.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverConfiguration.java
@@ -30,7 +30,7 @@ import org.apache.reef.runtime.common.launch.parameters.ErrorHandlerRID;
 import org.apache.reef.runtime.common.launch.parameters.LaunchID;
 import org.apache.reef.runtime.common.parameters.JVMHeapSlack;
 import org.apache.reef.runtime.yarn.YarnClasspathProvider;
-import org.apache.reef.runtime.yarn.driver.parameters.JobSubmissionDirectory;
+import org.apache.reef.driver.parameters.JobSubmissionDirectory;
 import org.apache.reef.runtime.yarn.driver.parameters.YarnHeartbeatPeriod;
 import org.apache.reef.runtime.yarn.util.YarnConfigurationConstructor;
 import org.apache.reef.tang.formats.*;


### PR DESCRIPTION
This PR is to return HttpEndPoint to the client after Job is submitted
*At Java side, the http endpoint is written to JobSubmission folder in HDFS and Driver folder. Both Local and Yarn cases are taken care of
*At REEFClient side, HttpClientHelper is added to pull the http endpoint from the file and return it in Submit()
*E2e test cases are updated to get the URI and verify on it.

JIRA: REEF-663(https://issues.apache.org/jira/browse/REEF-663)

This closes #

The change is part of the change in tlc branch with some modification and test cases update. 