### PR TITLE
[REEF-647] Remove APIs deprecated since 0.12 from reef-wake

### DIFF
--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameClient.java
@@ -24,7 +24,6 @@ import org.apache.reef.io.network.naming.serialization.NamingLookupResponse;
 import org.apache.reef.io.network.naming.serialization.NamingMessage;
 import org.apache.reef.io.network.naming.serialization.NamingRegisterResponse;
 import org.apache.reef.tang.annotations.Parameter;
-import org.apache.reef.util.cache.Cache;
 import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.Identifier;
 import org.apache.reef.wake.IdentifierFactory;
@@ -34,7 +33,6 @@ import org.apache.reef.wake.remote.address.LocalAddressProvider;
 import org.apache.reef.wake.remote.impl.TransportEvent;
 import org.apache.reef.wake.remote.transport.Transport;
 import org.apache.reef.wake.remote.transport.TransportFactory;
-import org.apache.reef.wake.remote.transport.netty.MessagingTransportFactory;
 
 import javax.inject.Inject;
 import java.io.IOException;
@@ -54,70 +52,6 @@ public final class NameClient implements NameResolver {
   private NameRegistryClient registryClient;
   private Transport transport;
 
-  /**
-   * Constructs a naming client.
-   *
-   * @param serverAddr a server address
-   * @param serverPort a server port number
-   * @param factory    an identifier factory
-   * @param cache      a cache
-   */
-  @Deprecated
-  public NameClient(final String serverAddr,
-                    final int serverPort,
-                    final IdentifierFactory factory,
-                    final int retryCount,
-                    final int retryTimeout,
-                    final Cache<Identifier, InetSocketAddress> cache,
-                    final LocalAddressProvider localAddressProvider) {
-    this(serverAddr, serverPort, 10000, factory, retryCount, retryTimeout, cache, localAddressProvider);
-  }
-
-  /**
-   * Constructs a naming client.
-   *
-   * @param serverAddr a server address
-   * @param serverPort a server port number
-   * @param timeout    timeout in ms
-   * @param factory    an identifier factory
-   * @param cache      a cache
-   */
-  @Deprecated
-  public NameClient(final String serverAddr,
-                    final int serverPort,
-                    final long timeout,
-                    final IdentifierFactory factory,
-                    final int retryCount,
-                    final int retryTimeout,
-                    final Cache<Identifier, InetSocketAddress> cache,
-                    final LocalAddressProvider localAddressProvider) {
-    this(serverAddr, serverPort, timeout, factory, retryCount, retryTimeout,
-        cache, localAddressProvider, new MessagingTransportFactory());
-  }
-
-  /**
-   * Constructs a naming client.
-   *
-   * @param serverAddr a server address
-   * @param serverPort a server port number
-   * @param timeout    timeout in ms
-   * @param factory    an identifier factory
-   * @param cache      a cache
-   * @param tpFactory  transport factory
-   */
-  @Deprecated
-  public NameClient(final String serverAddr,
-                    final int serverPort,
-                    final long timeout,
-                    final IdentifierFactory factory,
-                    final int retryCount,
-                    final int retryTimeout,
-                    final Cache<Identifier, InetSocketAddress> cache,
-                    final LocalAddressProvider localAddressProvider,
-                    final TransportFactory tpFactory) {
-    this(serverAddr, serverPort, timeout, factory, retryCount, retryTimeout, localAddressProvider, tpFactory);
-  }
-
     /**
      * Constructs a naming client.
      *
@@ -129,11 +63,9 @@ public final class NameClient implements NameResolver {
      * @param retryTimeout retry timeout
      * @param localAddressProvider a local address provider
      * @param tpFactory transport factory
-     * @deprecated in 0.12. Use Tang to obtain an instance of this instead.
      */
-  @Deprecated
   @Inject
-  public NameClient(
+  private NameClient(
       @Parameter(NameResolverNameServerAddr.class) final String serverAddr,
       @Parameter(NameResolverNameServerPort.class) final int serverPort,
       @Parameter(NameResolverCacheTimeout.class) final long timeout,

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameLookupClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameLookupClient.java
@@ -32,7 +32,6 @@ import org.apache.reef.wake.Stage;
 import org.apache.reef.wake.impl.SyncStage;
 import org.apache.reef.wake.remote.Codec;
 import org.apache.reef.wake.remote.address.LocalAddressProvider;
-import org.apache.reef.wake.remote.address.LocalAddressProviderFactory;
 import org.apache.reef.wake.remote.impl.TransportEvent;
 import org.apache.reef.wake.remote.transport.Link;
 import org.apache.reef.wake.remote.transport.Transport;
@@ -89,26 +88,6 @@ public class NameLookupClient implements Stage, NamingLookup {
    *
    * @param serverAddr a server address
    * @param serverPort a server port number
-   * @param factory    an identifier factory
-   * @param cache      an cache
-   * @deprecated in 0.12 use the constructor that takes a LocalAddressProvider instead.
-   */
-  @Deprecated
-  public NameLookupClient(final String serverAddr,
-                          final int serverPort,
-                          final IdentifierFactory factory,
-                          final int retryCount,
-                          final int retryTimeout,
-                          final Cache<Identifier, InetSocketAddress> cache) {
-    this(serverAddr, serverPort, 10000, factory, retryCount, retryTimeout, cache,
-         LocalAddressProviderFactory.getInstance());
-  }
-
-  /**
-   * Constructs a naming lookup client.
-   *
-   * @param serverAddr a server address
-   * @param serverPort a server port number
    * @param timeout    request timeout in ms
    * @param factory    an identifier factory
    * @param cache      an cache
@@ -122,7 +101,7 @@ public class NameLookupClient implements Stage, NamingLookup {
                           final Cache<Identifier, InetSocketAddress> cache,
                           final LocalAddressProvider localAddressProvider) {
     this(serverAddr, serverPort, timeout, factory, retryCount, retryTimeout,
-        cache, localAddressProvider, new MessagingTransportFactory());
+        cache, localAddressProvider, new MessagingTransportFactory(localAddressProvider));
   }
 
   /**

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameServerImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameServerImpl.java
@@ -36,7 +36,6 @@ import org.apache.reef.wake.remote.address.LocalAddressProviderFactory;
 import org.apache.reef.wake.remote.impl.TransportEvent;
 import org.apache.reef.wake.remote.transport.Transport;
 import org.apache.reef.wake.remote.transport.TransportFactory;
-import org.apache.reef.wake.remote.transport.netty.MessagingTransportFactory;
 import org.apache.reef.wake.remote.transport.netty.NettyMessagingTransport;
 import org.apache.reef.webserver.AvroReefServiceInfo;
 import org.apache.reef.webserver.ReefEventStateManager;
@@ -104,24 +103,6 @@ public final class NameServerImpl implements NameServer {
   @Deprecated
   public NameServerImpl(final int port, final IdentifierFactory factory) {
     this(port, factory, LocalAddressProviderFactory.getInstance());
-  }
-
-  /**
-   * Constructs a name server.
-   *
-   * @param port                  a listening port number
-   * @param factory               an identifier factory
-   * @param reefEventStateManager the event state manager used to register name server info
-   * @param localAddressProvider  a local address provider
-   * @deprecated have an instance injected instead
-   */
-  @Deprecated
-  public NameServerImpl(
-      final int port,
-      final IdentifierFactory factory,
-      final ReefEventStateManager reefEventStateManager,
-      final LocalAddressProvider localAddressProvider) {
-    this(port, factory, reefEventStateManager, localAddressProvider, new MessagingTransportFactory());
   }
 
   /**

--- a/lang/java/reef-io/src/test/java/org/apache/reef/io/network/NetworkServiceTest.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/io/network/NetworkServiceTest.java
@@ -98,11 +98,11 @@ public class NetworkServiceTest {
       LOG.log(Level.FINEST, "=== Test network service receiver start");
       LOG.log(Level.FINEST, "=== Test network service sender start");
       try (final NameResolver nameResolver = injector2.getInstance(NameResolver.class);
-           NetworkService<String> ns2 = new NetworkService<String>(factory, 0, nameResolver,
-               new StringCodec(), new MessagingTransportFactory(localAddressProvider),
+           final NetworkService<String> ns2 = new NetworkService<String>(factory, 0, nameResolver,
+               new StringCodec(), injector.getInstance(MessagingTransportFactory.class),
                new MessageHandler<String>(name2, monitor, numMessages), new ExceptionHandler(), localAddressProvider);
            final NetworkService<String> ns1 = new NetworkService<String>(factory, 0, nameResolver,
-               new StringCodec(), new MessagingTransportFactory(localAddressProvider),
+               new StringCodec(), injector.getInstance(MessagingTransportFactory.class),
                new MessageHandler<String>(name1, null, 0), new ExceptionHandler(), localAddressProvider)) {
 
         ns2.registerId(factory.getNewInstance(name2));
@@ -168,10 +168,10 @@ public class NetworkServiceTest {
         LOG.log(Level.FINEST, "=== Test network service sender start");
         try (final NameResolver nameResolver = injector2.getInstance(NameResolver.class);
              NetworkService<String> ns2 = new NetworkService<String>(factory, 0, nameResolver,
-                 new StringCodec(), new MessagingTransportFactory(localAddressProvider),
+                 new StringCodec(), injector.getInstance(MessagingTransportFactory.class),
                  new MessageHandler<String>(name2, monitor, numMessages), new ExceptionHandler(), localAddressProvider);
              NetworkService<String> ns1 = new NetworkService<String>(factory, 0, nameResolver,
-                 new StringCodec(), new MessagingTransportFactory(localAddressProvider),
+                 new StringCodec(), injector.getInstance(MessagingTransportFactory.class),
                  new MessageHandler<String>(name1, null, 0), new ExceptionHandler(), localAddressProvider)) {
 
           ns2.registerId(factory.getNewInstance(name2));
@@ -260,11 +260,11 @@ public class NetworkServiceTest {
               LOG.log(Level.FINEST, "=== Test network service sender start");
               try (final NameResolver nameResolver = injector.getInstance(NameResolver.class);
                    NetworkService<String> ns2 = new NetworkService<String>(factory, 0, nameResolver,
-                       new StringCodec(), new MessagingTransportFactory(localAddressProvider),
+                       new StringCodec(), injector.getInstance(MessagingTransportFactory.class),
                        new MessageHandler<String>(name2, monitor, numMessages),
                        new ExceptionHandler(), localAddressProvider);
                    NetworkService<String> ns1 = new NetworkService<String>(factory, 0, nameResolver,
-                       new StringCodec(), new MessagingTransportFactory(localAddressProvider),
+                       new StringCodec(), injector.getInstance(MessagingTransportFactory.class),
                        new MessageHandler<String>(name1, null, 0), new ExceptionHandler(), localAddressProvider)) {
 
                 ns2.registerId(factory.getNewInstance(name2));
@@ -356,11 +356,11 @@ public class NetworkServiceTest {
         LOG.log(Level.FINEST, "=== Test network service sender start");
         try (final NameResolver nameResolver = injector2.getInstance(NameResolver.class);
              NetworkService<String> ns2 = new NetworkService<String>(factory, 0, nameResolver,
-                 new StringCodec(), new MessagingTransportFactory(localAddressProvider),
+                 new StringCodec(), injector.getInstance(MessagingTransportFactory.class),
                  new MessageHandler<String>(name2, monitor, totalNumMessages),
                  new ExceptionHandler(), localAddressProvider);
              NetworkService<String> ns1 = new NetworkService<String>(factory, 0, nameResolver,
-                 new StringCodec(), new MessagingTransportFactory(localAddressProvider),
+                 new StringCodec(), injector.getInstance(MessagingTransportFactory.class),
                  new MessageHandler<String>(name1, null, 0), new ExceptionHandler(), localAddressProvider)) {
 
           ns2.registerId(factory.getNewInstance(name2));
@@ -453,10 +453,10 @@ public class NetworkServiceTest {
         LOG.log(Level.FINEST, "=== Test network service sender start");
         try (final NameResolver nameResolver = injector2.getInstance(NameResolver.class);
              NetworkService<String> ns2 = new NetworkService<String>(factory, 0, nameResolver,
-                 new StringCodec(), new MessagingTransportFactory(localAddressProvider),
+                 new StringCodec(), injector.getInstance(MessagingTransportFactory.class),
                  new MessageHandler<String>(name2, monitor, numMessages), new ExceptionHandler(), localAddressProvider);
              NetworkService<String> ns1 = new NetworkService<String>(factory, 0, nameResolver,
-                 new StringCodec(), new MessagingTransportFactory(localAddressProvider),
+                 new StringCodec(), injector.getInstance(MessagingTransportFactory.class),
                  new MessageHandler<String>(name1, null, 0), new ExceptionHandler(), localAddressProvider)) {
 
           ns2.registerId(factory.getNewInstance(name2));

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/MessagingTransportFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/MessagingTransportFactory.java
@@ -26,7 +26,6 @@ import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.impl.SyncStage;
 import org.apache.reef.wake.remote.RemoteConfiguration;
 import org.apache.reef.wake.remote.address.LocalAddressProvider;
-import org.apache.reef.wake.remote.address.LocalAddressProviderFactory;
 import org.apache.reef.wake.remote.impl.TransportEvent;
 import org.apache.reef.wake.remote.ports.RangeTcpPortProvider;
 import org.apache.reef.wake.remote.ports.TcpPortProvider;
@@ -47,16 +46,9 @@ public class MessagingTransportFactory implements TransportFactory {
    */
   @Deprecated
   @Inject
+  // TODO[JIRA REEF-703]: change constructor to private
   public MessagingTransportFactory(final LocalAddressProvider localAddressProvider) {
     this.localAddress = localAddressProvider.getLocalAddress();
-  }
-
-  /**
-   * @deprecated Have an instance injected instead.
-   */
-  @Deprecated
-  public MessagingTransportFactory() {
-    this.localAddress = LocalAddressProviderFactory.getInstance().getLocalAddress();
   }
 
   /**

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyMessagingTransport.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyMessagingTransport.java
@@ -37,10 +37,8 @@ import org.apache.reef.wake.impl.DefaultThreadFactory;
 import org.apache.reef.wake.remote.Encoder;
 import org.apache.reef.wake.remote.RemoteConfiguration;
 import org.apache.reef.wake.remote.address.LocalAddressProvider;
-import org.apache.reef.wake.remote.address.LocalAddressProviderFactory;
 import org.apache.reef.wake.remote.exception.RemoteRuntimeException;
 import org.apache.reef.wake.remote.impl.TransportEvent;
-import org.apache.reef.wake.remote.ports.RangeTcpPortProvider;
 import org.apache.reef.wake.remote.ports.TcpPortProvider;
 import org.apache.reef.wake.remote.transport.Link;
 import org.apache.reef.wake.remote.transport.LinkListener;
@@ -98,32 +96,6 @@ public class NettyMessagingTransport implements Transport {
    */
   public static final String UNKNOWN_HOST_NAME = "##UNKNOWN##";
 
-
-  /**
-   * Constructs a messaging transport.
-   *
-   * @param hostAddress   the server host address
-   * @param port          the server listening port; when it is 0, randomly assign a port number
-   * @param clientStage   the client-side stage that handles transport events
-   * @param serverStage   the server-side stage that handles transport events
-   * @param numberOfTries the number of tries of connection
-   * @param retryTimeout  the timeout of reconnection
-   * @param tcpPortProvider  gives an iterator that produces random tcp ports in a range
-   * @deprecated in 0.12 use the constructor that takes a LocalAddressProvider instead.
-   */
-  @Deprecated
-  public NettyMessagingTransport(
-      final String hostAddress,
-      final int port,
-      final EStage<TransportEvent> clientStage,
-      final EStage<TransportEvent> serverStage,
-      final int numberOfTries,
-      final int retryTimeout,
-      final TcpPortProvider tcpPortProvider) {
-
-    this(hostAddress, port, clientStage, serverStage, numberOfTries,
-        retryTimeout, tcpPortProvider, LocalAddressProviderFactory.getInstance());
-  }
   /**
    * Constructs a messaging transport.
    *
@@ -223,27 +195,6 @@ public class NettyMessagingTransport implements Transport {
     this.localAddress = new InetSocketAddress(host, this.serverPort);
 
     LOG.log(Level.FINE, "Starting netty transport socket address: {0}", this.localAddress);
-  }
-
-  /**
-   * Constructs a messaging transport.
-   *
-   * @param hostAddress   the server host address
-   * @param port          the server listening port; when it is 0, randomly assign a port number
-   * @param clientStage   the client-side stage that handles transport events
-   * @param serverStage   the server-side stage that handles transport events
-   * @param numberOfTries the number of tries of connection
-   * @param retryTimeout  the timeout of reconnection
-   * @deprecated in 0.11 use the constructor that takes a TcpProvider and LocalAddressProvider instead.
-   */
-  @Deprecated
-  public NettyMessagingTransport(final String hostAddress, final int port,
-                                 final EStage<TransportEvent> clientStage,
-                                 final EStage<TransportEvent> serverStage,
-                                 final int numberOfTries,
-                                 final int retryTimeout) {
-    this(hostAddress, port, clientStage, serverStage, numberOfTries, retryTimeout,
-            RangeTcpPortProvider.Default);
   }
 
   /**


### PR DESCRIPTION
This addressed the issue by:
  * removing deprecated methods in MessagingTransportFactory and NettyMessagingTransport
    which were deprecated since 0.12
  * removing deprecated methods in NameClient, NameLookupClient and NameServerImpl
    which were deprecated earlier but rely on methods mentioned above

JIRA:
  [REEF-647](https://issues.apache.org/jira/browse/REEF-647)

Pull Request:
  Closes #