### PR TITLE
[REEF-687] Restructure handler for DriverRestart in Java

### DIFF
--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/ClrHandlersInitializer.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/ClrHandlersInitializer.java
@@ -16,20 +16,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.driver.parameters;
+package org.apache.reef.javabridge.generic;
 
-import org.apache.reef.driver.restart.DriverRestarted;
-import org.apache.reef.tang.annotations.Name;
-import org.apache.reef.tang.annotations.NamedParameter;
-import org.apache.reef.wake.EventHandler;
-
-import java.util.Set;
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.javabridge.EvaluatorRequestorBridge;
 
 /**
- * The EventHandler invoked on Driver restart. Provides the set of Evaluator IDs of Evaluators that are expected to
- * report back to the Driver on restart as well as the time of restart.
+ * An initializer interface that initializes ClrHandlers for the CLR {@link JobDriver}.
  */
-@NamedParameter(doc = "The EventHandler invoked on Driver restart. Provides the set of Evaluator IDs of " +
-    "Evaluators that are expected to report back to the Driver on restart as well as the time of restart.")
-public final class DriverRestartHandler implements Name<Set<EventHandler<DriverRestarted>>> {
+@DriverSide
+@Private
+@Unstable
+interface ClrHandlersInitializer {
+
+  /**
+   * Returns the set of CLR handles.
+   */
+  long[] getClrHandlers(final String portNumber, final EvaluatorRequestorBridge evaluatorRequestorBridge);
 }

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/DriverRestartClrHandlersInitializer.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/DriverRestartClrHandlersInitializer.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.javabridge.generic;
+
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.driver.restart.DriverRestarted;
+import org.apache.reef.javabridge.EvaluatorRequestorBridge;
+import org.apache.reef.javabridge.NativeInterop;
+
+/**
+ * An initializer implementation that initializes ClrHandlers for the CLR {@link JobDriver} for the case
+ * where the Driver has restarted.
+ */
+@Private
+@DriverSide
+@Unstable
+final class DriverRestartClrHandlersInitializer implements ClrHandlersInitializer {
+  private final DriverRestarted driverRestarted;
+
+  DriverRestartClrHandlersInitializer(final DriverRestarted driverRestarted) {
+    this.driverRestarted = driverRestarted;
+  }
+
+  @Override
+  public long[] getClrHandlers(final String portNumber, final EvaluatorRequestorBridge evaluatorRequestorBridge) {
+    // TODO[REEF-689]: Make callClrSystemOnRestartedHandlerOnNext take DriverRestarted object.
+    return NativeInterop.callClrSystemOnRestartHandlerOnNext(
+        driverRestarted.getStartTime().toString(), portNumber, evaluatorRequestorBridge);
+  }
+}

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/DriverStartClrHandlersInitializer.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/DriverStartClrHandlersInitializer.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.javabridge.generic;
+
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.javabridge.EvaluatorRequestorBridge;
+import org.apache.reef.javabridge.NativeInterop;
+import org.apache.reef.wake.time.event.StartTime;
+
+/**
+ * An initializer implementation that initializes ClrHandlers for the CLR {@link JobDriver} for the case
+ * of regular Driver startup.
+ */
+@Private
+@DriverSide
+@Unstable
+final class DriverStartClrHandlersInitializer implements ClrHandlersInitializer {
+  private final StartTime startTime;
+
+  DriverStartClrHandlersInitializer(final StartTime startTime) {
+    this.startTime = startTime;
+  }
+
+  @Override
+  public long[] getClrHandlers(final String portNumber, final EvaluatorRequestorBridge evaluatorRequestorBridge) {
+    return NativeInterop.callClrSystemOnStartHandler(startTime.toString(), portNumber, evaluatorRequestorBridge);
+  }
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverRestartConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverRestartConfiguration.java
@@ -24,6 +24,7 @@ import org.apache.reef.annotations.audience.ClientSide;
 import org.apache.reef.annotations.audience.Public;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.parameters.*;
+import org.apache.reef.driver.restart.DriverRestarted;
 import org.apache.reef.driver.task.RunningTask;
 import org.apache.reef.runtime.common.DriverRestartCompleted;
 import org.apache.reef.tang.formats.ConfigurationModule;
@@ -31,7 +32,6 @@ import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
 import org.apache.reef.tang.formats.OptionalImpl;
 import org.apache.reef.tang.formats.OptionalParameter;
 import org.apache.reef.wake.EventHandler;
-import org.apache.reef.wake.time.event.StartTime;
 
 /**
  * EventHandlers specific to Driver Restart. Please remember to bind a runtime-specific DriverRestartConfiguration,
@@ -45,7 +45,7 @@ public final class DriverRestartConfiguration extends ConfigurationModuleBuilder
   /**
    * This event is fired in place of the ON_DRIVER_STARTED when the Driver is in fact restarted after failure.
    */
-  public static final OptionalImpl<EventHandler<StartTime>> ON_DRIVER_RESTARTED = new OptionalImpl<>();
+  public static final OptionalImpl<EventHandler<DriverRestarted>> ON_DRIVER_RESTARTED = new OptionalImpl<>();
 
   /**
    * Event handler for running tasks in previous evaluator, when driver restarted. Defaults to crash if not bound.

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverServiceConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverServiceConfiguration.java
@@ -29,6 +29,7 @@ import org.apache.reef.driver.evaluator.AllocatedEvaluator;
 import org.apache.reef.driver.evaluator.CompletedEvaluator;
 import org.apache.reef.driver.evaluator.FailedEvaluator;
 import org.apache.reef.driver.parameters.*;
+import org.apache.reef.driver.restart.DriverRestarted;
 import org.apache.reef.driver.task.*;
 import org.apache.reef.tang.formats.*;
 import org.apache.reef.wake.EventHandler;
@@ -77,7 +78,7 @@ public final class DriverServiceConfiguration extends ConfigurationModuleBuilder
   /**
    * The event handler invoked right after the driver restarts.
    */
-  public static final OptionalImpl<EventHandler<StartTime>> ON_DRIVER_RESTARTED = new OptionalImpl<>();
+  public static final OptionalImpl<EventHandler<DriverRestarted>> ON_DRIVER_RESTARTED = new OptionalImpl<>();
 
   /**
    * The event handler invoked right before the driver shuts down. Defaults to ignore.

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceDriverRestartedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceDriverRestartedHandlers.java
@@ -18,10 +18,10 @@
  */
 package org.apache.reef.driver.parameters;
 
+import org.apache.reef.driver.restart.DriverRestarted;
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 import org.apache.reef.wake.EventHandler;
-import org.apache.reef.wake.time.event.StartTime;
 
 import java.util.Set;
 
@@ -29,7 +29,7 @@ import java.util.Set;
  * Service Handler for driver restarts.
  */
 @NamedParameter(doc = "Service Handler for driver restarts.")
-public final class ServiceDriverRestartedHandlers implements Name<Set<EventHandler<StartTime>>> {
+public final class ServiceDriverRestartedHandlers implements Name<Set<EventHandler<DriverRestarted>>> {
   private ServiceDriverRestartedHandlers(){
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestarted.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestarted.java
@@ -34,7 +34,14 @@ import java.util.Set;
 @Provided
 @Unstable
 public interface DriverRestarted {
+  /**
+   * @return The time of restart.
+   */
   StartTime getStartTime();
 
+  /**
+   * @return The set of Evaluator IDs of Evaluators that are expected
+   * to report back to the Driver after restart.
+   */
   Set<String> getExpectedEvaluatorIds();
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestarted.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestarted.java
@@ -16,20 +16,25 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.driver.parameters;
+package org.apache.reef.driver.restart;
 
-import org.apache.reef.driver.restart.DriverRestarted;
-import org.apache.reef.tang.annotations.Name;
-import org.apache.reef.tang.annotations.NamedParameter;
-import org.apache.reef.wake.EventHandler;
+import org.apache.reef.annotations.Provided;
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Public;
+import org.apache.reef.wake.time.event.StartTime;
 
 import java.util.Set;
 
 /**
- * The EventHandler invoked on Driver restart. Provides the set of Evaluator IDs of Evaluators that are expected to
- * report back to the Driver on restart as well as the time of restart.
+ * Am event encapsulating the time of Driver restart as well as
+ * the set of Evaluator IDs of Evaluators that are expected to
+ * report back to the Driver after restart.
  */
-@NamedParameter(doc = "The EventHandler invoked on Driver restart. Provides the set of Evaluator IDs of " +
-    "Evaluators that are expected to report back to the Driver on restart as well as the time of restart.")
-public final class DriverRestartHandler implements Name<Set<EventHandler<DriverRestarted>>> {
+@Public
+@Provided
+@Unstable
+public interface DriverRestarted {
+  StartTime getStartTime();
+
+  Set<String> getExpectedEvaluatorIds();
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartedImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartedImpl.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.driver.restart;
+
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.wake.time.event.StartTime;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @see DriverRestarted
+ */
+@DriverSide
+@Private
+@Unstable
+public final class DriverRestartedImpl implements DriverRestarted {
+  private final StartTime startTime;
+  private final Set<String> expectedEvaluatorIds;
+
+  DriverRestartedImpl(final StartTime startTime, final RestartEvaluators restartEvaluators) {
+    this.startTime = startTime;
+    Set<String> expected = new HashSet<>();
+
+    for (final String evaluatorId : restartEvaluators.getEvaluatorIds()) {
+      if (restartEvaluators.get(evaluatorId).getEvaluatorRestartState() == EvaluatorRestartState.EXPECTED) {
+        expected.add(evaluatorId);
+      }
+    }
+
+    this.expectedEvaluatorIds = Collections.unmodifiableSet(expected);
+  }
+
+  @Override
+  public StartTime getStartTime() {
+    return startTime;
+  }
+
+  @Override
+  public Set<String> getExpectedEvaluatorIds() {
+    return expectedEvaluatorIds;
+  }
+}

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloDriverRestart.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloDriverRestart.java
@@ -18,9 +18,9 @@
  */
 package org.apache.reef.examples.hello;
 
+import org.apache.reef.driver.restart.DriverRestarted;
 import org.apache.reef.tang.annotations.Unit;
 import org.apache.reef.wake.EventHandler;
-import org.apache.reef.wake.time.event.StartTime;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -36,10 +36,10 @@ public final class HelloDriverRestart {
   /**
    * Handles Restarts. Prints a message.
    */
-  public final class DriverRestartHandler implements EventHandler<StartTime> {
+  public final class DriverRestartHandler implements EventHandler<DriverRestarted> {
     @Override
-    public void onNext(final StartTime value) {
-      LOG.log(Level.INFO, "Hello, driver restarted at " + value);
+    public void onNext(final DriverRestarted value) {
+      LOG.log(Level.INFO, "Hello, driver restarted at " + value.getStartTime());
     }
   }
 }

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/ReefEventStateManager.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/ReefEventStateManager.java
@@ -22,6 +22,7 @@ import org.apache.reef.driver.catalog.NodeDescriptor;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
 import org.apache.reef.driver.evaluator.EvaluatorDescriptor;
+import org.apache.reef.driver.restart.DriverRestarted;
 import org.apache.reef.driver.task.RunningTask;
 import org.apache.reef.runtime.common.driver.DriverStatusManager;
 import org.apache.reef.runtime.common.utils.RemoteManager;
@@ -229,10 +230,10 @@ public final class ReefEventStateManager {
   /**
    * Job Driver has been restarted.
    */
-  public final class DriverRestartHandler implements EventHandler<StartTime> {
+  public final class DriverRestartHandler implements EventHandler<DriverRestarted> {
     @Override
     @SuppressWarnings("checkstyle:hiddenfield")
-    public void onNext(final StartTime restartTime) {
+    public void onNext(final DriverRestarted restartTime) {
       LOG.log(Level.INFO, "DriverRestartHandler called. StartTime: {0}", restartTime);
     }
   }


### PR DESCRIPTION
This addressed the issue by
  * Created a ``DriverRestarted`` interface that provides the set of Evaluator IDs for Evaluators that are expected to report back.
  * Added a ``ClrHandlersInitializer`` interface that allows implementing classes to initialize CLR EventHandlers based on Driver condition.
  * Change ``DriverRestartHandlers`` to implement ``EventHandler<DriverRestarted>``.

JIRA:
  [REEF-687](https://issues.apache.org/jira/browse/REEF-687)