### PR TITLE
[REEF-688] Create a DriverRestartCompleted event in Java

### DIFF
--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
@@ -27,7 +27,7 @@ import org.apache.reef.driver.evaluator.*;
 import org.apache.reef.driver.task.*;
 import org.apache.reef.io.network.naming.NameServer;
 import org.apache.reef.javabridge.*;
-import org.apache.reef.runtime.common.DriverRestartCompleted;
+import org.apache.reef.driver.restart.DriverRestartCompleted;
 import org.apache.reef.runtime.common.driver.DriverStatusManager;
 import org.apache.reef.driver.evaluator.EvaluatorProcess;
 import org.apache.reef.tang.annotations.Unit;
@@ -612,10 +612,13 @@ public final class JobDriver {
     @Override
     public void onNext(final DriverRestartCompleted driverRestartCompleted) {
       LOG.log(Level.INFO, "Java DriverRestartCompleted event received at time [{0}]. ",
-          driverRestartCompleted.getTimeStamp());
-      try (final LoggingScope ls = loggingScopeFactory.driverRestartCompleted(driverRestartCompleted.getTimeStamp())) {
+          driverRestartCompleted.getCompletedTime());
+      try (final LoggingScope ls = loggingScopeFactory.driverRestartCompleted(
+          driverRestartCompleted.getCompletedTime().getTimeStamp())) {
         if (JobDriver.this.driverRestartHandler != 0) {
           LOG.log(Level.INFO, "CLR driver restart handler implemented, now handle it in CLR.");
+
+          // TODO[REEF-690]: Pass in DriverRestartCompleted object to .NET.
           NativeInterop.clrSystemDriverRestartCompletedHandlerOnNext(JobDriver.this.driverRestartCompletedHandler);
         } else {
           LOG.log(Level.WARNING, "No CLR driver restart handler implemented, done with DriverRestartCompletedHandler.");

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverRestartConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverRestartConfiguration.java
@@ -25,7 +25,7 @@ import org.apache.reef.annotations.audience.Public;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.parameters.*;
 import org.apache.reef.driver.task.RunningTask;
-import org.apache.reef.runtime.common.DriverRestartCompleted;
+import org.apache.reef.driver.restart.DriverRestartCompleted;
 import org.apache.reef.tang.formats.ConfigurationModule;
 import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
 import org.apache.reef.tang.formats.OptionalImpl;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverRestartCompletedHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverRestartCompletedHandlers.java
@@ -18,7 +18,7 @@
  */
 package org.apache.reef.driver.parameters;
 
-import org.apache.reef.runtime.common.DriverRestartCompleted;
+import org.apache.reef.driver.restart.DriverRestartCompleted;
 import org.apache.reef.runtime.common.driver.defaults.DefaultDriverRestartCompletedHandler;
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartCompleted.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartCompleted.java
@@ -16,13 +16,29 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.runtime.common;
+package org.apache.reef.driver.restart;
 
+import org.apache.reef.annotations.Provided;
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.Public;
 import org.apache.reef.wake.time.Time;
 
-public final class DriverRestartCompleted extends Time {
+/**
+ * The object used to notify the user that the Driver Restart process has been completed.
+ */
+@Public
+@Unstable
+@Provided
+public interface DriverRestartCompleted {
 
-  public DriverRestartCompleted(final long timestamp) {
-    super(timestamp);
-  }
+  /**
+   * @return the completed time of Driver restart.
+   */
+  Time getCompletedTime();
+
+  /**
+   * @return True if Driver restart completion was triggered by a timeout. False if triggered due to all Evaluators
+   * reporting back.
+   */
+  boolean getIsTimeout();
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartCompleted.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartCompleted.java
@@ -40,5 +40,5 @@ public interface DriverRestartCompleted {
    * @return True if Driver restart completion was triggered by a timeout. False if triggered due to all Evaluators
    * reporting back.
    */
-  boolean getIsTimeout();
+  boolean isTimedOut();
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartCompletedImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartCompletedImpl.java
@@ -25,11 +25,11 @@ import org.apache.reef.wake.time.Time;
  */
 class DriverRestartCompletedImpl implements DriverRestartCompleted {
   private final Time completedTime;
-  private final boolean isTimeout;
+  private final boolean isTimedOut;
 
-  DriverRestartCompletedImpl(final long completedTimeMillis, final boolean isTimeout) {
+  DriverRestartCompletedImpl(final long completedTimeMillis, final boolean isTimedOut) {
     this.completedTime = new Time(completedTimeMillis) { };
-    this.isTimeout = isTimeout;
+    this.isTimedOut = isTimedOut;
   }
 
   /**
@@ -44,7 +44,7 @@ class DriverRestartCompletedImpl implements DriverRestartCompleted {
    * {@inheritDoc}
    */
   @Override
-  public boolean getIsTimeout() {
-    return isTimeout;
+  public boolean isTimedOut() {
+    return isTimedOut;
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartCompletedImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartCompletedImpl.java
@@ -16,20 +16,35 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.driver.parameters;
+package org.apache.reef.driver.restart;
 
-import org.apache.reef.driver.restart.DriverRestartCompleted;
-import org.apache.reef.tang.annotations.Name;
-import org.apache.reef.tang.annotations.NamedParameter;
-import org.apache.reef.wake.EventHandler;
-
-import java.util.Set;
+import org.apache.reef.wake.time.Time;
 
 /**
- * Service handler for driver restart completed event.
+ * @see DriverRestartCompleted
  */
-@NamedParameter(doc = "Handler for driver restart completed event")
-public final class ServiceDriverRestartCompletedHandlers implements Name<Set<EventHandler<DriverRestartCompleted>>> {
-  private ServiceDriverRestartCompletedHandlers() {
+class DriverRestartCompletedImpl implements DriverRestartCompleted {
+  private final Time completedTime;
+  private final boolean isTimeout;
+
+  DriverRestartCompletedImpl(final long completedTimeMillis, final boolean isTimeout) {
+    this.completedTime = new Time(completedTimeMillis) { };
+    this.isTimeout = isTimeout;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Time getCompletedTime() {
+    return completedTime;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean getIsTimeout() {
+    return isTimeout;
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartManager.java
@@ -261,14 +261,14 @@ public final class DriverRestartManager implements DriverIdlenessSource {
   /**
    * Sets the driver restart status to be completed if not yet set and notifies the restart completed event handlers.
    */
-  private synchronized void onDriverRestartCompleted(final boolean isTimeout) {
+  private synchronized void onDriverRestartCompleted(final boolean isTimedOut) {
     if (this.state != DriverRestartState.COMPLETED) {
       final Set<String> outstandingEvaluatorIds = getOutstandingEvaluatorsAndMarkExpired();
       driverRuntimeRestartManager.informAboutEvaluatorFailures(outstandingEvaluatorIds);
 
       this.state = DriverRestartState.COMPLETED;
       final DriverRestartCompleted driverRestartCompleted = new DriverRestartCompletedImpl(
-          System.currentTimeMillis(), isTimeout);
+          System.currentTimeMillis(), isTimedOut);
 
       for (final EventHandler<DriverRestartCompleted> serviceRestartCompletedHandler
           : this.serviceDriverRestartCompletedHandlers) {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultDriverRestartCompletedHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/defaults/DefaultDriverRestartCompletedHandler.java
@@ -18,7 +18,7 @@
  */
 package org.apache.reef.runtime.common.driver.defaults;
 
-import org.apache.reef.runtime.common.DriverRestartCompleted;
+import org.apache.reef.driver.restart.DriverRestartCompleted;
 import org.apache.reef.wake.EventHandler;
 
 import javax.inject.Inject;
@@ -38,7 +38,7 @@ public final class DefaultDriverRestartCompletedHandler implements EventHandler<
 
   @Override
   public void onNext(final DriverRestartCompleted restartCompleted) {
-    LOG.log(Level.INFO, "Driver restart completed at time [{0}].", restartCompleted.getTimeStamp());
+    LOG.log(Level.INFO, "Driver restart completed at time [{0}].", restartCompleted.getCompletedTime());
   }
 }
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorMessageDispatcher.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorMessageDispatcher.java
@@ -27,7 +27,7 @@ import org.apache.reef.driver.evaluator.CompletedEvaluator;
 import org.apache.reef.driver.evaluator.FailedEvaluator;
 import org.apache.reef.driver.parameters.*;
 import org.apache.reef.driver.task.*;
-import org.apache.reef.runtime.common.DriverRestartCompleted;
+import org.apache.reef.driver.restart.DriverRestartCompleted;
 import org.apache.reef.runtime.common.driver.DriverExceptionHandler;
 import org.apache.reef.runtime.common.utils.DispatchingEStage;
 import org.apache.reef.tang.annotations.Parameter;


### PR DESCRIPTION
This addressed the issue by
  * Changed ``DriverRestartCompleted`` to an interface that has getters to the restart completion time and the flag that indicates a timeout on ``DriverRestartCompleted``.
  * Add implementation ``DriverRestartCompletedImpl``.
  * Change existing ``EventHandler<DriverRestartCompleted>``.

JIRA:
  [REEF-688](https://issues.apache.org/jira/browse/REEF-688)