### PR TITLE
[REEF-695] Reorganize reef-examples/scheduler classes into packages

### DIFF
--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/client/SchedulerREEF.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/client/SchedulerREEF.java
@@ -16,11 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.examples.scheduler;
+package org.apache.reef.examples.scheduler.client;
 
 import org.apache.commons.cli.ParseException;
 import org.apache.reef.client.DriverConfiguration;
 import org.apache.reef.client.REEF;
+import org.apache.reef.examples.scheduler.driver.SchedulerDriver;
+import org.apache.reef.examples.scheduler.driver.SchedulerHttpHandler;
 import org.apache.reef.runtime.local.client.LocalRuntimeConfiguration;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Configurations;

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/client/SchedulerREEFYarn.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/client/SchedulerREEFYarn.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.examples.scheduler;
+package org.apache.reef.examples.scheduler.client;
 
 import org.apache.commons.cli.ParseException;
 import org.apache.reef.runtime.yarn.client.YarnClientConfiguration;
@@ -25,7 +25,7 @@ import org.apache.reef.tang.exceptions.InjectionException;
 
 import java.io.IOException;
 
-import static org.apache.reef.examples.scheduler.SchedulerREEF.runTaskScheduler;
+import static org.apache.reef.examples.scheduler.client.SchedulerREEF.runTaskScheduler;
 
 /**
  * REEF TaskScheduler on YARN runtime.

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/client/package-info.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/client/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Task scheduler example client classes.
+ */
+package org.apache.reef.examples.scheduler.client;

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/driver/Scheduler.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/driver/Scheduler.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.examples.scheduler;
+package org.apache.reef.examples.scheduler.driver;
 
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.task.TaskConfiguration;

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/driver/SchedulerDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/driver/SchedulerDriver.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.examples.scheduler;
+package org.apache.reef.examples.scheduler.driver;
 
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.context.ContextConfiguration;
@@ -24,6 +24,7 @@ import org.apache.reef.driver.evaluator.AllocatedEvaluator;
 import org.apache.reef.driver.evaluator.EvaluatorRequest;
 import org.apache.reef.driver.evaluator.EvaluatorRequestor;
 import org.apache.reef.driver.task.CompletedTask;
+import org.apache.reef.examples.scheduler.client.SchedulerREEF;
 import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.tang.annotations.Unit;
 import org.apache.reef.wake.EventHandler;
@@ -87,7 +88,7 @@ public final class SchedulerDriver {
   /**
    * The driver is ready to run.
    */
-  final class StartHandler implements EventHandler<StartTime> {
+  public final class StartHandler implements EventHandler<StartTime> {
     @Override
     public void onNext(final StartTime startTime) {
       LOG.log(Level.INFO, "Driver started at {0}", startTime);
@@ -102,7 +103,7 @@ public final class SchedulerDriver {
    * Evaluator is allocated. This occurs every time to run commands in Non-retainable version,
    * while occurs only once in the Retainable version
    */
-  final class EvaluatorAllocatedHandler implements EventHandler<AllocatedEvaluator> {
+  public final class EvaluatorAllocatedHandler implements EventHandler<AllocatedEvaluator> {
     @Override
     public void onNext(final AllocatedEvaluator evaluator) {
       LOG.log(Level.INFO, "Evaluator is ready");
@@ -125,7 +126,7 @@ public final class SchedulerDriver {
    * It may happen, for example, when tasks are canceled during allocation.
    * In these cases, the new evaluator may be abandoned.
    */
-  final class ActiveContextHandler implements EventHandler<ActiveContext> {
+  public final class ActiveContextHandler implements EventHandler<ActiveContext> {
     @Override
     public void onNext(final ActiveContext context) {
       synchronized (SchedulerDriver.this) {
@@ -150,7 +151,7 @@ public final class SchedulerDriver {
    * The evaluator is reused for the next Task if retainable is set to {@code true}.
    * Otherwise the evaluator is released.
    */
-  final class CompletedTaskHandler implements EventHandler<CompletedTask> {
+  public final class CompletedTaskHandler implements EventHandler<CompletedTask> {
     @Override
     public void onNext(final CompletedTask task) {
       final int taskId = Integer.valueOf(task.getId());

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/driver/SchedulerHttpHandler.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/driver/SchedulerHttpHandler.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.examples.scheduler;
+package org.apache.reef.examples.scheduler.driver;
 
 import org.apache.reef.tang.InjectionFuture;
 import org.apache.reef.webserver.HttpHandler;
@@ -32,7 +32,7 @@ import java.util.Map;
 /**
  * Receive HttpRequest so that it can handle the command list.
  */
-final class SchedulerHttpHandler implements HttpHandler {
+public final class SchedulerHttpHandler implements HttpHandler {
   private final InjectionFuture<SchedulerDriver> schedulerDriver;
 
   private String uriSpecification = "reef-example-scheduler";

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/driver/SchedulerResponse.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/driver/SchedulerResponse.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.examples.scheduler;
+package org.apache.reef.examples.scheduler.driver;
 
 /**
  * This class specifies the response from the Scheduler.

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/driver/TaskEntity.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/driver/TaskEntity.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.reef.examples.scheduler;
+package org.apache.reef.examples.scheduler.driver;
 
 /**
  * TaskEntity represent a single entry of task queue used in

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/driver/package-info.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/scheduler/driver/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Task scheduler example driver classes.
+ */
+package org.apache.reef.examples.scheduler.driver;


### PR DESCRIPTION
Move classes into client and driver packages.
Task classes are in a separate package, o.a.r.examples.library.

JIRA:
  [REEF-695](https://issues.apache.org/jira/browse/REEF-695)

Pull Request:
  Closes #