### PR TITLE
[REEF-700] Clean up HelloREEF to be consistent across different runtimes

### DIFF
--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloDriver.java
@@ -47,7 +47,7 @@ public final class HelloDriver {
    * @param requestor evaluator requestor object used to create new evaluator containers.
    */
   @Inject
-  public HelloDriver(final EvaluatorRequestor requestor) {
+  private HelloDriver(final EvaluatorRequestor requestor) {
     this.requestor = requestor;
     LOG.log(Level.FINE, "Instantiated 'HelloDriver'");
   }

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloDriverRestart.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloDriverRestart.java
@@ -22,6 +22,7 @@ import org.apache.reef.tang.annotations.Unit;
 import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.time.event.StartTime;
 
+import javax.inject.Inject;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -32,6 +33,10 @@ import java.util.logging.Logger;
 public final class HelloDriverRestart {
 
   private static final Logger LOG = Logger.getLogger(HelloDriverRestart.class.getName());
+
+  @Inject
+  private HelloDriverRestart() {
+  }
 
   /**
    * Handles Restarts. Prints a message.

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloJVMOptionsDriver.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloJVMOptionsDriver.java
@@ -51,7 +51,7 @@ public final class HelloJVMOptionsDriver {
    * @param requestor evaluator requestor object used to create new evaluator containers.
    */
   @Inject
-  public HelloJVMOptionsDriver(final EvaluatorRequestor requestor,
+  private HelloJVMOptionsDriver(final EvaluatorRequestor requestor,
                                final JVMProcessFactory jvmProcessFactory) {
     this.requestor = requestor;
     this.jvmProcessFactory = jvmProcessFactory;

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloJVMOptionsREEF.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloJVMOptionsREEF.java
@@ -48,9 +48,18 @@ public final class HelloJVMOptionsREEF {
   private static final int JOB_TIMEOUT = 10000; // 10 sec.
 
   /**
+   * @return the configuration of the runtime
+   */
+  private static Configuration getRuntimeConfiguration() {
+    return LocalRuntimeConfiguration.CONF
+        .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, MAX_NUMBER_OF_EVALUATORS)
+        .build();
+  }
+
+  /**
    * @return the configuration of the HelloREEF driver.
    */
-  public static Configuration getDriverConfiguration() {
+  private static Configuration getDriverConfiguration() {
     return DriverConfiguration.CONF
         .set(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getClassLocation(HelloJVMOptionsDriver.class))
         .set(DriverConfiguration.DRIVER_IDENTIFIER, "HelloJVMOptions")
@@ -59,30 +68,26 @@ public final class HelloJVMOptionsREEF {
         .build();
   }
 
-  public static LauncherStatus runHelloReef(final Configuration runtimeConf, final int timeOut)
-      throws BindException, InjectionException {
-    final Configuration driverConf = getDriverConfiguration();
-    return DriverLauncher.getLauncher(runtimeConf).run(driverConf, timeOut);
-  }
-
   /**
-   * Start Hello REEF job. Runs method runHelloReef().
+   * Start HelloJVMOptions REEF job.
    *
    * @param args command line parameters.
    * @throws BindException      configuration error.
    * @throws InjectionException configuration error.
    */
   public static void main(final String[] args) throws BindException, InjectionException {
-    final Configuration runtimeConfiguration = LocalRuntimeConfiguration.CONF
-        .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, MAX_NUMBER_OF_EVALUATORS)
-        .build();
-    final LauncherStatus status = runHelloReef(runtimeConfiguration, JOB_TIMEOUT);
+    final Configuration runtimeConf = getRuntimeConfiguration();
+    final Configuration driverConf = getDriverConfiguration();
+
+    final LauncherStatus status = DriverLauncher
+        .getLauncher(runtimeConf)
+        .run(driverConf, JOB_TIMEOUT);
     LOG.log(Level.INFO, "REEF job completed: {0}", status);
   }
 
-    /**
-     * Empty private constructor to prohibit instantiation of utility class.
-     */
+  /**
+   * Empty private constructor to prohibit instantiation of utility class.
+   */
   private HelloJVMOptionsREEF() {
   }
 }

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEF.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEF.java
@@ -46,10 +46,20 @@ public final class HelloREEF {
    */
   private static final int JOB_TIMEOUT = 10000; // 10 sec.
 
+
+  /**
+   * @return the configuration of the runtime
+   */
+  private static Configuration getRuntimeConfiguration() {
+    return LocalRuntimeConfiguration.CONF
+        .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, MAX_NUMBER_OF_EVALUATORS)
+        .build();
+  }
+
   /**
    * @return the configuration of the HelloREEF driver.
    */
-  public static Configuration getDriverConfiguration() {
+  private static Configuration getDriverConfiguration() {
     return DriverConfiguration.CONF
         .set(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getClassLocation(HelloDriver.class))
         .set(DriverConfiguration.DRIVER_IDENTIFIER, "HelloREEF")
@@ -58,30 +68,26 @@ public final class HelloREEF {
         .build();
   }
 
-  public static LauncherStatus runHelloReef(final Configuration runtimeConf, final int timeOut)
-      throws BindException, InjectionException {
-    final Configuration driverConf = getDriverConfiguration();
-    return DriverLauncher.getLauncher(runtimeConf).run(driverConf, timeOut);
-  }
-
   /**
-   * Start Hello REEF job. Runs method runHelloReef().
+   * Start Hello REEF job.
    *
    * @param args command line parameters.
    * @throws BindException      configuration error.
    * @throws InjectionException configuration error.
    */
   public static void main(final String[] args) throws BindException, InjectionException {
-    final Configuration runtimeConfiguration = LocalRuntimeConfiguration.CONF
-        .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, MAX_NUMBER_OF_EVALUATORS)
-        .build();
-    final LauncherStatus status = runHelloReef(runtimeConfiguration, JOB_TIMEOUT);
+    final Configuration runtimeConf = getRuntimeConfiguration();
+    final Configuration driverConf = getDriverConfiguration();
+
+    final LauncherStatus status = DriverLauncher
+        .getLauncher(runtimeConf)
+        .run(driverConf, JOB_TIMEOUT);
     LOG.log(Level.INFO, "REEF job completed: {0}", status);
   }
 
-    /**
-     * Empty private constructor to prohibit instantiation of utility class.
-     */
+  /**
+   * Empty private constructor to prohibit instantiation of utility class.
+   */
   private HelloREEF() {
   }
 }

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEFMesos.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEFMesos.java
@@ -23,6 +23,7 @@ import org.apache.reef.client.DriverLauncher;
 import org.apache.reef.client.LauncherStatus;
 import org.apache.reef.runtime.mesos.client.MesosClientConfiguration;
 import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.exceptions.BindException;
 import org.apache.reef.tang.exceptions.InjectionException;
 
 import java.util.logging.Level;
@@ -31,6 +32,24 @@ import java.util.logging.Logger;
 public final class HelloREEFMesos {
   private static final Logger LOG = Logger.getLogger(HelloREEFMesos.class.getName());
 
+  /**
+   * Mesos Master IP address and port number.
+   * Change it to the master location of your cluster environment if needed
+   */
+  private static final String MASTER_IP = "localhost:5050";
+
+  /**
+   * @return the configuration of the runtime
+   */
+  private static Configuration getRuntimeConfiguration() {
+    return MesosClientConfiguration.CONF
+        .set(MesosClientConfiguration.MASTER_IP, MASTER_IP)
+        .build();
+  }
+
+  /**
+   * @return the configuration of the HelloREEF driver.
+   */
   private static Configuration getDriverConfiguration() {
     return DriverConfiguration.CONF
         .set(DriverConfiguration.GLOBAL_LIBRARIES,
@@ -42,15 +61,20 @@ public final class HelloREEFMesos {
   }
 
   /**
-   * MASTER_IP(Mesos Master IP) is set to "localhost:5050".
+   * MASTER_IP  is set to "localhost:5050".
    * You may change it to suit your cluster environment.
+   *
+   * @param args command line parameters.
+   * @throws BindException      configuration error.
+   * @throws InjectionException configuration error.
    */
-  public static void main(final String[] args) throws InjectionException {
+  public static void main(final String[] args) throws BindException, InjectionException {
+    final Configuration runtimeConf = getRuntimeConfiguration();
+    final Configuration driverConf = getDriverConfiguration();
+
     final LauncherStatus status = DriverLauncher
-        .getLauncher(MesosClientConfiguration.CONF
-            .set(MesosClientConfiguration.MASTER_IP, "localhost:5050")
-            .build())
-        .run(getDriverConfiguration());
+        .getLauncher(runtimeConf)
+        .run(driverConf);
     LOG.log(Level.INFO, "REEF job completed: {0}", status);
   }
 

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEFNoClient.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEFNoClient.java
@@ -37,28 +37,49 @@ public final class HelloREEFNoClient {
 
   private static final Logger LOG = Logger.getLogger(HelloREEFNoClient.class.getName());
 
-  public static void runHelloReefWithoutClient(
-      final Configuration runtimeConf) throws InjectionException {
+  /**
+   * The upper limit on the number of Evaluators that the local resourcemanager will hand out concurrently.
+   */
+  private static final int MAX_NUMBER_OF_EVALUATORS = 2;
 
-    final REEF reef = Tang.Factory.getTang().newInjector(runtimeConf).getInstance(REEF.class);
+  /**
+   * @return the configuration of the runtime
+   */
+  private static Configuration getRuntimeConfiguration() {
+    return LocalRuntimeConfiguration.CONF
+        .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, MAX_NUMBER_OF_EVALUATORS)
+        .build();
+  }
 
-    final Configuration driverConf = DriverConfiguration.CONF
+  /**
+   * @return the configuration of the HelloREEF driver.
+   */
+  private static Configuration getDriverConfiguration() {
+    return DriverConfiguration.CONF
         .set(DriverConfiguration.GLOBAL_LIBRARIES, EnvironmentUtils.getClassLocation(HelloDriver.class))
         .set(DriverConfiguration.DRIVER_IDENTIFIER, "HelloREEF")
         .set(DriverConfiguration.ON_DRIVER_STARTED, HelloDriver.StartHandler.class)
         .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, HelloDriver.EvaluatorAllocatedHandler.class)
         .build();
+  }
 
+  /**
+   * Used in the HDInsight example.
+   * @param runtimeConf the configuration of the runtime
+   * @throws InjectionException
+   */
+  public static void runHelloReefWithoutClient(final Configuration runtimeConf) throws InjectionException {
+    final REEF reef = Tang.Factory.getTang().newInjector(runtimeConf).getInstance(REEF.class);
+    final Configuration driverConf = getDriverConfiguration();
     reef.submit(driverConf);
   }
 
   public static void main(final String[] args) throws BindException, InjectionException {
+    final Configuration runtimeConf = getRuntimeConfiguration();
+    final Configuration driverConf = getDriverConfiguration();
 
-    final Configuration runtimeConfiguration = LocalRuntimeConfiguration.CONF
-        .set(LocalRuntimeConfiguration.MAX_NUMBER_OF_EVALUATORS, 2)
-        .build();
-
-    runHelloReefWithoutClient(runtimeConfiguration);
+    final REEF reef = Tang.Factory.getTang().newInjector(runtimeConf).getInstance(REEF.class);
+    reef.submit(driverConf);
     LOG.log(Level.INFO, "Job Submitted");
   }
 

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEFYarn.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEFYarn.java
@@ -23,6 +23,7 @@ import org.apache.reef.client.DriverLauncher;
 import org.apache.reef.client.LauncherStatus;
 import org.apache.reef.runtime.yarn.client.YarnClientConfiguration;
 import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.exceptions.BindException;
 import org.apache.reef.tang.exceptions.InjectionException;
 
 import java.util.logging.Level;
@@ -42,6 +43,12 @@ public final class HelloREEFYarn {
    */
   private static final int JOB_TIMEOUT = 100000; // 100 sec.
 
+  /**
+   * @return the configuration of the runtime
+   */
+  private static Configuration getRuntimeConfiguration() {
+    return YarnClientConfiguration.CONF.build();
+  }
 
   /**
    * @return the configuration of the HelloREEF driver.
@@ -60,14 +67,16 @@ public final class HelloREEFYarn {
    * Start Hello REEF job. Runs method runHelloReef().
    *
    * @param args command line parameters.
-   * @throws org.apache.reef.tang.exceptions.BindException      configuration error.
-   * @throws org.apache.reef.tang.exceptions.InjectionException configuration error.
+   * @throws BindException      configuration error.
+   * @throws InjectionException configuration error.
    */
-  public static void main(final String[] args) throws InjectionException {
+  public static void main(final String[] args) throws BindException, InjectionException {
+    final Configuration runtimeConf = getRuntimeConfiguration();
+    final Configuration driverConf = getDriverConfiguration();
 
     final LauncherStatus status = DriverLauncher
-        .getLauncher(YarnClientConfiguration.CONF.build())
-        .run(getDriverConfiguration(), JOB_TIMEOUT);
+        .getLauncher(runtimeConf)
+        .run(driverConf, JOB_TIMEOUT);
     LOG.log(Level.INFO, "REEF job completed: {0}", status);
   }
 

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEFYarnRestart.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloREEFYarnRestart.java
@@ -31,6 +31,9 @@ import org.apache.reef.tang.exceptions.InjectionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * The Client for running HelloREEF with DriverRestartHandler on YARN.
+ */
 public final class HelloREEFYarnRestart {
 
   private static final Logger LOG = Logger.getLogger(HelloREEFYarnRestart.class.getName());
@@ -42,6 +45,12 @@ public final class HelloREEFYarnRestart {
    */
   private static final int JOB_TIMEOUT = 100000; // 100 sec.
 
+  /**
+   * @return the configuration of the runtime
+   */
+  private static Configuration getRuntimeConfiguration() {
+    return YarnClientConfiguration.CONF.build();
+  }
 
   /**
    * @return the configuration of the HelloREEF driver.
@@ -63,17 +72,19 @@ public final class HelloREEFYarnRestart {
   }
 
   /**
-   * Start Hello REEF job. Runs method runHelloReefYarnRestart().
+   * Start HelloREEFYarnRestart job.
    *
    * @param args command line parameters.
    * @throws org.apache.reef.tang.exceptions.BindException      configuration error.
    * @throws org.apache.reef.tang.exceptions.InjectionException configuration error.
    */
   public static void main(final String[] args) throws InjectionException {
+    final Configuration runtimeConf = getRuntimeConfiguration();
+    final Configuration driverConf = getDriverConfiguration();
 
     final LauncherStatus status = DriverLauncher
-        .getLauncher(YarnClientConfiguration.CONF.build())
-        .run(getDriverConfiguration(), JOB_TIMEOUT);
+        .getLauncher(runtimeConf)
+        .run(driverConf, JOB_TIMEOUT);
     LOG.log(Level.INFO, "REEF job completed: {0}", status);
   }
 

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloReefYarnTcp.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloReefYarnTcp.java
@@ -26,6 +26,7 @@ import org.apache.reef.io.TcpPortConfigurationProvider;
 import org.apache.reef.runtime.yarn.client.YarnClientConfiguration;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.BindException;
 import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeBegin;
 import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeCount;
@@ -35,7 +36,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * The Client for Hello REEF example.
+ * The Client for running HelloREEF with tcp port configuration on YARN.
  */
 public final class HelloReefYarnTcp {
 
@@ -46,20 +47,16 @@ public final class HelloReefYarnTcp {
    */
   private static final int JOB_TIMEOUT = 150000; // 30 sec.
 
-  private HelloReefYarnTcp(){}
-  /**
-   * @return the configuration of the HelloREEF driver.
-   */
-  private static Configuration getDriverConfiguration() {
-    return DriverConfiguration.CONF
-        .set(DriverConfiguration.GLOBAL_LIBRARIES,
-            HelloReefYarnTcp.class.getProtectionDomain().getCodeSource().getLocation().getFile())
-        .set(DriverConfiguration.DRIVER_IDENTIFIER, "HelloREEF")
-        .set(DriverConfiguration.ON_DRIVER_STARTED, HelloDriver.StartHandler.class)
-        .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, HelloDriver.EvaluatorAllocatedHandler.class)
-        .build();
-  }
+  private static final int DEFAULT_TCP_BEGIN_PORT = 8900;
+  private static final int DEFAULT_TCP_RANGE_COUNT = 10;
+  private static final int DEFAULT_TCP_RANGE_TRY_COUNT = 1111;
 
+  /**
+   * @param tcpBeginPort  the first tcp port number to try
+   * @param tcpRangeCount the number of tcp ports in the range
+   * @param tcpTryCount maximum number of tries for port numbers
+   * @return the configuration of the runtime
+   */
   private static Configuration getRuntimeConfiguration(
       final int tcpBeginPort,
       final int tcpRangeCount,
@@ -74,22 +71,42 @@ public final class HelloReefYarnTcp {
   }
 
   /**
-   * Start Hello REEF job. Runs method runHelloReef().
-   * @param args command line parameters.
-   * @throws org.apache.reef.tang.exceptions.BindException      configuration error.
-   * @throws org.apache.reef.tang.exceptions.InjectionException configuration error.
+   * @return the configuration of the HelloREEF driver.
    */
-  public static final int DEFAULT_TCP_BEGIN_PORT = 8900;
-  public static final int DEFAULT_TCP_RANGE_COUNT = 10;
-  public static final int DEFAULT_TCP_RANGE_TRY_COUNT = 1111;
-  public static void main(final String[] args) throws InjectionException {
+  private static Configuration getDriverConfiguration() {
+    return DriverConfiguration.CONF
+        .set(DriverConfiguration.GLOBAL_LIBRARIES,
+            HelloReefYarnTcp.class.getProtectionDomain().getCodeSource().getLocation().getFile())
+        .set(DriverConfiguration.DRIVER_IDENTIFIER, "HelloREEF")
+        .set(DriverConfiguration.ON_DRIVER_STARTED, HelloDriver.StartHandler.class)
+        .set(DriverConfiguration.ON_EVALUATOR_ALLOCATED, HelloDriver.EvaluatorAllocatedHandler.class)
+        .build();
+  }
+
+  /**
+   * Start Hello REEF job.
+   *
+   * @param args command line parameters.
+   * @throws BindException      configuration error.
+   * @throws InjectionException configuration error.
+   */
+  public static void main(final String[] args) throws BindException, InjectionException {
     final int tcpBeginPort = args.length > 0 ? Integer.valueOf(args[0]) : DEFAULT_TCP_BEGIN_PORT;
     final int tcpRangeCount = args.length > 1 ? Integer.valueOf(args[1]) : DEFAULT_TCP_RANGE_COUNT;
     final int tcpTryCount = args.length > 2 ? Integer.valueOf(args[2]) : DEFAULT_TCP_RANGE_TRY_COUNT;
-    Configuration runtimeConfiguration = getRuntimeConfiguration(tcpBeginPort, tcpRangeCount, tcpTryCount);
+
+    final Configuration runtimeConf = getRuntimeConfiguration(tcpBeginPort, tcpRangeCount, tcpTryCount);
+    final Configuration driverConf = getDriverConfiguration();
+
     final LauncherStatus status = DriverLauncher
-        .getLauncher(runtimeConfiguration)
-        .run(getDriverConfiguration(), JOB_TIMEOUT);
+        .getLauncher(runtimeConf)
+        .run(driverConf, JOB_TIMEOUT);
     LOG.log(Level.INFO, "REEF job completed: {0}", status);
+  }
+
+  /**
+   * Empty private constructor to prohibit instantiation of utility class.
+   */
+  private HelloReefYarnTcp() {
   }
 }

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloTask.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/hello/HelloTask.java
@@ -28,7 +28,7 @@ import javax.inject.Inject;
 public final class HelloTask implements Task {
 
   @Inject
-  HelloTask() {
+  private HelloTask() {
   }
 
   @Override


### PR DESCRIPTION
This addressed the issue by
* Extracting out the building of the runtime configuration
* Consistently launching the HelloREEF job across different runtimes (and examples)

JIRA:
  [REEF-700](https://issues.apache.org/jira/browse/REEF-700)

Pull Request:
  Closes #