### PR TITLE
[REEF-661] Remove obsolete APIs from o.a.r.Network (.NET)

### DIFF
--- a/lang/cs/Org.Apache.REEF.Network/Naming/NameClient.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Naming/NameClient.cs
@@ -64,9 +64,8 @@ namespace Org.Apache.REEF.Network.Naming
         /// </summary>
         /// <param name="remoteAddress">The ip address of the NameServer</param>
         /// <param name="remotePort">The port of the NameServer</param>
-        [Obsolete("This constructor will be made private in 0.13 version", false)]
         [Inject]
-        public NameClient(
+        private NameClient(
             [Parameter(typeof (NamingConfigurationOptions.NameServerAddress))] string remoteAddress,
             [Parameter(typeof (NamingConfigurationOptions.NameServerPort))] int remotePort)
         {
@@ -93,19 +92,6 @@ namespace Org.Apache.REEF.Network.Naming
             Initialize(remoteEndpoint);
             _disposed = false;
             _cache = cache;
-        }
-
-        /// <summary>
-        /// Constructs a NameClient to register, lookup, and unregister IPEndpoints
-        /// with the NameServer.
-        /// </summary>
-        /// <param name="remoteEndpoint">The endpoint of the NameServer</param>
-        [Obsolete("This constructor will be removed in the 0.13 version", false)]
-        public NameClient(IPEndPoint remoteEndpoint)
-        {
-            Initialize(remoteEndpoint);
-            _cache = TangFactory.GetTang().NewInjector().GetInstance<NameCache>();
-            _disposed = false;
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Network/Naming/NameServer.cs
+++ b/lang/cs/Org.Apache.REEF.Network/Naming/NameServer.cs
@@ -54,9 +54,8 @@ namespace Org.Apache.REEF.Network.Naming
         /// <param name="tcpPortProvider">If port is 0, this interface provides 
         /// a port range to try.
         /// </param>
-        [Obsolete("Please use TANG injection instead.")]
         [Inject]
-        public NameServer(
+        private NameServer(
             [Parameter(typeof(NamingConfigurationOptions.NameServerPort))] int port,
             ITcpPortProvider tcpPortProvider)
         {


### PR DESCRIPTION
This removes/converts to private obsolete constructors of NameClient and NameServer

JIRA:
  [REEF-661](https://issues.apache.org/jira/browse/REEF-661)

Pull Request:
  Closes #