### PR TITLE
[REEF-662] Remove obsolete APIs from o.a.r.Wake (.NET)

### DIFF
--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/DefaultRemoteManager.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/DefaultRemoteManager.cs
@@ -43,59 +43,10 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
         /// available port.
         /// </summary>
         /// <param name="localAddress">The address to listen on</param>
-        /// <param name="codec">The codec used for serializing messages</param>
-        /// <param name="tcpPortProvider">provides port numbers to listen</param>
-        [Obsolete("Use IRemoteManagerFactory.GetInstance() instead.", false)]
-        public DefaultRemoteManager(IPAddress localAddress, ICodec<T> codec, ITcpPortProvider tcpPortProvider) : 
-            this(localAddress, 0, codec, tcpPortProvider)
-        {
-        }
-
-        /// <summary>
-        /// Constructs a DefaultRemoteManager listening on the specified IPEndPoint.
-        /// </summary>
-        /// <param name="localEndpoint">The endpoint to listen on</param>
-        /// <param name="codec">The codec used for serializing messages</param>
-        /// <param name="tcpPortProvider">provides port numbers to listen</param>
-        [Obsolete("Use IRemoteManagerFactory.GetInstance() instead.", false)]
-        public DefaultRemoteManager(IPEndPoint localEndpoint, ICodec<T> codec, ITcpPortProvider tcpPortProvider)
-        {
-            if (localEndpoint == null)
-            {
-                throw new ArgumentNullException("localEndpoint");
-            }
-            if (localEndpoint.Port < 0)
-            {
-                throw new ArgumentException("Listening port must be greater than or equal to zero");
-            }
-            if (codec == null)
-            {
-                throw new ArgumentNullException("codec");
-            }
-
-            _codec = new RemoteEventCodec<T>(codec);
-            _observerContainer = new ObserverContainer<T>();
-            _cachedClients = new Dictionary<IPEndPoint, ProxyObserver>();
-
-            // Begin to listen for incoming messages
-            _server = new TransportServer<IRemoteEvent<T>>(localEndpoint, _observerContainer, _codec, 
-                tcpPortProvider);
-            _server.Run();
-
-            LocalEndpoint = _server.LocalEndpoint;
-            Identifier = new SocketRemoteIdentifier(LocalEndpoint);
-        }
-
-        /// <summary>
-        /// Constructs a DefaultRemoteManager listening on the specified address and any
-        /// available port.
-        /// </summary>
-        /// <param name="localAddress">The address to listen on</param>
         /// <param name="port">The port to listen on</param>
         /// <param name="codec">The codec used for serializing messages</param>
         /// <param name="tcpPortProvider">provides port numbers to listen</param>
-        [Obsolete("Use IRemoteManagerFactory.GetInstance() instead.", false)]
-        public DefaultRemoteManager(IPAddress localAddress, int port, ICodec<T> codec, ITcpPortProvider tcpPortProvider)
+        internal DefaultRemoteManager(IPAddress localAddress, int port, ICodec<T> codec, ITcpPortProvider tcpPortProvider)
         {
             if (localAddress == null)
             {
@@ -129,8 +80,7 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
         /// Constructs a DefaultRemoteManager. Does not listen for incoming messages.
         /// </summary>
         /// <param name="codec">The codec used for serializing messages</param>
-        [Obsolete("Use IRemoteManagerFactory.GetInstance() instead.", false)]
-        public DefaultRemoteManager(ICodec<T> codec)
+        internal DefaultRemoteManager(ICodec<T> codec)
         {
             using (LOGGER.LogFunction("DefaultRemoteManager::DefaultRemoteManager"))
             {

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/DefaultRemoteManagerFactory.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/DefaultRemoteManagerFactory.cs
@@ -38,26 +38,17 @@ namespace Org.Apache.REEF.Wake.Impl
 
         public IRemoteManager<T> GetInstance<T>(IPAddress localAddress, int port, ICodec<T> codec)
         {
-#pragma warning disable 618
-            // This is the one place allowed to call this constructor. Hence, disabling the warning is OK.
             return new DefaultRemoteManager<T>(localAddress, port, codec, _tcpPortProvider);
-#pragma warning restore 618
         }
 
         public IRemoteManager<T> GetInstance<T>(IPAddress localAddress, ICodec<T> codec)
         {
-#pragma warning disable 618
-            // This is the one place allowed to call this constructor. Hence, disabling the warning is OK.
             return new DefaultRemoteManager<T>(localAddress, 0, codec, _tcpPortProvider);
-#pragma warning restore 618
         }
 
         public IRemoteManager<T> GetInstance<T>(ICodec<T> codec)
         {
-#pragma warning disable 618
-            // This is the one place allowed to call this constructor. Hence, disabling the warning is OK.
             return new DefaultRemoteManager<T>(codec);
-#pragma warning restore 618
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/RemoteEvent.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/RemoteEvent.cs
@@ -51,7 +51,7 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
 
         public T Value { get; set; }
 
-        [Obsolete("This field is used in Java code only. See [REEF-445]", false)]
+        [Obsolete("This field is used in Java code only; keeping it for consistency across languages. See [REEF-445]", false)]
         public long Sequence { get; set; }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingRemoteManager.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingRemoteManager.cs
@@ -42,8 +42,7 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
         /// <param name="localAddress">The address to listen on</param>
         /// <param name="tcpPortProvider">Tcp port provider</param>
         /// <param name="streamingCodec">Streaming codec</param>
-        [Obsolete("Use IRemoteManagerFactory.GetInstance() instead.", false)]
-        public StreamingRemoteManager(IPAddress localAddress, ITcpPortProvider tcpPortProvider, IStreamingCodec<T> streamingCodec)
+        internal StreamingRemoteManager(IPAddress localAddress, ITcpPortProvider tcpPortProvider, IStreamingCodec<T> streamingCodec)
         {
             if (localAddress == null)
             {

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingRemoteManagerFactory.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingRemoteManagerFactory.cs
@@ -41,10 +41,7 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
 
         public IRemoteManager<T> GetInstance<T>(IPAddress localAddress, IStreamingCodec<T> codec)
         {
-#pragma warning disable 618
-// This is the one place allowed to call this constructor. Hence, disabling the warning is OK.
             return new StreamingRemoteManager<T>(localAddress, _tcpPortProvider, codec);
-#pragma warning disable 618
         }
     }
 }


### PR DESCRIPTION
This removes/converts to internal obsolete constructors of DefaultRemoteManager
and StreamingRemoteManager and clarifies obsolete message of RemoteEvent#Sequence

JIRA:
  [REEF-662](https://issues.apache.org/jira/browse/REEF-662)

Pull Request:
  Closes #