### PR TITLE
[REEF-624] Replace all use of DriverBridgeConfiguration with DriverConfiguration

### DIFF
--- a/lang/cs/Org.Apache.REEF.Network.Examples.Client/BroadcastAndReduceClient.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples.Client/BroadcastAndReduceClient.cs
@@ -26,6 +26,7 @@ using Org.Apache.REEF.Driver.Bridge;
 using Org.Apache.REEF.Network.Examples.GroupCommunication;
 using Org.Apache.REEF.Network.Examples.GroupCommunication.BroadcastReduceDriverAndTasks;
 using Org.Apache.REEF.Network.Group.Config;
+using Org.Apache.REEF.Network.Naming;
 using Org.Apache.REEF.Network.NetworkService;
 using Org.Apache.REEF.Tang.Implementations.Configuration;
 using Org.Apache.REEF.Tang.Implementations.Tang;
@@ -46,13 +47,12 @@ namespace Org.Apache.REEF.Network.Examples.Client
             const int fanOut = 2;
 
             IConfiguration driverConfig = TangFactory.GetTang().NewConfigurationBuilder(
-                DriverBridgeConfiguration.ConfigurationModule
-                    .Set(DriverBridgeConfiguration.OnDriverStarted, GenericType<BroadcastReduceDriver>.Class)
-                    .Set(DriverBridgeConfiguration.OnEvaluatorAllocated, GenericType<BroadcastReduceDriver>.Class)
-                    .Set(DriverBridgeConfiguration.OnEvaluatorRequested, GenericType<BroadcastReduceDriver>.Class)
-                    .Set(DriverBridgeConfiguration.OnEvaluatorFailed, GenericType<BroadcastReduceDriver>.Class)
-                    .Set(DriverBridgeConfiguration.OnContextActive, GenericType<BroadcastReduceDriver>.Class)
-                    .Set(DriverBridgeConfiguration.CustomTraceLevel, Level.Info.ToString())
+                DriverConfiguration.ConfigurationModule
+                    .Set(DriverConfiguration.OnDriverStarted, GenericType<BroadcastReduceDriver>.Class)
+                    .Set(DriverConfiguration.OnEvaluatorAllocated, GenericType<BroadcastReduceDriver>.Class)
+                    .Set(DriverConfiguration.OnEvaluatorFailed, GenericType<BroadcastReduceDriver>.Class)
+                    .Set(DriverConfiguration.OnContextActive, GenericType<BroadcastReduceDriver>.Class)
+                    .Set(DriverConfiguration.CustomTraceLevel, Level.Info.ToString())
                     .Build())
                 .BindNamedParameter<GroupTestConfig.NumIterations, int>(
                     GenericType<GroupTestConfig.NumIterations>.Class,
@@ -77,6 +77,13 @@ namespace Org.Apache.REEF.Network.Examples.Client
                 .Build();
 
             IConfiguration merged = Configurations.Merge(driverConfig, groupCommDriverConfig);
+
+            IConfiguration taskConfig = TangFactory.GetTang().NewConfigurationBuilder()
+                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(MasterTask).Assembly.GetName().Name)
+                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(NameClient).Assembly.GetName().Name)
+                .Build();
+
+            merged = Configurations.Merge(merged, taskConfig);
 
             HashSet<string> appDlls = new HashSet<string>();
             appDlls.Add(typeof(IDriver).Assembly.GetName().Name);

--- a/lang/cs/Org.Apache.REEF.Network.Examples.Client/PipelineBroadcastAndReduceClient.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples.Client/PipelineBroadcastAndReduceClient.cs
@@ -30,6 +30,7 @@ using Org.Apache.REEF.Driver.Bridge;
 using Org.Apache.REEF.Network.Examples.GroupCommunication;
 using Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastReduceDriverAndTasks;
 using Org.Apache.REEF.Network.Group.Config;
+using Org.Apache.REEF.Network.Naming;
 using Org.Apache.REEF.Network.NetworkService;
 using Org.Apache.REEF.Tang.Implementations.Configuration;
 using Org.Apache.REEF.Tang.Implementations.Tang;
@@ -44,15 +45,12 @@ namespace Org.Apache.REEF.Network.Examples.Client
         public void RunPipelineBroadcastAndReduce(bool runOnYarn, int numTasks, int startingPortNo, int portRange, int arraySize, int chunkSize)
         {
             IConfiguration driverConfig = TangFactory.GetTang().NewConfigurationBuilder(
-                DriverBridgeConfiguration.ConfigurationModule
-                    .Set(DriverBridgeConfiguration.OnDriverStarted, GenericType<PipelinedBroadcastReduceDriver>.Class)
-                    .Set(DriverBridgeConfiguration.OnEvaluatorAllocated,
-                        GenericType<PipelinedBroadcastReduceDriver>.Class)
-                    .Set(DriverBridgeConfiguration.OnEvaluatorRequested,
-                        GenericType<PipelinedBroadcastReduceDriver>.Class)
-                    .Set(DriverBridgeConfiguration.OnEvaluatorFailed, GenericType<PipelinedBroadcastReduceDriver>.Class)
-                    .Set(DriverBridgeConfiguration.OnContextActive, GenericType<PipelinedBroadcastReduceDriver>.Class)
-                    .Set(DriverBridgeConfiguration.CustomTraceLevel, Level.Info.ToString())
+                DriverConfiguration.ConfigurationModule
+                    .Set(DriverConfiguration.OnDriverStarted, GenericType<PipelinedBroadcastReduceDriver>.Class)
+                    .Set(DriverConfiguration.OnEvaluatorAllocated, GenericType<PipelinedBroadcastReduceDriver>.Class)
+                    .Set(DriverConfiguration.OnEvaluatorFailed, GenericType<PipelinedBroadcastReduceDriver>.Class)
+                    .Set(DriverConfiguration.OnContextActive, GenericType<PipelinedBroadcastReduceDriver>.Class)
+                    .Set(DriverConfiguration.CustomTraceLevel, Level.Info.ToString())
                     .Build())
                 .BindNamedParameter<GroupTestConfig.NumIterations, int>(
                     GenericType<GroupTestConfig.NumIterations>.Class,
@@ -83,6 +81,14 @@ namespace Org.Apache.REEF.Network.Examples.Client
                 .Build();
 
             IConfiguration merged = Configurations.Merge(driverConfig, groupCommDriverConfig);
+
+            IConfiguration taskConfig = TangFactory.GetTang().NewConfigurationBuilder()
+                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(PipelinedMasterTask).Assembly.GetName().Name)
+                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(PipelinedSlaveTask).Assembly.GetName().Name)
+                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(NameClient).Assembly.GetName().Name)
+                .Build();
+
+            merged = Configurations.Merge(merged, taskConfig);
 
             HashSet<string> appDlls = new HashSet<string>();
             appDlls.Add(typeof(IDriver).Assembly.GetName().Name);

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Driver/DriverTestStartHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Driver/DriverTestStartHandler.cs
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+using System;
 using Org.Apache.REEF.Driver;
 using Org.Apache.REEF.Driver.Bridge;
 using Org.Apache.REEF.Tang.Annotations;
@@ -25,7 +26,7 @@ using Org.Apache.REEF.Wake.Time;
 
 namespace Org.Apache.REEF.Tests.Functional.Driver
 {
-    public class DriverTestStartHandler : IStartHandler
+    public class DriverTestStartHandler : IObserver<IDriverStarted>
     {
         private static readonly Logger LOGGER = Logger.GetLogger(typeof(DriverTestStartHandler));
 
@@ -37,10 +38,20 @@ namespace Org.Apache.REEF.Tests.Functional.Driver
         {
             _clock = clock;
             _httpServerPort = httpServerPort;
-            Identifier = "DriverTestStartHandler";
             LOGGER.Log(Level.Info, "Http Server port number: " + httpServerPort.PortNumber);
         }
 
-        public string Identifier { get; set; }
+        public void OnNext(IDriverStarted value)
+        {
+        }
+
+        public void OnError(Exception error)
+        {
+            throw error;
+        }
+
+        public void OnCompleted()
+        {
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Driver/TestDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Driver/TestDriver.cs
@@ -19,6 +19,7 @@
 
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Org.Apache.REEF.Driver;
 using Org.Apache.REEF.Driver.Bridge;
 using Org.Apache.REEF.Driver.Defaults;
 using Org.Apache.REEF.Tang.Interface;
@@ -46,15 +47,15 @@ namespace Org.Apache.REEF.Tests.Functional.Driver
         /// This is to test DriverTestStartHandler. No evaluator and tasks are involked.
         /// </summary>
         [TestMethod, Priority(1), TestCategory("FunctionalGated")]
-        [Description("Test DriverTestStartHandler. No evaluator and tasks are involked")]
+        [Description("Test DriverTestStartHandler. No evaluator and tasks are invoked")]
         [DeploymentItem(@".")]
         [Timeout(180 * 1000)]
         public void TestDriverStart()
         {
-            IConfiguration driverConfig = DriverBridgeConfiguration.ConfigurationModule
-             .Set(DriverBridgeConfiguration.OnDriverStarted, GenericType<DriverTestStartHandler>.Class)
-             .Set(DriverBridgeConfiguration.CustomTraceListeners, GenericType<DefaultCustomTraceListener>.Class)
-             .Set(DriverBridgeConfiguration.CustomTraceLevel, Level.Info.ToString())
+            IConfiguration driverConfig = DriverConfiguration.ConfigurationModule
+             .Set(DriverConfiguration.OnDriverStarted, GenericType<DriverTestStartHandler>.Class)
+             .Set(DriverConfiguration.CustomTraceListeners, GenericType<DefaultCustomTraceListener>.Class)
+             .Set(DriverConfiguration.CustomTraceLevel, Level.Info.ToString())
              .Build();
 
             HashSet<string> appDlls = new HashSet<string>();

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Group/ScatterReduceTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Group/ScatterReduceTest.cs
@@ -27,6 +27,7 @@ using Org.Apache.REEF.Driver.Bridge;
 using Org.Apache.REEF.Network.Examples.GroupCommunication;
 using Org.Apache.REEF.Network.Examples.GroupCommunication.ScatterReduceDriverAndTasks;
 using Org.Apache.REEF.Network.Group.Config;
+using Org.Apache.REEF.Network.Naming;
 using Org.Apache.REEF.Network.NetworkService;
 using Org.Apache.REEF.Tang.Implementations.Configuration;
 using Org.Apache.REEF.Tang.Implementations.Tang;
@@ -71,13 +72,12 @@ namespace Org.Apache.REEF.Tests.Functional.Group
         public void TestScatterAndReduce(bool runOnYarn, int numTasks)
         {
             IConfiguration driverConfig = TangFactory.GetTang().NewConfigurationBuilder(
-                DriverBridgeConfiguration.ConfigurationModule
-                    .Set(DriverBridgeConfiguration.OnDriverStarted, GenericType<ScatterReduceDriver>.Class)
-                    .Set(DriverBridgeConfiguration.OnEvaluatorAllocated, GenericType<ScatterReduceDriver>.Class)
-                    .Set(DriverBridgeConfiguration.OnEvaluatorRequested, GenericType<ScatterReduceDriver>.Class)
-                    .Set(DriverBridgeConfiguration.OnEvaluatorFailed, GenericType<ScatterReduceDriver>.Class)
-                    .Set(DriverBridgeConfiguration.OnContextActive, GenericType<ScatterReduceDriver>.Class)
-                    .Set(DriverBridgeConfiguration.CustomTraceLevel, Level.Info.ToString())
+                DriverConfiguration.ConfigurationModule
+                    .Set(DriverConfiguration.OnDriverStarted, GenericType<ScatterReduceDriver>.Class)
+                    .Set(DriverConfiguration.OnEvaluatorAllocated, GenericType<ScatterReduceDriver>.Class)
+                    .Set(DriverConfiguration.OnEvaluatorFailed, GenericType<ScatterReduceDriver>.Class)
+                    .Set(DriverConfiguration.OnContextActive, GenericType<ScatterReduceDriver>.Class)
+                    .Set(DriverConfiguration.CustomTraceLevel, Level.Info.ToString())
                     .Build())
                 .BindNamedParameter<GroupTestConfig.NumEvaluators, int>(
                     GenericType<GroupTestConfig.NumEvaluators>.Class,
@@ -93,6 +93,13 @@ namespace Org.Apache.REEF.Tests.Functional.Group
                .Build();
 
             IConfiguration merged = Configurations.Merge(driverConfig, groupCommDriverConfig);
+
+            IConfiguration taskConfig = TangFactory.GetTang().NewConfigurationBuilder()
+                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(MasterTask).Assembly.GetName().Name)
+                .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(NameClient).Assembly.GetName().Name)
+                .Build();
+
+            merged = Configurations.Merge(merged, taskConfig);
 
             HashSet<string> appDlls = new HashSet<string>();
             appDlls.Add(typeof(IDriver).Assembly.GetName().Name);


### PR DESCRIPTION
This addressed the issue by
  * replacing all usages of DriverBridgeConfiguration in examples and tests
    with DriverConfiguration
  * adding IObservable<IDriverStarted> and necessary methods to test drivers

JIRA:
  [REEF-624](https://issues.apache.org/jira/browse/REEF-624)

Pull Request:
  Closes #
