### PR TITLE
[REEF-691] Add DriverRestartEvaluatorFailedHandler

### DIFF
--- a/lang/cs/Org.Apache.REEF.Bridge/JavaClrBridge.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/JavaClrBridge.cpp
@@ -510,3 +510,21 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemDr
 		ManagedLog::LOGGER->LogError(errorMessage, ex);
 	}
 }
+
+/*
+* Class:     org_apache_reef_javabridge_NativeInterop
+* Method:    clrSystemDriverRestartFailedEvaluatorHandlerOnNext
+* Signature: (JLorg/apache/reef/javabridge/FailedEvaluatorBridge;Lorg/apache/reef/javabridge/InteropLogger;)V
+*/
+JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemDriverRestartFailedEvaluatorHandlerOnNext
+(JNIEnv * env, jclass cls, jlong handler, jobject jfailedEvaluator, jobject jlogger) {
+	ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_clrSystemDriverRestartFailedEvaluatorHandlerOnNext");
+	FailedEvaluatorClr2Java^ failedEvaluatorBridge = gcnew FailedEvaluatorClr2Java(env, jfailedEvaluator);
+	try {
+		ClrSystemHandlerWrapper::Call_ClrSystemDriverRestartFailedEvaluator_OnNext(handler, failedEvaluatorBridge);
+	}
+	catch (System::Exception^ ex) {
+		String^ errorMessage = "Exception in Call_ClrSystemDriverRestartFailedEvaluator_OnNext";
+		ManagedLog::LOGGER->LogError(errorMessage, ex);
+	}
+}

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/ClrSystemHandlerWrapper.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/ClrSystemHandlerWrapper.cs
@@ -220,6 +220,15 @@ namespace Org.Apache.REEF.Driver.Bridge
             }
         }
 
+        public static void Call_ClrSystemDriverRestartFailedEvaluator_OnNext(ulong handle, IFailedEvaluatorClr2Java clr2Java)
+        {
+            using (LOGGER.LogFunction("ClrSystemHandlerWrapper::Call_ClrSystemDriverRestartFailedEvaluator_OnNext"))
+            {
+                GCHandle gc = GCHandle.FromIntPtr((IntPtr)handle);
+                ClrSystemHandler<IFailedEvaluator> obj = (ClrSystemHandler<IFailedEvaluator>)gc.Target;
+                obj.OnNext(new FailedEvaluator(clr2Java));
+            }
+        }
 
         //Deprecate, remove after both Java and C# code gets checked in
         public static ulong[] Call_ClrSystemStartHandler_OnStart(

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverBridge.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverBridge.cs
@@ -59,6 +59,8 @@ namespace Org.Apache.REEF.Driver.Bridge
 
         private static ClrSystemHandler<IFailedEvaluator> _failedEvaluatorSubscriber;
 
+        private static ClrSystemHandler<IFailedEvaluator> _driverRestartFailedEvaluatorSubscriber;
+
         private static ClrSystemHandler<ICompletedEvaluator> _completedEvaluatorSubscriber;
 
         private static ClrSystemHandler<IHttpMessage> _httpServerEventSubscriber;
@@ -99,6 +101,8 @@ namespace Org.Apache.REEF.Driver.Bridge
 
         private readonly ISet<IObserver<IFailedEvaluator>> _failedEvaluatorHandlers;
 
+        private readonly ISet<IObserver<IFailedEvaluator>> _driverRestartFailedEvaluatorHandlers;
+
         private readonly ISet<IObserver<ICompletedEvaluator>> _completedEvaluatorHandlers;
 
         private readonly ISet<IObserver<IClosedContext>> _closedContextHandlers;
@@ -133,6 +137,7 @@ namespace Org.Apache.REEF.Driver.Bridge
             [Parameter(Value = typeof(DriverBridgeConfigurationOptions.DriverRestartActiveContextHandlers))] ISet<IObserver<IActiveContext>> driverRestartActiveContextHandlers,
             [Parameter(Value = typeof(DriverBridgeConfigurationOptions.DriverRestartRunningTaskHandlers))] ISet<IObserver<IRunningTask>> driverRestartRunningTaskHandlers,
             [Parameter(Value = typeof(DriverBridgeConfigurationOptions.DriverRestartCompletedHandlers))] ISet<IObserver<IDriverRestartCompleted>> driverRestartCompletedHandlers,
+            [Parameter(Value = typeof(DriverBridgeConfigurationOptions.DriverRestartFailedEvaluatorHandlers))] ISet<IObserver<IFailedEvaluator>> driverRestartFailedEvaluatorHandlers,
             [Parameter(Value = typeof(DriverBridgeConfigurationOptions.TraceListenersSet))] ISet<TraceListener> traceListeners,
             [Parameter(Value = typeof(EvaluatorConfigurationProviders))] ISet<IConfigurationProvider> configurationProviders,
             [Parameter(Value = typeof(DriverBridgeConfigurationOptions.TraceLevel))] string traceLevel,
@@ -173,6 +178,7 @@ namespace Org.Apache.REEF.Driver.Bridge
             _driverRestartActiveContextHandlers = driverRestartActiveContextHandlers;
             _driverRestartRunningTaskHandlers = driverRestartRunningTaskHandlers;
             _driverRestartCompletedHandlers = driverRestartCompletedHandlers;
+            _driverRestartFailedEvaluatorHandlers = driverRestartFailedEvaluatorHandlers;
             _httpServerHandler = httpServerHandler;
             _configurationProviders = configurationProviders;
             
@@ -193,6 +199,7 @@ namespace Org.Apache.REEF.Driver.Bridge
             _driverRestartActiveContextSubscriber = new ClrSystemHandler<IActiveContext>();
             _driverRestartRunningTaskSubscriber = new ClrSystemHandler<IRunningTask>();
             _driverRestartCompletedSubscriber = new ClrSystemHandler<IDriverRestartCompleted>();
+            _driverRestartFailedEvaluatorSubscriber = new ClrSystemHandler<IFailedEvaluator>();
         }
 
         public ulong[] Subscribe()
@@ -318,6 +325,14 @@ namespace Org.Apache.REEF.Driver.Bridge
                 _logger.Log(Level.Verbose, "subscribed to handler for IRestartCompleted received during driver restart: " + handler);
             }
             handlers[Constants.Handlers[Constants.DriverRestartCompletedHandler]] = ClrHandlerHelper.CreateHandler(_driverRestartCompletedSubscriber);
+
+            // subscribe to Failed Evaluator received during driver restart
+            foreach (var handler in _driverRestartFailedEvaluatorHandlers)
+            {
+                _driverRestartFailedEvaluatorSubscriber.Subscribe(handler);
+                _logger.Log(Level.Verbose, "subscribed to handler for IFailedEvaluator received during driver restart: " + handler);
+            }
+            handlers[Constants.Handlers[Constants.DriverRestartFailedEvaluatorHandler]] = ClrHandlerHelper.CreateHandler(_driverRestartFailedEvaluatorSubscriber);
 
             // subscribe to Http message
             _httpServerEventSubscriber.Subscribe(_httpServerHandler);

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverBridgeConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverBridgeConfiguration.cs
@@ -180,6 +180,12 @@ namespace Org.Apache.REEF.Driver.Bridge
         [SuppressMessage("Microsoft.Security", "CA2104:Do not declare read only mutable reference types", Justification = "not applicable")]
         public static readonly OptionalImpl<IObserver<IDriverRestartCompleted>> OnDriverRestartCompleted = new OptionalImpl<IObserver<IDriverRestartCompleted>>();
 
+        ///// <summary>
+        ///// Event handler for driver restart failed evaluator event received during driver restart. Defaults to job failure if not bound.
+        ///// </summary>
+        [SuppressMessage("Microsoft.Security", "CA2104:Do not declare read only mutable reference types", Justification = "not applicable")]
+        public static readonly OptionalImpl<IObserver<IFailedEvaluator>> OnDriverRestartEvaluatorFailed = new OptionalImpl<IObserver<IFailedEvaluator>>();
+
         /// <summary>
         /// Evaluator recovery timeout in seconds for driver restart. If value is greater than 0, restart is enabled. The default value is -1.
         /// </summary>
@@ -238,6 +244,7 @@ namespace Org.Apache.REEF.Driver.Bridge
                 .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.DriverRestartActiveContextHandlers>.Class, OnDriverRestartContextActive)
                 .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.DriverRestartRunningTaskHandlers>.Class, OnDriverRestartTaskRunning)
                 .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.DriverRestartCompletedHandlers>.Class, OnDriverRestartCompleted)
+                .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.DriverRestartFailedEvaluatorHandlers>.Class, OnDriverRestartEvaluatorFailed)
                 .BindNamedParameter(GenericType<DriverBridgeConfigurationOptions.TraceLevel>.Class, CustomTraceLevel)
                 .BindNamedParameter(GenericType<DriverBridgeConfigurationOptions.DriverRestartEvaluatorRecoverySeconds>.Class, DriverRestartEvaluatorRecoverySeconds)
                 .Build();

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverBridgeConfigurationOptions.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverBridgeConfigurationOptions.cs
@@ -57,6 +57,11 @@ namespace Org.Apache.REEF.Driver.Bridge
         {
         }
 
+        [NamedParameter(documentation: "Called when an evaluator has failed in the Driver Restart process.", defaultClasses: new[] { typeof(DefaultEvaluatorFailureHandler) })]
+        public class DriverRestartFailedEvaluatorHandlers : Name<ISet<IObserver<IFailedEvaluator>>>
+        {
+        }
+
         [NamedParameter(documentation: "Called when evaluator is requested.")] 
         public class EvaluatorRequestHandlers : Name<ISet<IObserver<IEvaluatorRequestor>>>
         {

--- a/lang/cs/Org.Apache.REEF.Driver/Constants.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Constants.cs
@@ -47,7 +47,7 @@ namespace Org.Apache.REEF.Driver
         /// <summary>
         /// The number of handlers total. Tightly coupled with Java.
         /// </summary>
-        public const int HandlersNumber = 17;
+        public const int HandlersNumber = 18;
 
         /// <summary>
         /// The name for EvaluatorRequestorHandler. Tightly coupled with Java.
@@ -134,6 +134,11 @@ namespace Org.Apache.REEF.Driver
         /// </summary>
         public const string DriverRestartCompletedHandler = "DriverRestartCompleted";
 
+        /// <summary>
+        /// The name for DriverRestartFailedEvaluatorHandler. Tightly coupled with Java
+        /// </summary>
+        public const string DriverRestartFailedEvaluatorHandler = "DriverRestartFailedEvaluator";
+
         [Obsolete(message:"Use REEFFileNames instead.")]
         public const string DriverBridgeConfiguration = Common.Constants.ClrBridgeRuntimeConfiguration;
 
@@ -199,7 +204,8 @@ namespace Org.Apache.REEF.Driver
                         { ContextMessageHandler, 13 },
                         { DriverRestartActiveContextHandler, 14 },
                         { DriverRestartRunningTaskHandler, 15 },
-                        { DriverRestartCompletedHandler, 16 }
+                        { DriverRestartCompletedHandler, 16 },
+                        { DriverRestartFailedEvaluatorHandler, 17 }
                     };
             }
         }

--- a/lang/cs/Org.Apache.REEF.Driver/DriverConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/DriverConfiguration.cs
@@ -146,6 +146,12 @@ namespace Org.Apache.REEF.Driver
         public static readonly OptionalImpl<IObserver<IDriverRestartCompleted>> OnDriverRestartCompleted =
             new OptionalImpl<IObserver<IDriverRestartCompleted>>();
 
+        ///// <summary>
+        ///// Event handler for driver restart failed evaluator event received during driver restart. Defaults to job failure if not bound.
+        ///// </summary>
+        public static readonly OptionalImpl<IObserver<IFailedEvaluator>> OnDriverRestartEvaluatorFailed =
+            new OptionalImpl<IObserver<IFailedEvaluator>>();
+
         /// <summary>
         /// Additional set of string arguments that can be pssed to handlers through client
         /// </summary>
@@ -220,6 +226,8 @@ namespace Org.Apache.REEF.Driver
                         OnDriverRestartContextActive)
                     .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.DriverRestartRunningTaskHandlers>.Class,
                         OnDriverRestartTaskRunning)
+                    .BindSetEntry(GenericType<DriverBridgeConfigurationOptions.DriverRestartFailedEvaluatorHandlers>.Class,
+                        OnDriverRestartEvaluatorFailed)
                     .BindNamedParameter(GenericType<DriverBridgeConfigurationOptions.TraceLevel>.Class, CustomTraceLevel)
                     .BindNamedParameter(GenericType<DriverBridgeConfigurationOptions.MaxApplicationSubmissions>.Class,
                         MaxApplicationSubmissions)

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/YarnJobSubmissionClient.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/YarnJobSubmissionClient.java
@@ -126,6 +126,8 @@ public final class YarnJobSubmissionClient {
                   driverRestartEvaluatorRecoverySeconds)
               .set(DriverRestartConfiguration.ON_DRIVER_RESTART_COMPLETED,
                   JobDriver.DriverRestartCompletedHandler.class)
+              .set(DriverRestartConfiguration.ON_DRIVER_RESTART_EVALUATOR_FAILED,
+                  JobDriver.DriverRestartFailedEvaluatorHandler.class)
               .build();
 
       driverConfiguration = Configurations.merge(

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/NativeInterop.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/NativeInterop.java
@@ -39,6 +39,7 @@ public final class NativeInterop {
   public static final String DRIVER_RESTART_ACTIVE_CONTEXT_KEY = "DriverRestartActiveContext";
   public static final String DRIVER_RESTART_RUNNING_TASK_KEY = "DriverRestartRunningTask";
   public static final String DRIVER_RESTART_COMPLETED_KEY = "DriverRestartCompleted";
+  public static final String DRIVER_RESTART_FAILED_EVALUATOR_KEY = "DriverRestartFailedEvaluator";
   public static final HashMap<String, Integer> HANDLERS = new HashMap<String, Integer>() {
     {
       put(ALLOCATED_EVALUATOR_KEY, 1);
@@ -57,10 +58,11 @@ public final class NativeInterop {
       put(DRIVER_RESTART_ACTIVE_CONTEXT_KEY, 14);
       put(DRIVER_RESTART_RUNNING_TASK_KEY, 15);
       put(DRIVER_RESTART_COMPLETED_KEY, 16);
+      put(DRIVER_RESTART_FAILED_EVALUATOR_KEY, 17);
     }
   };
 
-  public static final int N_HANDLERS = 17;
+  public static final int N_HANDLERS = 18;
 
   public static native void loadClrAssembly(final String filePath);
 
@@ -163,6 +165,12 @@ public final class NativeInterop {
 
   public static native void clrSystemDriverRestartCompletedHandlerOnNext(
       final long handle
+  );
+
+  public static native void clrSystemDriverRestartFailedEvaluatorHandlerOnNext(
+      final long handle,
+      final FailedEvaluatorBridge failedEvaluatorBridge,
+      final InteropLogger interopLogger
   );
 
   /**

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
@@ -133,10 +133,10 @@ public final class JobDriver {
   private long closedContextHandler = 0;
   private long failedContextHandler = 0;
   private long contextMessageHandler = 0;
-  private long driverRestartHandler = 0;
   private long driverRestartActiveContextHandler = 0;
   private long driverRestartRunningTaskHandler = 0;
   private long driverRestartCompletedHandler = 0;
+  private long driverRestartFailedEvaluatorHandler = 0;
   private boolean clrBridgeSetup = false;
   private boolean isRestarted = false;
 
@@ -226,6 +226,8 @@ public final class JobDriver {
             handlers[NativeInterop.HANDLERS.get(NativeInterop.DRIVER_RESTART_RUNNING_TASK_KEY)];
         this.driverRestartCompletedHandler =
             handlers[NativeInterop.HANDLERS.get(NativeInterop.DRIVER_RESTART_COMPLETED_KEY)];
+        this.driverRestartFailedEvaluatorHandler =
+            handlers[NativeInterop.HANDLERS.get(NativeInterop.DRIVER_RESTART_FAILED_EVALUATOR_KEY)];
       }
 
       try (final LoggingScope lp =
@@ -271,6 +273,78 @@ public final class JobDriver {
       NativeInterop.clrSystemAllocatedEvaluatorHandlerOnNext(JobDriver.this.allocatedEvaluatorHandler,
           allocatedEvaluatorBridge, this.interopLogger);
     }
+  }
+
+  private void handleFailedEvaluator(final FailedEvaluator eval, final boolean isRestartFailed) {
+    try (final LoggingScope ls = loggingScopeFactory.evaluatorFailed(eval.getId())) {
+      synchronized (JobDriver.this) {
+        LOG.log(Level.SEVERE, "FailedEvaluator", eval);
+        for (final FailedContext failedContext : eval.getFailedContextList()) {
+          final String failedContextId = failedContext.getId();
+          LOG.log(Level.INFO, "removing context " + failedContextId + " from job driver contexts.");
+          JobDriver.this.contexts.remove(failedContextId);
+        }
+        String message = "Evaluator " + eval.getId() + " failed with message: "
+            + eval.getEvaluatorException().getMessage();
+        JobDriver.this.jobMessageObserver.sendMessageToClient(message.getBytes());
+
+        if (isRestartFailed) {
+          evaluatorFailedHandlerWaitForCLRBridgeSetup(driverRestartFailedEvaluatorHandler, eval, isRestartFailed);
+        } else {
+          evaluatorFailedHandlerWaitForCLRBridgeSetup(failedEvaluatorHandler, eval, isRestartFailed);
+        }
+      }
+    }
+  }
+
+  private void evaluatorFailedHandlerWaitForCLRBridgeSetup(final long handle,
+                                                           final FailedEvaluator eval,
+                                                           final boolean isRestartFailed) {
+    if (handle == 0) {
+      if (JobDriver.this.clrBridgeSetup) {
+        final String message = "No CLR FailedEvaluator handler was set, exiting now";
+        LOG.log(Level.WARNING, message);
+        JobDriver.this.jobMessageObserver.sendMessageToClient(message.getBytes());
+        return;
+      } else {
+        clock.scheduleAlarm(0, new EventHandler<Alarm>() {
+          @Override
+          public void onNext(final Alarm time) {
+            if (JobDriver.this.clrBridgeSetup) {
+              handleFailedEvaluatorInCLR(eval, isRestartFailed);
+            } else {
+              LOG.log(Level.INFO, "Waiting for CLR bridge to be set up");
+              clock.scheduleAlarm(5000, this);
+            }
+          }
+        });
+      }
+    } else{
+      handleFailedEvaluatorInCLR(eval, isRestartFailed);
+    }
+  }
+
+  private void handleFailedEvaluatorInCLR(final FailedEvaluator eval, final boolean isRestartFailed) {
+    final String message = "CLR FailedEvaluator handler set, handling things with CLR handler.";
+    LOG.log(Level.INFO, message);
+    final FailedEvaluatorBridge failedEvaluatorBridge =
+        new FailedEvaluatorBridge(eval, JobDriver.this.evaluatorRequestor,
+        JobDriver.this.isRestarted, loggingScopeFactory);
+    if (isRestartFailed) {
+      NativeInterop.clrSystemDriverRestartFailedEvaluatorHandlerOnNext(
+          JobDriver.this.driverRestartFailedEvaluatorHandler, failedEvaluatorBridge, JobDriver.this.interopLogger);
+    } else {
+      NativeInterop.clrSystemFailedEvaluatorHandlerOnNext(JobDriver.this.failedEvaluatorHandler, failedEvaluatorBridge,
+          JobDriver.this.interopLogger);
+    }
+
+    final int additionalRequestedEvaluatorNumber = failedEvaluatorBridge.getNewlyRequestedEvaluatorNumber();
+    if (additionalRequestedEvaluatorNumber > 0) {
+      LOG.log(Level.INFO, "number of additional evaluators requested after evaluator failure: " +
+          additionalRequestedEvaluatorNumber);
+    }
+
+    JobDriver.this.jobMessageObserver.sendMessageToClient(message.getBytes());
   }
 
   /**
@@ -359,57 +433,17 @@ public final class JobDriver {
   public final class FailedEvaluatorHandler implements EventHandler<FailedEvaluator> {
     @Override
     public void onNext(final FailedEvaluator eval) {
-      try (final LoggingScope ls = loggingScopeFactory.evaluatorFailed(eval.getId())) {
-        synchronized (JobDriver.this) {
-          LOG.log(Level.SEVERE, "FailedEvaluator", eval);
-          for (final FailedContext failedContext : eval.getFailedContextList()) {
-            final String failedContextId = failedContext.getId();
-            LOG.log(Level.INFO, "removing context " + failedContextId + " from job driver contexts.");
-            JobDriver.this.contexts.remove(failedContextId);
-          }
-          String message = "Evaluator " + eval.getId() + " failed with message: "
-              + eval.getEvaluatorException().getMessage();
-          JobDriver.this.jobMessageObserver.sendMessageToClient(message.getBytes());
-
-          if (failedEvaluatorHandler == 0) {
-            if (JobDriver.this.clrBridgeSetup) {
-              message = "No CLR FailedEvaluator handler was set, exiting now";
-              LOG.log(Level.WARNING, message);
-              JobDriver.this.jobMessageObserver.sendMessageToClient(message.getBytes());
-              return;
-            } else {
-              clock.scheduleAlarm(0, new EventHandler<Alarm>() {
-                @Override
-                public void onNext(final Alarm time) {
-                  if (JobDriver.this.clrBridgeSetup) {
-                    handleFailedEvaluatorInCLR(eval);
-                  } else {
-                    LOG.log(Level.INFO, "Waiting for CLR bridge to be set up");
-                    clock.scheduleAlarm(5000, this);
-                  }
-                }
-              });
-            }
-          } else {
-            handleFailedEvaluatorInCLR(eval);
-          }
-        }
-      }
+      JobDriver.this.handleFailedEvaluator(eval, false);
     }
+  }
 
-    private void handleFailedEvaluatorInCLR(final FailedEvaluator eval) {
-      final String message = "CLR FailedEvaluator handler set, handling things with CLR handler.";
-      LOG.log(Level.INFO, message);
-      FailedEvaluatorBridge failedEvaluatorBridge = new FailedEvaluatorBridge(eval, JobDriver.this.evaluatorRequestor,
-          JobDriver.this.isRestarted, loggingScopeFactory);
-      NativeInterop.clrSystemFailedEvaluatorHandlerOnNext(JobDriver.this.failedEvaluatorHandler, failedEvaluatorBridge,
-          JobDriver.this.interopLogger);
-      final int additionalRequestedEvaluatorNumber = failedEvaluatorBridge.getNewlyRequestedEvaluatorNumber();
-      if (additionalRequestedEvaluatorNumber > 0) {
-        LOG.log(Level.INFO, "number of additional evaluators requested after evaluator failure: " +
-            additionalRequestedEvaluatorNumber);
-      }
-      JobDriver.this.jobMessageObserver.sendMessageToClient(message.getBytes());
+  /**
+   * Receive notification that the entire Evaluator had failed on Driver Restart.
+   */
+  public final class DriverRestartFailedEvaluatorHandler implements EventHandler<FailedEvaluator> {
+    @Override
+    public void onNext(final FailedEvaluator eval) {
+      JobDriver.this.handleFailedEvaluator(eval, true);
     }
   }
 
@@ -613,14 +647,13 @@ public final class JobDriver {
           driverRestartCompleted.getCompletedTime());
       try (final LoggingScope ls = loggingScopeFactory.driverRestartCompleted(
           driverRestartCompleted.getCompletedTime().getTimeStamp())) {
-        if (JobDriver.this.driverRestartHandler != 0) {
+        if (JobDriver.this.driverRestartCompletedHandler != 0) {
           LOG.log(Level.INFO, "CLR driver restart handler implemented, now handle it in CLR.");
 
           // TODO[REEF-690]: Pass in DriverRestartCompleted object to .NET.
           NativeInterop.clrSystemDriverRestartCompletedHandlerOnNext(JobDriver.this.driverRestartCompletedHandler);
         } else {
           LOG.log(Level.WARNING, "No CLR driver restart handler implemented, done with DriverRestartCompletedHandler.");
-
         }
       }
     }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverRestartConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverRestartConfiguration.java
@@ -23,6 +23,7 @@ import org.apache.reef.annotations.Unstable;
 import org.apache.reef.annotations.audience.ClientSide;
 import org.apache.reef.annotations.audience.Public;
 import org.apache.reef.driver.context.ActiveContext;
+import org.apache.reef.driver.evaluator.FailedEvaluator;
 import org.apache.reef.driver.parameters.*;
 import org.apache.reef.driver.restart.DriverRestarted;
 import org.apache.reef.driver.task.RunningTask;
@@ -64,6 +65,12 @@ public final class DriverRestartConfiguration extends ConfigurationModuleBuilder
       new OptionalImpl<>();
 
   /**
+   * Event handler for the event of driver restart completion, default to logging if not bound.
+   */
+  public static final OptionalImpl<EventHandler<FailedEvaluator>> ON_DRIVER_RESTART_EVALUATOR_FAILED =
+      new OptionalImpl<>();
+
+  /**
    * The amount of time in seconds the driver waits for evaluators to report back on restart.
    * Defaults to 3 minutes. If the value is set to Integer.MAX_VALUE, the driver will wait forever.
    */
@@ -83,6 +90,7 @@ public final class DriverRestartConfiguration extends ConfigurationModuleBuilder
       .bindSetEntry(DriverRestartTaskRunningHandlers.class, ON_DRIVER_RESTART_TASK_RUNNING)
       .bindSetEntry(DriverRestartContextActiveHandlers.class, ON_DRIVER_RESTART_CONTEXT_ACTIVE)
       .bindSetEntry(DriverRestartCompletedHandlers.class, ON_DRIVER_RESTART_COMPLETED)
+      .bindSetEntry(DriverRestartFailedEvaluatorHandlers.class, ON_DRIVER_RESTART_EVALUATOR_FAILED)
       .build();
 
   private DriverRestartConfiguration(){

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverRestartFailedEvaluatorHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/DriverRestartFailedEvaluatorHandlers.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.driver.parameters;
+
+import org.apache.reef.driver.evaluator.FailedEvaluator;
+import org.apache.reef.runtime.common.driver.defaults.DefaultEvaluatorFailureHandler;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+import org.apache.reef.wake.EventHandler;
+
+import java.util.Set;
+
+/**
+ * The {@link org.apache.reef.tang.annotations.NamedParameter} for Evaluators that have failed on Driver Restart.
+ */
+@NamedParameter(doc = "Handler for event of evaluator failed on driver restart.",
+    default_classes = DefaultEvaluatorFailureHandler.class)
+public final class DriverRestartFailedEvaluatorHandlers implements Name<Set<EventHandler<FailedEvaluator>>> {
+  private DriverRestartFailedEvaluatorHandlers(){
+  }
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceDriverRestartFailedEvaluatorHandlers.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/parameters/ServiceDriverRestartFailedEvaluatorHandlers.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.driver.parameters;
+
+import org.apache.reef.driver.evaluator.FailedEvaluator;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+import org.apache.reef.wake.EventHandler;
+
+import java.util.Set;
+
+/**
+ * Service handler for driver restart evaluator failed event.
+ */
+@NamedParameter(doc = "Handler for failed evaluator on Driver Restart.")
+public final class ServiceDriverRestartFailedEvaluatorHandlers implements Name<Set<EventHandler<FailedEvaluator>>> {
+  private ServiceDriverRestartFailedEvaluatorHandlers() {
+  }
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/EvaluatorRestartState.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/EvaluatorRestartState.java
@@ -71,6 +71,7 @@ public enum EvaluatorRestartState {
     switch(from) {
     case EXPECTED:
       switch(to) {
+      case EXPIRED:
       case REPORTED:
         return true;
       default:


### PR DESCRIPTION
This addressed the issue by
  * Adding a separate ``FailedEvaluatorHandler`` for Driver restart, i.e. ``DriverRestartFailedEvaluatorHandlers``.
  * Wiring up the new handler through to .NET.
  * Additionally small bug fixes that include the right handler check for ``DriverRestartCompleted`` in ``JobDriver`` and enable transition of Restart State from ``EXPECTED`` to ``EXPIRED``.

JIRA:
  [REEF-691](https://issues.apache.org/jira/browse/REEF-691)

Conflicts:
	lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java