### PR TITLE
[REEF-512]  Allow alias for NamedParameter in C# Tang

### DIFF
--- a/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestNamedParameter.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/ClassHierarchy/TestNamedParameter.cs
@@ -1,0 +1,112 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Tang.Formats;
+using Org.Apache.REEF.Tang.Implementations.Tang;
+using Org.Apache.REEF.Tang.Protobuf;
+using Org.Apache.REEF.Tang.Types;
+using Org.Apache.REEF.Tang.Util;
+
+namespace Org.Apache.REEF.Tang.Tests.ClassHierarchy
+{
+    [TestClass]
+    public class TestNamedParameter
+    {
+        [TestMethod]
+        public void TestNamedParameterWithDefaultValues()
+        {
+            var ns = TangFactory.GetTang().GetDefaultClassHierarchy();
+            INamedParameterNode cls = (INamedParameterNode)ns.GetNode(typeof(NamedParameterWithDefaultValues).AssemblyQualifiedName);
+            Assert.IsTrue(cls.GetDocumentation().Equals("NamedParameterWithDefaultValues"));
+            Assert.IsTrue(cls.GetShortName().Equals("NamedParameterWithDefaultValues"));
+            Assert.IsTrue(cls.GetAlias().Equals("org.apache.REEF.tang.tests.classHierarchy.NamedParameterWithDefaultValues"));
+            Assert.IsTrue(cls.GetAliasLanguage().Equals(AvroConfigurationSerializer.Java));
+        }
+
+        [TestMethod]
+        public void TestNamedParameterWithAlias()
+        {
+            var ns = TangFactory.GetTang().GetDefaultClassHierarchy();
+            INamedParameterNode cls = (INamedParameterNode)ns.GetNode(typeof(NamedParameterWithAlias).AssemblyQualifiedName);
+            Assert.IsTrue(cls.GetAlias().Equals("org.apache.REEF.tang.tests.classHierarchy.NamedParameterWithAlias"));
+            Assert.IsTrue(cls.GetAliasLanguage().Equals(AvroConfigurationSerializer.Java));
+        }
+
+        [TestMethod]
+        public void TestNamedParameterWithAliasRoundTrip()
+        {
+            var ns = TangFactory.GetTang().GetDefaultClassHierarchy();
+            INamedParameterNode node1 = (INamedParameterNode)ns.GetNode(typeof(NamedParameterWithAlias).AssemblyQualifiedName);
+
+            var ns1 = new ProtocolBufferClassHierarchy(ProtocolBufferClassHierarchy.Serialize(ns));
+            var node2 = ns1.GetNode(typeof(NamedParameterWithAlias).AssemblyQualifiedName);
+
+            Assert.IsTrue(node2 is INamedParameterNode);
+            Assert.IsTrue(((INamedParameterNode)node2).GetAliasLanguage().Equals(AvroConfigurationSerializer.Java));
+            Assert.IsTrue(((INamedParameterNode)node2).GetFullName().Equals(typeof(NamedParameterWithAlias).AssemblyQualifiedName));
+            Assert.IsTrue(((INamedParameterNode)node2).GetAlias().Equals("org.apache.REEF.tang.tests.classHierarchy.NamedParameterWithAlias"));
+        }
+
+        [TestMethod]
+        public void TestGetNamedparameterValue()
+        {
+            var b = TangFactory.GetTang().NewConfigurationBuilder()
+                .BindNamedParameter<NamedParameterWithAlias, string>(GenericType<NamedParameterWithAlias>.Class, "test")
+                .Build();
+
+            var c = b.GetClassHierarchy();
+            var i = TangFactory.GetTang().NewInjector(b);
+            var o = i.GetInstance<ClassWithNamedParameterWithAlias>();
+            var no = i.GetNamedInstance<NamedParameterWithAlias, string>();
+            Assert.IsTrue(o.Value.Equals("test"));
+        }      
+    }
+
+    [NamedParameter(Documentation = "NamedParameterWithDefaultValues",
+        ShortName = "NamedParameterWithDefaultValues",
+        DefaultValue = "default",
+        DefaultClass = null,
+        DefaultValues = null,
+        DefaultClasses = null,
+        Alias = "org.apache.REEF.tang.tests.classHierarchy.NamedParameterWithDefaultValues",
+        AliasLanguage = AvroConfigurationSerializer.Java
+     )]
+
+    public class NamedParameterWithDefaultValues : Name<string> 
+    {
+    }
+
+    [NamedParameter(alias: "org.apache.REEF.tang.tests.classHierarchy.NamedParameterWithAlias", aliasLanguage: AvroConfigurationSerializer.Java)]
+    public class NamedParameterWithAlias : Name<string>
+    {
+    }
+
+    public class ClassWithNamedParameterWithAlias
+    {
+        public string Value;
+
+        [Inject]
+        private ClassWithNamedParameterWithAlias([Parameter(typeof(NamedParameterWithAlias))] string abc)
+        {
+            Value = abc;
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/Org.Apache.REEF.Tang.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/Org.Apache.REEF.Tang.Tests.csproj
@@ -52,6 +52,7 @@ under the License.
     <Compile Include="ClassHierarchy\TestClassHierarchy.cs" />
     <Compile Include="ClassHierarchy\TestGeneric.cs" />
     <Compile Include="ClassHierarchy\TestMultipleInterface.cs" />
+    <Compile Include="ClassHierarchy\TestNamedParameter.cs" />
     <Compile Include="ClassHierarchy\TestParameterParser.cs" />
     <Compile Include="ClassHierarchy\TestSerilization.cs" />
     <Compile Include="Configuration\TestAvroConfiguration.cs" />

--- a/lang/cs/Org.Apache.REEF.Tang/Annotations/NamedParameter.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Annotations/NamedParameter.cs
@@ -18,6 +18,7 @@
  */
 
 using System;
+using Org.Apache.REEF.Tang.Formats;
 
 namespace Org.Apache.REEF.Tang.Annotations
 {
@@ -30,9 +31,11 @@ namespace Org.Apache.REEF.Tang.Annotations
         public Type DefaultClass { get; set; }
         public string[] DefaultValues { get; set; }
         public Type[] DefaultClasses { get; set; }
+        public string Alias { get; set; }
+        public string AliasLanguage { get; set; }
 
         public NamedParameterAttribute(string documentation = "", string shortName = "",
-            string defaultValue = "", Type defaultClass = null, string[] defaultValues = null, Type[] defaultClasses = null)
+            string defaultValue = "", Type defaultClass = null, string[] defaultValues = null, Type[] defaultClasses = null, string alias = null, string aliasLanguage = AvroConfigurationSerializer.Java)
         {
             this.Documentation = documentation;
             this.ShortName = shortName;
@@ -40,6 +43,8 @@ namespace Org.Apache.REEF.Tang.Annotations
             this.DefaultClass = defaultClass;
             this.DefaultValues = defaultValues;
             this.DefaultClasses = defaultClasses;
+            this.Alias = alias;
+            this.AliasLanguage = aliasLanguage;
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/AvroClassHierarchy.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/AvroClassHierarchy.cs
@@ -19,7 +19,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Runtime.Remoting.Messaging;
 using Org.Apache.REEF.Tang.Exceptions;
 using Org.Apache.REEF.Tang.Implementations.ClassHierarchy.AvroDataContract;
 using Org.Apache.REEF.Tang.Interface;
@@ -37,6 +39,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
 
         private readonly IPackageNode _rootNode;
         private readonly IDictionary<string, INode> _lookupTable = new Dictionary<string, INode>();
+        private readonly IDictionary<string, IDictionary<string, string>> _aliasLookupTable = new Dictionary<string, IDictionary<string, string>>();
 
         /// <summary>
         /// create a AvroClassHierarchy with empty nodes and lookup table. It can be used to merge other class hierarchy to it
@@ -177,7 +180,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
         }
 
         /// <summary>
-        /// Build hashtable to index the node
+        /// Build hash table to index the node
         /// </summary>
         /// <param name="n"></param>
         public void BuildHashTable(INode n)
@@ -185,7 +188,35 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             foreach (INode child in n.GetChildren())
             {
                 _lookupTable.Add(child.GetFullName(), child);
+                if (child is INamedParameterNode)
+                {
+                    AddAlias((INamedParameterNode)child);
+                }
                 BuildHashTable(child);
+            }
+        }
+
+        private void AddAlias(INamedParameterNode np)
+        {
+            if (np.GetAlias() != null && !np.GetAlias().Equals(""))
+            {
+                IDictionary<string, string> mapping = null;
+                _aliasLookupTable.TryGetValue(np.GetAliasLanguage(), out mapping);
+                if (mapping == null)
+                {
+                    mapping = new Dictionary<string, string>();
+                    _aliasLookupTable.Add(np.GetAliasLanguage(), mapping);
+                }
+
+                try
+                {
+                    mapping.Add(np.GetAlias(), np.GetFullName());
+                }
+                catch (Exception)
+                {
+                    var e = new ApplicationException(string.Format(CultureInfo.CurrentCulture, "Duplicated alias {0} on named parameter {1}.", np.GetAlias(), np.GetFullName()));
+                    Utilities.Diagnostics.Exceptions.Throw(e, LOGGER);
+                }
             }
         }
 
@@ -202,6 +233,40 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             {
                 var ex = new NameResolutionException(fullName, "Cannot resolve the name from the class hierarchy during deserialization: " + fullName);
                 Utilities.Diagnostics.Exceptions.Throw(ex, LOGGER);
+            }
+            return ret;
+        }
+
+        /// <summary>
+        /// This method get INode from deSerialized class hierarchy by fullName. 
+        /// If the name is not found, it will found alias for aliasLanguage. If alias is found,
+        /// it will use the alias to do look up again. 
+        /// </summary>
+        /// <param name="fullName"></param>
+        /// <param name="aliasLanguage"></param>
+        /// <returns></returns>
+        public INode GetNode(string fullName, string aliasLanguage)
+        {
+            INode ret = null;
+            _lookupTable.TryGetValue(fullName, out ret);
+            if (ret == null)
+            {
+                IDictionary<string, string> mapping = null;
+                string assemblyName = null;
+                _aliasLookupTable.TryGetValue(aliasLanguage, out mapping);
+                if (mapping != null)
+                {
+                    mapping.TryGetValue(fullName, out assemblyName);
+                    if (assemblyName != null)
+                    {
+                        _lookupTable.TryGetValue(assemblyName, out ret);
+                    }
+                }
+                if (mapping == null || assemblyName == null || ret == null)
+                {
+                    var ex = new NameResolutionException(fullName, "Cannot resolve the name from the class hierarchy during de-serialization: " + fullName);
+                    Utilities.Diagnostics.Exceptions.Throw(ex, LOGGER);
+                }
             }
             return ret;
         }

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/NamedParameterNodeImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/NamedParameterNodeImpl.cs
@@ -18,6 +18,7 @@
  */
 
 using System;
+using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Types;
 
 namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
@@ -31,10 +32,12 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
         private readonly String[] defaultInstanceAsStrings;
         private readonly bool isSet;
         private readonly bool isList;
+        private readonly string alias;
+        private readonly string aliasLanguage;
 
         public NamedParameterNodeImpl(INode parent, String simpleName,
             String fullName, String fullArgName, String simpleArgName, bool isSet, bool isList,
-            String documentation, String shortName, String[] defaultInstanceAsStrings)
+            String documentation, String shortName, String[] defaultInstanceAsStrings, string alias, string aliasLanguage)
             : base(parent, simpleName, fullName)
         {
             this.fullArgName = fullArgName;
@@ -44,6 +47,15 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             this.documentation = documentation;
             this.shortName = shortName;
             this.defaultInstanceAsStrings = defaultInstanceAsStrings;
+            this.alias = alias;
+            this.aliasLanguage = aliasLanguage;
+        }
+
+        public NamedParameterNodeImpl(INode parent, String simpleName,
+            String fullName, String fullArgName, String simpleArgName, bool isSet, bool isList,
+            String documentation, String shortName, String[] defaultInstanceAsStrings)
+            : this(parent, simpleName, fullName, simpleArgName, simpleArgName, isSet, isList, documentation, shortName, defaultInstanceAsStrings, null, null)
+        {
         }
 
         public override String ToString()
@@ -84,6 +96,16 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
         public bool IsList()
         {
             return isList;
+        }
+
+        public string GetAlias()
+        {
+            return alias;
+        }
+
+        public string GetAliasLanguage()
+        {
+            return aliasLanguage;
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/NodeFactory.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/NodeFactory.cs
@@ -291,7 +291,7 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
             }
 
             return new NamedParameterNodeImpl(parent, simpleName, fullName,
-                fullArgName, simpleArgName, isSet, isList, documentation, shortName, defaultInstanceAsStrings);
+                fullArgName, simpleArgName, isSet, isList, documentation, shortName, defaultInstanceAsStrings, namedParameter.Alias, namedParameter.AliasLanguage);
         }
 
         // private static void assertIsSubclassOf(Class<?> named_parameter, Class<?> default_class, Type argClass) {

--- a/lang/cs/Org.Apache.REEF.Tang/Interface/IClassHierarchy.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Interface/IClassHierarchy.cs
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+using System;
+using System.Runtime.Remoting.Channels;
 using Org.Apache.REEF.Tang.Types;
 
 namespace Org.Apache.REEF.Tang.Interface
@@ -24,6 +26,17 @@ namespace Org.Apache.REEF.Tang.Interface
     public interface IClassHierarchy
     {
         INode GetNode(string fullName);
+
+        /// <summary>
+        /// This method gets INode from the class hierarchy by fullName. 
+        /// If the name is not found, it will found alias for aliasLanguage. If alias is found,
+        /// it will use the alias to find Node again. 
+        /// </summary>
+        /// <param name="fullName"></param>
+        /// <param name="aliasLanguage"></param>
+        /// <returns></returns>
+        INode GetNode(string fullName, string aliasLanguage);
+
         INode GetNamespace();
         bool IsImplementation(IClassNode inter, IClassNode impl);
         IClassHierarchy Merge(IClassHierarchy ch);

--- a/lang/cs/Org.Apache.REEF.Tang/Protobuf/class_hierarchy.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Protobuf/class_hierarchy.cs
@@ -29,246 +29,261 @@
 // Generated from: class_hierarchy.proto
 namespace Org.Apache.REEF.Tang.Protobuf
 {
-  [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"Node")]
-  public partial class Node : global::ProtoBuf.IExtensible
-  {
-    public Node() {}
-    
-    private string _name;
-    [global::ProtoBuf.ProtoMember(1, IsRequired = true, Name=@"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    public string name
+    [global::System.Serializable, global::ProtoBuf.ProtoContract(Name = @"Node")]
+    public partial class Node : global::ProtoBuf.IExtensible
     {
-      get { return _name; }
-      set { _name = value; }
+        public Node() { }
+
+        private string _name;
+        [global::ProtoBuf.ProtoMember(1, IsRequired = true, Name = @"name", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        public string name
+        {
+            get { return _name; }
+            set { _name = value; }
+        }
+        private string _full_name;
+        [global::ProtoBuf.ProtoMember(2, IsRequired = true, Name = @"full_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        public string full_name
+        {
+            get { return _full_name; }
+            set { _full_name = value; }
+        }
+        private ClassNode _class_node = null;
+        [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name = @"class_node", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        [global::System.ComponentModel.DefaultValue(null)]
+        public ClassNode class_node
+        {
+            get { return _class_node; }
+            set { _class_node = value; }
+        }
+        private NamedParameterNode _named_parameter_node = null;
+        [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name = @"named_parameter_node", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        [global::System.ComponentModel.DefaultValue(null)]
+        public NamedParameterNode named_parameter_node
+        {
+            get { return _named_parameter_node; }
+            set { _named_parameter_node = value; }
+        }
+        private PackageNode _package_node = null;
+        [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name = @"package_node", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        [global::System.ComponentModel.DefaultValue(null)]
+        public PackageNode package_node
+        {
+            get { return _package_node; }
+            set { _package_node = value; }
+        }
+        private readonly global::System.Collections.Generic.List<Node> _children = new global::System.Collections.Generic.List<Node>();
+        [global::ProtoBuf.ProtoMember(6, Name = @"children", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        public global::System.Collections.Generic.List<Node> children
+        {
+            get { return _children; }
+        }
+
+        private global::ProtoBuf.IExtension extensionObject;
+        global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
+        { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
     }
-    private string _full_name;
-    [global::ProtoBuf.ProtoMember(2, IsRequired = true, Name=@"full_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    public string full_name
+
+    [global::System.Serializable, global::ProtoBuf.ProtoContract(Name = @"ClassNode")]
+    public partial class ClassNode : global::ProtoBuf.IExtensible
     {
-      get { return _full_name; }
-      set { _full_name = value; }
+        public ClassNode() { }
+
+        private bool _is_injection_candidate;
+        [global::ProtoBuf.ProtoMember(1, IsRequired = true, Name = @"is_injection_candidate", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        public bool is_injection_candidate
+        {
+            get { return _is_injection_candidate; }
+            set { _is_injection_candidate = value; }
+        }
+        private bool _is_external_constructor;
+        [global::ProtoBuf.ProtoMember(2, IsRequired = true, Name = @"is_external_constructor", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        public bool is_external_constructor
+        {
+            get { return _is_external_constructor; }
+            set { _is_external_constructor = value; }
+        }
+        private bool _is_unit;
+        [global::ProtoBuf.ProtoMember(3, IsRequired = true, Name = @"is_unit", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        public bool is_unit
+        {
+            get { return _is_unit; }
+            set { _is_unit = value; }
+        }
+        private readonly global::System.Collections.Generic.List<ConstructorDef> _InjectableConstructors = new global::System.Collections.Generic.List<ConstructorDef>();
+        [global::ProtoBuf.ProtoMember(4, Name = @"InjectableConstructors", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        public global::System.Collections.Generic.List<ConstructorDef> InjectableConstructors
+        {
+            get { return _InjectableConstructors; }
+        }
+
+        private readonly global::System.Collections.Generic.List<ConstructorDef> _OtherConstructors = new global::System.Collections.Generic.List<ConstructorDef>();
+        [global::ProtoBuf.ProtoMember(5, Name = @"OtherConstructors", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        public global::System.Collections.Generic.List<ConstructorDef> OtherConstructors
+        {
+            get { return _OtherConstructors; }
+        }
+
+        private readonly global::System.Collections.Generic.List<string> _impl_full_names = new global::System.Collections.Generic.List<string>();
+        [global::ProtoBuf.ProtoMember(6, Name = @"impl_full_names", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        public global::System.Collections.Generic.List<string> impl_full_names
+        {
+            get { return _impl_full_names; }
+        }
+
+        private string _default_implementation = "";
+        [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name = @"default_implementation", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        [global::System.ComponentModel.DefaultValue("")]
+        public string default_implementation
+        {
+            get { return _default_implementation; }
+            set { _default_implementation = value; }
+        }
+        private global::ProtoBuf.IExtension extensionObject;
+        global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
+        { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
     }
-    private ClassNode _class_node = null;
-    [global::ProtoBuf.ProtoMember(3, IsRequired = false, Name=@"class_node", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
-    public ClassNode class_node
+
+    [global::System.Serializable, global::ProtoBuf.ProtoContract(Name = @"NamedParameterNode")]
+    public partial class NamedParameterNode : global::ProtoBuf.IExtensible
     {
-      get { return _class_node; }
-      set { _class_node = value; }
+        public NamedParameterNode() { }
+
+        private string _simple_arg_class_name;
+        [global::ProtoBuf.ProtoMember(1, IsRequired = true, Name = @"simple_arg_class_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        public string simple_arg_class_name
+        {
+            get { return _simple_arg_class_name; }
+            set { _simple_arg_class_name = value; }
+        }
+        private string _full_arg_class_name;
+        [global::ProtoBuf.ProtoMember(2, IsRequired = true, Name = @"full_arg_class_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        public string full_arg_class_name
+        {
+            get { return _full_arg_class_name; }
+            set { _full_arg_class_name = value; }
+        }
+        private bool _is_set;
+        [global::ProtoBuf.ProtoMember(3, IsRequired = true, Name = @"is_set", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        public bool is_set
+        {
+            get { return _is_set; }
+            set { _is_set = value; }
+        }
+        private bool _is_list;
+        [global::ProtoBuf.ProtoMember(4, IsRequired = true, Name = @"is_list", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        public bool is_list
+        {
+            get { return _is_list; }
+            set { _is_list = value; }
+        }
+        private string _documentation = "";
+        [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name = @"documentation", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        [global::System.ComponentModel.DefaultValue("")]
+        public string documentation
+        {
+            get { return _documentation; }
+            set { _documentation = value; }
+        }
+        private string _short_name = "";
+        [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name = @"short_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        [global::System.ComponentModel.DefaultValue("")]
+        public string short_name
+        {
+            get { return _short_name; }
+            set { _short_name = value; }
+        }
+        private readonly global::System.Collections.Generic.List<string> _instance_default = new global::System.Collections.Generic.List<string>();
+        [global::ProtoBuf.ProtoMember(7, Name = @"instance_default", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        public global::System.Collections.Generic.List<string> instance_default
+        {
+            get { return _instance_default; }
+        }
+
+        private string _alias_name = "";
+        [global::ProtoBuf.ProtoMember(8, IsRequired = false, Name = @"alias_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        [global::System.ComponentModel.DefaultValue("")]
+        public string alias_name
+        {
+            get { return _alias_name; }
+            set { _alias_name = value; }
+        }
+        private string _alias_language = "";
+        [global::ProtoBuf.ProtoMember(9, IsRequired = false, Name = @"alias_language", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        [global::System.ComponentModel.DefaultValue("")]
+        public string alias_language
+        {
+            get { return _alias_language; }
+            set { _alias_language = value; }
+        }
+        private global::ProtoBuf.IExtension extensionObject;
+        global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
+        { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
     }
-    private NamedParameterNode _named_parameter_node = null;
-    [global::ProtoBuf.ProtoMember(4, IsRequired = false, Name=@"named_parameter_node", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
-    public NamedParameterNode named_parameter_node
+
+    [global::System.Serializable, global::ProtoBuf.ProtoContract(Name = @"PackageNode")]
+    public partial class PackageNode : global::ProtoBuf.IExtensible
     {
-      get { return _named_parameter_node; }
-      set { _named_parameter_node = value; }
+        public PackageNode() { }
+
+        private global::ProtoBuf.IExtension extensionObject;
+        global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
+        { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
     }
-    private PackageNode _package_node = null;
-    [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"package_node", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue(null)]
-    public PackageNode package_node
+
+    [global::System.Serializable, global::ProtoBuf.ProtoContract(Name = @"ConstructorDef")]
+    public partial class ConstructorDef : global::ProtoBuf.IExtensible
     {
-      get { return _package_node; }
-      set { _package_node = value; }
+        public ConstructorDef() { }
+
+        private string _full_class_name;
+        [global::ProtoBuf.ProtoMember(1, IsRequired = true, Name = @"full_class_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        public string full_class_name
+        {
+            get { return _full_class_name; }
+            set { _full_class_name = value; }
+        }
+        private readonly global::System.Collections.Generic.List<ConstructorArg> _args = new global::System.Collections.Generic.List<ConstructorArg>();
+        [global::ProtoBuf.ProtoMember(2, Name = @"args", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        public global::System.Collections.Generic.List<ConstructorArg> args
+        {
+            get { return _args; }
+        }
+
+        private global::ProtoBuf.IExtension extensionObject;
+        global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
+        { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
     }
-    private readonly global::System.Collections.Generic.List<Node> _children = new global::System.Collections.Generic.List<Node>();
-    [global::ProtoBuf.ProtoMember(6, Name=@"children", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    public global::System.Collections.Generic.List<Node> children
+
+    [global::System.Serializable, global::ProtoBuf.ProtoContract(Name = @"ConstructorArg")]
+    public partial class ConstructorArg : global::ProtoBuf.IExtensible
     {
-      get { return _children; }
+        public ConstructorArg() { }
+
+        private string _full_arg_class_name;
+        [global::ProtoBuf.ProtoMember(1, IsRequired = true, Name = @"full_arg_class_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        public string full_arg_class_name
+        {
+            get { return _full_arg_class_name; }
+            set { _full_arg_class_name = value; }
+        }
+        private string _named_parameter_name = "";
+        [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name = @"named_parameter_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        [global::System.ComponentModel.DefaultValue("")]
+        public string named_parameter_name
+        {
+            get { return _named_parameter_name; }
+            set { _named_parameter_name = value; }
+        }
+        private bool _is_injection_future;
+        [global::ProtoBuf.ProtoMember(3, IsRequired = true, Name = @"is_injection_future", DataFormat = global::ProtoBuf.DataFormat.Default)]
+        public bool is_injection_future
+        {
+            get { return _is_injection_future; }
+            set { _is_injection_future = value; }
+        }
+        private global::ProtoBuf.IExtension extensionObject;
+        global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
+        { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
     }
-  
-    private global::ProtoBuf.IExtension extensionObject;
-    global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
-      { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
-  }
-  
-  [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"ClassNode")]
-  public partial class ClassNode : global::ProtoBuf.IExtensible
-  {
-    public ClassNode() {}
-    
-    private bool _is_injection_candidate;
-    [global::ProtoBuf.ProtoMember(1, IsRequired = true, Name=@"is_injection_candidate", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    public bool is_injection_candidate
-    {
-      get { return _is_injection_candidate; }
-      set { _is_injection_candidate = value; }
-    }
-    private bool _is_external_constructor;
-    [global::ProtoBuf.ProtoMember(2, IsRequired = true, Name=@"is_external_constructor", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    public bool is_external_constructor
-    {
-      get { return _is_external_constructor; }
-      set { _is_external_constructor = value; }
-    }
-    private bool _is_unit;
-    [global::ProtoBuf.ProtoMember(3, IsRequired = true, Name=@"is_unit", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    public bool is_unit
-    {
-      get { return _is_unit; }
-      set { _is_unit = value; }
-    }
-    private readonly global::System.Collections.Generic.List<ConstructorDef> _InjectableConstructors = new global::System.Collections.Generic.List<ConstructorDef>();
-    [global::ProtoBuf.ProtoMember(4, Name=@"InjectableConstructors", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    public global::System.Collections.Generic.List<ConstructorDef> InjectableConstructors
-    {
-      get { return _InjectableConstructors; }
-    }
-  
-    private readonly global::System.Collections.Generic.List<ConstructorDef> _OtherConstructors = new global::System.Collections.Generic.List<ConstructorDef>();
-    [global::ProtoBuf.ProtoMember(5, Name=@"OtherConstructors", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    public global::System.Collections.Generic.List<ConstructorDef> OtherConstructors
-    {
-      get { return _OtherConstructors; }
-    }
-  
-    private readonly global::System.Collections.Generic.List<string> _impl_full_names = new global::System.Collections.Generic.List<string>();
-    [global::ProtoBuf.ProtoMember(6, Name=@"impl_full_names", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    public global::System.Collections.Generic.List<string> impl_full_names
-    {
-      get { return _impl_full_names; }
-    }
-  
-    private string _default_implementation = "";
-    [global::ProtoBuf.ProtoMember(7, IsRequired = false, Name=@"default_implementation", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
-    public string default_implementation
-    {
-      get { return _default_implementation; }
-      set { _default_implementation = value; }
-    }
-    private global::ProtoBuf.IExtension extensionObject;
-    global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
-      { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
-  }
-  
-  [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"NamedParameterNode")]
-  public partial class NamedParameterNode : global::ProtoBuf.IExtensible
-  {
-    public NamedParameterNode() {}
-    
-    private string _simple_arg_class_name;
-    [global::ProtoBuf.ProtoMember(1, IsRequired = true, Name=@"simple_arg_class_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    public string simple_arg_class_name
-    {
-      get { return _simple_arg_class_name; }
-      set { _simple_arg_class_name = value; }
-    }
-    private string _full_arg_class_name;
-    [global::ProtoBuf.ProtoMember(2, IsRequired = true, Name=@"full_arg_class_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    public string full_arg_class_name
-    {
-      get { return _full_arg_class_name; }
-      set { _full_arg_class_name = value; }
-    }
-    private bool _is_set;
-    [global::ProtoBuf.ProtoMember(3, IsRequired = true, Name=@"is_set", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    public bool is_set
-    {
-      get { return _is_set; }
-      set { _is_set = value; }
-    }
-    private bool _is_list;
-    [global::ProtoBuf.ProtoMember(4, IsRequired = true, Name=@"is_list", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    public bool is_list
-    {
-      get { return _is_list; }
-      set { _is_list = value; }
-    }
-    private string _documentation = "";
-    [global::ProtoBuf.ProtoMember(5, IsRequired = false, Name=@"documentation", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
-    public string documentation
-    {
-      get { return _documentation; }
-      set { _documentation = value; }
-    }
-    private string _short_name = "";
-    [global::ProtoBuf.ProtoMember(6, IsRequired = false, Name=@"short_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
-    public string short_name
-    {
-      get { return _short_name; }
-      set { _short_name = value; }
-    }
-    private readonly global::System.Collections.Generic.List<string> _instance_default = new global::System.Collections.Generic.List<string>();
-    [global::ProtoBuf.ProtoMember(7, Name=@"instance_default", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    public global::System.Collections.Generic.List<string> instance_default
-    {
-      get { return _instance_default; }
-    }
-  
-    private global::ProtoBuf.IExtension extensionObject;
-    global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
-      { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
-  }
-  
-  [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"PackageNode")]
-  public partial class PackageNode : global::ProtoBuf.IExtensible
-  {
-    public PackageNode() {}
-    
-    private global::ProtoBuf.IExtension extensionObject;
-    global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
-      { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
-  }
-  
-  [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"ConstructorDef")]
-  public partial class ConstructorDef : global::ProtoBuf.IExtensible
-  {
-    public ConstructorDef() {}
-    
-    private string _full_class_name;
-    [global::ProtoBuf.ProtoMember(1, IsRequired = true, Name=@"full_class_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    public string full_class_name
-    {
-      get { return _full_class_name; }
-      set { _full_class_name = value; }
-    }
-    private readonly global::System.Collections.Generic.List<ConstructorArg> _args = new global::System.Collections.Generic.List<ConstructorArg>();
-    [global::ProtoBuf.ProtoMember(2, Name=@"args", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    public global::System.Collections.Generic.List<ConstructorArg> args
-    {
-      get { return _args; }
-    }
-  
-    private global::ProtoBuf.IExtension extensionObject;
-    global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
-      { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
-  }
-  
-  [global::System.Serializable, global::ProtoBuf.ProtoContract(Name=@"ConstructorArg")]
-  public partial class ConstructorArg : global::ProtoBuf.IExtensible
-  {
-    public ConstructorArg() {}
-    
-    private string _full_arg_class_name;
-    [global::ProtoBuf.ProtoMember(1, IsRequired = true, Name=@"full_arg_class_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    public string full_arg_class_name
-    {
-      get { return _full_arg_class_name; }
-      set { _full_arg_class_name = value; }
-    }
-    private string _named_parameter_name = "";
-    [global::ProtoBuf.ProtoMember(2, IsRequired = false, Name=@"named_parameter_name", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    [global::System.ComponentModel.DefaultValue("")]
-    public string named_parameter_name
-    {
-      get { return _named_parameter_name; }
-      set { _named_parameter_name = value; }
-    }
-    private bool _is_injection_future;
-    [global::ProtoBuf.ProtoMember(3, IsRequired = true, Name=@"is_injection_future", DataFormat = global::ProtoBuf.DataFormat.Default)]
-    public bool is_injection_future
-    {
-      get { return _is_injection_future; }
-      set { _is_injection_future = value; }
-    }
-    private global::ProtoBuf.IExtension extensionObject;
-    global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
-      { return global::ProtoBuf.Extensible.GetExtensionObject(ref extensionObject, createIfMissing); }
-  }
-  
 }

--- a/lang/cs/Org.Apache.REEF.Tang/Types/INamedParameterNode.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Types/INamedParameterNode.cs
@@ -16,7 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-﻿
+
+using Org.Apache.REEF.Tang.Annotations;
+
 namespace Org.Apache.REEF.Tang.Types
 {
     public interface INamedParameterNode : INode
@@ -34,5 +36,19 @@ namespace Org.Apache.REEF.Tang.Types
         bool IsSet();
 
         bool IsList();
+
+        /// <summary>
+        /// It returns an alias of the NamedParameter
+        /// The alias is defined as an attribute of the NamedParameter
+        /// </summary>
+        /// <returns></returns>
+        string GetAlias();
+
+        /// <summary>
+        /// It returns the programming language for the alias
+        /// Examples are "Java", "Cs"
+        /// </summary>
+        /// <returns></returns>
+        string GetAliasLanguage();
     }
 }

--- a/lang/java/reef-tang/tang/src/main/proto/class_hierarchy.proto
+++ b/lang/java/reef-tang/tang/src/main/proto/class_hierarchy.proto
@@ -137,6 +137,14 @@ message NamedParameterNode {
    */
   // calling this "default_instance" breaks protoc.
   repeated string instance_default = 7;
+  /*
+     An alias of the named parameter
+   */
+  optional string alias_name = 8;
+  /*
+     An alias language of the named parameter
+   */
+  optional string alias_language = 9;
 }
 
 message PackageNode {


### PR DESCRIPTION
This PR added the alias in NamedParameter at REEF C# side. It is prepared for deserializing configuration sent from Java.
-Adding new properties alias and language in NamedParameter
-Parse alias and language when creating class hierarchy
-Added overloading method for GetNode() in IClassHierarchy and its implementations
-Add new optional properties in class_hierarchy protobuffer schema and updated data contract
-Added test cases

JIRA: REEF-512(https://issues.apache.org/jira/browse/REEF-512)

This closes #

Author: Julia Wang  Email: juliaw@apache.org