### PR TITLE
[REEF-689] Restructure handler for DriverRestart in .NET

### DIFF
--- a/lang/cs/Org.Apache.REEF.Bridge/Clr2JavaImpl.h
+++ b/lang/cs/Org.Apache.REEF.Bridge/Clr2JavaImpl.h
@@ -215,6 +215,18 @@ namespace Org {
 						  virtual String^ GetId();
 						  virtual String^ GetMessageSourceId();
 					  };
+
+					  public ref class DriverRestartedClr2Java : public IDriverRestartedClr2Java {
+						  jobject _jobjectDriverRestarted;
+						  JavaVM* _jvm;
+						  array<String^>^ _expectedEvaluatorIds;
+						  DateTime _startTime;
+					  public:
+						  DriverRestartedClr2Java(JNIEnv *env, jobject jobjectDriverRestarted);
+						  virtual void OnError(String^ message);
+						  virtual array<String^>^ GetExpectedEvaluatorIds();
+						  virtual DateTime GetStartTime();
+					  };
 				  }
 			  }
 		  }

--- a/lang/cs/Org.Apache.REEF.Bridge/DriverRestartedClr2Java.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/DriverRestartedClr2Java.cpp
@@ -1,0 +1,74 @@
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+#include "Clr2JavaImpl.h"
+
+namespace Org {
+	namespace Apache {
+		namespace REEF {
+			namespace Driver {
+				namespace Bridge {
+					namespace Clr2java {
+						ref class ManagedLog {
+						internal:
+							static BridgeLogger^ LOGGER = BridgeLogger::GetLogger("<C++>");
+						};
+
+						DriverRestartedClr2Java::DriverRestartedClr2Java(JNIEnv *env, jobject jdriverRestarted) {
+							ManagedLog::LOGGER->LogStart("DriverRestartedClr2Java::DriverRestartedClr2Java");
+							pin_ptr<JavaVM*> pJavaVm = &_jvm;
+							if (env->GetJavaVM(pJavaVm) != 0) {
+								ManagedLog::LOGGER->LogError("Failed to get JavaVM", nullptr);
+							}
+							_jobjectDriverRestarted = reinterpret_cast<jobject>(env->NewGlobalRef(jdriverRestarted));
+
+							jclass jclassDriverRestarted = env->GetObjectClass(_jobjectDriverRestarted);
+							jfieldID jidExpectedEvaluatorIds = env->GetFieldID(jclassDriverRestarted, "expectedEvaluatorIds", "[Ljava/lang/String;");
+
+							jobjectArray jevaluatorIds = reinterpret_cast<jobjectArray>(env->NewGlobalRef(env->GetObjectField(_jobjectDriverRestarted, jidExpectedEvaluatorIds)));
+							_startTime = System::DateTime::Now;
+							int count = env->GetArrayLength(jevaluatorIds);
+							_expectedEvaluatorIds = gcnew array<String^>(count);
+
+							for (int i = 0; i < count; i++) {
+								jstring string = (jstring)(*env).GetObjectArrayElement(jevaluatorIds, i);
+								_expectedEvaluatorIds[i] = ManagedStringFromJavaString(env, string);
+							}
+
+							ManagedLog::LOGGER->LogStop("DriverRestartedClr2Java::DriverRestartedClr2Java");
+						}
+
+						array<String^>^ DriverRestartedClr2Java::GetExpectedEvaluatorIds() {
+							return _expectedEvaluatorIds;
+						}
+
+						DateTime DriverRestartedClr2Java::GetStartTime() {
+							return _startTime;
+						}
+
+						void DriverRestartedClr2Java::OnError(String^ message) {
+							ManagedLog::LOGGER->Log("DriverRestartedClr2Java::OnError");
+							JNIEnv *env = RetrieveEnv(_jvm);
+							HandleClr2JavaError(env, message, _jobjectDriverRestarted);
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/lang/cs/Org.Apache.REEF.Bridge/JavaClrBridge.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/JavaClrBridge.cpp
@@ -431,22 +431,20 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemCo
   }
 }
 
-
 /*
 * Class:     org_apache_reef_javabridge_NativeInterop
 * Method:    callClrSystemOnRestartHandlerOnNext
-* Signature: (Ljava/lang/String;Ljava/lang/String;Lorg/apache/reef/javabridge/EvaluatorRequestorBridge;)[J
+* Signature: (Ljava/lang/String;Lorg/apache/reef/javabridge/EvaluatorRequestorBridge;Lorg/apache/reef/javabridge/DriverRestartedBridge;)[J
 */
 JNIEXPORT jlongArray JNICALL Java_org_apache_reef_javabridge_NativeInterop_callClrSystemOnRestartHandlerOnNext
-(JNIEnv * env, jclass jclassx, jstring dateTimeString, jstring httpServerPort, jobject jevaluatorRequestorBridge)
-{
+(JNIEnv * env, jclass jclassx, jstring httpServerPort, jobject jevaluatorRequestorBridge, jobject jdriverRestartedBridge) {
 	try {
 		ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_callClrSystemOnStartHandler");
-		DateTime dt = DateTime::Now;
 		String^ strPort = ManagedStringFromJavaString(env, httpServerPort);
 
 		EvaluatorRequestorClr2Java^ evaluatorRequestorBridge = gcnew EvaluatorRequestorClr2Java(env, jevaluatorRequestorBridge);
-		array<unsigned long long>^ handlers = ClrSystemHandlerWrapper::Call_ClrSystemRestartHandler_OnRestart(dt, strPort, evaluatorRequestorBridge);
+		DriverRestartedClr2Java^ driverRestartedBridge = gcnew DriverRestartedClr2Java(env, jdriverRestartedBridge);
+		array<unsigned long long>^ handlers = ClrSystemHandlerWrapper::Call_ClrSystemRestartHandler_OnRestart(strPort, evaluatorRequestorBridge, driverRestartedBridge);
 		return JavaLongArrayFromManagedLongArray(env, handlers);
 	}
 	catch (System::Exception^ ex) {

--- a/lang/cs/Org.Apache.REEF.Bridge/Org.Apache.REEF.Bridge.vcxproj
+++ b/lang/cs/Org.Apache.REEF.Bridge/Org.Apache.REEF.Bridge.vcxproj
@@ -134,6 +134,7 @@ under the License.
     <ClCompile Include="CompletedEvaluatorClr2Java.cpp" />
     <ClCompile Include="CompletedTaskClr2Java.cpp" />
     <ClCompile Include="ContextMessageClr2Java.cpp" />
+    <ClCompile Include="DriverRestartedClr2Java.cpp" />
     <ClCompile Include="EvaluatorRequestorClr2Java.cpp" />
     <ClCompile Include="FailedContextClr2Java.cpp" />
     <ClCompile Include="FailedEvaluatorClr2Java.cpp" />

--- a/lang/cs/Org.Apache.REEF.Bridge/Org.Apache.REEF.Bridge.vcxproj.filters
+++ b/lang/cs/Org.Apache.REEF.Bridge/Org.Apache.REEF.Bridge.vcxproj.filters
@@ -113,6 +113,9 @@
     <ClCompile Include="TaskMessageClr2Java.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="DriverRestartedClr2Java.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Text Include="ReadMe.txt" />

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Clr2java/IDriverRestartedClr2Java.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Clr2java/IDriverRestartedClr2Java.cs
@@ -18,17 +18,19 @@
  */
 
 using System;
-using System.Collections.Generic;
 
-namespace Org.Apache.REEF.Driver
+namespace Org.Apache.REEF.Driver.Bridge.Clr2java
 {
-    /// <summary>
-    /// Event fired on Driver restarts instead of IDriverStarted.
-    /// </summary>
-    public interface IDriverRestarted
+    public interface IDriverRestartedClr2Java : IClr2Java
     {
-        DateTime StartTime { get; }
+        /// <summary>
+        /// IDs of the expected Evaluators on Driver Restart.
+        /// </summary>
+        string[] GetExpectedEvaluatorIds();
 
-        ISet<string> ExpectedEvaluatorIds { get; } 
+        /// <summary>
+        /// StartTime of the restart.
+        /// </summary>
+        DateTime GetStartTime();
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/ClrSystemHandlerWrapper.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/ClrSystemHandlerWrapper.cs
@@ -262,17 +262,17 @@ namespace Org.Apache.REEF.Driver.Bridge
         }
 
         public static ulong[] Call_ClrSystemRestartHandler_OnRestart(
-            DateTime startTime,
             string httpServerPort,
-            IEvaluatorRequestorClr2Java evaluatorRequestorClr2Java)
+            IEvaluatorRequestorClr2Java evaluatorRequestorClr2Java,
+            IDriverRestartedClr2Java driverRestartedClr2Java)
         {
             IEvaluatorRequestor evaluatorRequestor = new EvaluatorRequestor(evaluatorRequestorClr2Java);
             using (LOGGER.LogFunction("ClrSystemHandlerWrapper::Call_ClrSystemRestartHandler_OnRestart"))
             {
-                LOGGER.Log(Level.Info, "*** Restart time is " + startTime);
+                LOGGER.Log(Level.Info, "*** Restart time is " + driverRestartedClr2Java.GetStartTime());
                 LOGGER.Log(Level.Info, "*** httpServerPort: " + httpServerPort);
                 var handlers = GetHandlers(httpServerPort, evaluatorRequestor);
-                _driverBridge.RestartHandlerOnNext(startTime);
+                _driverBridge.RestartHandlerOnNext(driverRestartedClr2Java);
 
                 return handlers;
             }

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverBridge.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverBridge.cs
@@ -31,6 +31,7 @@ using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Utilities.Logging;
 using Org.Apache.REEF.Wake.Time.Event;
 using Org.Apache.REEF.Common.Evaluator.Parameters;
+using Org.Apache.REEF.Driver.Bridge.Clr2java;
 using Org.Apache.REEF.Driver.Bridge.Events;
 
 namespace Org.Apache.REEF.Driver.Bridge
@@ -368,9 +369,9 @@ namespace Org.Apache.REEF.Driver.Bridge
         /// <summary>
         /// Call restart handlers
         /// </summary>
-        internal void RestartHandlerOnNext(DateTime startTime)
+        internal void RestartHandlerOnNext(IDriverRestartedClr2Java driverRestartedClr2Java)
         {
-            var driverRestarted = new DriverRestarted(startTime);
+            var driverRestarted = new DriverRestarted(driverRestartedClr2Java);
             foreach (var handler in _driverRestartedHandlers)
             {
                 handler.OnNext(driverRestarted);

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/DriverRestarted.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/DriverRestarted.cs
@@ -17,21 +17,30 @@
  * under the License.
  */
 using System;
+using System.Collections.Generic;
+using Org.Apache.REEF.Driver.Bridge.Clr2java;
 
 namespace Org.Apache.REEF.Driver.Bridge.Events
 {
     internal sealed class DriverRestarted : IDriverRestarted
     {
         private readonly DateTime _startTime;
+        private readonly ISet<string> _expectedEvaluatorIds; 
 
-        internal DriverRestarted(DateTime startTime)
+        internal DriverRestarted(IDriverRestartedClr2Java driverRestartedClr2Java)
         {
-            _startTime = startTime;
+            _startTime = driverRestartedClr2Java.GetStartTime();
+            _expectedEvaluatorIds = new HashSet<string>(driverRestartedClr2Java.GetExpectedEvaluatorIds());
         }
 
         public DateTime StartTime
         {
             get { return _startTime; }
         }
+
+        public ISet<string> ExpectedEvaluatorIds
+        {
+            get { return _expectedEvaluatorIds; }
+        } 
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/DriverRestarted.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/DriverRestarted.cs
@@ -22,6 +22,9 @@ using Org.Apache.REEF.Driver.Bridge.Clr2java;
 
 namespace Org.Apache.REEF.Driver.Bridge.Events
 {
+    /// <summary>
+    /// The implementation of IDriverRestarted.
+    /// </summary>
     internal sealed class DriverRestarted : IDriverRestarted
     {
         private readonly DateTime _startTime;

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/DriverRestarted.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/DriverRestarted.cs
@@ -43,7 +43,7 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
 
         public ISet<string> ExpectedEvaluatorIds
         {
-            get { return _expectedEvaluatorIds; }
+            get { return new HashSet<string>(_expectedEvaluatorIds); }
         } 
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/IDriverRestarted.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/IDriverRestarted.cs
@@ -25,10 +25,12 @@ namespace Org.Apache.REEF.Driver
     /// <summary>
     /// Event fired on Driver restarts instead of IDriverStarted.
     /// </summary>
-    public interface IDriverRestarted
+    public interface IDriverRestarted : IDriverStarted
     {
-        DateTime StartTime { get; }
-
+        /// <summary>
+        /// The set of expected Evaluator IDs that are returned to the Driver by the
+        /// RM on Driver Restart.
+        /// </summary>
         ISet<string> ExpectedEvaluatorIds { get; } 
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/Org.Apache.REEF.Driver.csproj
+++ b/lang/cs/Org.Apache.REEF.Driver/Org.Apache.REEF.Driver.csproj
@@ -47,6 +47,7 @@ under the License.
     <Compile Include="Bridge\Clr2java\ICompletedEvaluatorClr2Java.cs" />
     <Compile Include="Bridge\Clr2java\ICompletedTaskClr2Java.cs" />
     <Compile Include="Bridge\Clr2java\IContextMessageClr2Java.cs" />
+    <Compile Include="Bridge\Clr2java\IDriverRestartedClr2Java.cs" />
     <Compile Include="Bridge\Clr2java\IEvaluatorRequestorClr2Java.cs" />
     <Compile Include="Bridge\Clr2java\IFailedContextClr2Java.cs" />
     <Compile Include="Bridge\Clr2java\IFailedEvaluatorClr2Java.cs" />

--- a/lang/cs/Org.Apache.REEF.Examples/DriverRestart/HelloRestartDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Examples/DriverRestart/HelloRestartDriver.cs
@@ -101,7 +101,7 @@ namespace Org.Apache.REEF.Examples.DriverRestart
         public void OnNext(IDriverRestarted value)
         {
             _restarted = true;
-            Logger.Log(Level.Info, "Hello! HelloRestartDriver has restarted!");
+            Logger.Log(Level.Info, "Hello! HelloRestartDriver has restarted! Expecting these Evaluator IDs [{0}]", string.Join(", ", value.ExpectedEvaluatorIds));
         }
 
         public void OnNext(IActiveContext value)

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/DriverRestartedBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/DriverRestartedBridge.java
@@ -1,4 +1,4 @@
-﻿/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,19 +16,32 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.apache.reef.javabridge;
 
-using System;
-using System.Collections.Generic;
+import org.apache.reef.annotations.Unstable;
+import org.apache.reef.annotations.audience.DriverSide;
+import org.apache.reef.annotations.audience.Private;
 
-namespace Org.Apache.REEF.Driver
-{
-    /// <summary>
-    /// Event fired on Driver restarts instead of IDriverStarted.
-    /// </summary>
-    public interface IDriverRestarted
-    {
-        DateTime StartTime { get; }
+import java.util.Set;
 
-        ISet<string> ExpectedEvaluatorIds { get; } 
-    }
+/**
+ * Created by anchung on 9/1/2015.
+ */
+@Private
+@DriverSide
+@Unstable
+public final class DriverRestartedBridge extends NativeBridge {
+  private final String[] expectedEvaluatorIds;
+
+  public DriverRestartedBridge(final Set<String> expectedEvaluatorIds) {
+    this.expectedEvaluatorIds = expectedEvaluatorIds.toArray(new String[expectedEvaluatorIds.size()]);
+  }
+
+  public String[] getExpectedEvaluatorIds() {
+    return expectedEvaluatorIds;
+  }
+
+  @Override
+  public void close() throws Exception {
+  }
 }

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/NativeInterop.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/NativeInterop.java
@@ -148,9 +148,9 @@ public final class NativeInterop {
   );
 
   public static native long[] callClrSystemOnRestartHandlerOnNext(
-      final String dateTime,
       final String httpServerPortNumber,
-      final EvaluatorRequestorBridge javaEvaluatorRequestorBridge
+      final EvaluatorRequestorBridge javaEvaluatorRequestorBridge,
+      final DriverRestartedBridge driverRestartedBridge
   );
 
   public static native void clrSystemDriverRestartActiveContextHandlerOnNext(

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/DriverRestartClrHandlersInitializer.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/DriverRestartClrHandlersInitializer.java
@@ -22,6 +22,7 @@ import org.apache.reef.annotations.Unstable;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.restart.DriverRestarted;
+import org.apache.reef.javabridge.DriverRestartedBridge;
 import org.apache.reef.javabridge.EvaluatorRequestorBridge;
 import org.apache.reef.javabridge.NativeInterop;
 
@@ -43,6 +44,7 @@ final class DriverRestartClrHandlersInitializer implements ClrHandlersInitialize
   public long[] getClrHandlers(final String portNumber, final EvaluatorRequestorBridge evaluatorRequestorBridge) {
     // TODO[REEF-689]: Make callClrSystemOnRestartedHandlerOnNext take DriverRestarted object.
     return NativeInterop.callClrSystemOnRestartHandlerOnNext(
-        driverRestarted.getStartTime().toString(), portNumber, evaluatorRequestorBridge);
+        portNumber,
+        evaluatorRequestorBridge, new DriverRestartedBridge(driverRestarted.getExpectedEvaluatorIds()));
   }
 }


### PR DESCRIPTION
This addressed the issue by
  * Propagate the expected Evaluator IDs on restart to .NET.
  * Modified bridge code to propagate the Evaluator IDs.

JIRA:
  [REEF-689](https://issues.apache.org/jira/browse/REEF-689)