### PR TITLE
[REEF 715] Allow to create GroupCommDrivers with different fanOuts

### DIFF
--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/GroupCommDriver.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/GroupCommDriver.java
@@ -47,6 +47,19 @@ public interface GroupCommDriver {
   CommunicationGroupDriver newCommunicationGroup(Class<? extends Name<String>> groupName, int numberOfTasks);
 
   /**
+   * Create a new communication group with the specified name,
+   * the minimum number of tasks needed in this group before
+   * communication can start, and a custom fanOut.
+   *
+   * @param groupName
+   * @param numberOfTasks
+   * @param customFanOut
+   * @return
+   */
+  CommunicationGroupDriver newCommunicationGroup(Class<? extends Name<String>> groupName, int numberOfTasks,
+      int customFanOut);
+
+  /**
    * Tests whether the activeContext is a context configured.
    * using the Group Communication Service
    *

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/GroupCommDriverImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/GroupCommDriverImpl.java
@@ -181,6 +181,12 @@ public class GroupCommDriverImpl implements GroupCommServiceDriver {
   @Override
   public CommunicationGroupDriver newCommunicationGroup(final Class<? extends Name<String>> groupName,
                                                         final int numberOfTasks) {
+    return newCommunicationGroup(groupName, numberOfTasks, fanOut);
+  }
+
+  @Override
+  public CommunicationGroupDriver newCommunicationGroup(final Class<? extends Name<String>> groupName,
+                                                        final int numberOfTasks, final int customFanOut) {
     LOG.entering("GroupCommDriverImpl", "newCommunicationGroup",
         new Object[]{Utils.simpleName(groupName), numberOfTasks});
     final BroadcastingEventHandler<RunningTask> commGroupRunningTaskHandler = new BroadcastingEventHandler<>();
@@ -194,7 +200,7 @@ public class GroupCommDriverImpl implements GroupCommServiceDriver {
         commGroupFailedTaskHandler,
         commGroupFailedEvaluatorHandler,
         commGroupMessageHandler,
-        driverId, numberOfTasks, fanOut);
+        driverId, numberOfTasks, customFanOut);
     commGroupDrivers.put(groupName, commGroupDriver);
     groupCommRunningTaskHandler.addHandler(commGroupRunningTaskHandler);
     groupCommFailedTaskHandler.addHandler(commGroupFailedTaskHandler);


### PR DESCRIPTION
This change adds a method to the public interface of GroupCommDriver
to allow creation of groups with different fan outs.
This change is needed when we have multiple communication groups
and we want to specify different topologies among them.

JIRA:
  [REEF-715](https://issues.apache.org/jira/browse/REEF-715)

Pull request:
  This closes #