### PR TITLE
[REEF-674] Made IEvaluatorDescriptor and its implementation immutable.

### DIFF
--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/EvaluatorRequestor.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/EvaluatorRequestor.cs
@@ -71,8 +71,7 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
             {
                 for (int i = 0; i < request.Number; i++)
                 {
-                    EvaluatorDescriptorImpl descriptor = new EvaluatorDescriptorImpl(new NodeDescriptorImpl(), EvaluatorType.CLR, request.MemoryMegaBytes, request.VirtualCore);
-                    descriptor.Rack = request.Rack;
+                    EvaluatorDescriptorImpl descriptor = new EvaluatorDescriptorImpl(new NodeDescriptorImpl(), EvaluatorType.CLR, request.MemoryMegaBytes, request.VirtualCore, request.Rack);
                     string key = string.Format(CultureInfo.InvariantCulture, "{0}_{1}", request.EvaluatorBatchId, i);
                     try
                     {

--- a/lang/cs/Org.Apache.REEF.Driver/Evaluator/IEvaluatorDescriptor.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Evaluator/IEvaluatorDescriptor.cs
@@ -23,35 +23,33 @@ using Org.Apache.REEF.Common.Evaluator;
 namespace Org.Apache.REEF.Driver.Evaluator
 {
     /// <summary>
-    ///  Metadata about an Evaluator.
+    /// Metadata about an Evaluator.
     /// </summary>
     public interface IEvaluatorDescriptor
     {
         /// <summary>
-        ///  NodeDescriptor of the node where this Evaluator is running.
+        /// NodeDescriptor of the node where this Evaluator is running.
         /// </summary>
-        INodeDescriptor NodeDescriptor { get; set; }
+        INodeDescriptor NodeDescriptor { get; }
 
         /// <summary>
         /// type of Evaluator.
         /// </summary>
-        EvaluatorType EvaluatorType { get; set; }
+        EvaluatorType EvaluatorType { get; }
 
         /// <summary>
         /// the amount of memory allocated to this Evaluator.
         /// </summary>
-        int Memory { get; set; }
+        int Memory { get; }
 
         /// <summary>
         /// the virtual core allocated to this Evaluator.
         /// </summary>
-        int VirtualCore { get; set; }
+        int VirtualCore { get; }
 
         /// <summary>
         /// rack on which the evaluator was allocated
         /// </summary>
-        string Rack { get; set; }
-
-        void FromString(string str);
+        string Rack { get; }
     }
 }


### PR DESCRIPTION
`EvaluatorRequestor` was changed to call the new constructor of `EvaluatorDescriptorImpl`.

This also removes the `FromString` method from both the interface and the implementation. Its code is folded into the constructor which was the only place it was called from.

Lastly, standard ReSharper cleanup has been applied to `IEvaluatorDescriptor` and `EvaluatorDescriptorImpl`.

JIRA:
  [REEF-674](https://issues.apache.org/jira/browse/REEF-674)