### PR TITLE
[REEF-730] Fix issues with InProcessIMRU

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU/InProcess/InProcessIMRUClient.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/InProcess/InProcessIMRUClient.cs
@@ -20,13 +20,18 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using Org.Apache.REEF.IMRU.API;
 using Org.Apache.REEF.IMRU.InProcess.Parameters;
+using Org.Apache.REEF.IO.PartitionedData;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Implementations.Configuration;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
+using Org.Apache.REEF.Utilities.Diagnostics;
+using Org.Apache.REEF.Utilities.Logging;
+using Org.Apache.REEF.Wake.StreamingCodec;
 
 namespace Org.Apache.REEF.IMRU.InProcess
 {
@@ -41,6 +46,9 @@ namespace Org.Apache.REEF.IMRU.InProcess
     /// <typeparam name="TResult">The return type of the computation.</typeparam>
     public class InProcessIMRUClient<TMapInput, TMapOutput, TResult> : IIMRUClient<TMapInput, TMapOutput, TResult>
     {
+        private static readonly Logger Logger =
+            Logger.GetLogger(typeof (InProcessIMRUClient<TMapInput, TMapOutput, TResult>));
+
         private readonly int _numberOfMappers;
 
         /// <summary>
@@ -61,27 +69,60 @@ namespace Org.Apache.REEF.IMRU.InProcess
         /// <returns>The result of the job</returns>
         public IEnumerable<TResult> Submit(IMRUJobDefinition jobDefinition)
         {
+            IConfiguration overallPerMapConfig = null;
+            try
+            {
+                overallPerMapConfig = Configurations.Merge(jobDefinition.PerMapConfigGeneratorConfig.ToArray());
+            }
+            catch (Exception e)
+            {
+                Exceptions.Throw(e, "Issues in merging PerMapCOnfigGenerator configurations", Logger);
+            }
+
             var mergedConfig = Configurations.Merge(
                 jobDefinition.ReduceFunctionConfiguration,
-                jobDefinition.UpdateFunctionConfiguration);
+                jobDefinition.UpdateFunctionConfiguration,
+                jobDefinition.UpdateFunctionCodecsConfiguration,
+                overallPerMapConfig);
 
             var injector = TangFactory.GetTang().NewInjector(mergedConfig);
 
+            ISet<IPerMapperConfigGenerator> perMapConfigGenerators =
+                (ISet<IPerMapperConfigGenerator>) injector.GetNamedInstance(typeof (PerMapConfigGeneratorSet));
+
             injector.BindVolatileInstance(GenericType<MapFunctions<TMapInput, TMapOutput>>.Class,
-                MakeMapFunctions(jobDefinition.MapFunctionConfiguration));
+                MakeMapFunctions(jobDefinition.MapFunctionConfiguration, jobDefinition.PartitionedDatasetConfiguration, perMapConfigGenerators));
 
             var runner = injector.GetInstance<IMRURunner<TMapInput, TMapOutput, TResult>>();
             return runner.Run();
         }
 
-        private MapFunctions<TMapInput, TMapOutput> MakeMapFunctions(IConfiguration configuration)
+        /// <summary>
+        /// We also need IPartition at each map function
+        /// </summary>
+        /// <param name="mapConfiguration">Map configuration given by user</param>
+        /// <param name="partitionedDataSetConfig">Partitioned dataset configuration</param>
+        /// <param name="perMapConfigGenerators">Per map configuration generators</param>
+        /// <returns></returns>
+        private MapFunctions<TMapInput, TMapOutput> MakeMapFunctions(IConfiguration mapConfiguration, IConfiguration partitionedDataSetConfig, ISet<IPerMapperConfigGenerator> perMapConfigGenerators)
         {
-            var injector = TangFactory.GetTang().NewInjector(configuration);
+            IPartitionedDataSet dataset =
+                TangFactory.GetTang().NewInjector(partitionedDataSetConfig).GetInstance<IPartitionedDataSet>();
 
             ISet<IMapFunction<TMapInput, TMapOutput>> mappers = new HashSet<IMapFunction<TMapInput, TMapOutput>>();
-            for (var i = 0; i < _numberOfMappers; ++i)
+
+            int counter = 0;
+            foreach(var descriptor in dataset )
             {
-                mappers.Add(injector.ForkInjector().GetInstance<IMapFunction<TMapInput, TMapOutput>>());
+                var emptyConfig = TangFactory.GetTang().NewConfigurationBuilder().Build();
+                IConfiguration perMapConfig = perMapConfigGenerators.Aggregate(emptyConfig,
+                    (current, configGenerator) =>
+                        Configurations.Merge(current, configGenerator.GetMapperConfiguration(counter, dataset.Count)));
+
+                var injector = TangFactory.GetTang()
+                    .NewInjector(mapConfiguration, descriptor.GetPartitionConfiguration(), perMapConfig);
+                mappers.Add(injector.GetInstance<IMapFunction<TMapInput, TMapOutput>>());
+                counter++;
             }
             return new MapFunctions<TMapInput, TMapOutput>(mappers);
         }

--- a/lang/cs/Org.Apache.REEF.IMRU/InProcess/InputCodecWrapper.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/InProcess/InputCodecWrapper.cs
@@ -1,0 +1,35 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Wake.StreamingCodec;
+
+namespace Org.Apache.REEF.IMRU.InProcess
+{
+    internal class InputCodecWrapper<T>
+    {
+        [Inject]
+        private InputCodecWrapper(IStreamingCodec<T> codec)
+        {
+            Codec = codec;
+        }
+
+        internal IStreamingCodec<T> Codec { get; private set; }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IMRU/InProcess/OutputCodecWrapper.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/InProcess/OutputCodecWrapper.cs
@@ -1,0 +1,35 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Wake.StreamingCodec;
+
+namespace Org.Apache.REEF.IMRU.InProcess
+{
+    internal class OutputCodecWrapper<T>
+    {
+        [Inject]
+        private OutputCodecWrapper(IStreamingCodec<T> codec)
+        {
+            Codec = codec;
+        }
+
+        internal IStreamingCodec<T> Codec { get; private set; }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IMRU/Org.Apache.REEF.IMRU.csproj
+++ b/lang/cs/Org.Apache.REEF.IMRU/Org.Apache.REEF.IMRU.csproj
@@ -58,6 +58,8 @@ under the License.
     <Compile Include="InProcess\IMRURunner.cs" />
     <Compile Include="InProcess\InProcessIMRUClient.cs" />
     <Compile Include="InProcess\InProcessIMRUConfiguration.cs" />
+    <Compile Include="InProcess\OutputCodecWrapper.cs" />
+    <Compile Include="InProcess\InputCodecWrapper.cs" />
     <Compile Include="InProcess\MapFunctions.cs" />
     <Compile Include="InProcess\Parameters\NumberOfMappers.cs" />
     <Compile Include="OnREEF\Client\REEFIMRUClientConfiguration.cs" />


### PR DESCRIPTION
This addressed the issue by
* using codecs so that there are no issues in case Map and Update tasks try to use/reuse the same fields in MapInput and MapOutput and codec functions are also debugged for On-REEF runs.
b) using Per-Map configuration to give mapper specific configuration also.
c) using PartitionedDataset configuration so that Partition configuration is merged with each mapper configuration.
JIRA:
[REEF-730](https://issues.apache.org/jira/browse/REEF-730)