### PR TITLE
[REEF-736] Make Named Parameter PerMapConfigGeneratorSet public

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU/API/PerMapConfigGeneratorSet.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/API/PerMapConfigGeneratorSet.cs
@@ -25,7 +25,7 @@ using Org.Apache.REEF.Tang.Annotations;
 namespace Org.Apache.REEF.IMRU.API
 {
     [NamedParameter("Set of mapper specfic configuration generators", "setofmapconfig")]
-    internal sealed class PerMapConfigGeneratorSet : Name<ISet<IPerMapperConfigGenerator>>
+    public sealed class PerMapConfigGeneratorSet : Name<ISet<IPerMapperConfigGenerator>>
     {
     }
 }


### PR DESCRIPTION
This addressed the issue by
* making the parameter public
JIRA:
[REEF-736](https://issues.apache.org/jira/browse/REEF-736)