### PR TITLE
[REEF-731] Improve DriverRestart Example

### DIFF
--- a/lang/cs/Org.Apache.REEF.Examples.DriverRestart/DriverRestart.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.DriverRestart/DriverRestart.cs
@@ -63,6 +63,7 @@ namespace Org.Apache.REEF.Examples.DriverRestart
                 .Set(DriverConfiguration.OnDriverRestartTaskRunning, GenericType<HelloRestartDriver>.Class)
                 .Set(DriverConfiguration.OnEvaluatorAllocated, GenericType<HelloRestartDriver>.Class)
                 .Set(DriverConfiguration.OnEvaluatorFailed, GenericType<HelloRestartDriver>.Class)
+                .Set(DriverConfiguration.OnDriverRestartEvaluatorFailed, GenericType<HelloRestartDriver>.Class)
                 .Set(DriverConfiguration.OnDriverReconnect, GenericType<DefaultYarnClusterHttpDriverConnection>.Class)
                 .Set(DriverConfiguration.DriverRestartEvaluatorRecoverySeconds, (5 * 60).ToString())
                 .Set(DriverConfiguration.MaxApplicationSubmissions, 2.ToString())


### PR DESCRIPTION
This addressed the issue by
  * Adding more checks and keeping more state in DriverRestart example.
  * Adding a success message to print such that the job submitter knows whether the example has passed.
  * Bind ``DriverRestartEvaluatorFailedHandler`` properly.

JIRA:
  [REEF-731](https://issues.apache.org/jira/browse/REEF-731)