### PR TITLE
[REEF-735  update test cases and examples to use new REEFClient API

### DIFF
--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/ClrClientHelper.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/ClrClientHelper.cs
@@ -22,9 +22,12 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net.Configuration;
+using System.Runtime.InteropServices;
 using Org.Apache.REEF.Tang.Formats;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Utilities.Logging;
+using Org.Apache.REEF.Wake.Remote.Impl;
 
 namespace Org.Apache.REEF.Driver.Bridge
 {
@@ -32,6 +35,7 @@ namespace Org.Apache.REEF.Driver.Bridge
     {
         private static readonly Logger LOGGER = Logger.GetLogger(typeof(ClrClientHelper));
 
+        [Obsolete(message:"please use ReefClient API")]
         public static void Run(HashSet<string> appDlls, IConfiguration driverBridgeConfig, DriverSubmissionSettings driverSubmissionSettings, string reefJar = Constants.JavaBridgeJarFileName, string runCommand = "run.cmd", string clrFolder = ".", string className = Constants.BridgeLaunchClass)
         {
             using (LOGGER.LogFunction("ClrHandlerHelper::Run"))
@@ -82,6 +86,7 @@ namespace Org.Apache.REEF.Driver.Bridge
             }
         }
 
+        [Obsolete(message: "please use ReefClient API")]
         public static void UpdateJarFileWithAssemblies(string reefJar)
         {
             using (LOGGER.LogFunction("ClrHandlerHelper::UpdateJarFileWithAssemblies"))

--- a/lang/cs/Org.Apache.REEF.Network.Examples.Client/PipelineBroadcastAndReduceClient.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples.Client/PipelineBroadcastAndReduceClient.cs
@@ -17,21 +17,13 @@
  * under the License.
  */
 
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Org.Apache.REEF.Common.Io;
-using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.Driver;
 using Org.Apache.REEF.Driver.Bridge;
 using Org.Apache.REEF.Network.Examples.GroupCommunication;
 using Org.Apache.REEF.Network.Examples.GroupCommunication.PipelineBroadcastReduceDriverAndTasks;
 using Org.Apache.REEF.Network.Group.Config;
 using Org.Apache.REEF.Network.Naming;
-using Org.Apache.REEF.Network.NetworkService;
 using Org.Apache.REEF.Tang.Implementations.Configuration;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
@@ -90,14 +82,8 @@ namespace Org.Apache.REEF.Network.Examples.Client
 
             merged = Configurations.Merge(merged, taskConfig);
 
-            HashSet<string> appDlls = new HashSet<string>();
-            appDlls.Add(typeof(IDriver).Assembly.GetName().Name);
-            appDlls.Add(typeof(ITask).Assembly.GetName().Name);
-            appDlls.Add(typeof(PipelinedBroadcastReduceDriver).Assembly.GetName().Name);
-            appDlls.Add(typeof(INameClient).Assembly.GetName().Name);
-            appDlls.Add(typeof(INetworkService<>).Assembly.GetName().Name);
-
-            ClrClientHelper.Run(appDlls, merged, new DriverSubmissionSettings() { RunOnYarn = runOnYarn, JavaLogLevel = JavaLoggingSetting.VERBOSE });
+            string runPlatform = runOnYarn ? "yarn" : "local";
+            BroadcastAndReduceClient.TestRun(merged, typeof(PipelinedBroadcastReduceDriver), numTasks, "PipelinedBroadcastReduceDriver", runPlatform);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestBridgeClient.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestBridgeClient.cs
@@ -47,7 +47,8 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         [Ignore] //This test needs to be run on Yarn environment with test framework installed.
         public void CanRunClrBridgeExampleOnYarn()
         {
-            RunClrBridgeClient(true);
+            string testRuntimeFolder = DefaultRuntimeFolder + TestNumber++;
+            RunClrBridgeClient(true, testRuntimeFolder);
         }
 
         [TestMethod, Priority(1), TestCategory("FunctionalGated")]
@@ -56,12 +57,13 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         [Timeout(180 * 1000)]
         public void CanRunClrBridgeExampleOnLocalRuntime()
         {
-            RunClrBridgeClient(false);
+            string testRuntimeFolder = DefaultRuntimeFolder + TestNumber++;
+            CleanUp(testRuntimeFolder);
+            RunClrBridgeClient(false, testRuntimeFolder);
         }
 
-        private void RunClrBridgeClient(bool runOnYarn)
+        private void RunClrBridgeClient(bool runOnYarn, string testRuntimeFolder)
         {
-            string testRuntimeFolder = DefaultRuntimeFolder + TestNumber++;
             string[] a = new[] { runOnYarn ? "yarn" : "local", testRuntimeFolder };
             AllHandlers.Run(a);
             ValidateSuccessForLocalRuntime(2, testRuntimeFolder);

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSimpleEventHandlers.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSimpleEventHandlers.cs
@@ -49,13 +49,14 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         public void RunSimpleEventHandlerOnLocalRuntime()
         {
             string testFolder = DefaultRuntimeFolder + TestNumber++;
-            TestRun(DriverConfiguration(), typeof(HelloSimpleEventHandlers), "simpleHandler", "local", testFolder);
+            CleanUp(testFolder);
+            TestRun(DriverConfigurations(), typeof(HelloSimpleEventHandlers), 2, "simpleHandler", "local", testFolder);
             ValidateSuccessForLocalRuntime(1, testFolder);
             ValidateEvaluatorSetting(testFolder);
             CleanUp(testFolder);
         }
 
-        public IConfiguration DriverConfiguration()
+        public IConfiguration DriverConfigurations()
         {
             var helloDriverConfiguration = REEF.Driver.DriverConfiguration.ConfigurationModule
                 .Set(REEF.Driver.DriverConfiguration.OnDriverStarted, GenericType<HelloSimpleEventHandlers>.Class)

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Driver/TestDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Driver/TestDriver.cs
@@ -44,7 +44,7 @@ namespace Org.Apache.REEF.Tests.Functional.Driver
         }
 
         /// <summary>
-        /// This is to test DriverTestStartHandler. No evaluator and tasks are involked.
+        /// This is to test DriverTestStartHandler. No evaluator and tasks are involved.
         /// </summary>
         [TestMethod, Priority(1), TestCategory("FunctionalGated")]
         [Description("Test DriverTestStartHandler. No evaluator and tasks are invoked")]
@@ -52,18 +52,20 @@ namespace Org.Apache.REEF.Tests.Functional.Driver
         [Timeout(180 * 1000)]
         public void TestDriverStart()
         {
+            string testFolder = DefaultRuntimeFolder + TestNumber++;
+            CleanUp(testFolder);
+            TestRun(DriverConfigurations(), typeof(DriverTestStartHandler), 0, "DriverTestStartHandler", "local", testFolder);
+            ValidateSuccessForLocalRuntime(0, testFolder);
+        }
+
+        public IConfiguration DriverConfigurations()
+        {
             IConfiguration driverConfig = DriverConfiguration.ConfigurationModule
              .Set(DriverConfiguration.OnDriverStarted, GenericType<DriverTestStartHandler>.Class)
              .Set(DriverConfiguration.CustomTraceListeners, GenericType<DefaultCustomTraceListener>.Class)
              .Set(DriverConfiguration.CustomTraceLevel, Level.Info.ToString())
              .Build();
-
-            HashSet<string> appDlls = new HashSet<string>();
-            appDlls.Add(typeof(DriverTestStartHandler).Assembly.GetName().Name);
-
-            TestRun(appDlls, driverConfig);
-
-            ValidateSuccessForLocalRuntime(0);
+            return driverConfig;
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Group/BroadcastReduceTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Group/BroadcastReduceTest.cs
@@ -17,18 +17,14 @@
  * under the License.
  */
 
-using System.Collections.Generic;
 using System.Globalization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Org.Apache.REEF.Common.Io;
-using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.Driver;
 using Org.Apache.REEF.Driver.Bridge;
 using Org.Apache.REEF.Network.Examples.GroupCommunication;
 using Org.Apache.REEF.Network.Examples.GroupCommunication.BroadcastReduceDriverAndTasks;
 using Org.Apache.REEF.Network.Group.Config;
 using Org.Apache.REEF.Network.Naming;
-using Org.Apache.REEF.Network.NetworkService;
 using Org.Apache.REEF.Tang.Implementations.Configuration;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
@@ -56,8 +52,10 @@ namespace Org.Apache.REEF.Tests.Functional.Group
         public void TestBroadcastAndReduceOnLocalRuntime()
         {
             int numTasks = 9;
-            TestBroadcastAndReduce(false, numTasks);
-            ValidateSuccessForLocalRuntime(numTasks);
+            string testFolder = DefaultRuntimeFolder + TestNumber++;
+            CleanUp(testFolder);
+            TestBroadcastAndReduce(false, numTasks, testFolder);
+            ValidateSuccessForLocalRuntime(numTasks, testFolder);
         }
 
         [Ignore]
@@ -65,11 +63,17 @@ namespace Org.Apache.REEF.Tests.Functional.Group
         public void TestBroadcastAndReduceOnYarn()
         {
             int numTasks = 9;
-            TestBroadcastAndReduce(true, numTasks);
+            string testFolder = DefaultRuntimeFolder + TestNumber++;
+            TestBroadcastAndReduce(true, numTasks, testFolder);
         }
 
-        [TestMethod]
-        public void TestBroadcastAndReduce(bool runOnYarn, int numTasks)
+        private void TestBroadcastAndReduce(bool runOnYarn, int numTasks, string testFolder)
+        {
+            string runPlatform = runOnYarn ? "yarn" : "local";
+            TestRun(DriverConfigurations(numTasks), typeof(BroadcastReduceDriver), numTasks, "BroadcastReduceDriver", runPlatform, testFolder);
+        }
+
+        public IConfiguration DriverConfigurations(int numTasks)
         {
             IConfiguration driverConfig = TangFactory.GetTang().NewConfigurationBuilder(
                 DriverConfiguration.ConfigurationModule
@@ -102,16 +106,7 @@ namespace Org.Apache.REEF.Tests.Functional.Group
                 .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(NameClient).Assembly.GetName().Name)
                 .Build();
 
-            merged = Configurations.Merge(merged, taskConfig);
-
-            HashSet<string> appDlls = new HashSet<string>();
-            appDlls.Add(typeof(IDriver).Assembly.GetName().Name);
-            appDlls.Add(typeof(ITask).Assembly.GetName().Name);
-            appDlls.Add(typeof(BroadcastReduceDriver).Assembly.GetName().Name);
-            appDlls.Add(typeof(INameClient).Assembly.GetName().Name);
-            appDlls.Add(typeof(INetworkService<>).Assembly.GetName().Name);
-
-            TestRun(appDlls, merged, runOnYarn, JavaLoggingSetting.VERBOSE);
+            return Configurations.Merge(merged, taskConfig);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/ML/KMeans/TestKMeans.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/ML/KMeans/TestKMeans.cs
@@ -127,8 +127,10 @@ namespace Org.Apache.REEF.Tests.Functional.ML.KMeans
         public void TestKMeansOnLocalRuntimeWithGroupCommunications()
         {
             IsOnLocalRuntiime = true;
-            TestRun(AssembliesToCopy(), DriverConfiguration());
-            ValidateSuccessForLocalRuntime(Partitions + 1);
+            string testFolder = DefaultRuntimeFolder + TestNumber++;
+            CleanUp(testFolder);
+            TestRun(DriverConfiguration(), typeof(KMeansDriverHandlers), Partitions + 1, "KMeansDriverHandlers", "local", testFolder);
+            ValidateSuccessForLocalRuntime(Partitions + 1, testFolder);
         }
 
         [TestMethod, Priority(1), TestCategory("FunctionalGated")]
@@ -139,7 +141,8 @@ namespace Org.Apache.REEF.Tests.Functional.ML.KMeans
         [Ignore]    // ignored by default
         public void TestKMeansOnYarnOneBoxWithGroupCommunications()
         {
-            TestRun(AssembliesToCopy(), DriverConfiguration(), runOnYarn: true);
+            string testFolder = DefaultRuntimeFolder + TestNumber++;
+            TestRun(DriverConfiguration(), typeof(KMeansDriverHandlers), Partitions + 1, "KMeansDriverHandlers", "yarn", testFolder);
             Assert.IsNotNull("BreakPointChecker");
         }
 
@@ -176,16 +179,6 @@ namespace Org.Apache.REEF.Tests.Functional.ML.KMeans
                 .Build();
 
             return Configurations.Merge(merged, taskConfig);
-        }
-
-        private HashSet<string> AssembliesToCopy()
-        {
-            HashSet<string> appDlls = new HashSet<string>();
-            appDlls.Add(typeof(LegacyKMeansTask).Assembly.GetName().Name);
-            appDlls.Add(typeof(INameClient).Assembly.GetName().Name);
-            appDlls.Add(typeof(KMeansDriverHandlers).Assembly.GetName().Name);
-            appDlls.Add(typeof(INetworkService<>).Assembly.GetName().Name);
-            return appDlls;
         }
     }
 }


### PR DESCRIPTION
Updated existing tests cases and examples that still use old REEFClient and mark ClrClientHelper.Run as Obsolete

JIRA: REEF-735(https://issues.apache.org/jira/browse/REEF-735)

This closes #

Author: Julia Wang  Email: juliaw@apache.org