### PR TITLE
[REEF-741] Remove external link icons on website

### DIFF
--- a/website/src/site/resources/css/site.css
+++ b/website/src/site/resources/css/site.css
@@ -19,3 +19,9 @@
 .pull-left {
   margin: 10px
 }
+
+a.externalLink[href] {
+  background: none;
+  padding-right: 0;
+}
+


### PR DESCRIPTION
This addressed the issue by
* Removing auto-generated link icons (rose and globe) from website

JIRA: [REEF-741](https://issues.apache.org/jira/browse/REEF-741)

Pull Request: Closes #