### PR TITLE
[REEF-600] Added a ConfigurationModule for the TcpPortProvider

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/API/TcpPortConfigurationModule.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/TcpPortConfigurationModule.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using Org.Apache.REEF.Client.API.Parameters;
+using Org.Apache.REEF.Common.Attributes;
+using Org.Apache.REEF.Common.Io;
+using Org.Apache.REEF.Tang.Formats;
+using Org.Apache.REEF.Tang.Interface;
+using Org.Apache.REEF.Tang.Util;
+using Org.Apache.REEF.Wake.Remote.Parameters;
+
+namespace Org.Apache.REEF.Client.API
+{
+    /// <summary>
+    /// Configuration Module for the TCP port provider.
+    /// </summary>
+    [Unstable("0.13", "Move to another namespace.")]
+    public sealed class TcpPortConfigurationModule : ConfigurationModuleBuilder
+    {
+        /// <summary>
+        /// Port number range start for listening on tcp ports.
+        /// </summary>
+        public static RequiredParameter<int> PortRangeStart = new RequiredParameter<int>();
+
+        /// <summary>
+        /// Seed for the random port number generator.
+        /// </summary>
+        public static OptionalParameter<int> PortRangeSeed = new OptionalParameter<int>();
+
+        /// <summary>
+        /// Port number count in the range for listening on tcp ports.
+        /// </summary>
+        public static RequiredParameter<int> PortRangeCount = new RequiredParameter<int>();
+
+        /// <summary>
+        /// Count of tries to get a tcp port in the port range.
+        /// </summary>
+        public static RequiredParameter<int> PortRangeTryCount = new RequiredParameter<int>();
+
+        public static ConfigurationModule ConfigurationModule = new TcpPortConfigurationModule()
+            .BindSetEntry<DriverConfigurationProviders, TcpPortConfigurationProvider, IConfigurationProvider>(
+                GenericType<DriverConfigurationProviders>.Class, GenericType<TcpPortConfigurationProvider>.Class)
+            .BindNamedParameter(GenericType<TcpPortRangeStart>.Class, PortRangeStart)
+            .BindNamedParameter(GenericType<TcpPortRangeSeed>.Class, PortRangeSeed)
+            .BindNamedParameter(GenericType<TcpPortRangeCount>.Class, PortRangeCount)
+            .BindNamedParameter(GenericType<TcpPortRangeTryCount>.Class, PortRangeTryCount)
+            .Build();
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Client/API/TcpPortConfigurationModule.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/TcpPortConfigurationModule.cs
@@ -34,24 +34,24 @@ namespace Org.Apache.REEF.Client.API
         /// <summary>
         /// Port number range start for listening on tcp ports.
         /// </summary>
-        public static RequiredParameter<int> PortRangeStart = new RequiredParameter<int>();
+        public static readonly RequiredParameter<int> PortRangeStart = new RequiredParameter<int>();
 
         /// <summary>
         /// Seed for the random port number generator.
         /// </summary>
-        public static OptionalParameter<int> PortRangeSeed = new OptionalParameter<int>();
+        public static readonly OptionalParameter<int> PortRangeSeed = new OptionalParameter<int>();
 
         /// <summary>
         /// Port number count in the range for listening on tcp ports.
         /// </summary>
-        public static RequiredParameter<int> PortRangeCount = new RequiredParameter<int>();
+        public static readonly RequiredParameter<int> PortRangeCount = new RequiredParameter<int>();
 
         /// <summary>
         /// Count of tries to get a tcp port in the port range.
         /// </summary>
-        public static OptionalParameter<int> PortRangeTryCount = new OptionalParameter<int>();
+        public static readonly OptionalParameter<int> PortRangeTryCount = new OptionalParameter<int>();
 
-        public static ConfigurationModule ConfigurationModule = new TcpPortConfigurationModule()
+        public static readonly ConfigurationModule ConfigurationModule = new TcpPortConfigurationModule()
             .BindSetEntry<DriverConfigurationProviders, TcpPortConfigurationProvider, IConfigurationProvider>(
                 GenericType<DriverConfigurationProviders>.Class, GenericType<TcpPortConfigurationProvider>.Class)
             .BindNamedParameter(GenericType<TcpPortRangeStart>.Class, PortRangeStart)

--- a/lang/cs/Org.Apache.REEF.Client/API/TcpPortConfigurationModule.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/TcpPortConfigurationModule.cs
@@ -49,7 +49,7 @@ namespace Org.Apache.REEF.Client.API
         /// <summary>
         /// Count of tries to get a tcp port in the port range.
         /// </summary>
-        public static RequiredParameter<int> PortRangeTryCount = new RequiredParameter<int>();
+        public static OptionalParameter<int> PortRangeTryCount = new OptionalParameter<int>();
 
         public static ConfigurationModule ConfigurationModule = new TcpPortConfigurationModule()
             .BindSetEntry<DriverConfigurationProviders, TcpPortConfigurationProvider, IConfigurationProvider>(

--- a/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
+++ b/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
@@ -53,6 +53,7 @@ under the License.
     <Compile Include="API\JobSubmissionBuilder.cs" />
     <Compile Include="API\JobSubmissionBuilderFactory.cs" />
     <Compile Include="API\Parameters\DriverConfigurationProviders.cs" />
+    <Compile Include="API\TcpPortConfigurationModule.cs" />
     <Compile Include="Common\ClientConstants.cs" />
     <Compile Include="Common\ClrClient2JavaClientCuratedParameters.cs" />
     <Compile Include="Common\DriverFolderPreparationHelper.cs" />

--- a/lang/cs/Org.Apache.REEF.Common/Attributes/UnstableAttribute.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Attributes/UnstableAttribute.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+
+namespace Org.Apache.REEF.Common.Attributes
+{
+    /// <summary>
+    /// Signals that the API is NOT stabilized.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.All)]
+    public sealed class UnstableAttribute : Attribute
+    {
+        private readonly string _descriptionOfLikelyChange;
+        private readonly string _versionIntroduced;
+
+        /// <summary>
+        /// </summary>
+        /// <param name="versionIntroduced">The version in which this unstable API was introduced.</param>
+        /// <param name="descriptionOfLikelyChange">Description of the likely change in the future.</param>
+        public UnstableAttribute(string versionIntroduced, string descriptionOfLikelyChange = "")
+        {
+            _versionIntroduced = versionIntroduced;
+            _descriptionOfLikelyChange = descriptionOfLikelyChange;
+        }
+
+        /// <summary>
+        /// The version in which this unstable API was introduced.
+        /// </summary>
+        public string VersionIntroduced
+        {
+            get { return _versionIntroduced; }
+        }
+
+        /// <summary>
+        /// Description of the likely change in the future.
+        /// </summary>
+        public string DescriptionOfLikelyChange
+        {
+            get { return _descriptionOfLikelyChange; }
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
+++ b/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
@@ -54,6 +54,7 @@ under the License.
     <Compile Include="Api\AbstractFailure.cs" />
     <Compile Include="Api\IAbstractFailure.cs" />
     <Compile Include="Api\IFailure.cs" />
+    <Compile Include="Attributes\UnstableAttribute.cs" />
     <Compile Include="Avro\AvroDriverInfo.cs" />
     <Compile Include="Avro\AvroHttpRequest.cs" />
     <Compile Include="Avro\AvroHttpSerializer.cs" />


### PR DESCRIPTION
This change also adds the new custom attribute `[Unstable]` which we use to mark the new configuration module as unstable.

JIRA:
  [REEF-600](https://issues.apache.org/jira/browse/REEF-600)