### PR TITLE
[REEF-522] Add missing Javadoc comments in Java code: reef-checkpoint

### DIFF
--- a/lang/java/reef-checkpoint/pom.xml
+++ b/lang/java/reef-checkpoint/pom.xml
@@ -48,6 +48,17 @@ under the License.
                 </excludes>
             </resource>
         </resources>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <configuration>
+                        <configLocation>lang/java/reef-common/src/main/resources/checkstyle-strict.xml</configLocation>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <dependencies>

--- a/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/CheckpointService.java
+++ b/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/CheckpointService.java
@@ -92,9 +92,15 @@ public interface CheckpointService {
    */
   boolean delete(CheckpointID checkpointId) throws IOException, InterruptedException;
 
+  /**
+   * A channel to write to a checkpoint.
+   */
   interface CheckpointWriteChannel extends WritableByteChannel {
   }
 
+  /**
+   * A channel to read from a checkpoint.
+   */
   interface CheckpointReadChannel extends ReadableByteChannel {
   }
 }

--- a/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/RandomNameCNS.java
+++ b/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/RandomNameCNS.java
@@ -42,6 +42,9 @@ public class RandomNameCNS implements CheckpointNamingService {
     return this.prefix + RandomStringUtils.randomAlphanumeric(8);
   }
 
+  /**
+   * The prefix used for the random names returned.
+   */
   @NamedParameter(doc = "The prefix used for the random names returned.", default_value = "checkpoint_")
   public static class PREFIX implements Name<String> {
   }

--- a/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/fs/package-info.java
+++ b/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/fs/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * FileSystem based checkpoints.
  */
 package org.apache.reef.io.checkpoint.fs;

--- a/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/package-info.java
+++ b/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Checkpoints that provide APIs and implementations to store and retrieve the state of a task.
  */
 package org.apache.reef.io.checkpoint;


### PR DESCRIPTION
This adds missing Javadoc comments in reef-checkpoint project
and enforces more strict checkstyle rules.

JIRA:
  [REEF-522](https://issues.apache.org/jira/browse/REEF-522)

Pull Request:
  Closes #