### PR TITLE
[REEF-526] Add missing Javadoc comments in Java code: reef-poison

### DIFF
--- a/lang/java/reef-poison/pom.xml
+++ b/lang/java/reef-poison/pom.xml
@@ -31,6 +31,20 @@ under the License.
     <name>REEF Poison</name>
     <description>Fault injection for REEF</description>
 
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <configuration>
+                        <configLocation>lang/java/reef-common/src/main/resources/checkstyle-strict.xml</configLocation>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/lang/java/reef-poison/src/main/java/org/apache/reef/poison/context/PoisonedContextStartHandler.java
+++ b/lang/java/reef-poison/src/main/java/org/apache/reef/poison/context/PoisonedContextStartHandler.java
@@ -32,6 +32,9 @@ import java.util.Random;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * Fault-injected handler for ContextStart.
+ */
 public final class PoisonedContextStartHandler implements EventHandler<ContextStart> {
 
   private static final Logger LOG = Logger.getLogger(PoisonedContextStartHandler.class.getName());

--- a/lang/java/reef-poison/src/main/java/org/apache/reef/poison/params/CrashTimeout.java
+++ b/lang/java/reef-poison/src/main/java/org/apache/reef/poison/params/CrashTimeout.java
@@ -21,6 +21,9 @@ package org.apache.reef.poison.params;
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
+/**
+ * The time window after ContextStart in which the crash will occur.
+ */
 @NamedParameter(doc = "The time window (in seconds) after ContextStart in which the crash will occur",
     default_value = "" + CrashTimeout.DEFAULT_VALUE)
 public final class CrashTimeout implements Name<Integer> {

--- a/lang/java/reef-poison/src/main/java/org/apache/reef/poison/params/package-info.java
+++ b/lang/java/reef-poison/src/main/java/org/apache/reef/poison/params/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Parameters of fault injections.
  */
 package org.apache.reef.poison.params;

--- a/lang/java/reef-poison/src/main/java/org/apache/reef/poison/task/PoisonedTaskStartHandler.java
+++ b/lang/java/reef-poison/src/main/java/org/apache/reef/poison/task/PoisonedTaskStartHandler.java
@@ -32,6 +32,9 @@ import java.util.Random;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * Fault-injected handler for TaskStart.
+ */
 public final class PoisonedTaskStartHandler implements EventHandler<TaskStart> {
 
   private static final Logger LOG = Logger.getLogger(PoisonedTaskStartHandler.class.getName());


### PR DESCRIPTION
This adds missing Javadoc comments in reef-poison project
and enforces more strict checkstyle rules.

JIRA:
  [REEF-526](https://issues.apache.org/jira/browse/REEF-526)

Pull Request:
  Closes #