### PR TITLE
[REEF-755] Add Findbugs check to our build tools

### DIFF
--- a/lang/java/reef-common/src/main/resources/findbugs-exclude.xml
+++ b/lang/java/reef-common/src/main/resources/findbugs-exclude.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<FindBugsFilter>
+    <Match>
+        <Class name="~.*\.proto\..*" />
+    </Match>
+    <Match>
+        <Class name="~.*\.avro\..*" />
+    </Match>
+</FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,8 @@ under the License.
         <protobuf.version>2.5.0</protobuf.version>
         <maven-checkstyle-plugin.version>2.15</maven-checkstyle-plugin.version>
         <checkstyle.version>6.6</checkstyle.version>
+        <findbugs.version>3.0.2</findbugs.version>
+        <rootPath>${user.dir}</rootPath>
     </properties>
 
     <scm>
@@ -294,6 +296,48 @@ under the License.
                         <format>html</format>
                         <outputFile>${project.build.directory}/test/checkstyle-errors.xml</outputFile>
                         <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>findbugs-maven-plugin</artifactId>
+                    <version>${findbugs.version}</version>
+                    <configuration>
+                        <effort>Max</effort>
+                        <threshold>Low</threshold>
+                        <failOnError>false</failOnError>
+                        <findbugsXmlOutputDirectory>${project.build.directory}/findbugs</findbugsXmlOutputDirectory>
+                        <excludeFilterFile>${rootPath}/lang/java/reef-common/src/main/resources/findbugs-exclude.xml</excludeFilterFile>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>xml-maven-plugin</artifactId>
+                    <version>1.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>findbugs-maven-plugin</artifactId>
+                            <version>${findbugs.version}</version>
+                        </dependency>
+                    </dependencies>
+                    <configuration>
+                        <transformationSets>
+                            <transformationSet>
+                                <dir>${project.build.directory}/findbugs</dir>
+                                <includes>
+                                    <include>findbugsXml.xml</include>
+                                </includes>
+                                <outputDir>${project.build.directory}/findbugs</outputDir>
+                                <stylesheet>default.xsl</stylesheet>
+                                <fileMappers>
+                                    <!-- Configures the file extension of the output files. -->
+                                    <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FileExtensionMapper">
+                                        <targetExtension>.html</targetExtension>
+                                    </fileMapper>
+                                </fileMappers>
+                            </transformationSet>
+                        </transformationSets>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
This adds Findbugs to plugins we can use with our Java build.
This does not add Findbug to our regular build process, because
we don't want to increase the build time for a non-blocking tool.
Instead, it can be invoked separately using command

mvn findbugs:check; mvn xml:transform

Output can be found in target/findbugs folder of each project.

JIRA:
  [REEF-755](https://issues.apache.org/jira/browse/REEF-755)

Pull Request:
  Closes #