### PR TITLE
[REEF-756] Log assembly load errors instead of dying during class

### DIFF
--- a/lang/cs/Org.Apache.REEF.Tang.Tests/Org.Apache.REEF.Tang.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/Org.Apache.REEF.Tang.Tests.csproj
@@ -108,6 +108,7 @@ under the License.
     <Compile Include="Tang\TestExternalConstructors.cs" />
     <Compile Include="Tang\TestLegacyConstructors.cs" />
     <Compile Include="Tang\TestTang.cs" />
+    <Compile Include="Utilities\AssemblyLoaderTests.cs" />
     <Compile Include="Utilities\TestUtilities.cs" />
     <Compile Include="Utilities\Utilities.cs" />
   </ItemGroup>

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/Utilities/AssemblyLoaderTests.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/Utilities/AssemblyLoaderTests.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Org.Apache.REEF.Tang.Examples;
+using Org.Apache.REEF.Tang.Util;
+
+namespace Org.Apache.REEF.Tang.Tests.Utilities
+{
+    [TestClass]
+    public class AssemblyLoaderTests
+    {
+        [TestMethod]
+        public void AssemblyLoadingFailsNoException()
+        {
+            var notUsed = new AssemblyLoader(new []{"DoesNotExist.dll"});
+        }
+
+        [TestMethod]
+        public void AssemblyLoadingSomeSucceedFailuresAreIgnored()
+        {
+            var loader = new AssemblyLoader(new []{"DoesNotExist.dll", FileNames.Examples});
+            Assert.AreEqual(1, loader.Assemblies.Count);
+            Assert.IsTrue(loader.Assemblies.First().GetName().Name == FileNames.Examples);
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ClassHierarchyImpl.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/ClassHierarchyImpl.cs
@@ -20,6 +20,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -79,9 +80,30 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
 
             foreach (var a in loader.Assemblies)
             {
-                foreach (var t in a.GetTypes())
+                Type[] types;
+                try
                 {
-                    RegisterType(t);
+                    types  = a.GetTypes();
+                }
+                catch (ReflectionTypeLoadException exception)
+                {
+                    LOGGER.Log(Level.Warning,
+                        "GetTypes failed for assembly: {0} LoaderExceptions: {1}",
+                        a,
+                        string.Join<Exception>("; ", exception.LoaderExceptions));
+                    continue;
+                }
+
+                foreach (var t in types)
+                {
+                    try
+                    {
+                        RegisterType(t);
+                    }
+                    catch (FileNotFoundException exception)
+                    {
+                        LOGGER.Log(Level.Warning, "Could not register type: {0} Exception: {1}", t, exception);
+                    }
                 }
             }
         }

--- a/lang/cs/Org.Apache.REEF.Tang/Util/AssemblyLoader.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Util/AssemblyLoader.cs
@@ -36,7 +36,14 @@ namespace Org.Apache.REEF.Tang.Util
             Assemblies = new List<Assembly>();
             foreach (var a in files)
             {
-                Assemblies.Add(Assembly.Load(a));
+                try
+                {
+                    Assemblies.Add(Assembly.Load(a));
+                }
+                catch (FileNotFoundException exception)
+                {
+                    LOGGER.Log(Level.Warning, "Could not load assembly: {0} Exception: {1}", a, exception);
+                }
             }
         }
 


### PR DESCRIPTION
hierarchy generation in Tang

This addressed the issue by
 * Catching exception when assembly loading fails
 * Generate appropriate log to facilitate debugging

JIRA:
 [REEF-756](https://issues.apache.org/jira/browse/REEF-756)