### PR TITLE
[REEF-754  Eliminate deserialization for context and service configuration submitted from .Net to Java

### DIFF
--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ActiveContextBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ActiveContextBridge.java
@@ -21,8 +21,6 @@ package org.apache.reef.javabridge;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.io.naming.Identifiable;
 import org.apache.reef.runtime.common.driver.context.EvaluatorContext;
-import org.apache.reef.tang.ClassHierarchy;
-import org.apache.reef.tang.formats.AvroConfigurationSerializer;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -31,17 +29,11 @@ public final class ActiveContextBridge extends NativeBridge implements Identifia
   private static final Logger LOG = Logger.getLogger(ActiveContextBridge.class.getName());
 
   private final ActiveContext jactiveContext;
-  private final AvroConfigurationSerializer serializer;
   private final String contextId;
   private final String evaluatorId;
-  private final ClassHierarchy clrClassHierarchy;
 
-  ActiveContextBridge(final ActiveContext activeContext,
-                      final ClassHierarchy clrClassHierarchy,
-                      final AvroConfigurationSerializer serializer) {
+  ActiveContextBridge(final ActiveContext activeContext) {
     this.jactiveContext = activeContext;
-    this.clrClassHierarchy = clrClassHierarchy;
-    this.serializer = serializer;
     this.contextId = activeContext.getId();
     this.evaluatorId = activeContext.getEvaluatorId();
   }

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ActiveContextBridgeFactory.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/ActiveContextBridgeFactory.java
@@ -18,13 +18,10 @@
  */
 package org.apache.reef.javabridge;
 
-import net.jcip.annotations.GuardedBy;
 import net.jcip.annotations.ThreadSafe;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.context.ActiveContext;
-import org.apache.reef.tang.ClassHierarchy;
-import org.apache.reef.tang.formats.AvroConfigurationSerializer;
 
 import javax.inject.Inject;
 
@@ -35,18 +32,11 @@ import javax.inject.Inject;
 @ThreadSafe
 @Private
 public final class ActiveContextBridgeFactory {
-  @GuardedBy("this")
-  private ClassHierarchy clrClassHierarchy;
-  private final AvroConfigurationSerializer configurationSerializer;
-
   /**
    * This is always instantiated via Tang.
-   *
-   * @param configurationSerializer passed to the ActiveContextBridge instances for configuration serialization.
    */
   @Inject
-  private ActiveContextBridgeFactory(final AvroConfigurationSerializer configurationSerializer) {
-    this.configurationSerializer = configurationSerializer;
+  private ActiveContextBridgeFactory() {
   }
 
   /**
@@ -56,18 +46,6 @@ public final class ActiveContextBridgeFactory {
    * @return a new ActiveContextBridge.
    */
   public ActiveContextBridge getActiveContextBridge(final ActiveContext context) {
-    return new ActiveContextBridge(context, this.getClrClassHierarchy(), this.configurationSerializer);
-  }
-
-  /**
-   * Returns the clr ClassHierarchy. Loads it if needed.
-   *
-   * @return the clr ClassHierarchy.
-   */
-  private synchronized ClassHierarchy getClrClassHierarchy() {
-    if (null == this.clrClassHierarchy) {
-      this.clrClassHierarchy = Utilities.loadClassHierarchy(NativeInterop.CLASS_HIERARCHY_FILENAME);
-    }
-    return this.clrClassHierarchy;
+    return new ActiveContextBridge(context);
   }
 }

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/AllocatedEvaluatorBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/AllocatedEvaluatorBridge.java
@@ -21,9 +21,6 @@ package org.apache.reef.javabridge;
 import org.apache.reef.io.naming.Identifiable;
 import org.apache.reef.runtime.common.driver.evaluator.AllocatedEvaluatorImpl;
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
-import org.apache.reef.tang.ClassHierarchy;
-import org.apache.reef.tang.Configuration;
-import org.apache.reef.tang.formats.AvroConfigurationSerializer;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -36,8 +33,6 @@ public final class AllocatedEvaluatorBridge extends NativeBridge implements Iden
   private static final Logger LOG = Logger.getLogger(AllocatedEvaluatorBridge.class.getName());
 
   private final AllocatedEvaluator jallocatedEvaluator;
-  private final AvroConfigurationSerializer serializer;
-  private final ClassHierarchy clrClassHierarchy;
   private final String evaluatorId;
   private final String nameServerInfo;
 
@@ -45,12 +40,8 @@ public final class AllocatedEvaluatorBridge extends NativeBridge implements Iden
    * This constructor should only be called by the AllocatedEvaluatorBridgeFactory.
    */
   AllocatedEvaluatorBridge(final AllocatedEvaluator allocatedEvaluator,
-                           final ClassHierarchy clrClassHierarchy,
-                           final String serverInfo,
-                           final AvroConfigurationSerializer serializer) {
+                           final String serverInfo) {
     this.jallocatedEvaluator = allocatedEvaluator;
-    this.serializer = serializer;
-    this.clrClassHierarchy = clrClassHierarchy;
     this.evaluatorId = allocatedEvaluator.getId();
     this.nameServerInfo = serverInfo;
   }
@@ -68,20 +59,11 @@ public final class AllocatedEvaluatorBridge extends NativeBridge implements Iden
     if (taskConfigurationString.isEmpty()) {
       throw new RuntimeException("empty taskConfigurationString provided.");
     }
-    final Configuration contextConfiguration;
-    final Configuration taskConfiguration;
-    try {
-      contextConfiguration = serializer.fromString(contextConfigurationString, clrClassHierarchy);
-    } catch (final Exception e) {
-      final String message = "Unable to de-serialize CLR context or task configurations using class hierarchy.";
-      LOG.log(Level.SEVERE, message, e);
-      throw new RuntimeException(message, e);
-    }
-
-    //When submit over the bridge, we would keep the task configuration as a serialized string.
-    //submitContextAndTask(final Configuration contextConfiguration,
+    //When submit over the bridge, we would keep the task configurations as a serialized strings.
+    //submitContextAndTask(final String contextConfiguration,
     //final String taskConfiguration) is not exposed in the interface. Therefore cast is necessary.
-    ((AllocatedEvaluatorImpl)jallocatedEvaluator).submitContextAndTask(contextConfiguration, taskConfigurationString);
+    ((AllocatedEvaluatorImpl)jallocatedEvaluator)
+        .submitContextAndTask(contextConfigurationString, taskConfigurationString);
   }
 
   /**
@@ -92,15 +74,11 @@ public final class AllocatedEvaluatorBridge extends NativeBridge implements Iden
     if (contextConfigurationString.isEmpty()) {
       throw new RuntimeException("empty contextConfigurationString provided.");
     }
-    final Configuration contextConfiguration;
-    try {
-      contextConfiguration = serializer.fromString(contextConfigurationString, clrClassHierarchy);
-    } catch (final Exception e) {
-      final String message = "Unable to de-serialize CLR context configurations using class hierarchy.";
-      LOG.log(Level.SEVERE, message, e);
-      throw new RuntimeException(message, e);
-    }
-    jallocatedEvaluator.submitContext(contextConfiguration);
+
+    //When submit over the bridge, we would keep the contextConfigurationString as serialized strings.
+    //public void submitContext(final String contextConfiguration)
+    // is not exposed in the interface. Therefore cast is necessary.
+    ((AllocatedEvaluatorImpl)jallocatedEvaluator).submitContext(contextConfigurationString);
   }
 
   /**
@@ -117,17 +95,11 @@ public final class AllocatedEvaluatorBridge extends NativeBridge implements Iden
       throw new RuntimeException("empty serviceConfigurationString provided.");
     }
 
-    final Configuration contextConfiguration;
-    final Configuration servicetConfiguration;
-    try {
-      contextConfiguration = serializer.fromString(contextConfigurationString, clrClassHierarchy);
-      servicetConfiguration = serializer.fromString(serviceConfigurationString, clrClassHierarchy);
-    } catch (final Exception e) {
-      final String message = "Unable to de-serialize CLR context or service  configurations using class hierarchy.";
-      LOG.log(Level.SEVERE, message, e);
-      throw new RuntimeException(message, e);
-    }
-    jallocatedEvaluator.submitContextAndService(contextConfiguration, servicetConfiguration);
+    //When submit over the bridge, we would keep the configurations as serialized strings.
+    //public void submitContextAndService(final String contextConfiguration,
+    //final String serviceConfiguration) is not exposed in the interface. Therefore cast is necessary.
+    ((AllocatedEvaluatorImpl)jallocatedEvaluator)
+        .submitContextAndService(contextConfigurationString, serviceConfigurationString);
   }
 
   /**
@@ -149,24 +121,12 @@ public final class AllocatedEvaluatorBridge extends NativeBridge implements Iden
     if (taskConfigurationString.isEmpty()) {
       throw new RuntimeException("empty taskConfigurationString provided.");
     }
-    final Configuration contextConfiguration;
-    final Configuration servicetConfiguration;
-    final Configuration taskConfiguration;
-    try {
-      contextConfiguration = serializer.fromString(contextConfigurationString, clrClassHierarchy);
-      servicetConfiguration = serializer.fromString(serviceConfigurationString, clrClassHierarchy);
-    } catch (final Exception e) {
-      final String message =
-          "Unable to de-serialize CLR context or service or task configurations using class hierarchy.";
-      LOG.log(Level.SEVERE, message, e);
-      throw new RuntimeException(message, e);
-    }
 
     //When submit over the bridge, we would keep the task configuration as a serialized string.
     //submitContextAndServiceAndTask(final Configuration contextConfiguration, final Configuration serviceConfiguration,
     //final String taskConfiguration) is not exposed in the interface. Therefore cast is necessary.
-    ((AllocatedEvaluatorImpl)jallocatedEvaluator)
-        .submitContextAndServiceAndTask(contextConfiguration, servicetConfiguration, taskConfigurationString);
+    ((AllocatedEvaluatorImpl)jallocatedEvaluator).submitContextAndServiceAndTask(
+        contextConfigurationString, serviceConfigurationString, taskConfigurationString);
   }
 
   /**

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/AllocatedEvaluatorBridgeFactory.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/AllocatedEvaluatorBridgeFactory.java
@@ -18,12 +18,9 @@
  */
 package org.apache.reef.javabridge;
 
-import net.jcip.annotations.GuardedBy;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.evaluator.AllocatedEvaluator;
-import org.apache.reef.tang.ClassHierarchy;
-import org.apache.reef.tang.formats.AvroConfigurationSerializer;
 
 import javax.inject.Inject;
 
@@ -34,18 +31,12 @@ import javax.inject.Inject;
 @DriverSide
 @Private
 public final class AllocatedEvaluatorBridgeFactory {
-  @GuardedBy("this")
-  private ClassHierarchy clrClassHierarchy;
-  private AvroConfigurationSerializer serializer;
-
   /**
    * This is always instantiated via Tang.
    */
   @Inject
-  private AllocatedEvaluatorBridgeFactory(final AvroConfigurationSerializer serializer) {
-    this.serializer = serializer;
+  private AllocatedEvaluatorBridgeFactory() {
   }
-
 
   /**
    * Instantiates a new AllocatedEvaluatorBridge.
@@ -55,18 +46,6 @@ public final class AllocatedEvaluatorBridgeFactory {
    */
   public AllocatedEvaluatorBridge getAllocatedEvaluatorBridge(final AllocatedEvaluator allocatedEvaluator,
                                                               final String serverInfo) {
-    return new AllocatedEvaluatorBridge(allocatedEvaluator, getClrClassHierarchy(), serverInfo, serializer);
-  }
-
-  /**
-   * Returns the clr ClassHierarchy. Loads it if needed.
-   *
-   * @return the clr ClassHierarchy.
-   */
-  private synchronized ClassHierarchy getClrClassHierarchy() {
-    if (null == this.clrClassHierarchy) {
-      this.clrClassHierarchy = Utilities.loadClassHierarchy(NativeInterop.CLASS_HIERARCHY_FILENAME);
-    }
-    return this.clrClassHierarchy;
+    return new AllocatedEvaluatorBridge(allocatedEvaluator, serverInfo);
   }
 }


### PR DESCRIPTION
This PR contains the following changes:
-User original serialized configuration strings when creating evauator configuration when calling from bridge
-Remove class hierarchy from ActiveContextBridge Bridge and AllocatedEvaluatorBridge and corresponding Factories as it is need in those cases.
-remove AvroConfigurationSerializer from those classes
-refactor and clean up previouse added task configuration string methods

JIRA: REEF-754(https://issues.apache.org/jira/browse/REEF-754)

This closes #

Author: Julia Wang  Email: juliaw@apache.org