### PR TITLE
[REEF-679] Made IContext immutable

### DIFF
--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/ActiveContext.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/ActiveContext.cs
@@ -33,10 +33,9 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
     internal class ActiveContext : IActiveContext
     {
         private static readonly Logger LOGGER = Logger.GetLogger(typeof(ActiveContext));
-
         private readonly AvroConfigurationSerializer _serializer;
 
-        public ActiveContext(IActiveContextClr2Java clr2Java)
+        internal ActiveContext(IActiveContextClr2Java clr2Java)
         {
             InstanceId = Guid.NewGuid().ToString("N");
             Clr2Java = clr2Java;
@@ -44,48 +43,35 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
         }
 
         [DataMember]
-        public string InstanceId { get; set; }
+        public string InstanceId { get; private set; }
+
+        private IActiveContextClr2Java Clr2Java { get; set; }
 
         public string Id
         {
-            get
-            {
-                return Clr2Java.GetId();
-            }
+            get { return Clr2Java.GetId(); }
         }
 
         public string EvaluatorId
         {
-            get
-            {
-                return Clr2Java.GetEvaluatorId();
-            }
-
-            set
-            {
-            }
+            get { return Clr2Java.GetEvaluatorId(); }
         }
 
-        public Optional<string> ParentId { get; set; }
+        public Optional<string> ParentId
+        {
+            // TODO[REEF-760]: Implement
+            get { return Optional<string>.Empty(); }
+        }
 
         public IEvaluatorDescriptor EvaluatorDescriptor
         {
-            get
-            {
-                return Clr2Java.GetEvaluatorDescriptor();
-            }
-
-            set
-            {
-            }
+            get { return Clr2Java.GetEvaluatorDescriptor(); }
         }
-
-        private IActiveContextClr2Java Clr2Java { get; set; }
 
         public void SubmitTask(IConfiguration taskConfiguration)
         {
             LOGGER.Log(Level.Info, "ActiveContext::SubmitTask");
-            string task = _serializer.ToString(taskConfiguration);
+            var task = _serializer.ToString(taskConfiguration);
             LOGGER.Log(Level.Verbose, "serialized taskConfiguration: " + task);
             Clr2Java.SubmitTask(task);
         }

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/ClosedContext.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/ClosedContext.cs
@@ -26,13 +26,12 @@ using Org.Apache.REEF.Utilities;
 
 namespace Org.Apache.REEF.Driver.Bridge.Events
 {
-    public class ClosedContext : IClosedContext
+    internal sealed class ClosedContext : IClosedContext
     {
+        private readonly string _evaluatorId;
         private readonly string _id;
 
-        private readonly string _evaluatorId;
-
-        public ClosedContext(IClosedContextClr2Java clr2java)
+        internal ClosedContext(IClosedContextClr2Java clr2java)
         {
             InstanceId = Guid.NewGuid().ToString("N");
             _id = clr2java.GetId();
@@ -40,52 +39,35 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
         }
 
         [DataMember]
-        public string InstanceId { get; set; }
+        public string InstanceId { get; private set; }
+
+        private IActiveContextClr2Java ParentContextClr2Java { get; set; }
+        private IClosedContextClr2Java ClosedContextClr2JavaClr2Java { get; set; }
 
         public string Id
         {
-            get
-            {
-                return _id;
-            }
+            get { return _id; }
         }
 
         public string EvaluatorId
         {
-            get
-            {
-                return _evaluatorId;
-            }
-
-            set
-            {
-            }
+            get { return _evaluatorId; }
         }
 
-        public Optional<string> ParentId { get; set; }
+        public Optional<string> ParentId
+        {
+            // TODO[REEF-762]: Implement
+            get { return Optional<string>.Empty(); }
+        }
 
         public IEvaluatorDescriptor EvaluatorDescriptor
         {
-            get
-            {
-                return ClosedContextClr2JavaClr2Java.GetEvaluatorDescriptor();
-            }
-
-            set
-            {
-            }
+            get { return ClosedContextClr2JavaClr2Java.GetEvaluatorDescriptor(); }
         }
 
         public IActiveContext ParentContext
         {
-            get
-            {
-                return new ActiveContext(ParentContextClr2Java);
-            }
+            get { return new ActiveContext(ParentContextClr2Java); }
         }
-
-        private IActiveContextClr2Java ParentContextClr2Java { get; set; }
-
-        private IClosedContextClr2Java ClosedContextClr2JavaClr2Java { get; set; }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/FailedContext.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/FailedContext.cs
@@ -28,13 +28,15 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
     {
         private readonly string _evaluatorId;
         private readonly string _id;
-        private readonly string _parentId;
+        private readonly Optional<string> _parentId;
 
         internal FailedContext(IFailedContextClr2Java clr2Java)
         {
             _id = clr2Java.GetId();
             _evaluatorId = clr2Java.GetEvaluatorId();
-            _parentId = clr2Java.GetParentId();
+            _parentId = string.IsNullOrEmpty(clr2Java.GetParentId())
+                ? Optional<string>.Empty()
+                : Optional<string>.Of(clr2Java.GetParentId());
             FailedContextClr2Java = clr2Java;
         }
 
@@ -52,12 +54,7 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
 
         public Optional<string> ParentId
         {
-            get
-            {
-                return string.IsNullOrEmpty(_parentId)
-                    ? Optional<string>.Empty()
-                    : Optional<string>.Of(_parentId);
-            }
+            get { return _parentId; }
         }
 
         public IEvaluatorDescriptor EvaluatorDescriptor

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/FailedContext.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/FailedContext.cs
@@ -24,15 +24,13 @@ using Org.Apache.REEF.Utilities;
 
 namespace Org.Apache.REEF.Driver.Bridge.Events
 {
-    public class FailedContext : IFailedContext
+    internal class FailedContext : IFailedContext
     {
-        private readonly string _id;
-
         private readonly string _evaluatorId;
-
+        private readonly string _id;
         private readonly string _parentId;
 
-        public FailedContext(IFailedContextClr2Java clr2Java)
+        internal FailedContext(IFailedContextClr2Java clr2Java)
         {
             _id = clr2Java.GetId();
             _evaluatorId = clr2Java.GetEvaluatorId();
@@ -40,68 +38,44 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
             FailedContextClr2Java = clr2Java;
         }
 
+        private IFailedContextClr2Java FailedContextClr2Java { get; set; }
+
         public string Id
         {
-            get
-            {
-                return _id;
-            }
+            get { return _id; }
         }
 
         public string EvaluatorId
         {
-            get
-            {
-                return _evaluatorId;
-            }
-
-            set
-            {
-            }
+            get { return _evaluatorId; }
         }
 
         public Optional<string> ParentId
         {
             get
             {
-                return string.IsNullOrEmpty(_parentId) ? 
-                    Optional<string>.Empty() : 
-                    Optional<string>.Of(_parentId);
-            }
-
-            set
-            {
+                return string.IsNullOrEmpty(_parentId)
+                    ? Optional<string>.Empty()
+                    : Optional<string>.Of(_parentId);
             }
         }
 
         public IEvaluatorDescriptor EvaluatorDescriptor
         {
-            get
-            {
-                return FailedContextClr2Java.GetEvaluatorDescriptor();
-            }
-
-            set
-            {
-            }
+            get { return FailedContextClr2Java.GetEvaluatorDescriptor(); }
         }
 
         public Optional<IActiveContext> ParentContext
         {
             get
             {
-                IActiveContextClr2Java context = FailedContextClr2Java.GetParentContext();
+                var context = FailedContextClr2Java.GetParentContext();
                 if (context != null)
                 {
                     return Optional<IActiveContext>.Of(new ActiveContext(context));
                 }
-                else
-                {
-                    return Optional<IActiveContext>.Empty();
-                }
+                return Optional<IActiveContext>.Empty();
             }
         }
-
-        private IFailedContextClr2Java FailedContextClr2Java { get; set; }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/FailedEvaluator.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/FailedEvaluator.cs
@@ -21,44 +21,59 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Org.Apache.REEF.Driver.Bridge.Clr2java;
+using Org.Apache.REEF.Driver.Context;
 using Org.Apache.REEF.Driver.Evaluator;
 using Org.Apache.REEF.Driver.Task;
 using Org.Apache.REEF.Utilities;
 using Org.Apache.REEF.Utilities.Diagnostics;
 using Org.Apache.REEF.Utilities.Logging;
-using Org.Apache.REEF.Driver.Context;
 
 namespace Org.Apache.REEF.Driver.Bridge.Events
 {
     [DataContract]
-    internal class FailedEvaluator : IFailedEvaluator
+    internal sealed class FailedEvaluator : IFailedEvaluator
     {
         private static readonly Logger LOGGER = Logger.GetLogger(typeof(FailedEvaluator));
+        private readonly string _id;
 
         public FailedEvaluator(IFailedEvaluatorClr2Java clr2Java)
         {
             InstanceId = Guid.NewGuid().ToString("N");
             FailedEvaluatorClr2Java = clr2Java;
             EvaluatorRequestorClr2Java = FailedEvaluatorClr2Java.GetEvaluatorRequestor();
-            Id = FailedEvaluatorClr2Java.GetId();
+            _id = FailedEvaluatorClr2Java.GetId();
         }
 
         [DataMember]
         public string InstanceId { get; set; }
-
-        public string Id { get; private set; }
-
-        public EvaluatorException EvaluatorException { get; set; }
-
-        public List<IFailedContext> FailedContexts { get; set; }
-
-        public Optional<IFailedTask> FailedTask { get; set; }
 
         [DataMember]
         private IFailedEvaluatorClr2Java FailedEvaluatorClr2Java { get; set; }
 
         [DataMember]
         private IEvaluatorRequestorClr2Java EvaluatorRequestorClr2Java { get; set; }
+
+        public string Id
+        {
+            get { return _id; }
+        }
+
+        //TODO[REEF-769]: Implement
+        public EvaluatorException EvaluatorException
+        {
+            get { return null; }
+        }
+
+        //TODO[REEF-769]: Implement
+        public IList<IFailedContext> FailedContexts
+        {
+            get { return new List<IFailedContext>(0); }
+        }
+        //TODO[REEF-769]: Implement
+        public Optional<IFailedTask> FailedTask
+        {
+            get { return Optional<IFailedTask>.Empty(); }
+        }
 
         public IEvaluatorRequestor GetEvaluatorRequetor()
         {

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/FailedEvaluator.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/FailedEvaluator.cs
@@ -26,6 +26,7 @@ using Org.Apache.REEF.Driver.Task;
 using Org.Apache.REEF.Utilities;
 using Org.Apache.REEF.Utilities.Diagnostics;
 using Org.Apache.REEF.Utilities.Logging;
+using Org.Apache.REEF.Driver.Context;
 
 namespace Org.Apache.REEF.Driver.Bridge.Events
 {
@@ -49,7 +50,7 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
 
         public EvaluatorException EvaluatorException { get; set; }
 
-        public List<FailedContext> FailedContexts { get; set; }
+        public List<IFailedContext> FailedContexts { get; set; }
 
         public Optional<IFailedTask> FailedTask { get; set; }
 

--- a/lang/cs/Org.Apache.REEF.Driver/Context/IContext.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Context/IContext.cs
@@ -30,16 +30,16 @@ namespace Org.Apache.REEF.Driver.Context
         /// <summary>
         /// the identifier of the Evaluator this EvaluatorContext is instantiated on.
         /// </summary>
-        string EvaluatorId { get; set; }
+        string EvaluatorId { get; }
 
         /// <summary>
         /// ID of the parent context, if there is any.
         /// </summary>
-        Optional<string> ParentId { get; set; }
+        Optional<string> ParentId { get; }
 
         /// <summary>
         /// descriptor of the Evaluator this Context is on.
         /// </summary>
-        IEvaluatorDescriptor EvaluatorDescriptor { get; set; }
+        IEvaluatorDescriptor EvaluatorDescriptor { get; }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/Evaluator/IFailedEvaluator.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Evaluator/IFailedEvaluator.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using Org.Apache.REEF.Driver.Bridge.Events;
 using Org.Apache.REEF.Driver.Task;
 using Org.Apache.REEF.Utilities;
+using Org.Apache.REEF.Driver.Context;
 
 namespace Org.Apache.REEF.Driver.Evaluator
 {
@@ -32,7 +33,7 @@ namespace Org.Apache.REEF.Driver.Evaluator
     {
         EvaluatorException EvaluatorException { get; set; }
 
-        List<FailedContext> FailedContexts { get; set; }
+        List<IFailedContext> FailedContexts { get; set; }
 
         Optional<IFailedTask> FailedTask { get; set; }
 

--- a/lang/cs/Org.Apache.REEF.Driver/Evaluator/IFailedEvaluator.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Evaluator/IFailedEvaluator.cs
@@ -19,23 +19,35 @@
 
 using System;
 using System.Collections.Generic;
-using Org.Apache.REEF.Driver.Bridge.Events;
+using Org.Apache.REEF.Driver.Context;
 using Org.Apache.REEF.Driver.Task;
 using Org.Apache.REEF.Utilities;
-using Org.Apache.REEF.Driver.Context;
 
 namespace Org.Apache.REEF.Driver.Evaluator
 {
     /// <summary>
     /// Represents an Evaluator that became unavailable.
     /// </summary>
+    /// <remarks>
+    /// As per REEF-769, this interface isn't actually implemented beyond the Id property.
+    /// </remarks>
     public interface IFailedEvaluator : IIdentifiable
     {
-        EvaluatorException EvaluatorException { get; set; }
+        /// <summary>
+        /// The exception captured on the Evaluator or null if none is available.
+        /// </summary>
+        EvaluatorException EvaluatorException { get; }
 
-        List<IFailedContext> FailedContexts { get; set; }
+        /// <summary>
+        /// The list of contexts that were active on the Evaluator when it crashed.
+        /// </summary>
+        /// <remarks>The list is empty if there were none.</remarks>
+        IList<IFailedContext> FailedContexts { get; }
 
-        Optional<IFailedTask> FailedTask { get; set; }
+        /// <summary>
+        /// The task that failed with the Evaluator if there was one.
+        /// </summary>
+        Optional<IFailedTask> FailedTask { get; }
 
         [Obsolete("Will be removed after 0.13. Have an instance injected instead.")]
         IEvaluatorRequestor GetEvaluatorRequetor();


### PR DESCRIPTION
This makes all fields in `IContext` immutable. This change is reflected in the implementation classes. Also, those are now `internal`, which prompted a change to `(I)FailedEvaluator` which wasn't coded against the context interfaces.

JIRA:
  [REEF-679](https://issues.apache.org/jira/browse/REEF-679)