### PR TITLE
[REEF-758] TcpPortProvider Configuration is not propagated correctly …

### DIFF
--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/AllocatedEvaluator.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/AllocatedEvaluator.cs
@@ -108,8 +108,9 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
         {
             LOGGER.Log(Level.Info, "AllocatedEvaluator::SubmitContextAndService");
 
+            var serviceConf = MergeWithConfigurationProviders(serviceConfiguration);
             string context = _serializer.ToString(contextConfiguration);
-            string service = _serializer.ToString(WrapServiceConfigAsString(serviceConfiguration));
+            string service = _serializer.ToString(WrapServiceConfigAsString(serviceConf));
 
             LOGGER.Log(Level.Verbose, "serialized contextConfiguration: " + context);
             LOGGER.Log(Level.Verbose, "serialized serviceConfiguration: " + service);
@@ -121,10 +122,9 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
         {
             LOGGER.Log(Level.Info, "AllocatedEvaluator::SubmitContextAndServiceAndTask");
 
-            //TODO: Change this to service configuration when REEF-289(https://issues.apache.org/jira/browse/REEF-289) is fixed.
-            taskConfiguration = MergeWithConfigurationProviders(taskConfiguration);
+            var serviceConf = MergeWithConfigurationProviders(serviceConfiguration);
             string context = _serializer.ToString(contextConfiguration);
-            string service = _serializer.ToString(WrapServiceConfigAsString(serviceConfiguration));
+            string service = _serializer.ToString(WrapServiceConfigAsString(serviceConf));
             string task = _serializer.ToString(taskConfiguration);
 
             LOGGER.Log(Level.Verbose, "serialized contextConfiguration: " + context);


### PR DESCRIPTION
…to the Evaluators

This addressed the issue by
  * merging configuration from the configuration providers in function SubmitContextAndService
  * shifting the merging of configuration from configuration providers from task to service in SubmitContextAndServiceAndTask
  * maintaining the logic that configuration from configuration providers will be merged with service configuration if it is present and with task configuration if service configuration is not to be submitted

JIRA:
  [REEF-758](https://issues.apache.org/jira/browse/REEF-758)