### PR TITLE
[REEF-764] TcpPortProvider configuration is not passed correctly to e…

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/Run.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/Run.cs
@@ -20,6 +20,7 @@
 using System;
 using System.Globalization;
 using System.Linq;
+using Org.Apache.REEF.Client.API;
 using Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
@@ -142,10 +143,10 @@ namespace Org.Apache.REEF.IMRU.Examples
                 }
             }
 
-            var tcpPortConfig = TangFactory.GetTang().NewConfigurationBuilder()
-                .BindNamedParameter(typeof(TcpPortRangeStart),
+            var tcpPortConfig = TcpPortConfigurationModule.ConfigurationModule
+                .Set(TcpPortConfigurationModule.PortRangeStart,
                     startPort.ToString(CultureInfo.InvariantCulture))
-                .BindNamedParameter(typeof(TcpPortRangeCount),
+                .Set(TcpPortConfigurationModule.PortRangeCount,
                     portRange.ToString(CultureInfo.InvariantCulture))
                 .Build();
 

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/ServiceAndContextConfigurationProvider.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/ServiceAndContextConfigurationProvider.cs
@@ -49,11 +49,10 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         private int _assignedPartitionDescriptors;
         private readonly IGroupCommDriver _groupCommDriver;
         private readonly ConfigurationManager _configurationManager;
-        private readonly IConfiguration _tcpPortProviderConfig;
         private readonly Stack<IPartitionDescriptor> _partitionDescriptors;
 
         internal ServiceAndContextConfigurationProvider(int numNodes, IGroupCommDriver groupCommDriver,
-            ConfigurationManager configurationManager, IConfiguration tcpPortProviderConfig, Stack<IPartitionDescriptor> partitionDescriptors)
+            ConfigurationManager configurationManager, Stack<IPartitionDescriptor> partitionDescriptors)
         {
             _configurationProvider = new Dictionary<string, ContextAndServiceConfiguration>();
             _failedEvaluators = new HashSet<string>();
@@ -61,7 +60,6 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
             _numNodes = numNodes;
             _groupCommDriver = groupCommDriver;
             _configurationManager = configurationManager;
-            _tcpPortProviderConfig = tcpPortProviderConfig;
             _assignedPartitionDescriptors = 0;
             _partitionDescriptors = partitionDescriptors;
             _lock = new object();
@@ -157,8 +155,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
                     ).Build();
 
             var contextConf = Configurations.Merge(_groupCommDriver.GetContextConfiguration(), partitionDescriptor.GetPartitionConfiguration());
-            var serviceConf = Configurations.Merge(_groupCommDriver.GetServiceConfiguration(), codecConfig,
-                            _tcpPortProviderConfig);
+            var serviceConf = Configurations.Merge(_groupCommDriver.GetServiceConfiguration(), codecConfig);
 
             return new ContextAndServiceConfiguration(contextConf, serviceConf);
         }
@@ -178,8 +175,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
                         }
                     ).Build();
 
-            var serviceConf = Configurations.Merge(_groupCommDriver.GetServiceConfiguration(), codecConfig,
-                _tcpPortProviderConfig);
+            var serviceConf = Configurations.Merge(_groupCommDriver.GetServiceConfiguration(), codecConfig);
             return new ContextAndServiceConfiguration(_groupCommDriver.GetContextConfiguration(), serviceConf);
         }
     }


### PR DESCRIPTION
…valuators

This addressed the issue by
  * removing any explicit setting of TcpPortProvider configuration in IMRU Driver and ServiceAndContextConfigurationProvider.
  * using  TCPConfigurationProviderModule to set TcpPortProvider configuration in REEF.IMRU.Examples so that it is automagically passed to driver and other evaluators.

JIRA:
  [REEF-764](https://issues.apache.org/jira/browse/REEF-764)