### PR TITLE
[REEF-489] Add concept of application attempt to driver startup

### DIFF
--- a/lang/cs/Org.Apache.REEF.Bridge/Clr2JavaImpl.h
+++ b/lang/cs/Org.Apache.REEF.Bridge/Clr2JavaImpl.h
@@ -221,11 +221,13 @@ namespace Org {
 						  JavaVM* _jvm;
 						  array<String^>^ _expectedEvaluatorIds;
 						  DateTime _startTime;
+						  int _resubmissionAttempts;
 					  public:
 						  DriverRestartedClr2Java(JNIEnv *env, jobject jobjectDriverRestarted);
 						  virtual void OnError(String^ message);
 						  virtual array<String^>^ GetExpectedEvaluatorIds();
 						  virtual DateTime GetStartTime();
+						  virtual int GetResubmissionAttempts();
 					  };
 
 					  public ref class DriverRestartCompletedClr2Java : public IDriverRestartCompletedClr2Java {

--- a/lang/cs/Org.Apache.REEF.Bridge/DriverRestartedClr2Java.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/DriverRestartedClr2Java.cpp
@@ -39,7 +39,9 @@ namespace Org {
 
 							jclass jclassDriverRestarted = env->GetObjectClass(_jobjectDriverRestarted);
 							jfieldID jidExpectedEvaluatorIds = env->GetFieldID(jclassDriverRestarted, "expectedEvaluatorIds", "[Ljava/lang/String;");
+							jfieldID jidResubmissionAttempts = env->GetFieldID(jclassDriverRestarted, "resubmissionAttempts", "I");
 
+							_resubmissionAttempts = env->GetIntField(_jobjectDriverRestarted, jidResubmissionAttempts);
 							jobjectArray jevaluatorIds = reinterpret_cast<jobjectArray>(env->NewGlobalRef(env->GetObjectField(_jobjectDriverRestarted, jidExpectedEvaluatorIds)));
 							_startTime = System::DateTime::Now;
 							int count = env->GetArrayLength(jevaluatorIds);
@@ -59,6 +61,10 @@ namespace Org {
 
 						DateTime DriverRestartedClr2Java::GetStartTime() {
 							return _startTime;
+						}
+
+						int DriverRestartedClr2Java::GetResubmissionAttempts() {
+							return _resubmissionAttempts;
 						}
 
 						void DriverRestartedClr2Java::OnError(String^ message) {

--- a/lang/cs/Org.Apache.REEF.Bridge/JavaClrBridge.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/JavaClrBridge.cpp
@@ -433,13 +433,13 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemCo
 
 /*
 * Class:     org_apache_reef_javabridge_NativeInterop
-* Method:    callClrSystemOnRestartHandlerOnNext
+* Method:    callClrSystemOnRestartHandler
 * Signature: (Ljava/lang/String;Lorg/apache/reef/javabridge/EvaluatorRequestorBridge;Lorg/apache/reef/javabridge/DriverRestartedBridge;)[J
 */
-JNIEXPORT jlongArray JNICALL Java_org_apache_reef_javabridge_NativeInterop_callClrSystemOnRestartHandlerOnNext
+JNIEXPORT jlongArray JNICALL Java_org_apache_reef_javabridge_NativeInterop_callClrSystemOnRestartHandler
 (JNIEnv * env, jclass jclassx, jstring httpServerPort, jobject jevaluatorRequestorBridge, jobject jdriverRestartedBridge) {
 	try {
-		ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_callClrSystemOnStartHandler");
+		ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_callClrSystemOnRestartHandler");
 		String^ strPort = ManagedStringFromJavaString(env, httpServerPort);
 
 		EvaluatorRequestorClr2Java^ evaluatorRequestorBridge = gcnew EvaluatorRequestorClr2Java(env, jevaluatorRequestorBridge);
@@ -449,7 +449,7 @@ JNIEXPORT jlongArray JNICALL Java_org_apache_reef_javabridge_NativeInterop_callC
 	}
 	catch (System::Exception^ ex) {
 		// we cannot get error back to java here since we don't have an object to call back (although we ideally should...)
-		ManagedLog::LOGGER->LogError("Exceptions in Java_org_apache_reef_javabridge_NativeInterop_callClrSystemOnStartHandler", ex);
+		ManagedLog::LOGGER->LogError("Exceptions in Java_org_apache_reef_javabridge_NativeInterop_callClrSystemOnRestartHandler", ex);
 		return NULL;
 	}
 }
@@ -575,8 +575,8 @@ static JNINativeMethod methods[] = {
 	{ "clrSystemContextMessageHandlerOnNext", "(JLorg/apache/reef/javabridge/ContextMessageBridge;)V",
 	(void*)&Java_org_apache_reef_javabridge_NativeInterop_clrSystemContextMessageHandlerOnNext },
 
-	{ "callClrSystemOnRestartHandlerOnNext", "(Ljava/lang/String;Ljava/lang/String;Lorg/apache/reef/javabridge/EvaluatorRequestorBridge;)[J",
-	(void*)&Java_org_apache_reef_javabridge_NativeInterop_callClrSystemOnRestartHandlerOnNext },
+	{ "callClrSystemOnRestartHandler", "(Ljava/lang/String;Lorg/apache/reef/javabridge/EvaluatorRequestorBridge;Lorg/apache/reef/javabridge/DriverRestartedBridge;)[J",
+	(void*)&Java_org_apache_reef_javabridge_NativeInterop_callClrSystemOnRestartHandler },
 
 	{ "clrSystemDriverRestartActiveContextHandlerOnNext", "(JLorg/apache/reef/javabridge/ActiveContextBridge;)V",
 	(void*)&Java_org_apache_reef_javabridge_NativeInterop_clrSystemDriverRestartActiveContextHandlerOnNext },
@@ -584,7 +584,7 @@ static JNINativeMethod methods[] = {
 	{ "clrSystemDriverRestartRunningTaskHandlerOnNext", "(JLorg/apache/reef/javabridge/RunningTaskBridge;)V",
 	(void*)&Java_org_apache_reef_javabridge_NativeInterop_clrSystemDriverRestartRunningTaskHandlerOnNext },
 
-	{ "clrSystemDriverRestartCompletedHandlerOnNext", "(J)V",
+	{ "clrSystemDriverRestartCompletedHandlerOnNext", "(JLorg/apache/reef/javabridge/generic/DriverRestartCompletedBridge;)V",
 	(void*)&Java_org_apache_reef_javabridge_NativeInterop_clrSystemDriverRestartCompletedHandlerOnNext },
 };
 

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Clr2java/IDriverRestartedClr2Java.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Clr2java/IDriverRestartedClr2Java.cs
@@ -32,5 +32,10 @@ namespace Org.Apache.REEF.Driver.Bridge.Clr2java
         /// StartTime of the restart.
         /// </summary>
         DateTime GetStartTime();
+
+        /// <summary>
+        /// The number of times the Driver has been resubmitted. Does not include the initial submission.
+        /// </summary>
+        int GetResubmissionAttempts();
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/DriverRestarted.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/DriverRestarted.cs
@@ -36,7 +36,6 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
             ResubmissionAttempts = driverRestartedClr2Java.GetResubmissionAttempts();
         }
 
-
         public ISet<string> ExpectedEvaluatorIds
         {
             get { return new HashSet<string>(_expectedEvaluatorIds); }

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/DriverRestarted.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/DriverRestarted.cs
@@ -27,23 +27,23 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
     /// </summary>
     internal sealed class DriverRestarted : IDriverRestarted
     {
-        private readonly DateTime _startTime;
-        private readonly ISet<string> _expectedEvaluatorIds; 
+        private readonly ISet<string> _expectedEvaluatorIds;
 
         internal DriverRestarted(IDriverRestartedClr2Java driverRestartedClr2Java)
         {
-            _startTime = driverRestartedClr2Java.GetStartTime();
             _expectedEvaluatorIds = new HashSet<string>(driverRestartedClr2Java.GetExpectedEvaluatorIds());
+            StartTime = driverRestartedClr2Java.GetStartTime();
+            ResubmissionAttempts = driverRestartedClr2Java.GetResubmissionAttempts();
         }
 
-        public DateTime StartTime
-        {
-            get { return _startTime; }
-        }
 
         public ISet<string> ExpectedEvaluatorIds
         {
             get { return new HashSet<string>(_expectedEvaluatorIds); }
-        } 
+        }
+
+        public DateTime StartTime { get; private set; }
+
+        public int ResubmissionAttempts { get; private set; }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/IDriverRestarted.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/IDriverRestarted.cs
@@ -31,6 +31,13 @@ namespace Org.Apache.REEF.Driver
         /// The set of expected Evaluator IDs that are returned to the Driver by the
         /// RM on Driver Restart.
         /// </summary>
-        ISet<string> ExpectedEvaluatorIds { get; } 
+        ISet<string> ExpectedEvaluatorIds { get; }
+
+        /// <summary>
+        /// The number of times the Driver has been resubmitted. Does not include the initial submission.
+        /// i.e. ResubmissionAttempts is 0 on first launch and should always be at least 1 when called on
+        /// the DriverRestartedHandler.
+        /// </summary>
+        int ResubmissionAttempts { get; }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Examples/DriverRestart/HelloRestartDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Examples/DriverRestart/HelloRestartDriver.cs
@@ -65,7 +65,7 @@ namespace Org.Apache.REEF.Examples.DriverRestart
         {
             _exceptionTimer = new Timer(obj =>
             {
-                throw new Exception("Expected driver to be finished by now.");
+                throw new ApplicationException("Expected driver to be finished by now.");
             }, new object(), TimeSpan.FromMinutes(10), TimeSpan.FromMinutes(10));
 
             _evaluatorRequestor = evaluatorRequestor;
@@ -107,7 +107,7 @@ namespace Org.Apache.REEF.Examples.DriverRestart
         {
             if (value.ResubmissionAttempts != 1)
             {
-                throw new Exception("Only expected the driver to restart once.");
+                throw new ApplicationException("Only expected the driver to restart once.");
             }
 
             _isRestart = true;

--- a/lang/cs/Org.Apache.REEF.Examples/DriverRestart/HelloRestartDriver.cs
+++ b/lang/cs/Org.Apache.REEF.Examples/DriverRestart/HelloRestartDriver.cs
@@ -105,6 +105,11 @@ namespace Org.Apache.REEF.Examples.DriverRestart
         /// </summary>
         public void OnNext(IDriverRestarted value)
         {
+            if (value.ResubmissionAttempts != 1)
+            {
+                throw new Exception("Only expected the driver to restart once.");
+            }
+
             _isRestart = true;
             Logger.Log(Level.Info, "Hello! HelloRestartDriver has restarted! Expecting these Evaluator IDs [{0}]", string.Join(", ", value.ExpectedEvaluatorIds));
             foreach (var expectedEvaluatorId in value.ExpectedEvaluatorIds)

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/DriverRestartedBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/DriverRestartedBridge.java
@@ -21,6 +21,7 @@ package org.apache.reef.javabridge;
 import org.apache.reef.annotations.Unstable;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.driver.restart.DriverRestarted;
 
 import java.util.Set;
 
@@ -33,13 +34,20 @@ import java.util.Set;
 public final class DriverRestartedBridge extends NativeBridge {
   // Used by bridge to extract field. Please take this into consideration when changing the name of the field.
   private final String[] expectedEvaluatorIds;
+  private final int resubmissionAttempts;
 
-  public DriverRestartedBridge(final Set<String> expectedEvaluatorIds) {
-    this.expectedEvaluatorIds = expectedEvaluatorIds.toArray(new String[expectedEvaluatorIds.size()]);
+  public DriverRestartedBridge(final DriverRestarted driverRestarted) {
+    final Set<String> evaluatorIds = driverRestarted.getExpectedEvaluatorIds();
+    this.expectedEvaluatorIds = evaluatorIds.toArray(new String[evaluatorIds.size()]);
+    this.resubmissionAttempts = driverRestarted.getResubmissionAttempts();
   }
 
   public String[] getExpectedEvaluatorIds() {
     return expectedEvaluatorIds;
+  }
+
+  public int getResubmissionAttempts() {
+    return resubmissionAttempts;
   }
 
   @Override

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/NativeInterop.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/NativeInterop.java
@@ -89,7 +89,7 @@ public final class NativeInterop {
 
   public static native void clrSystemTaskMessageHandlerOnNext(
       final long handle,
-      final byte[] mesage,
+      final byte[] message,
       final TaskMessageBridge javaTaskMessageBridge,
       final InteropLogger interopLogger
   );
@@ -149,7 +149,7 @@ public final class NativeInterop {
       final ContextMessageBridge contextMessageBridge
   );
 
-  public static native long[] callClrSystemOnRestartHandlerOnNext(
+  public static native long[] callClrSystemOnRestartHandler(
       final String httpServerPortNumber,
       final EvaluatorRequestorBridge javaEvaluatorRequestorBridge,
       final DriverRestartedBridge driverRestartedBridge

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/DriverRestartClrHandlersInitializer.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/DriverRestartClrHandlersInitializer.java
@@ -42,9 +42,8 @@ final class DriverRestartClrHandlersInitializer implements ClrHandlersInitialize
 
   @Override
   public long[] getClrHandlers(final String portNumber, final EvaluatorRequestorBridge evaluatorRequestorBridge) {
-    // TODO[REEF-689]: Make callClrSystemOnRestartedHandlerOnNext take DriverRestarted object.
-    return NativeInterop.callClrSystemOnRestartHandlerOnNext(
+    return NativeInterop.callClrSystemOnRestartHandler(
         portNumber,
-        evaluatorRequestorBridge, new DriverRestartedBridge(driverRestarted.getExpectedEvaluatorIds()));
+        evaluatorRequestorBridge, new DriverRestartedBridge(driverRestarted));
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DefaultDriverRuntimeRestartMangerImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DefaultDriverRuntimeRestartMangerImpl.java
@@ -29,7 +29,7 @@ import java.util.Set;
 /**
  * The default driver runtime restart manager that is not able to perform any restart actions.
  * Thus, when performing actions pertaining to restart, it is recommended to call
- * {@link DriverRuntimeRestartManager#hasRestarted()} first.
+ * {@link DriverRuntimeRestartManager#getResubmissionAttempts()} first and check for > 0.
  */
 @Private
 @DriverSide
@@ -40,8 +40,8 @@ final class DefaultDriverRuntimeRestartMangerImpl implements DriverRuntimeRestar
   }
 
   @Override
-  public boolean hasRestarted() {
-    return false;
+  public int getResubmissionAttempts() {
+    return 0;
   }
 
   @Override

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestarted.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestarted.java
@@ -35,6 +35,11 @@ import java.util.Set;
 @Unstable
 public interface DriverRestarted {
   /**
+   * @return The number of times the Driver has been resubmitted. Not including the initial attempt.
+   */
+  int getResubmissionAttempts();
+
+  /**
    * @return The time of restart.
    */
   StartTime getStartTime();

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartedImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartedImpl.java
@@ -43,7 +43,7 @@ public final class DriverRestartedImpl implements DriverRestarted {
                       final RestartEvaluators restartEvaluators) {
     this.resubmissionAttempts = resubmissionAttempts;
     this.startTime = startTime;
-    Set<String> expected = new HashSet<>();
+    final Set<String> expected = new HashSet<>();
 
     for (final String evaluatorId : restartEvaluators.getEvaluatorIds()) {
       if (restartEvaluators.get(evaluatorId).getEvaluatorRestartState() == EvaluatorRestartState.EXPECTED) {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartedImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRestartedImpl.java
@@ -34,10 +34,14 @@ import java.util.Set;
 @Private
 @Unstable
 public final class DriverRestartedImpl implements DriverRestarted {
+  private final int resubmissionAttempts;
   private final StartTime startTime;
   private final Set<String> expectedEvaluatorIds;
 
-  DriverRestartedImpl(final StartTime startTime, final RestartEvaluators restartEvaluators) {
+  DriverRestartedImpl(final int resubmissionAttempts,
+                      final StartTime startTime,
+                      final RestartEvaluators restartEvaluators) {
+    this.resubmissionAttempts = resubmissionAttempts;
     this.startTime = startTime;
     Set<String> expected = new HashSet<>();
 
@@ -48,6 +52,11 @@ public final class DriverRestartedImpl implements DriverRestarted {
     }
 
     this.expectedEvaluatorIds = Collections.unmodifiableSet(expected);
+  }
+
+  @Override
+  public int getResubmissionAttempts() {
+    return resubmissionAttempts;
   }
 
   @Override

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRuntimeRestartManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRuntimeRestartManager.java
@@ -38,11 +38,12 @@ import java.util.Set;
 @DefaultImplementation(DefaultDriverRuntimeRestartMangerImpl.class)
 public interface DriverRuntimeRestartManager {
   /**
-   * @return true if the driver has been restarted. Note that this is different from whether
-   * the driver is in the process of restarting. This returns true both on when the driver is in the
-   * restart process or has already finished restarting. The default implementation always returns false.
+   * @return > 0 if the driver has been restarted as reported by the resource manager. 0 otherwise.
+   * Note that this is different from whether the driver is in the process of restarting.
+   * This returns > 0 both on when the driver is in the restart process or has already finished restarting.
+   * The default implementation always returns 0.
    */
-  boolean hasRestarted();
+  int getResubmissionAttempts();
 
   /**
    * Records the evaluators when it is allocated.

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRuntimeRestartManager.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRuntimeRestartManager.java
@@ -54,13 +54,20 @@ public final class YarnDriverRuntimeRestartManager implements DriverRuntimeResta
 
   private static final Logger LOG = Logger.getLogger(YarnDriverRuntimeRestartManager.class.getName());
 
+  /**
+   * The default resubmission attempts number returned if:
+   * 1) we are not able to determine the number of application attempts based on the environment provided by YARN.
+   * 2) we are able to receive a list of previous containers from the Resource Manager.
+   */
+  private static final int DEFAULT_RESTART_RESUBMISSION_ATTEMPTS = 1;
+
   private final EvaluatorPreserver evaluatorPreserver;
   private final ApplicationMasterRegistration registration;
   private final REEFEventHandlers reefEventHandlers;
   private final YarnContainerManager yarnContainerManager;
   private final RackNameFormatter rackNameFormatter;
 
-  private Set<Container> previousContainers;
+  private Set<Container> previousContainers = null;
 
   @Inject
   private YarnDriverRuntimeRestartManager(@Parameter(YarnEvaluatorPreserver.class)
@@ -74,7 +81,6 @@ public final class YarnDriverRuntimeRestartManager implements DriverRuntimeResta
     this.reefEventHandlers = reefEventHandlers;
     this.yarnContainerManager = yarnContainerManager;
     this.rackNameFormatter = rackNameFormatter;
-    this.previousContainers = null;
   }
 
   /**
@@ -87,25 +93,17 @@ public final class YarnDriverRuntimeRestartManager implements DriverRuntimeResta
   @Override
   public int getResubmissionAttempts() {
     final String containerIdString = getContainerIdString();
-
-    if (containerIdString == null) {
-      // container id should always be set in the env by the framework
-      LOG.log(Level.WARNING, "Container ID is null, determining restart based on previous containers.");
-      if (this.isRestartByPreviousContainers()) {
-        LOG.log(Level.WARNING, "Driver is a restarted instance. Returning 1.");
-        return 1;
-      }
-
-      return 0;
-    }
-
     final ApplicationAttemptId appAttemptID = getAppAttemptId(containerIdString);
 
-    if (appAttemptID == null) {
-      LOG.log(Level.WARNING, "applicationAttempt ID is null, determining restart based on previous containers.");
+    if (containerIdString == null || appAttemptID == null) {
+      LOG.log(Level.WARNING, "Was not able to fetch application attempt, container ID is [" + containerIdString +
+          "] and application attempt is [" + appAttemptID + "]. Determining restart based on previous containers.");
+
       if (this.isRestartByPreviousContainers()) {
-        LOG.log(Level.WARNING, "Driver is a restarted instance. Returning 1.");
-        return 1;
+        LOG.log(Level.WARNING, "Driver is a restarted instance based on the number of previous containers. " +
+            "As returned by the Resource Manager. Returning default resubmission attempts " +
+            DEFAULT_RESTART_RESUBMISSION_ATTEMPTS + ".");
+        return DEFAULT_RESTART_RESUBMISSION_ATTEMPTS;
       }
 
       return 0;
@@ -129,6 +127,10 @@ public final class YarnDriverRuntimeRestartManager implements DriverRuntimeResta
   }
 
   private static ApplicationAttemptId getAppAttemptId(final String containerIdString) {
+    if (containerIdString == null) {
+      return null;
+    }
+
     try {
       final ContainerId containerId = ConverterUtils.toContainerId(containerIdString);
       return containerId.getApplicationAttemptId();


### PR DESCRIPTION
This addressed the issue by
  * Adds a getter to resubmissionAttempts for DriverRestarted and IDriverRestarted.
  * Modify the DriverRestart example to check for only restarted once.
  * Fix interop calls that broke Driver Restart.

JIRA:
  [REEF-489](https://issues.apache.org/jira/browse/REEF-489)