### PR TITLE
[REEF-703] Make NameLookupClient injectable

### DIFF
--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameClient.java
@@ -65,6 +65,7 @@ public final class NameClient implements NameResolver {
      * @param tpFactory transport factory
      */
   @Inject
+  @SuppressWarnings("deprecation")
   private NameClient(
       @Parameter(NameResolverNameServerAddr.class) final String serverAddr,
       @Parameter(NameResolverNameServerPort.class) final int serverPort,


### PR DESCRIPTION
This patch:
  * Adds a Tang-injectable constructor for NameLookupClient
  * Marks the constructor "private" to emphasize that it
    should be called only by Tang
  * Deprecates all non-injectable constructors

JIRA:
  [REEF-703](https://issues.apache.org/jira/browse/REEF-703)