### PR TITLE
[REEF-774] Remove Serializable interface from Tasklet

### DIFF
--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/Tasklet.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/driver/Tasklet.java
@@ -28,7 +28,7 @@ import java.io.Serializable;
  * Representation of user task in Driver.
  */
 @DriverSide
-class Tasklet<TInput extends Serializable, TOutput extends Serializable> implements Serializable {
+class Tasklet<TInput extends Serializable, TOutput extends Serializable> {
   private final int taskletId;
   private final VortexFunction<TInput, TOutput> userTask;
   private final TInput input;


### PR DESCRIPTION
This PR makes VortexFuture class serializable and
consequently resolves a high-priority findbug warning on Tasklet class.

JIRA:
  [REEF-774](https://issues.apache.org/jira/browse/REEF-774)

Pull Request:
  This closes #512