### PR TITLE
[REEF-777] Fix build error caused by InternalsVisibleTo in REEF.Client

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Properties/AssemblyInfo.cs
@@ -66,8 +66,10 @@ using System.Runtime.InteropServices;
  "618392a1095f4049ad079d4f4f0b429bb535699155fd6a7652ec7d6c1f1ba2b560f11ef3a86b5945d288cf")]
 
 // Make internals visible to NSubstitute assembly for mocking in unit tests
-[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=" +
- "00240000048000009400000006020000002400005253413100040000010001005df3e621d886a9" +
- "9c03469d0f93a9f5d45aa2c883f50cd158759e93673f759ec4657fd84cc79d2db38ef1a2d914cc" +
- "b7c717846a897e11dd22eb260a7ce2da2dccf0263ea63e2b3f7dac24f28882aa568ef544341d17" +
- "618392a1095f4049ad079d4f4f0b429bb535699155fd6a7652ec7d6c1f1ba2b560f11ef3a86b5945d288cf")]
+ [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=00240000048000009" +
+                               "40000000602000000240000525341310004000001000100c547cac37a" +
+                               "bd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc07" +
+                               "34aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f71724" +
+                               "1550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15" +
+                               "605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3" +
+                               "113e92484cf7045cc7")]

--- a/lang/cs/Org.Apache.REEF.Client/Properties/AssemblyInfo.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Properties/AssemblyInfo.cs
@@ -54,31 +54,20 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("0.13.0.0")]
 [assembly: AssemblyFileVersion("0.13.0.0")]
 
-
-#if DEBUG
-[assembly: InternalsVisibleTo("Org.Apache.REEF.Tests")]
-[assembly: InternalsVisibleTo("Org.Apache.REEF.Client.Tests")]
-
-// Make internals visible to NSubstitute assembly for mocking in unit tests
-[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
-#else
 [assembly: InternalsVisibleTo("Org.Apache.REEF.Tests, publickey=" +
  "00240000048000009400000006020000002400005253413100040000010001005df3e621d886a9" +
  "9c03469d0f93a9f5d45aa2c883f50cd158759e93673f759ec4657fd84cc79d2db38ef1a2d914cc" +
  "b7c717846a897e11dd22eb260a7ce2da2dccf0263ea63e2b3f7dac24f28882aa568ef544341d17" +
  "618392a1095f4049ad079d4f4f0b429bb535699155fd6a7652ec7d6c1f1ba2b560f11ef3a86b5945d288cf")]
-[assembly: InternalsVisibleTo("Org.Apache.REEF.Client.Tests, publickey=" +
+ [assembly: InternalsVisibleTo("Org.Apache.REEF.Client.Tests, publickey=" +
  "00240000048000009400000006020000002400005253413100040000010001005df3e621d886a9" +
  "9c03469d0f93a9f5d45aa2c883f50cd158759e93673f759ec4657fd84cc79d2db38ef1a2d914cc" +
  "b7c717846a897e11dd22eb260a7ce2da2dccf0263ea63e2b3f7dac24f28882aa568ef544341d17" +
  "618392a1095f4049ad079d4f4f0b429bb535699155fd6a7652ec7d6c1f1ba2b560f11ef3a86b5945d288cf")]
 
 // Make internals visible to NSubstitute assembly for mocking in unit tests
-[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=00240000048000009" +
-                              "40000000602000000240000525341310004000001000100c547cac37a" +
-                              "bd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc07" +
-                              "34aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f71724" +
-                              "1550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15" +
-                              "605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3" +
-                              "113e92484cf7045cc7")]
-#endif
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=" +
+ "00240000048000009400000006020000002400005253413100040000010001005df3e621d886a9" +
+ "9c03469d0f93a9f5d45aa2c883f50cd158759e93673f759ec4657fd84cc79d2db38ef1a2d914cc" +
+ "b7c717846a897e11dd22eb260a7ce2da2dccf0263ea63e2b3f7dac24f28882aa568ef544341d17" +
+ "618392a1095f4049ad079d4f4f0b429bb535699155fd6a7652ec7d6c1f1ba2b560f11ef3a86b5945d288cf")]


### PR DESCRIPTION
All the debug build now is signed. #ifdebug flag for InternalsVisibleTo is not needed anymore.

JIRA: [REEF-777](https://issues.apache.org/jira/browse/REEF-777)

This closes #

Author: Julia Wang  Email: juliaw@apache.org