### PR TITLE
[REEF-776] IParititon Configuration does not get passed to task from …

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/ServiceAndContextConfigurationProvider.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/ServiceAndContextConfigurationProvider.cs
@@ -154,8 +154,8 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
                         _configurationManager.MapInputCodecConfiguration
                     ).Build();
 
-            var contextConf = Configurations.Merge(_groupCommDriver.GetContextConfiguration(), partitionDescriptor.GetPartitionConfiguration());
-            var serviceConf = Configurations.Merge(_groupCommDriver.GetServiceConfiguration(), codecConfig);
+            var contextConf = _groupCommDriver.GetContextConfiguration();
+            var serviceConf = Configurations.Merge(_groupCommDriver.GetServiceConfiguration(), codecConfig, partitionDescriptor.GetPartitionConfiguration());
 
             return new ContextAndServiceConfiguration(contextConf, serviceConf);
         }


### PR DESCRIPTION
…Root context in IMRU Driver

This addressed the issue by
* making IPartitionConfiguration part of service configuration
JIRA:
[REEF-776](https://issues.apache.org/jira/browse/REEF-776)