### PR TITLE
[REEF-787] IMRUDriver is not setting TMapOutput Pipeline converter in…

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
@@ -311,7 +311,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
             try
             {
                 TangFactory.GetTang()
-                    .NewInjector(mapInputPipelineDataConverterConfig)
+                    .NewInjector(mapOutputPipelineDataConverterConfig)
                     .GetInstance<IPipelineDataConverter<TMapOutput>>();
             }
             catch (Exception)


### PR DESCRIPTION
… right fashion

This addressed the issue by
* Correcting the typo. MapOutputPipelineDataConverter is now injected instead of MapInputPipelineDataConverter in try except statement in driver.

JIRA:
[REEF-787](https://issues.apache.org/jira/browse/REEF-787)