### PR TITLE
[REEF-788] IMRU Map and Update host tasks take a lot of internal memory

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU/API/IMRUJobDefinition.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/API/IMRUJobDefinition.cs
@@ -41,6 +41,7 @@ namespace Org.Apache.REEF.IMRU.API
         private readonly int _memoryPerMapper;
         private readonly int _updateTaskMemory;
         private readonly ISet<IConfiguration> _perMapConfigGeneratorConfig;
+        private readonly bool _invokeGC;
 
         /// <summary>
         /// Constructor
@@ -61,6 +62,7 @@ namespace Org.Apache.REEF.IMRU.API
         /// <param name="numberOfMappers">Number of mappers</param>
         /// <param name="memoryPerMapper">Per Mapper memory.</param>
         /// <param name="jobName">Job name</param>
+        /// <param name="invokeGC">Whether to call garbage collector after each iteration</param>
         internal IMRUJobDefinition(
             IConfiguration mapFunctionConfiguration,
             IConfiguration mapInputCodecConfiguration,
@@ -74,7 +76,8 @@ namespace Org.Apache.REEF.IMRU.API
             int numberOfMappers,
             int memoryPerMapper,
             int updateTaskMemory,
-            string jobName)
+            string jobName,
+            bool invokeGC)
         {
             _mapFunctionConfiguration = mapFunctionConfiguration;
             _mapInputCodecConfiguration = mapInputCodecConfiguration;
@@ -89,6 +92,7 @@ namespace Org.Apache.REEF.IMRU.API
             _memoryPerMapper = memoryPerMapper;
             _updateTaskMemory = updateTaskMemory;
             _perMapConfigGeneratorConfig = perMapConfigGeneratorConfig;
+            _invokeGC = invokeGC;
         }
 
         /// <summary>
@@ -196,6 +200,14 @@ namespace Org.Apache.REEF.IMRU.API
         internal ISet<IConfiguration> PerMapConfigGeneratorConfig
         {
             get { return _perMapConfigGeneratorConfig; }
+        }
+
+        /// <summary>
+        /// Whether to call Garbage Collector after each iteration
+        /// </summary>
+        internal bool InvokeGarbageCollectorAfterIteration
+        {
+            get { return _invokeGC; }
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IMRU/API/IMRUJobDefinitionBuilder.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/API/IMRUJobDefinitionBuilder.cs
@@ -51,6 +51,7 @@ namespace Org.Apache.REEF.IMRU.API
         private IConfiguration _mapInputPipelineDataConverterConfiguration;
         private IConfiguration _partitionedDatasetConfiguration;
         private readonly ISet<IConfiguration> _perMapConfigGeneratorConfig;
+        private bool _invokeGC;
 
         private static readonly IConfiguration EmptyConfiguration =
             TangFactory.GetTang().NewConfigurationBuilder().Build();
@@ -65,6 +66,7 @@ namespace Org.Apache.REEF.IMRU.API
             _partitionedDatasetConfiguration = EmptyConfiguration;
             _memoryPerMapper = 512;
             _updateTaskMemory = 512;
+            _invokeGC = true;
             _perMapConfigGeneratorConfig = new HashSet<IConfiguration>();
         }
 
@@ -220,6 +222,18 @@ namespace Org.Apache.REEF.IMRU.API
         }
 
         /// <summary>
+        /// Whether to invoke Garbage Collector after each IMRU iteration
+        /// </summary>
+        /// <param name="invokeGC">variable telling whether to invoke or not</param>
+        /// <returns>The modified definition builder</returns>
+        public IMRUJobDefinitionBuilder InvokeGarbageCollectorAfterIteration(bool invokeGC)
+        {
+            _invokeGC = invokeGC;
+            return this;
+        }
+
+
+        /// <summary>
         /// Instantiate the IMRUJobDefinition.
         /// </summary>
         /// <returns>The IMRUJobDefintion configured.</returns>
@@ -271,7 +285,8 @@ namespace Org.Apache.REEF.IMRU.API
                 _numberOfMappers,
                 _memoryPerMapper,
                 _updateTaskMemory,
-                _jobName);
+                _jobName,
+                _invokeGC);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Client/REEFIMRUClient.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Client/REEFIMRUClient.cs
@@ -96,7 +96,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Client
                         GenericType<IMRUDriver<TMapInput, TMapOutput, TResult>>.Class)
                     .Set(DriverConfiguration.OnEvaluatorFailed,
                         GenericType<IMRUDriver<TMapInput, TMapOutput, TResult>>.Class)
-                    .Set(DriverConfiguration.CustomTraceLevel, TraceLevel.Verbose.ToString())
+                    .Set(DriverConfiguration.CustomTraceLevel, TraceLevel.Info.ToString())
                     .Build(),
                 TangFactory.GetTang().NewConfigurationBuilder()
                     .BindStringNamedParam<GroupCommConfigurationOptions.DriverId>(driverId)
@@ -130,6 +130,8 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Client
                     jobDefinition.MapperMemory.ToString(CultureInfo.InvariantCulture))
                 .BindNamedParameter(typeof (MemoryForUpdateTask),
                     jobDefinition.UpdateTaskMemory.ToString(CultureInfo.InvariantCulture))
+                .BindNamedParameter(typeof (InvokeGC),
+                    jobDefinition.InvokeGarbageCollectorAfterIteration.ToString(CultureInfo.InvariantCulture))
                 .Build();
 
             // The JobSubmission contains the Driver configuration as well as the files needed on the Driver.

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Client/REEFIMRUClient.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Client/REEFIMRUClient.cs
@@ -96,7 +96,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Client
                         GenericType<IMRUDriver<TMapInput, TMapOutput, TResult>>.Class)
                     .Set(DriverConfiguration.OnEvaluatorFailed,
                         GenericType<IMRUDriver<TMapInput, TMapOutput, TResult>>.Class)
-                    .Set(DriverConfiguration.CustomTraceLevel, TraceLevel.Info.ToString())
+                    .Set(DriverConfiguration.CustomTraceLevel, TraceLevel.Verbose.ToString())
                     .Build(),
                 TangFactory.GetTang().NewConfigurationBuilder()
                     .BindStringNamedParam<GroupCommConfigurationOptions.DriverId>(driverId)

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
@@ -76,6 +76,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         private readonly int _allowedFailedEvaluators;
         private int _currentFailedEvaluators = 0;
         private bool _reachedUpdateTaskActiveContext = false;
+        private readonly bool _invokeGC;
 
         private readonly ServiceAndContextConfigurationProvider<TMapInput, TMapOutput>
             _serviceAndContextConfigurationProvider;
@@ -90,6 +91,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
             [Parameter(typeof (MemoryPerMapper))] int memoryPerMapper,
             [Parameter(typeof (MemoryForUpdateTask))] int memoryForUpdateTask,
             [Parameter(typeof (AllowedFailedEvaluatorsFraction))] double failedEvaluatorsFraction,
+            [Parameter(typeof(InvokeGC))] bool invokeGC,
             IGroupCommDriver groupCommDriver)
         {
             _dataSet = dataSet;
@@ -103,6 +105,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
             _perMapperConfigs = perMapperConfigs;
             _completedTasks = new ConcurrentBag<ICompletedTask>();
             _allowedFailedEvaluators = (int) (failedEvaluatorsFraction*dataSet.Count);
+            _invokeGC = invokeGC;
 
             AddGroupCommunicationOperators();
             _groupCommTaskStarter = new TaskStarter(_groupCommDriver, _dataSet.Count + 1);
@@ -202,6 +205,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
                             _configurationManager.MapFunctionConfiguration,
                             mapSpecificConfig
                         })
+                        .BindNamedParameter(typeof (InvokeGC), _invokeGC.ToString())
                         .Build();
 
                 _commGroup.AddTask(taskId);

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/MapTaskHost.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/MapTaskHost.cs
@@ -15,10 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
+using System;
+using System.Diagnostics;
+using System.Runtime;
 using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.IMRU.API;
 using Org.Apache.REEF.IMRU.OnREEF.Driver;
 using Org.Apache.REEF.IMRU.OnREEF.MapInputWithControlMessage;
+using Org.Apache.REEF.IMRU.OnREEF.Parameters;
 using Org.Apache.REEF.Network.Group.Operators;
 using Org.Apache.REEF.Network.Group.Task;
 using Org.Apache.REEF.Tang.Annotations;
@@ -38,18 +42,25 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
         private readonly IBroadcastReceiver<MapInputWithControlMessage<TMapInput>> _dataAndMessageReceiver;
         private readonly IReduceSender<TMapOutput> _dataReducer;
         private readonly IMapFunction<TMapInput, TMapOutput> _mapTask;
+        private readonly bool _invokeGC;
 
         /// <summary>
         /// </summary>
         /// <param name="mapTask">The MapTask hosted in this REEF Task.</param>
         /// <param name="groupCommunicationsClient">Used to setup the communications.</param>
+        /// <param name="invokeGC">Whether to call Garbage Collector after each iteration or not</param>
         [Inject]
-        private MapTaskHost(IMapFunction<TMapInput, TMapOutput> mapTask, IGroupCommClient groupCommunicationsClient)
+        private MapTaskHost(
+            IMapFunction<TMapInput, TMapOutput> mapTask,
+            IGroupCommClient groupCommunicationsClient,
+            [Parameter(typeof (InvokeGC))] bool invokeGC)
         {
             _mapTask = mapTask;
             var cg = groupCommunicationsClient.GetCommunicationGroup(IMRUConstants.CommunicationGroupName);
-            _dataAndMessageReceiver = cg.GetBroadcastReceiver<MapInputWithControlMessage<TMapInput>>(IMRUConstants.BroadcastOperatorName);
+            _dataAndMessageReceiver =
+                cg.GetBroadcastReceiver<MapInputWithControlMessage<TMapInput>>(IMRUConstants.BroadcastOperatorName);
             _dataReducer = cg.GetReduceSender<TMapOutput>(IMRUConstants.ReduceOperatorName);
+            _invokeGC = invokeGC;
         }
 
         /// <summary>
@@ -59,15 +70,29 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
         /// <returns></returns>
         public byte[] Call(byte[] memento)
         {
-            MapInputWithControlMessage<TMapInput> mapInput = _dataAndMessageReceiver.Receive();
-
-            while (mapInput.ControlMessage == MapControlMessage.AnotherRound)
+            while (true)
             {
-                var result = _mapTask.Map(mapInput.Message);
-                _dataReducer.Send(result);
-                mapInput = _dataAndMessageReceiver.Receive();
-            }
+                if (_invokeGC)
+                {
+                    Logger.Log(Level.Verbose,"Calling Garbage Collector");
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                }
 
+                TMapOutput result;
+
+                using (
+                    MapInputWithControlMessage<TMapInput> mapInput = _dataAndMessageReceiver.Receive())
+                {
+                    if (mapInput.ControlMessage == MapControlMessage.Stop)
+                    {
+                        break;
+                    }
+                    result = _mapTask.Map(mapInput.Message);
+                }
+             
+                _dataReducer.Send(result);
+            }
             return null;
         }
 

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/MapInputWithControlMessage/MapInputWithControlMessage.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/MapInputWithControlMessage/MapInputWithControlMessage.cs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+using System;
+
 namespace Org.Apache.REEF.IMRU.OnREEF.MapInputWithControlMessage
 {
     /// <summary>
@@ -23,7 +25,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.MapInputWithControlMessage
     /// message from UpdateTask
     /// </summary>
     /// <typeparam name="TMapInput"></typeparam>
-    internal class MapInputWithControlMessage<TMapInput>
+    internal class MapInputWithControlMessage<TMapInput> : IDisposable
     {
         /// <summary>
         /// Internal constructor
@@ -54,5 +56,9 @@ namespace Org.Apache.REEF.IMRU.OnREEF.MapInputWithControlMessage
         /// Control message from Update Task to Map task
         /// </summary>
         internal MapControlMessage ControlMessage { get; set; }
+
+        public void Dispose()
+        {
+        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/InvokeGC .cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/InvokeGC .cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using Org.Apache.REEF.Tang.Annotations;
+
+namespace Org.Apache.REEF.IMRU.OnREEF.Parameters
+{
+    [NamedParameter("Whether to invoke GC after each map or update step", "callgc", "false")]
+    internal sealed class InvokeGC : Name<bool>
+    {
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IMRU/Org.Apache.REEF.IMRU.csproj
+++ b/lang/cs/Org.Apache.REEF.IMRU/Org.Apache.REEF.IMRU.csproj
@@ -75,6 +75,7 @@ under the License.
     <Compile Include="OnREEF\MapInputWithControlMessage\MapInputWithControlMessage.cs" />
     <Compile Include="OnREEF\MapInputWithControlMessage\MapInputWithControlMessageCodec.cs" />
     <Compile Include="OnREEF\MapInputWithControlMessage\MapInputwithControlMessagePipelineDataConverter.cs" />
+    <Compile Include="OnREEF\Parameters\InvokeGC .cs" />
     <Compile Include="OnREEF\Parameters\AllowedFailedEvaluatorsFraction.cs" />
     <Compile Include="OnREEF\Parameters\CoresForUpdateTask.cs" />
     <Compile Include="OnREEF\Parameters\CoresPerMapper.cs" />


### PR DESCRIPTION
This addressed the issue by
* removing the maintenance of input and output between the iterations
* using GC.Collect in between the interations to remove memory overheads
JIRA:
[REEF-788](https://issues.apache.org/jira/browse/REEF-788)