### PR TITLE
[REEF-528] Add missing Javadoc comments/triage TODO notes in Java code: reef-runtime-local

### DIFF
--- a/lang/java/reef-runtime-local/pom.xml
+++ b/lang/java/reef-runtime-local/pom.xml
@@ -62,6 +62,17 @@ under the License.
                 </excludes>
             </resource>
         </resources>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <configuration>
+                        <configLocation>lang/java/reef-common/src/main/resources/checkstyle-strict.xml</configLocation>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
 </project>

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ContainerManager.java
@@ -212,7 +212,7 @@ final class ContainerManager implements AutoCloseable {
             .setRackName(rackName)
             .setHostName(this.localAddress)
             .setPort(j)
-            .setMemorySize(this.defaultMemorySize) // TODO Find the actual system memory on this machine.
+            .setMemorySize(this.defaultMemorySize) // TODO[JIRA REEF-792] Find the actual system memory on this machine.
             .build());
         j++;
       }
@@ -229,8 +229,8 @@ final class ContainerManager implements AutoCloseable {
    * Returns the node name of the container to be allocated if it's available, selected from the list of preferred
    * node names. If the list is empty, then an empty optional is returned
    *
-   * @param rackNames
-   *          the list of preferred racks
+   * @param nodeNames
+   *          the list of preferred nodes
    * @return the node name where to allocate the container
    */
   private Optional<String> getPreferredNode(final List<String> nodeNames) {

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/package-info.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * A local implementation of REEF that uses local JVMs for execution.
  */
 package org.apache.reef.runtime.local;

--- a/lang/java/reef-runtime-local/src/test/java/org/apache/reef/runtime/local/driver/ResourceRequestQueueTest.java
+++ b/lang/java/reef-runtime-local/src/test/java/org/apache/reef/runtime/local/driver/ResourceRequestQueueTest.java
@@ -22,6 +22,9 @@ import org.apache.reef.runtime.common.driver.api.ResourceRequestEventImpl;
 import org.junit.Assert;
 import org.junit.Test;
 
+/**
+ * Test for ResourceRequestQueue.
+ */
 public class ResourceRequestQueueTest {
 
   @Test

--- a/lang/java/reef-runtime-local/src/test/java/org/apache/reef/runtime/local/driver/ResourceRequestTest.java
+++ b/lang/java/reef-runtime-local/src/test/java/org/apache/reef/runtime/local/driver/ResourceRequestTest.java
@@ -22,6 +22,9 @@ import org.apache.reef.runtime.common.driver.api.ResourceRequestEventImpl;
 import org.junit.Assert;
 import org.junit.Test;
 
+/**
+ * Test for ResourceRequest.
+ */
 public final class ResourceRequestTest {
 
   @Test()

--- a/lang/java/reef-runtime-local/src/test/java/org/apache/reef/runtime/local/driver/package-info.java
+++ b/lang/java/reef-runtime-local/src/test/java/org/apache/reef/runtime/local/driver/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Test for the resource manager for the local runtime.
  */
 package org.apache.reef.runtime.local.driver;


### PR DESCRIPTION
JIRA:
  [REEF-528](https://issues.apache.org/jira/browse/REEF-528)

Pull request:
  This closes #