### PR TITLE
[REEF-804] Garbage collection setting is not passed to update task

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
@@ -166,6 +166,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
                                 .Build(),
                             _configurationManager.UpdateFunctionConfiguration
                         })
+                        .BindNamedParameter(typeof (InvokeGC), _invokeGC.ToString())
                         .Build();
 
                 _commGroup.AddTask(IMRUConstants.UpdateTaskName);


### PR DESCRIPTION
This addressed the issue by
* passing the grabge collection named parameter to the UpdateTaskHost in the driver.

JIRA:
[REEF-804](https://issues.apache.org/jira/browse/REEF-804)