### PR TITLE
[REEF-805] IMRUJobDefinition does not allow user to set number of cores

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/MapperCount/MapperCount.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/MapperCount/MapperCount.cs
@@ -68,6 +68,8 @@ namespace Org.Apache.REEF.IMRU.Examples.MapperCount
                     .SetPartitionedDatasetConfiguration(
                         RandomDataConfiguration.ConfigurationModule.Set(RandomDataConfiguration.NumberOfPartitions,
                             numberofMappers.ToString()).Build())
+                    .SetMapTaskCores(2)
+                    .SetUpdateTaskCores(3)
                     .SetJobName("MapperCount")
                     .SetNumberOfMappers(numberofMappers)
                     .Build());

--- a/lang/cs/Org.Apache.REEF.IMRU/API/IMRUJobDefinition.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/API/IMRUJobDefinition.cs
@@ -40,6 +40,8 @@ namespace Org.Apache.REEF.IMRU.API
         private readonly int _numberOfMappers;
         private readonly int _memoryPerMapper;
         private readonly int _updateTaskMemory;
+        private readonly int _mapTaskCores;
+        private readonly int _updateTaskCores;
         private readonly ISet<IConfiguration> _perMapConfigGeneratorConfig;
         private readonly bool _invokeGC;
 
@@ -61,6 +63,9 @@ namespace Org.Apache.REEF.IMRU.API
         /// <param name="perMapConfigGeneratorConfig">Per mapper configuration</param>
         /// <param name="numberOfMappers">Number of mappers</param>
         /// <param name="memoryPerMapper">Per Mapper memory.</param>
+        /// <param name="updateTaskMemory">Update task memory</param>
+        /// <param name="mapTaskCores">Number of map task cores</param>
+        /// <param name="updateTaskCores">Number of update task cores</param>
         /// <param name="jobName">Job name</param>
         /// <param name="invokeGC">Whether to call garbage collector after each iteration</param>
         internal IMRUJobDefinition(
@@ -76,6 +81,8 @@ namespace Org.Apache.REEF.IMRU.API
             int numberOfMappers,
             int memoryPerMapper,
             int updateTaskMemory,
+            int mapTaskCores,
+            int updateTaskCores,
             string jobName,
             bool invokeGC)
         {
@@ -91,6 +98,8 @@ namespace Org.Apache.REEF.IMRU.API
             _jobName = jobName;
             _memoryPerMapper = memoryPerMapper;
             _updateTaskMemory = updateTaskMemory;
+            _mapTaskCores = mapTaskCores;
+            _updateTaskCores = updateTaskCores;
             _perMapConfigGeneratorConfig = perMapConfigGeneratorConfig;
             _invokeGC = invokeGC;
         }
@@ -192,6 +201,23 @@ namespace Org.Apache.REEF.IMRU.API
         internal int UpdateTaskMemory
         {
             get { return _updateTaskMemory; }
+        }
+
+
+        /// <summary>
+        /// Cores for each mapper
+        /// </summary>
+        internal int MapTaskCores
+        {
+            get { return _mapTaskCores; }
+        }
+
+        /// <summary>
+        /// Cores for update task
+        /// </summary>
+        internal int UpdateTaskCores
+        {
+            get { return _updateTaskCores; }
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.IMRU/API/IMRUJobDefinitionBuilder.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/API/IMRUJobDefinitionBuilder.cs
@@ -42,6 +42,8 @@ namespace Org.Apache.REEF.IMRU.API
         private int _numberOfMappers;
         private int _memoryPerMapper;
         private int _updateTaskMemory;
+        private int _coresPerMapper;
+        private int _updateTaskCores;
         private IConfiguration _mapFunctionConfiguration;
         private IConfiguration _mapInputCodecConfiguration;
         private IConfiguration _updateFunctionCodecsConfiguration;
@@ -66,6 +68,8 @@ namespace Org.Apache.REEF.IMRU.API
             _partitionedDatasetConfiguration = EmptyConfiguration;
             _memoryPerMapper = 512;
             _updateTaskMemory = 512;
+            _coresPerMapper = 1;
+            _updateTaskCores = 1;
             _invokeGC = true;
             _perMapConfigGeneratorConfig = new HashSet<IConfiguration>();
         }
@@ -211,6 +215,28 @@ namespace Org.Apache.REEF.IMRU.API
         }
 
         /// <summary>
+        /// Sets cores for map tasks
+        /// </summary>
+        /// <param name="cores">number of cores</param>
+        /// <returns></returns>
+        public IMRUJobDefinitionBuilder SetMapTaskCores(int cores)
+        {
+            _coresPerMapper = cores;
+            return this;
+        }
+
+        /// <summary>
+        /// Set update task cores
+        /// </summary>
+        /// <param name="cores">number of cores</param>
+        /// <returns></returns>
+        public IMRUJobDefinitionBuilder SetUpdateTaskCores(int cores)
+        {
+            _updateTaskCores = cores;
+            return this;
+        }
+
+        /// <summary>
         /// Sets Per Map Configuration
         /// </summary>
         /// <param name="perMapperConfig">Mapper configs</param>
@@ -285,6 +311,8 @@ namespace Org.Apache.REEF.IMRU.API
                 _numberOfMappers,
                 _memoryPerMapper,
                 _updateTaskMemory,
+                _coresPerMapper,
+                _updateTaskCores,
                 _jobName,
                 _invokeGC);
         }

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Client/REEFIMRUClient.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Client/REEFIMRUClient.cs
@@ -112,25 +112,29 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Client
                 jobDefinition.PartitionedDatasetConfiguration,
                 overallPerMapConfig
             })
-                .BindNamedParameter(typeof (SerializedMapConfiguration),
+                .BindNamedParameter(typeof(SerializedMapConfiguration),
                     _configurationSerializer.ToString(jobDefinition.MapFunctionConfiguration))
-                .BindNamedParameter(typeof (SerializedUpdateConfiguration),
+                .BindNamedParameter(typeof(SerializedUpdateConfiguration),
                     _configurationSerializer.ToString(jobDefinition.UpdateFunctionConfiguration))
-                .BindNamedParameter(typeof (SerializedMapInputCodecConfiguration),
+                .BindNamedParameter(typeof(SerializedMapInputCodecConfiguration),
                     _configurationSerializer.ToString(jobDefinition.MapInputCodecConfiguration))
-                .BindNamedParameter(typeof (SerializedMapInputPipelineDataConverterConfiguration),
+                .BindNamedParameter(typeof(SerializedMapInputPipelineDataConverterConfiguration),
                     _configurationSerializer.ToString(jobDefinition.MapInputPipelineDataConverterConfiguration))
-                .BindNamedParameter(typeof (SerializedUpdateFunctionCodecsConfiguration),
+                .BindNamedParameter(typeof(SerializedUpdateFunctionCodecsConfiguration),
                     _configurationSerializer.ToString(jobDefinition.UpdateFunctionCodecsConfiguration))
-                .BindNamedParameter(typeof (SerializedMapOutputPipelineDataConverterConfiguration),
+                .BindNamedParameter(typeof(SerializedMapOutputPipelineDataConverterConfiguration),
                     _configurationSerializer.ToString(jobDefinition.MapOutputPipelineDataConverterConfiguration))
-                .BindNamedParameter(typeof (SerializedReduceConfiguration),
+                .BindNamedParameter(typeof(SerializedReduceConfiguration),
                     _configurationSerializer.ToString(jobDefinition.ReduceFunctionConfiguration))
-                .BindNamedParameter(typeof (MemoryPerMapper),
+                .BindNamedParameter(typeof(MemoryPerMapper),
                     jobDefinition.MapperMemory.ToString(CultureInfo.InvariantCulture))
-                .BindNamedParameter(typeof (MemoryForUpdateTask),
+                .BindNamedParameter(typeof(MemoryForUpdateTask),
                     jobDefinition.UpdateTaskMemory.ToString(CultureInfo.InvariantCulture))
-                .BindNamedParameter(typeof (InvokeGC),
+                .BindNamedParameter(typeof(CoresPerMapper),
+                    jobDefinition.MapTaskCores.ToString(CultureInfo.InvariantCulture))
+                .BindNamedParameter(typeof(CoresForUpdateTask),
+                    jobDefinition.UpdateTaskCores.ToString(CultureInfo.InvariantCulture))
+                .BindNamedParameter(typeof(InvokeGC),
                     jobDefinition.InvokeGarbageCollectorAfterIteration.ToString(CultureInfo.InvariantCulture))
                 .Build();
 

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
@@ -117,6 +117,10 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
             _serviceAndContextConfigurationProvider =
                 new ServiceAndContextConfigurationProvider<TMapInput, TMapOutput>(dataSet.Count + 1, groupCommDriver,
                     _configurationManager, _partitionDescriptorStack);
+
+            Logger.Log(Level.Info,
+                string.Format("map task memory:{0}, update task memory:{1}, map task cores:{2}, update task cores:{3}",
+                    _memoryPerMapper, _memoryForUpdateTask, _coresPerMapper, _coresForUpdateTask));
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/MapTaskHost.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/IMRUTasks/MapTaskHost.cs
@@ -74,7 +74,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.IMRUTasks
             {
                 if (_invokeGC)
                 {
-                    Logger.Log(Level.Verbose,"Calling Garbage Collector");
+                    Logger.Log(Level.Verbose, "Calling Garbage Collector");
                     GC.Collect();
                     GC.WaitForPendingFinalizers();
                 }


### PR DESCRIPTION
This addressed the issue by
* providing user the ability to set map task and update task cores in IMRUJobDefinition

JIRA:
[REEF-805](https://issues.apache.org/jira/browse/REEF-805)