### PR TITLE
[REEF-803] Add a ConfigurationProvider for HadoopFileSystem

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client/API/JobSubmissionBuilderFactory.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/JobSubmissionBuilderFactory.cs
@@ -18,7 +18,7 @@
  */
 
 using System.Collections.Generic;
-using Org.Apache.REEF.Common.Parameters;
+using Org.Apache.REEF.Common.Client.Parameters;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Interface;
 

--- a/lang/cs/Org.Apache.REEF.Client/API/JobSubmissionBuilderFactory.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/JobSubmissionBuilderFactory.cs
@@ -18,7 +18,7 @@
  */
 
 using System.Collections.Generic;
-using Org.Apache.REEF.Client.API.Parameters;
+using Org.Apache.REEF.Common.Parameters;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Interface;
 

--- a/lang/cs/Org.Apache.REEF.Client/API/TcpPortConfigurationModule.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/TcpPortConfigurationModule.cs
@@ -17,7 +17,7 @@
 
 using Org.Apache.REEF.Common.Attributes;
 using Org.Apache.REEF.Common.Io;
-using Org.Apache.REEF.Common.Parameters;
+using Org.Apache.REEF.Common.Client.Parameters;
 using Org.Apache.REEF.Tang.Formats;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;

--- a/lang/cs/Org.Apache.REEF.Client/API/TcpPortConfigurationModule.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/TcpPortConfigurationModule.cs
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-using Org.Apache.REEF.Client.API.Parameters;
 using Org.Apache.REEF.Common.Attributes;
 using Org.Apache.REEF.Common.Io;
+using Org.Apache.REEF.Common.Parameters;
 using Org.Apache.REEF.Tang.Formats;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;

--- a/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
+++ b/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
@@ -62,7 +62,6 @@ under the License.
     <Compile Include="API\JobSubmission.cs" />
     <Compile Include="API\JobSubmissionBuilder.cs" />
     <Compile Include="API\JobSubmissionBuilderFactory.cs" />
-    <Compile Include="API\Parameters\DriverConfigurationProviders.cs" />
     <Compile Include="API\TcpPortConfigurationModule.cs" />
     <Compile Include="Common\ClientConstants.cs" />
     <Compile Include="Common\ClrClient2JavaClientCuratedParameters.cs" />

--- a/lang/cs/Org.Apache.REEF.Common/Client/Parameters/DriverConfigurationProviders.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Client/Parameters/DriverConfigurationProviders.cs
@@ -17,11 +17,12 @@
  * under the License.
  */
 
+using System;
 using System.Collections.Generic;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Interface;
 
-namespace Org.Apache.REEF.Common.Parameters
+namespace Org.Apache.REEF.Common.Client.Parameters
 {
     /// <summary>
     // This name parameter is used to target receivers Configuration providers at driver level

--- a/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
+++ b/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
@@ -96,7 +96,7 @@ under the License.
     <Compile Include="Io\NamingConfigurationOptions.cs" />
     <Compile Include="Io\TcpPortConfigurationProvider.cs" />
     <Compile Include="ITaskSubmittable.cs" />
-    <Compile Include="Parameters\DriverConfigurationProviders.cs" />
+    <Compile Include="Client\Parameters\DriverConfigurationProviders.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Protobuf\ReefProtocol\ClientRuntime.pb.cs" />
     <Compile Include="Protobuf\ReefProtocol\DriverRuntime.pb.cs" />

--- a/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
+++ b/lang/cs/Org.Apache.REEF.Common/Org.Apache.REEF.Common.csproj
@@ -96,6 +96,7 @@ under the License.
     <Compile Include="Io\NamingConfigurationOptions.cs" />
     <Compile Include="Io\TcpPortConfigurationProvider.cs" />
     <Compile Include="ITaskSubmittable.cs" />
+    <Compile Include="Parameters\DriverConfigurationProviders.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Protobuf\ReefProtocol\ClientRuntime.pb.cs" />
     <Compile Include="Protobuf\ReefProtocol\DriverRuntime.pb.cs" />

--- a/lang/cs/Org.Apache.REEF.Common/Parameters/DriverConfigurationProviders.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Parameters/DriverConfigurationProviders.cs
@@ -21,10 +21,10 @@ using System.Collections.Generic;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Interface;
 
-namespace Org.Apache.REEF.Client.API.Parameters
+namespace Org.Apache.REEF.Common.Parameters
 {
     /// <summary>
-    // This name parameter is used to target receviers Configuration providers at driver level
+    // This name parameter is used to target receivers Configuration providers at driver level
     /// </summary>
     [NamedParameter]
     public sealed class DriverConfigurationProviders : Name<ISet<IConfigurationProvider>>

--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/OnREEFIMRURunTimeConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/OnREEFIMRURunTimeConfiguration.cs
@@ -21,6 +21,7 @@ using System.Globalization;
 using Org.Apache.REEF.Client.Local;
 using Org.Apache.REEF.Client.Yarn;
 using Org.Apache.REEF.IMRU.OnREEF.Client;
+using Org.Apache.REEF.IO.FileSystem.Hadoop;
 using Org.Apache.REEF.Tang.Implementations.Configuration;
 using Org.Apache.REEF.Tang.Interface;
 
@@ -72,9 +73,11 @@ namespace Org.Apache.REEF.IMRU.Examples
             IConfiguration imruClientConfig =
                 REEFIMRUClientConfiguration<TMapInput, TMapOutput, TResult>.ConfigurationModule.Build();
 
+            var fileSystemConfig = HadoopFileSystemConfiguration.ConfigurationModule.Build();
+
             IConfiguration runtimeConfig =
                 YARNClientConfiguration.ConfigurationModule.Build();
-            return Configurations.Merge(runtimeConfig, imruClientConfig);
+            return Configurations.Merge(runtimeConfig, imruClientConfig, fileSystemConfig);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestHadoopFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestHadoopFileSystem.cs
@@ -19,7 +19,10 @@ using System;
 using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Org.Apache.REEF.IO.FileSystem;
 using Org.Apache.REEF.IO.FileSystem.Hadoop;
+using Org.Apache.REEF.IO.FileSystem.Hadoop.Parameters;
+using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 
 namespace Org.Apache.REEF.IO.Tests
@@ -27,7 +30,7 @@ namespace Org.Apache.REEF.IO.Tests
     /// <summary>
     /// Tests for HadoopFileSystem.
     /// </summary>
-    /// <see cref="HadoopFileSystem" />
+    /// <see cref="HadoopFileSystem" />    
     [TestClass]
     [Ignore] // These tests need to be run in an environment with HDFS installed.
     public sealed class TestHadoopFileSystem
@@ -142,6 +145,29 @@ namespace Org.Apache.REEF.IO.Tests
         public void TestCreate()
         {
             _fileSystem.Create(GetTempUri());
+        }
+
+        /// <summary>
+        /// This test is to make sure with the HadoopFileSystemConfiguration, HadoopFileSystem can be injected.
+        /// </summary>
+        [TestMethod]
+        public void TestHadoopFileSystemConfiguration()
+        {
+            var fileSystemTest = TangFactory.GetTang().NewInjector(HadoopFileSystemConfiguration.ConfigurationModule
+                .Build())
+                .GetInstance<FileSystemTest>();
+            Assert.IsTrue(fileSystemTest.FileSystem is HadoopFileSystem);
+        }
+    }
+
+    class FileSystemTest
+    {
+        public IFileSystem FileSystem { get; private set; }
+
+        [Inject]
+        private FileSystemTest(IFileSystem fileSystem)
+        {
+            FileSystem = fileSystem;
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HadoopFileSystemConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HadoopFileSystemConfiguration.cs
@@ -15,8 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
+using Org.Apache.REEF.Common.Io;
+using Org.Apache.REEF.Common.Parameters;
 using Org.Apache.REEF.IO.FileSystem.Hadoop.Parameters;
 using Org.Apache.REEF.Tang.Formats;
+using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 
 namespace Org.Apache.REEF.IO.FileSystem.Hadoop
@@ -46,7 +49,13 @@ namespace Org.Apache.REEF.IO.FileSystem.Hadoop
         /// </summary>
         public static readonly OptionalParameter<string> HadoopHome = new OptionalParameter<string>();
 
+        /// <summary>
+        /// Set HadoopFileSystemConfigurationProvider to DriverConfigurationProviders.
+        /// Set all the parameters needed for injecting HadoopFileSystemConfigurationProvider.
+        /// </summary>
         public static readonly ConfigurationModule ConfigurationModule = new HadoopFileSystemConfiguration()
+            .BindSetEntry<DriverConfigurationProviders, HadoopFileSystemConfigurationProvider, IConfigurationProvider>(
+                GenericType<DriverConfigurationProviders>.Class, GenericType<HadoopFileSystemConfigurationProvider>.Class)
             .BindImplementation(GenericType<IFileSystem>.Class, GenericType<HadoopFileSystem>.Class)
             .BindNamedParameter(GenericType<NumberOfRetries>.Class, CommandRetries)
             .BindNamedParameter(GenericType<CommandTimeOut>.Class, CommandTimeOut)

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HadoopFileSystemConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HadoopFileSystemConfiguration.cs
@@ -16,7 +16,7 @@
 // under the License.
 
 using Org.Apache.REEF.Common.Io;
-using Org.Apache.REEF.Common.Parameters;
+using Org.Apache.REEF.Common.Client.Parameters;
 using Org.Apache.REEF.IO.FileSystem.Hadoop.Parameters;
 using Org.Apache.REEF.Tang.Formats;
 using Org.Apache.REEF.Tang.Interface;

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HadoopFileSystemConfigurationProvider.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HadoopFileSystemConfigurationProvider.cs
@@ -31,7 +31,7 @@ namespace Org.Apache.REEF.IO.FileSystem.Hadoop
     /// The client that is going to use HadoopFileSystem in its driver and evaluators should set 
     /// configuration data through HadoopFileSystemConfiguration module in he client's configuration
     /// </summary>
-    public class HadoopFileSystemConfigurationProvider : IConfigurationProvider
+    internal sealed class HadoopFileSystemConfigurationProvider : IConfigurationProvider
     {
         private readonly IConfiguration _configuration;
 

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HadoopFileSystemConfigurationProvider.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HadoopFileSystemConfigurationProvider.cs
@@ -18,29 +18,35 @@
  */
 
 using Org.Apache.REEF.Common.Evaluator.Parameters;
+using Org.Apache.REEF.IO.FileSystem.Hadoop.Parameters;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
-using Org.Apache.REEF.Wake.Remote.Parameters;
+using Org.Apache.REEF.Tang.Util;
 
-namespace Org.Apache.REEF.Common.Io
+namespace Org.Apache.REEF.IO.FileSystem.Hadoop
 {
-    public class TcpPortConfigurationProvider : IConfigurationProvider
+    /// <summary>
+    /// This provider provides configuration for HardoopFileSystem
+    /// The client that is going to use HadoopFileSystem in its driver and evaluators should set 
+    /// configuration data through HadoopFileSystemConfiguration module in he client's configuration
+    /// </summary>
+    public class HadoopFileSystemConfigurationProvider : IConfigurationProvider
     {
         private readonly IConfiguration _configuration;
+
         [Inject]
-        private TcpPortConfigurationProvider(
-            [Parameter(typeof(TcpPortRangeStart))] int tcpPortRangeStart,
-            [Parameter(typeof(TcpPortRangeCount))] int tcpPortRangeCount,
-            [Parameter(typeof(TcpPortRangeTryCount))] int tcpPortRangeTryCount,
-            [Parameter(typeof(TcpPortRangeSeed))] int tcpPortRangeTrySeed)
+        private HadoopFileSystemConfigurationProvider(
+            [Parameter(typeof(NumberOfRetries))] int numberOfRetries,
+            [Parameter(typeof(CommandTimeOut))] int commandTimeOut,
+            [Parameter(typeof(HadoopHome))] string hadoopHome)
         {
             _configuration = TangFactory.GetTang().NewConfigurationBuilder()
-                .BindIntNamedParam<TcpPortRangeStart>(tcpPortRangeStart.ToString())
-                .BindIntNamedParam<TcpPortRangeCount>(tcpPortRangeCount.ToString())
-                .BindIntNamedParam<TcpPortRangeTryCount>(tcpPortRangeTryCount.ToString())
-                .BindIntNamedParam<TcpPortRangeSeed>(tcpPortRangeTrySeed.ToString())
-                .BindSetEntry<EvaluatorConfigurationProviders, TcpPortConfigurationProvider, IConfigurationProvider>()
+                .BindImplementation(GenericType<IFileSystem>.Class, GenericType<HadoopFileSystem>.Class)
+                .BindIntNamedParam<NumberOfRetries>(numberOfRetries.ToString())
+                .BindIntNamedParam<CommandTimeOut>(commandTimeOut.ToString())
+                .BindStringNamedParam<HadoopHome>(hadoopHome)
+                .BindSetEntry<EvaluatorConfigurationProviders, HadoopFileSystemConfigurationProvider, IConfigurationProvider>()
                 .Build();
         }
 

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/IFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/IFileSystem.cs
@@ -18,12 +18,15 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Org.Apache.REEF.IO.FileSystem.Local;
+using Org.Apache.REEF.Tang.Annotations;
 
 namespace Org.Apache.REEF.IO.FileSystem
 {
     /// <summary>
     /// A file system abstraction.
     /// </summary>
+    [DefaultImplementation(typeof(LocalFileSystem), "default")]
     public interface IFileSystem
     {
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.IO/Org.Apache.REEF.IO.csproj
+++ b/lang/cs/Org.Apache.REEF.IO/Org.Apache.REEF.IO.csproj
@@ -43,6 +43,7 @@ under the License.
   <ItemGroup>
     <Compile Include="FileSystem\Hadoop\CommandResult.cs" />
     <Compile Include="FileSystem\Hadoop\HadoopFileSystemConfiguration.cs" />
+    <Compile Include="FileSystem\Hadoop\HadoopFileSystemConfigurationProvider.cs" />
     <Compile Include="FileSystem\Hadoop\HDFSCommandRunner.cs" />
     <Compile Include="FileSystem\Hadoop\HadoopFileSystem.cs" />
     <Compile Include="FileSystem\Hadoop\Parameters\CommandTimeOut.cs" />


### PR DESCRIPTION
Added HadoopFileSystemConfigurationProvider
Moved DriverConfigurationProviders  to Common as it is shared by multiple providers

JIRA: [REEF-803](https://issues.apache.org/jira/browse/REEF-803)

This closes #