### PR TITLE
[REEF-807] Set JVM max memory limit used in testsuites properly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,8 +105,9 @@ under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.17</version>
+                    <version>2.18.1</version>
                     <configuration>
+                        <argLine>-Xmx2g</argLine>
                         <systemProperties>
                             <property>
                                 <name>org.apache.reef.runtime.local.folder</name>


### PR DESCRIPTION
This PR upgrades Maven surefire plugin and sets the proper value of JVM
max memory limit for it in order to recover JDK 1.7 Apache Jenkins builds.

JIRA:
  [REEF-807](https://issues.apache.org/jira/browse/REEF-807)

Pull Request:
  This closes #