### PR TITLE
[REEF-828] Fix name typos of Class/Functions in REEF.NET IO

### DIFF
--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestFilePartitionDataSet.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestFilePartitionDataSet.cs
@@ -59,7 +59,7 @@ namespace Org.Apache.REEF.IO.Tests
             var dataSet = TangFactory.GetTang()
                 .NewInjector(FileSystemPartitionConfiguration<byte>.ConfigurationModule
                     .Set(FileSystemPartitionConfiguration<byte>.FilePathForPartitions, sourceFilePath1 + ";" + sourceFilePath2)
-                    .Set(FileSystemPartitionConfiguration<byte>.FileSerializerConfig, GetByteSerilizerConfigString())
+                    .Set(FileSystemPartitionConfiguration<byte>.FileSerializerConfig, GetByteSerializerConfigString())
                     .Build())
                 .GetInstance<IPartitionedDataSet>();
 
@@ -100,9 +100,9 @@ namespace Org.Apache.REEF.IO.Tests
 
             var partitionConfig = TangFactory.GetTang().NewConfigurationBuilder()
                 .BindImplementation(GenericType<IPartitionedDataSet>.Class, GenericType<FileSystemPartitionDataSet<byte>>.Class)
-                .BindStringNamedParam<FileSerializerConfigString>(GetByteSerilizerConfigString())
-                .BindSetEntry<FilePathsForPatitions, string>(GenericType<FilePathsForPatitions>.Class, sourceFilePath1)
-                .BindSetEntry<FilePathsForPatitions, string>(GenericType<FilePathsForPatitions>.Class, sourceFilePath2)
+                .BindStringNamedParam<FileSerializerConfigString>(GetByteSerializerConfigString())
+                .BindSetEntry<FilePathsForPartitions, string>(GenericType<FilePathsForPartitions>.Class, sourceFilePath1)
+                .BindSetEntry<FilePathsForPartitions, string>(GenericType<FilePathsForPartitions>.Class, sourceFilePath2)
                 .Build();
 
             var dataSet = TangFactory.GetTang()
@@ -137,9 +137,9 @@ namespace Org.Apache.REEF.IO.Tests
 
             var c = TangFactory.GetTang().NewConfigurationBuilder()
                 .BindImplementation(GenericType<IPartitionedDataSet>.Class, GenericType<FileSystemPartitionDataSet<byte>>.Class)
-                .BindStringNamedParam<FileSerializerConfigString>(GetByteSerilizerConfigString())
-                .BindSetEntry<FilePathsForPatitions, string>(GenericType<FilePathsForPatitions>.Class, sourceFilePath1)
-                .BindSetEntry<FilePathsForPatitions, string>(GenericType<FilePathsForPatitions>.Class, sourceFilePath2)
+                .BindStringNamedParam<FileSerializerConfigString>(GetByteSerializerConfigString())
+                .BindSetEntry<FilePathsForPartitions, string>(GenericType<FilePathsForPartitions>.Class, sourceFilePath1)
+                .BindSetEntry<FilePathsForPartitions, string>(GenericType<FilePathsForPartitions>.Class, sourceFilePath2)
                 .Build();
 
             var dataSet = TangFactory.GetTang()
@@ -180,7 +180,7 @@ namespace Org.Apache.REEF.IO.Tests
                 .NewInjector(FileSystemPartitionConfiguration<Row>.ConfigurationModule
                     .Set(FileSystemPartitionConfiguration<Row>.FilePathForPartitions, sourceFilePath1)
                     .Set(FileSystemPartitionConfiguration<Row>.FilePathForPartitions, sourceFilePath2)
-                    .Set(FileSystemPartitionConfiguration<Row>.FileSerializerConfig, GetRowSerilizerConfigString())
+                    .Set(FileSystemPartitionConfiguration<Row>.FileSerializerConfig, GetRowSerializerConfigString())
                     .Build())
                 .GetInstance<IPartitionedDataSet>();
 
@@ -219,7 +219,7 @@ namespace Org.Apache.REEF.IO.Tests
             }
         }
 
-        private string GetByteSerilizerConfigString()
+        private string GetByteSerializerConfigString()
         {
             var serializerConf = TangFactory.GetTang().NewConfigurationBuilder()
                 .BindImplementation<IFileDeSerializer<byte>, ByteSerializer>(
@@ -229,7 +229,7 @@ namespace Org.Apache.REEF.IO.Tests
             return (new AvroConfigurationSerializer()).ToString(serializerConf);
         }
 
-        private string GetRowSerilizerConfigString()
+        private string GetRowSerializerConfigString()
         {
             var serializerConf = TangFactory.GetTang().NewConfigurationBuilder()
                 .BindImplementation<IFileDeSerializer<Row>, RowSerializer>(

--- a/lang/cs/Org.Apache.REEF.IO/Org.Apache.REEF.IO.csproj
+++ b/lang/cs/Org.Apache.REEF.IO/Org.Apache.REEF.IO.csproj
@@ -58,7 +58,7 @@ under the License.
     <Compile Include="PartitionedData\FileSystem\IFileDeSerializer.cs" />
     <Compile Include="PartitionedData\FileSystem\FileSystemPartitionDataSet.cs" />
     <Compile Include="PartitionedData\FileSystem\FileSystemPartitionConfiguration.cs" />
-    <Compile Include="PartitionedData\FileSystem\Parameters\FilePathsForPatitions.cs" />
+    <Compile Include="PartitionedData\FileSystem\Parameters\FilePathsForPartitions.cs" />
     <Compile Include="PartitionedData\FileSystem\Parameters\FilePathsInPartition.cs" />
     <Compile Include="PartitionedData\IPartition.cs" />
     <Compile Include="PartitionedData\IPartitionDescriptor.cs" />

--- a/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemPartitionConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemPartitionConfiguration.cs
@@ -46,7 +46,7 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
         /// </summary>
         public static ConfigurationModule ConfigurationModule = new FileSystemPartitionConfiguration<T>()
             .BindImplementation(GenericType<IPartitionedDataSet>.Class, GenericType<FileSystemPartitionDataSet<T>>.Class)
-            .BindSetEntry(GenericType<FilePathsForPatitions>.Class, FilePathForPartitions)
+            .BindSetEntry(GenericType<FilePathsForPartitions>.Class, FilePathForPartitions)
             .BindNamedParameter(GenericType<FileSerializerConfigString>.Class, FileSerializerConfig)
             .Build();
     }

--- a/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemPartitionDataSet.cs
+++ b/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemPartitionDataSet.cs
@@ -48,7 +48,7 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
         
         [Inject]
         private FileSystemPartitionDataSet(
-            [Parameter(typeof(FilePathsForPatitions))] ISet<string> filePaths,
+            [Parameter(typeof(FilePathsForPartitions))] ISet<string> filePaths,
             IFileSystem fileSystem,
             [Parameter(typeof(FileSerializerConfigString))] string fileSerializerConfigString,
             AvroConfigurationSerializer avroConfigurationSerializer

--- a/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/Parameters/FilePathsForPartitions.cs
+++ b/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/Parameters/FilePathsForPartitions.cs
@@ -23,11 +23,11 @@ using Org.Apache.REEF.Tang.Annotations;
 namespace Org.Apache.REEF.IO.PartitionedData.FileSystem.Parameters
 {
     /// <summary>
-    /// Each element in the set contains input files for one partition, seperated by semicolon. 
+    /// Each element in the set contains input files for one partition, separated by semicolon. 
     /// The set contains file paths for all the partitions
     /// </summary>
     [NamedParameter("All file paths")]
-    internal sealed class FilePathsForPatitions : Name<ISet<string>>
+    internal sealed class FilePathsForPartitions : Name<ISet<string>>
     {
     }
 }


### PR DESCRIPTION
This PR renames the following functions and class.

  * GetByteSerilizerConfigString -> GetByteSerializerConfigString
  * GetRowSerilizerConfigString -> GetRowSerializerConfigString
  * FilePathsForPatitions -> FilePathsForPartitions

JIRA:
  [REEF-828](https://issues.apache.org/jira/browse/REEF-828)

Pull Request:
  This closes #