### PR TITLE
[REEF-709/710/711] Act on obsoletes in CustomTraceLevel, CommandLineArguments and CustomTraceListeners

### DIFF
--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/CommandLineArguments.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/CommandLineArguments.cs
@@ -21,18 +21,15 @@ using Org.Apache.REEF.Tang.Annotations;
 
 namespace Org.Apache.REEF.Driver.Bridge
 {
-    // TODO[REEF-710] Act on the obsoletes
     public sealed class CommandLineArguments
     {
-        [Obsolete("This constructor will be made `private` after 0.13.")]
         [Inject]
-        public CommandLineArguments(
+        private CommandLineArguments(
             [Parameter(typeof(DriverBridgeConfigurationOptions.ArgumentSets))] ISet<string> arguments)
         {
             Arguments = arguments;
         }
 
-        [Obsolete("The setter will be made `private` after 0.13.")]
-        public ISet<string> Arguments { get; set; }
+        public ISet<string> Arguments { get; private set; }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/CustomTraceLevel.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/CustomTraceLevel.cs
@@ -22,12 +22,10 @@ using Org.Apache.REEF.Utilities.Logging;
 
 namespace Org.Apache.REEF.Driver.Bridge
 {
-    // TODO[REEF-709] Act on the obsoletes here.
     public sealed class CustomTraceLevel
     {
-        [Obsolete("This constructor will be made `private` after 0.13.")]
         [Inject]
-        public CustomTraceLevel([Parameter(typeof(DriverBridgeConfigurationOptions.TraceLevel))] string traceLevel)
+        private CustomTraceLevel([Parameter(typeof(DriverBridgeConfigurationOptions.TraceLevel))] string traceLevel)
         {
             var level = Level.Verbose;
             if (Enum.TryParse(traceLevel.ToString(CultureInfo.InvariantCulture), out level))
@@ -41,7 +39,6 @@ namespace Org.Apache.REEF.Driver.Bridge
             TraceLevel = level;
         }
 
-        [Obsolete("The setter will be made `private` after 0.13.")]
-        public Level TraceLevel { get; set; }
+        public Level TraceLevel { get; private set; }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/CustomTraceListeners.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/CustomTraceListeners.cs
@@ -22,18 +22,15 @@ using Org.Apache.REEF.Tang.Annotations;
 
 namespace Org.Apache.REEF.Driver.Bridge
 {
-    // TODO[REEF-711] Act on the obsoletes.
     public sealed class CustomTraceListeners
     {
-        [Obsolete("This constructor will be made `private` after 0.13.")]
         [Inject]
-        public CustomTraceListeners(
+        private CustomTraceListeners(
             [Parameter(typeof(DriverBridgeConfigurationOptions.TraceListenersSet))] ISet<TraceListener> listeners)
         {
             Listeners = listeners;
         }
 
-        [Obsolete("The setter will be made `private` after 0.13.")]
-        public ISet<TraceListener> Listeners { get; set; }
+        public ISet<TraceListener> Listeners { get; private set; }
     }
 }


### PR DESCRIPTION
This converts constructors and setters for these classes to private.

JIRA:
  [REEF-709](https://issues.apache.org/jira/browse/REEF-709)
  [REEF-710](https://issues.apache.org/jira/browse/REEF-710)
  [REEF-711](https://issues.apache.org/jira/browse/REEF-711)

Pull request:
  This closes #