### PR TITLE
[REEF-523] Add missing Javadoc/triage TODOd in Java code: reef-common

### DIFF
--- a/lang/java/reef-common/pom.xml
+++ b/lang/java/reef-common/pom.xml
@@ -32,6 +32,17 @@ under the License.
 
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <configuration>
+                        <configLocation>lang/java/reef-common/src/main/resources/checkstyle-strict.xml</configLocation>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>

--- a/lang/java/reef-common/src/main/java/org/apache/reef/common/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/common/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * REEF Common.
  */
 package org.apache.reef.common;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/PreemptionEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/PreemptionEvent.java
@@ -41,7 +41,7 @@ public interface PreemptionEvent {
   /**
    * @return the Set of RunningEvaluators that the underlying resource manager is about to take away from the Driver.
    */
-  // TODO: We need to have a set of things to present to the user as preempted.
+  // TODO[JIRA REEF-836]: We need to have a set of things to present to the user as preempted.
   // Probably a Set<String> with the Evaluator IDs.
   // public Set<RunningEvaluator> getToBePreemptedEvaluators();
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/catalog/ResourceCatalog.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/catalog/ResourceCatalog.java
@@ -51,11 +51,14 @@ public interface ResourceCatalog {
   /**
    * Get the node descriptor with the given identifier.
    *
-   * @param id of the node.
+   * @param nodeId id of the node.
    * @return the node descriptor assigned to the identifier.
    */
   NodeDescriptor getNode(String nodeId);
 
+  /**
+   * Resource descriptor interface.
+   */
   public interface Descriptor {
 
     String getName();

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/catalog/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/catalog/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Interfaces describing resources available to a REEF instance (physical nodes, racks etc).
  */
 package org.apache.reef.driver.catalog;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/ActiveContext.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/ActiveContext.java
@@ -29,7 +29,7 @@ import org.apache.reef.tang.Configuration;
 /**
  * Represents an active context on an Evaluator.
  * <p/>
- * A context consists of twp configurations:
+ * A context consists of two configurations:
  * <ol>
  * <li>ContextConfiguration: Its visibility is limited to the context itself and tasks spawned from it.</li>
  * <li>ServiceConfiguration: This is "inherited" by child context spawned.</li>
@@ -64,7 +64,7 @@ public interface ActiveContext extends Identifiable, AutoCloseable, ContextBase,
    * Send the active context the message, which will be delivered to all registered
    * {@link org.apache.reef.evaluator.context.ContextMessageHandler}, for this context.
    *
-   * @param message
+   * @param message The message to be sent.
    */
   void sendMessage(final byte[] message);
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/ClosedContext.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/ClosedContext.java
@@ -23,7 +23,7 @@ import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Public;
 
 /**
- * Represents a Context that has been closed succesfully.
+ * Represents a Context that has been closed successfully.
  */
 @Public
 @DriverSide

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/ContextConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/ContextConfiguration.java
@@ -102,6 +102,9 @@ public class ContextConfiguration extends ConfigurationModuleBuilder {
       .bindSetEntry(TaskConfigurationOptions.StopHandlers.class, ON_TASK_STOP)
       .build();
 
+  /**
+   * Implementation for re-connecting to driver after driver restart.
+   */
   @NamedParameter(doc = "House the implementation for re-connecting to driver after driver restart",
       default_classes = DefaultDriverConnection.class)
   public static final class DriverReconnect implements Name<DriverConnection> {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Driver Contexts and their configurations.
  */
 package org.apache.reef.driver.context;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Evaluator-related utilities.
  */
 package org.apache.reef.driver.evaluator;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/RestartEvaluators.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/RestartEvaluators.java
@@ -73,6 +73,9 @@ public final class RestartEvaluators {
     return new Builder();
   }
 
+  /**
+   * Builder to build {@link RestartEvaluators}.
+   */
   public static final class Builder implements org.apache.reef.util.Builder<RestartEvaluators>{
     private final Map<String, EvaluatorRestartInfo> restartInfoMap = new HashMap<>();
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/TaskConfigurationOptions.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/TaskConfigurationOptions.java
@@ -40,37 +40,61 @@ import java.util.Set;
 @Provided
 public final class TaskConfigurationOptions {
 
+  /**
+   * The Identifier of the Task.
+   */
   @NamedParameter(default_value = "Unnamed Task", doc = "The Identifier of the Task")
   public static final class Identifier implements Name<String> {
   }
 
+  /**
+   * The memento to be used for the Task.
+   */
   @NamedParameter(doc = "The memento to be used for the Task.")
   public final class Memento implements Name<String> {
   }
 
+  /**
+   * TaskMessageSource instances.
+   */
   @NamedParameter(doc = "TaskMessageSource instances.")
   public final class TaskMessageSources implements Name<Set<TaskMessageSource>> {
   }
 
+  /**
+   * The set of event handlers for the TaskStart event.
+   */
   @NamedParameter(doc = "The set of event handlers for the TaskStart event.")
   public final class StartHandlers implements Name<Set<EventHandler<TaskStart>>> {
   }
 
+  /**
+   * The set of event handlers for the TaskStop event.
+   */
   @NamedParameter(doc = "The set of event handlers for the TaskStop event.")
   public final class StopHandlers implements Name<Set<EventHandler<TaskStop>>> {
   }
 
-  @NamedParameter(doc = "The event handler that receives the close event",
+  /**
+   * The event handler that receives the close event.
+   */
+  @NamedParameter(doc = "The event handler that receives the close event.",
       default_class = DefaultCloseHandler.class)
   public final class CloseHandler implements Name<EventHandler<CloseEvent>> {
   }
 
-  @NamedParameter(doc = "The event handler that receives the suspend event",
+  /**
+   * The event handler that receives the suspend event.
+   */
+  @NamedParameter(doc = "The event handler that receives the suspend event.",
       default_class = DefaultSuspendHandler.class)
   public final class SuspendHandler implements Name<EventHandler<SuspendEvent>> {
   }
 
-  @NamedParameter(doc = "The event handler that receives messages from the driver",
+  /**
+   * The event handler that receives messages from the driver.
+   */
+  @NamedParameter(doc = "The event handler that receives messages from the driver.",
       default_class = DefaultDriverMessageHandler.class)
   public final class MessageHandler implements Name<EventHandler<DriverMessage>> {
   }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Tasks and their configurations.
  */
 package org.apache.reef.driver.task;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/events/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/events/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Events signaling change of Evaluator state.
  */
 package org.apache.reef.evaluator.context.events;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Evaluator Contexts.
  */
 package org.apache.reef.evaluator.context;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/parameters/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/evaluator/context/parameters/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Named parameters used by the Evaluator.
  */
 package org.apache.reef.evaluator.context.parameters;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/exception/evaluator/StorageException.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/exception/evaluator/StorageException.java
@@ -18,6 +18,9 @@
  */
 package org.apache.reef.exception.evaluator;
 
+/**
+ * Storage exception.
+ */
 public class StorageException extends ServiceException {
   private static final long serialVersionUID = 1L;
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/PartitionSpec.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/PartitionSpec.java
@@ -20,9 +20,9 @@ package org.apache.reef.io;
 
 import org.apache.reef.annotations.Unstable;
 
-// FIXME:
-// This was another more type safe
-// alternative to integer partitions
+/**
+ * This was another more type safe alternative to integer partitions.
+ */
 @Unstable
 public class PartitionSpec {
   private final Type type;
@@ -41,6 +41,9 @@ public class PartitionSpec {
     return id;
   }
 
+  /**
+   * Partition type.
+   */
   public enum Type {
     SINGLE,
     ALL,

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/Tuple.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/Tuple.java
@@ -20,7 +20,9 @@ package org.apache.reef.io;
 
 import org.apache.reef.annotations.Unstable;
 
-// TODO: Document
+/**
+ * A key-value pair of elements.
+ */
 @Unstable
 public final class Tuple<K, V> {
   private final K k;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/naming/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/naming/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Utilities for assigning Identifiers to objects and associating socket addresses with them.
  */
 package org.apache.reef.io.naming;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/parameters/TempFileRootFolder.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/parameters/TempFileRootFolder.java
@@ -18,10 +18,12 @@
  */
 package org.apache.reef.io.parameters;
 
-
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
-@NamedParameter(doc = "directory for temp files", default_value = "./reef/temp")
+/**
+ * Directory for temp files.
+ */
+@NamedParameter(doc = "Directory for temp files", default_value = "./reef/temp")
 public final class TempFileRootFolder implements Name<String> {
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/serialization/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/serialization/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Serialization utilities.
  */
 package org.apache.reef.io.serialization;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/REEFLauncher.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/REEFLauncher.java
@@ -53,6 +53,9 @@ import java.util.logging.Logger;
  */
 public final class REEFLauncher {
 
+  /**
+   * Parameter which enables profiling.
+   */
   @NamedParameter(doc = "If true, profiling will be enabled", short_name = "profiling", default_value = "false")
   public static final class ProfilingEnabled implements Name<Boolean> {
   }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/REEFImplementation.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/REEFImplementation.java
@@ -41,6 +41,9 @@ import javax.inject.Inject;
 import java.util.Set;
 import java.util.logging.Logger;
 
+/**
+ * Default REEF implementation.
+ */
 @ClientSide
 @Provided
 @Private
@@ -128,6 +131,9 @@ public final class REEFImplementation implements REEF {
     return configurationBuilder.build();
   }
 
+  /**
+   * The driver remote identifier.
+   */
   @NamedParameter(doc = "The driver remote identifier.")
   public static final class DriverRemoteIdentifier implements Name<String> {
   }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/ClientRuntimeParameters.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/ClientRuntimeParameters.java
@@ -21,8 +21,14 @@ package org.apache.reef.runtime.common.client.api;
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
+/**
+ * Parameters used by client runtime.
+ */
 public final class ClientRuntimeParameters {
 
+  /**
+   * The runtime error handler RID.
+   */
   @NamedParameter(doc = "The runtime error handler RID.")
   public static final class RuntimeErrorHandlerRID implements Name<String> {
   }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/JobSubmissionHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/api/JobSubmissionHandler.java
@@ -21,6 +21,9 @@ package org.apache.reef.runtime.common.client.api;
 import org.apache.reef.annotations.audience.RuntimeAuthor;
 import org.apache.reef.wake.EventHandler;
 
+/**
+ * A Handler for JobSubmissionEvent.
+ */
 @RuntimeAuthor
 public interface JobSubmissionHandler extends EventHandler<JobSubmissionEvent>, AutoCloseable {
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/parameters/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/client/parameters/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Parameters used by client.
  */
 package org.apache.reef.runtime.common.client.parameters;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeConfiguration.java
@@ -38,6 +38,9 @@ import org.apache.reef.tang.formats.ConfigurationModule;
 import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
 import org.apache.reef.wake.time.Clock;
 
+/**
+ * ConfigurationModule for driver runtime.
+ */
 @Private
 @ClientSide
 public final class DriverRuntimeConfiguration extends ConfigurationModuleBuilder {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeConfigurationOptions.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeConfigurationOptions.java
@@ -27,6 +27,9 @@ import org.apache.reef.wake.EventHandler;
  * Houses the Driver resourcemanager configuration's NamedParameters.
  */
 public class DriverRuntimeConfigurationOptions {
+  /**
+   * Handler called when a job control message is received by the client.
+   */
   @NamedParameter(doc = "Called when a job control message is received by the client.")
   public static final class JobControlHandler implements Name<EventHandler<ClientRuntimeProtocol.JobControlProto>> {
   }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/RuntimeParameters.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/RuntimeParameters.java
@@ -33,20 +33,31 @@ import org.apache.reef.wake.EventHandler;
  */
 @RuntimeAuthor
 public final class RuntimeParameters {
-
+  /**
+   * The resource allocation handler that stub runtimes send along allocated resources e.g., containers.
+   */
   @NamedParameter(doc = "The resource allocation handler that stub runtimes send along allocated resources " +
       "e.g., containers.")
   public static final class ResourceAllocationHandler implements Name<EventHandler<ResourceAllocationEvent>> {
   }
 
+  /**
+   * The node descriptor handler that stub runtimes send along node information.
+   */
   @NamedParameter(doc = "The node descriptor handler that stub runtimes send along node information.")
   public static final class NodeDescriptorHandler implements Name<EventHandler<NodeDescriptorEvent>> {
   }
 
+  /**
+   * The resource status handler.
+   */
   @NamedParameter(doc = "The resource status handler.")
   public static final class ResourceStatusHandler implements Name<EventHandler<ResourceStatusEvent>> {
   }
 
+  /**
+   * The resourcemanager status handler.
+   */
   @NamedParameter(doc = "The resourcemanager status handler.")
   public static final class RuntimeStatusHandler implements Name<EventHandler<RuntimeStatusEvent>> {
   }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/catalog/NodeDescriptorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/catalog/NodeDescriptorImpl.java
@@ -24,6 +24,9 @@ import org.apache.reef.driver.catalog.RackDescriptor;
 
 import java.net.InetSocketAddress;
 
+/**
+ * Descriptor of the physical setup of an Evaluator.
+ */
 @Private
 public class NodeDescriptorImpl implements NodeDescriptor {
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/catalog/RackDescriptorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/catalog/RackDescriptorImpl.java
@@ -25,6 +25,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * A rack in the cluster.
+ */
 public final class RackDescriptorImpl implements RackDescriptor {
 
   private final String name;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/catalog/ResourceCatalogImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/catalog/ResourceCatalogImpl.java
@@ -30,6 +30,9 @@ import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * A catalog of the resources available to a REEF instance.
+ */
 @Private
 public final class ResourceCatalogImpl implements ResourceCatalog {
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/catalog/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/catalog/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Implementations of descriptors for resources available to a REEF instance (physical nodes, racks etc).
  */
 package org.apache.reef.runtime.common.driver.catalog;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
@@ -155,7 +155,7 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
    * Get the id of current job/application.
    */
   public static String getJobIdentifier() {
-    // TODO: currently we obtain the job id directly by parsing execution (container) directory path
+    // TODO[JIRA REEF-818]: currently we obtain the job id directly by parsing execution (container) directory path
     // #845 is open to get the id from RM properly
     for (File directory = new File(System.getProperty("user.dir"));
          directory != null; directory = directory.getParentFile()) {
@@ -576,10 +576,17 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
   }
 
   // Dynamic Parameters
+
+  /**
+   * The Evaluator Identifier.
+   */
   @NamedParameter(doc = "The Evaluator Identifier.")
   public static final class EvaluatorIdentifier implements Name<String> {
   }
 
+  /**
+   * The Evaluator Host.
+   */
   @NamedParameter(doc = "The Evaluator Host.")
   public static final class EvaluatorDescriptorName implements Name<EvaluatorDescriptorImpl> {
   }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorState.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorState.java
@@ -31,7 +31,7 @@ enum EvaluatorState {
   ALLOCATED,  // initial state
   SUBMITTED,  // client called AllocatedEvaluator.submitTask() and we're waiting for first contact
   RUNNING,    // first contact received, all communication channels established, Evaluator sent to client.
-  // TODO: Add CLOSING state
+  // TODO[JIRA REEF-832]: Add CLOSING state
   DONE,       // clean shutdown
   FAILED,     // some failure occurred.
   KILLED      // unclean shutdown

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/parameters/ClientRemoteIdentifier.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/parameters/ClientRemoteIdentifier.java
@@ -30,6 +30,7 @@ public final class ClientRemoteIdentifier implements Name<String> {
   /**
    * Indicates that there is no Client.
    */
+  // TODO[JIRA REEF-837]: Replace comparisons with this constant with interface with different implementations
   public static final String NONE = ErrorHandlerRID.NONE;
 
   /**

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceManagerStatus.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceManagerStatus.java
@@ -146,7 +146,7 @@ public final class ResourceManagerStatus implements EventHandler<RuntimeStatusEv
 
 
   private synchronized void setState(final ReefServiceProtos.State state) {
-    // TODO: Add state transition check
+    // TODO[JIRA REEF-826]: Add state transition check
     this.state = state;
   }
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/CompletedTaskImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/CompletedTaskImpl.java
@@ -24,6 +24,9 @@ import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.task.CompletedTask;
 
+/**
+ * Implementation of CompletedTask.
+ */
 @Private
 @DriverSide
 public final class CompletedTaskImpl implements CompletedTask {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/SuspendedTaskImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/SuspendedTaskImpl.java
@@ -23,6 +23,9 @@ import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.context.ActiveContext;
 import org.apache.reef.driver.task.SuspendedTask;
 
+/**
+ * Implementation of SuspendedTask.
+ */
 @Private
 @DriverSide
 public final class SuspendedTaskImpl implements SuspendedTask {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/TaskMessageImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/task/TaskMessageImpl.java
@@ -22,6 +22,9 @@ import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.task.TaskMessage;
 
+/**
+ * Implementation of TaskMessage.
+ */
 @Private
 @DriverSide
 public final class TaskMessageImpl implements TaskMessage {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/DefaultDriverConnection.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/DefaultDriverConnection.java
@@ -38,7 +38,7 @@ public final class DefaultDriverConnection implements DriverConnection {
   @Override
   public String getDriverRemoteIdentifier() {
     LOG.log(Level.FINE, "Trying to get driver remote identifier by querying Http server.");
-    // TODO: implement a proper mechanism to obtain driver remote identifier.
+    // TODO[JIRA REEF-843]: implement a proper mechanism to obtain driver remote identifier.
     throw new UnsupportedOperationException("Not implemented");
   }
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/HeartBeatManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/HeartBeatManager.java
@@ -38,6 +38,9 @@ import java.util.Collection;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * Heartbeat manager.
+ */
 @Unit
 public final class HeartBeatManager {
 
@@ -84,12 +87,12 @@ public final class HeartBeatManager {
   }
 
   /**
-   * Called with a specific TaskStatus that must be delivered to the driver.
+   * Called with a specific ContextStatus that must be delivered to the driver.
    */
   public synchronized void sendContextStatus(
       final ReefServiceProtos.ContextStatusProto contextStatusProto) {
 
-    // TODO: Write a test that checks for the order.
+    // TODO[JIRA REEF-833]: Write a test that verifies correct order of heartbeats.
     final Collection<ReefServiceProtos.ContextStatusProto> contextStatusList = new ArrayList<>();
     contextStatusList.add(contextStatusProto);
     contextStatusList.addAll(this.contextManager.get().getContextStatusCollection());
@@ -114,7 +117,7 @@ public final class HeartBeatManager {
   }
 
   /**
-   * Sends the actual heartbeat out and logs it, so desired.
+   * Sends the actual heartbeat out and logs it, if so desired.
    *
    * @param heartbeatProto
    */

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/ContextRuntime.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/ContextRuntime.java
@@ -77,7 +77,7 @@ public final class ContextRuntime {
 
   private Thread taskRuntimeThread = null;
 
-  // TODO: Which lock guards this?
+  // TODO[JIRA REEF-835]: Which lock guards this?
   private ReefServiceProtos.ContextStatusProto.State contextState =
       ReefServiceProtos.ContextStatusProto.State.READY;
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/parameters/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/parameters/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Parameters used by Evaluator.
  */
 package org.apache.reef.runtime.common.evaluator.parameters;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/TaskRuntime.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/TaskRuntime.java
@@ -69,7 +69,6 @@ public final class TaskRuntime implements Runnable {
 
   private final TaskStatus currentStatus;
 
-  // TODO: Document
   @Inject
   private TaskRuntime(
       final HeartBeatManager heartBeatManager,
@@ -86,7 +85,6 @@ public final class TaskRuntime implements Runnable {
         taskLifeCycleHandlers);
   }
 
-  // TODO: Document
   @Inject
   private TaskRuntime(
       final HeartBeatManager heartBeatManager,

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskStartHandlerFailure.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/TaskStartHandlerFailure.java
@@ -24,7 +24,7 @@ import org.apache.reef.task.events.TaskStart;
 import org.apache.reef.wake.EventHandler;
 
 /**
- * Thrown when a TastStart handler throws an exception.
+ * Thrown when a TaskStart handler throws an exception.
  */
 @EvaluatorSide
 @Private

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/exceptions/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Exceptions thrown by Tasks and Task Handlers.
  */
 package org.apache.reef.runtime.common.evaluator.task.exceptions;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/JavaLaunchCommandBuilder.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/JavaLaunchCommandBuilder.java
@@ -32,6 +32,9 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Build the launch command for Java REEF processes.
+ */
 public final class JavaLaunchCommandBuilder implements LaunchCommandBuilder {
   private static final Logger LOG = Logger.getLogger(JavaLaunchCommandBuilder.class.getName());
 
@@ -138,7 +141,7 @@ public final class JavaLaunchCommandBuilder implements LaunchCommandBuilder {
   /**
    * Set the path to the java executable. Will default to a heuristic search if not set.
    *
-   * @param path
+   * @param path Path to the java executable.
    * @return this
    */
   public JavaLaunchCommandBuilder setJavaPath(final String path) {
@@ -177,7 +180,7 @@ public final class JavaLaunchCommandBuilder implements LaunchCommandBuilder {
    * Enable or disable assertions on the child process.
    * If not set, the setting is taken from the JVM that executes the code.
    *
-   * @param assertionsEnabled
+   * @param assertionsEnabled If true, enable assertions.
    * @return this
    */
   @SuppressWarnings("checkstyle:hiddenfield")

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/REEFErrorHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/REEFErrorHandler.java
@@ -60,9 +60,6 @@ public final class REEFErrorHandler implements EventHandler<Throwable>, AutoClos
   @Override
   public void onNext(final Throwable e) {
     LOG.log(Level.SEVERE, "Uncaught exception.", e);
-    // TODO: This gets a new EventHandler each time an exception is caught. It would be better to cache the handler. But
-    // that introduces threading issues and isn't really worth it, as the JVM typically will be killed once we catch an
-    // Exception in here.
     if (!this.errorHandlerRID.equals(ErrorHandlerRID.NONE)) {
       final EventHandler<ReefServiceProtos.RuntimeErrorProto> runtimeErrorHandler = this.remoteManager.get()
           .getHandler(errorHandlerRID, ReefServiceProtos.RuntimeErrorProto.class);

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/parameters/ErrorHandlerRID.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/parameters/ErrorHandlerRID.java
@@ -21,13 +21,16 @@ package org.apache.reef.runtime.common.launch.parameters;
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
+/**
+ * The error handler remote identifier.
+ */
 @NamedParameter(doc = "The error handler remote identifier.", short_name = ErrorHandlerRID.SHORT_NAME,
     default_value = ErrorHandlerRID.NONE)
 public final class ErrorHandlerRID implements Name<String> {
   /**
    * Indicates that no ErrorHandler is bound.
    */
-  // TODO: Find all comparisons with this and see whether we can do something about them
+  // TODO[JIRA REEF-837]: Replace comparisons with this constant with interface with different implementations
   public static final String NONE = "NO_ERROR_HANDLER_REMOTE_ID";
 
   /**

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/parameters/LaunchID.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/parameters/LaunchID.java
@@ -21,6 +21,9 @@ package org.apache.reef.runtime.common.launch.parameters;
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
+/**
+ * The launch identifier.
+ */
 @NamedParameter(doc = "The launch identifier.", short_name = LaunchID.SHORT_NAME)
 public final class LaunchID implements Name<String> {
   public static final String SHORT_NAME = "launch_id";

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/package-info.java
@@ -21,6 +21,6 @@
  * This is referred to as the `common resourcemanager` that contains code
  * common to implementations of REEF on all resource managers.
  * The individual resource managers are implemented by providing implementations
- * of the various interfaces presribed in sub-packages called `API`.
+ * of the various interfaces prescribed in sub-packages called `API`.
  */
 package org.apache.reef.runtime.common;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/parameters/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/parameters/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Parameters used by runtime.
  */
 package org.apache.reef.runtime.common.parameters;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/BroadCastEventHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/BroadCastEventHandler.java
@@ -24,6 +24,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+/**
+ * Handler for BroadCastEvent which sends event to all handlers in the list.
+ */
 public class BroadCastEventHandler<E> implements EventHandler<E> {
   private final List<EventHandler<E>> handlers;
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/ExceptionCodec.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/ExceptionCodec.java
@@ -31,7 +31,7 @@ public interface ExceptionCodec {
    * Deserializes a Throwable that has been serialized using toBytes().
    *
    * @param bytes
-   * @return the Throable or Optional.empty() if the deserialization fails.
+   * @return the Throwable or Optional.empty() if the deserialization fails.
    */
   Optional<Throwable> fromBytes(final byte[] bytes);
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/RemoteManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/RemoteManager.java
@@ -26,6 +26,9 @@ import javax.inject.Inject;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * Wrapper for org.apache.reef.wake.remote.RemoteManager.
+ */
 public class RemoteManager {
 
   private static final Logger LOG = Logger.getLogger(RemoteManager.class.getName());
@@ -65,7 +68,7 @@ public class RemoteManager {
     return this.raw.registerHandler(messageType, theHandler);
   }
 
-  // TODO[REEF-547]: This method uses deprecated raw.registerErrorHandler.
+  // TODO[JIRA REEF-547]: This method uses deprecated raw.registerErrorHandler.
   public AutoCloseable registerErrorHandler(final EventHandler<Exception> theHandler) {
     return this.raw.registerErrorHandler(theHandler);
   }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/utils/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Runtime utilities used by various REEF modules.
  */
 package org.apache.reef.runtime.common.utils;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/task/events/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/task/events/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Task-related events.
  */
 package org.apache.reef.task.events;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/task/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/task/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Tasks.
  */
 package org.apache.reef.task;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/EnvironmentUtils.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/EnvironmentUtils.java
@@ -26,6 +26,9 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * Utils which detect environment settings.
+ */
 public final class EnvironmentUtils {
 
   private static final Logger LOG = Logger.getLogger(EnvironmentUtils.class.getName());

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/OSUtils.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/OSUtils.java
@@ -23,6 +23,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * OS utils.
+ */
 public final class OSUtils {
   private static final Logger LOG = Logger.getLogger(OSUtils.class.getName());
 
@@ -74,7 +77,7 @@ public final class OSUtils {
   /**
    * Applies `kill -9` to the process.
    *
-   * @param pid
+   * @param pid Process id
    * @throws IOException
    */
   public static void kill(final long pid) throws IOException, InterruptedException {
@@ -90,7 +93,7 @@ public final class OSUtils {
   }
 
   /**
-   * Formats the given variable for expansion by Windows (<code>%VARIABE%</code>) or Linux (<code>$VARIABLE</code>).
+   * Formats the given variable for expansion by Windows (<code>%VARIABLE%</code>) or Linux (<code>$VARIABLE</code>).
    *
    * @param variableName
    * @return

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/Config.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/Config.java
@@ -21,6 +21,9 @@ package org.apache.reef.util.logging;
 import java.io.IOException;
 import java.util.logging.LogManager;
 
+/**
+ * Wrapper for logging config.
+ */
 public final class Config {
 
   public Config() throws IOException {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Logging utilities.
  */
 package org.apache.reef.util.logging;

--- a/lang/java/reef-common/src/test/java/org/apache/reef/runtime/common/driver/catalog/CatalogTest.java
+++ b/lang/java/reef-common/src/test/java/org/apache/reef/runtime/common/driver/catalog/CatalogTest.java
@@ -22,13 +22,10 @@ import org.apache.reef.runtime.common.driver.resourcemanager.NodeDescriptorEvent
 import org.junit.Assert;
 import org.junit.Test;
 
+/**
+ * Basic catalog test that adds some nodes and checks that they exist.
+ */
 public final class CatalogTest {
-
-
-  /**
-   * Basic catalog test that addes some nodes and checks
-   * that they exist.
-   */
   @Test
   public void testResourceCatalog() {
     final int nodes = 10;

--- a/lang/java/reef-common/src/test/java/org/apache/reef/runtime/common/driver/catalog/package-info.java
+++ b/lang/java/reef-common/src/test/java/org/apache/reef/runtime/common/driver/catalog/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Tests for driver resource catalog.
  */
 package org.apache.reef.runtime.common.driver.catalog;

--- a/lang/java/reef-common/src/test/java/org/apache/reef/runtime/common/driver/package-info.java
+++ b/lang/java/reef-common/src/test/java/org/apache/reef/runtime/common/driver/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Tests for implementation of the Driver-side REEF APIs.
  */
 package org.apache.reef.runtime.common.driver;

--- a/lang/java/reef-common/src/test/java/org/apache/reef/runtime/common/launch/JavaLaunchCommandBuilderTest.java
+++ b/lang/java/reef-common/src/test/java/org/apache/reef/runtime/common/launch/JavaLaunchCommandBuilderTest.java
@@ -25,6 +25,9 @@ import java.util.List;
 import static org.apache.reef.runtime.common.launch.JavaLaunchCommandBuilder.JVMOption;
 import static org.junit.Assert.*;
 
+/**
+ * Test for JavaLaunchCommandBuilder.
+ */
 public final class JavaLaunchCommandBuilderTest {
 
   @Test

--- a/lang/java/reef-common/src/test/java/org/apache/reef/util/SingletonAsserterTest.java
+++ b/lang/java/reef-common/src/test/java/org/apache/reef/util/SingletonAsserterTest.java
@@ -23,6 +23,9 @@ import org.junit.Test;
 
 import java.util.List;
 
+/**
+ * Test for SingletonAsserter.
+ */
 public final class SingletonAsserterTest {
 
   @Test

--- a/lang/java/reef-common/src/test/java/org/apache/reef/util/package-info.java
+++ b/lang/java/reef-common/src/test/java/org/apache/reef/util/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Tests for utilities used by various REEF modules.
  */
 package org.apache.reef.util;


### PR DESCRIPTION
This adds missing Javadoc comments and links to JIRA items in TODOs.
Also fixes several typos.

JIRA:
  [REEF-523](https://issues.apache.org/jira/browse/REEF-523)

Pull request:
  This closes #