### PR TITLE
[REEF-588] DeadlockInfo throws NullPointerException when deadlock is not detected

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/DeadlockInfo.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/DeadlockInfo.java
@@ -36,11 +36,18 @@ import java.util.Map;
 final class DeadlockInfo {
   private final ThreadMXBean mxBean;
   private final ThreadInfo[] deadlockedThreads;
+  private final long[]  deadlockedThreadsIDs;
+  private static final ThreadInfo[] EMPTY_ARRAY = new ThreadInfo[0];
   private final Map<ThreadInfo, Map<StackTraceElement, List<MonitorInfo>>> monitorLockedElements;
 
   public DeadlockInfo() {
     mxBean = ManagementFactory.getThreadMXBean();
-    deadlockedThreads = mxBean.getThreadInfo(mxBean.findDeadlockedThreads(), true, true);
+    deadlockedThreadsIDs = mxBean.findDeadlockedThreads();
+
+    deadlockedThreads = (null == deadlockedThreadsIDs)
+                        ? EMPTY_ARRAY
+                        : mxBean.getThreadInfo(deadlockedThreadsIDs, true, true);
+
     monitorLockedElements = new HashMap<>();
     for (final ThreadInfo threadInfo : deadlockedThreads) {
       monitorLockedElements.put(threadInfo, constructMonitorLockedElements(threadInfo));
@@ -48,7 +55,7 @@ final class DeadlockInfo {
   }
 
   /**
-   * @return An array of deadlocked threads
+   * @return A (potentially empty) array of deadlocked threads
    */
   public ThreadInfo[] getDeadlockedThreads() {
     return deadlockedThreads;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/ThreadLogger.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/ThreadLogger.java
@@ -98,7 +98,15 @@ public final class ThreadLogger {
     final StringBuilder message = new StringBuilder(prefix);
 
     final DeadlockInfo deadlockInfo = new DeadlockInfo();
-    for (final ThreadInfo threadInfo : deadlockInfo.getDeadlockedThreads()) {
+
+    final ThreadInfo[] deadlockedThreads = deadlockInfo.getDeadlockedThreads();
+
+    if (0 == deadlockedThreads.length) {
+      message.append(" none ");
+      return message.toString();
+    }
+
+    for (final ThreadInfo threadInfo : deadlockedThreads) {
       message.append(threadPrefix).append("Thread '").append(threadInfo.getThreadName())
           .append("' with state ").append(threadInfo.getThreadState());
 

--- a/lang/java/reef-common/src/test/java/org/apache/reef/util/DeadlockInfoWithDeadlockAbsentTest.java
+++ b/lang/java/reef-common/src/test/java/org/apache/reef/util/DeadlockInfoWithDeadlockAbsentTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.reef.util;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Test DeadlockInfo by requesting information about
+ * non-deadlocked threads.
+ *
+ * Reproduces REEF-588.
+ */
+public class DeadlockInfoWithDeadlockAbsentTest {
+
+  private static final Logger LOG = Logger.getLogger(DeadlockInfoWithDeadlockAbsentTest.class.getName());
+
+  private static final long TIMEOUT_MILLIS = 100;
+
+  private static final CountDownLatch FIRST_LATCH = new CountDownLatch(1);
+  private static final CountDownLatch SECOND_LATCH = new CountDownLatch(1);
+
+  /**
+    * Create a situation where a deadlock is possible but not present.
+    *
+    * Sleep for TIMEOUT_MILLIS to allow this situation to set up.
+   *
+  */
+  @BeforeClass
+  public static void setUp(){
+    startNonDeadlockedThreads();
+    threadSleep(TIMEOUT_MILLIS);
+  }
+
+  /**
+   * Test the normal DeadlockInfo behaviour in the
+   * absence of deadlocks.
+   *
+   * DeadlockInfo instantiation reproduces the REEF-588
+   * because the NPE was thrown in the DeadlockInfo constructor.
+   */
+  @Test
+  public void testDeadlockInfoWithDeadlockAbsent()
+          throws NullPointerException {
+
+    final DeadlockInfo deadlockInfo = new DeadlockInfo();
+    LOG.log(Level.INFO, ThreadLogger.getFormattedDeadlockInfo(
+              "DeadlockInfo test, none deadlocks expected. Deadlocks found: "));
+    Assert.assertEquals("DeadlockInfo found deadlocks when none should exist.", 0,
+              deadlockInfo.getDeadlockedThreads().length);
+
+  }
+
+  /**
+   * Test logging in the absence of deadlocks.
+   */
+  @Test
+  public void testLogDeadlockInfo() throws NullPointerException {
+    LOG.log(Level.INFO, ThreadLogger.getFormattedDeadlockInfo(
+            "DeadlockInfo test, none deadlocks expected. Deadlocks found: "));
+  }
+
+  /**
+   * Create a situation where a deadlock is possible but not present.
+   *
+   * Assume there are two resources guarded by latches.
+   * The deadlock is possible if multiple threads attempt to acquire both latches.
+   *
+   * Spawn two threads so that each thread acquires only one latch.
+   * By design circular wait between the threads can't occur, so the deadlock can't exist.
+   *
+   * The threads wait on their latches until the DeadlockInfo tests finish.
+   * Then the tearDown() wakes up the threads to avoid liveness issues.
+   */
+  private static void startNonDeadlockedThreads(){
+
+    final Thread thread1 = new Thread(){
+        @Override
+        public void run(){
+            awaitOnLatch(FIRST_LATCH);
+        }
+    };
+
+    final Thread thread2 = new Thread(){
+        @Override
+        public void run(){
+            awaitOnLatch(SECOND_LATCH);
+        }
+    };
+
+    thread1.start();
+    thread2.start();
+  }
+
+  /**
+   * Allow both threads to finish.
+   */
+  @AfterClass
+  public static void tearDown(){
+    FIRST_LATCH.countDown();
+    SECOND_LATCH.countDown();
+  }
+
+  private static void awaitOnLatch(final CountDownLatch latch) {
+    try {
+      latch.await();
+    } catch (final InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private static void threadSleep(final long millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (final InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+}

--- a/lang/java/reef-common/src/test/java/org/apache/reef/util/DeadlockInfoWithDeadlockPresentTest.java
+++ b/lang/java/reef-common/src/test/java/org/apache/reef/util/DeadlockInfoWithDeadlockPresentTest.java
@@ -42,9 +42,9 @@ import static org.junit.Assert.fail;
 /**
  * Test DeadlockInfo by creating a deadlock.
  */
-public final class DeadlockInfoTest {
 
-  private static final Logger LOG = Logger.getLogger(DeadlockInfoTest.class.getName());
+public final class DeadlockInfoWithDeadlockPresentTest {
+  private static final Logger LOG = Logger.getLogger(DeadlockInfoWithDeadlockPresentTest.class.getName());
 
   private static final long TIMEOUT_MILLIS = 100;
 


### PR DESCRIPTION
This patch:

  * Adds a DeadlockInfoTestWithDeadlockAbsent to reproduce the NPE and test the normal behavior when a deadlock does not exist
  * Renames the DeadlockInfoTest to DeadlockInfoTestWithDeadlockPresent to avoid confusion
  * Adds a check to the DeadlockInfo constructor to test if the result of findDeadlockedThreads() is null
  * Makes DeadlockInfo return an empty ThreadInfo array if no deadlocks are found
  * Makes ThreadLogger log "none" if no deadlocks are found

JIRA:
  [REEF-588](https://issues.apache.org/jira/browse/REEF-588)