### PR TITLE
[REEF-831] Make YarnConfigurationUrlProviderTests stable

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client.Tests/YarnConfigurationUrlProviderTests.cs
+++ b/lang/cs/Org.Apache.REEF.Client.Tests/YarnConfigurationUrlProviderTests.cs
@@ -129,36 +129,6 @@ namespace Org.Apache.REEF.Client.Tests
         }
 
         [TestMethod]
-        public void UrlProviderReadsUpdatedConfigFile()
-        {
-            string tempFile = Path.GetTempFileName();
-            string tempDir = Path.GetDirectoryName(tempFile);
-            string yarnConfigFile = Path.Combine(tempDir, YarnConfigFileName);
-
-            using (new TempFileWriter(yarnConfigFile, YarnConfigurationXmlContent))
-            {
-                YarnConfigurationUrlProvider urlProvider = GetYarnConfigurationUrlProvider(
-                    anyHadoopConfigDir: tempDir);
-                var url = urlProvider.GetUrlAsync().GetAwaiter().GetResult();
-
-                Assert.AreEqual("http", url.Scheme);
-                Assert.AreEqual(AnyHttpAddressConfig.Split(':')[0], url.Host);
-                Assert.AreEqual(AnyHttpAddressConfig.Split(':')[1], url.Port.ToString(CultureInfo.InvariantCulture));
-
-                File.WriteAllText(yarnConfigFile, YarnConfigurationXmlContentChanged);
-
-                // Wait for file to be reloaded or timeout
-                Assert.IsTrue(urlProvider.TestHook_ConfigReloaded.Wait(TimeSpan.FromSeconds(10)), "Config reload failed");
-
-                url = urlProvider.GetUrlAsync().GetAwaiter().GetResult();
-                // assert updated changes loaded
-                Assert.AreEqual("http", url.Scheme);
-                Assert.AreEqual(AnyHttpAddressConfigUpdated.Split(':')[0], url.Host);
-                Assert.AreEqual(AnyHttpAddressConfigUpdated.Split(':')[1], url.Port.ToString(CultureInfo.InvariantCulture));
-            }
-        }
-
-        [TestMethod]
         public void CannotFindHadoopConfigDirThrowsArgumentException()
         {
             using (new TemporaryOverrideEnvironmentVariable(HadoopConfDirEnvVariable, string.Empty))

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnConfigurationUrlProvider.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnConfigurationUrlProvider.cs
@@ -18,7 +18,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Org.Apache.REEF.Tang.Annotations;
@@ -68,22 +67,7 @@ namespace Org.Apache.REEF.Client.Yarn.RestClient
             Logger.Log(Level.Verbose, "Using {0} as hadoop configuration directory", hadoopConfigDir);
             string yarnConfigurationFile = Path.Combine(hadoopConfigDir, YarnConfigFileName);
             LoadYarnConfiguration(yarnConfigurationFile, useHttps);
-
-            var configFileWatcher = new FileSystemWatcher(hadoopConfigDir, YarnConfigFileName)
-            {
-                NotifyFilter = NotifyFilters.LastWrite,
-                EnableRaisingEvents = true
-            };
-
-            TestHook_ConfigReloaded = new ManualResetEventSlim(false);
-            configFileWatcher.Changed += (sender, args) =>
-            {
-                LoadYarnConfiguration(yarnConfigurationFile, useHttps);
-                TestHook_ConfigReloaded.Set();
-            };
         }
-
-        internal ManualResetEventSlim TestHook_ConfigReloaded { get; set; }
 
         public Task<Uri> GetUrlAsync()
         {


### PR DESCRIPTION
The issue was caused by
 * There was a race between FileSystemWatcher holding a handle to the
 * config file being tested and the test itself trying to delete the
 * configuration file. Ideal solution is not to use physical files for
 * these tests but that is non-trivial amount of effort.

This addressed the issue by
 * Removing the config reloaded logic as it is not needed yet. We can
 * revisit if this is needed by users.

JIRA:
 [REEF-831](https://issues.apache.org/jira/browse/REEF-831)