### PR TITLE
[REEF-846] Make DriverSubmissionSettings class obsolete

### DIFF
--- a/lang/cs/Org.Apache.REEF.Driver/DriverSubmissionSettings.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/DriverSubmissionSettings.cs
@@ -24,6 +24,7 @@ namespace Org.Apache.REEF.Driver
 {
     // TODO: merge with EvaluatorConfigurations class
     // TODO[REEF-842] Act on the obsoletes
+    [Obsolete("Deprecated in 0.14. Please use DriverConfigurationSettings instead.")]
     public class DriverSubmissionSettings
     {
         // default to "ReefDevClrBridge"


### PR DESCRIPTION
This makes DriverSubmissionSettings class obsolete since it's unused.

JIRA:
  [REEF-846](https://issues.apache.org/jira/browse/REEF-846)

Pull Request:
  This closes #