### PR TITLE
[REEF-850] Delete or suppress verbose outputs in Unit Tests

### DIFF
--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/address/HostnameBasedLocalAddressProvider.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/address/HostnameBasedLocalAddressProvider.java
@@ -39,7 +39,7 @@ public final class HostnameBasedLocalAddressProvider implements LocalAddressProv
    */
   @Inject
   private HostnameBasedLocalAddressProvider() {
-    LOG.log(Level.INFO, "Instantiating HostnameBasedLocalAddressProvider");
+    LOG.log(Level.FINE, "Instantiating HostnameBasedLocalAddressProvider");
   }
 
   @Override

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/address/LegacyLocalAddressProvider.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/address/LegacyLocalAddressProvider.java
@@ -46,7 +46,7 @@ public final class LegacyLocalAddressProvider implements LocalAddressProvider {
    */
   @Inject
   private LegacyLocalAddressProvider() {
-    LOG.log(Level.INFO, "Instantiating LegacyLocalAddressProvider");
+    LOG.log(Level.FINE, "Instantiating LegacyLocalAddressProvider");
   }
 
   @Override

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestCombiner.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestCombiner.java
@@ -57,7 +57,6 @@ public class TestCombiner {
 
           @Override
           public void onNext(final Entry<Integer, Integer> value) {
-            System.out.println(value.getKey() + "=" + value.getValue());
             x.incrementAndGet();
             try {
               if (!done) {


### PR DESCRIPTION
This addresses the followings:
  * Delete println() from TestCombiner
  * Replace Level.INFO with Level.FINE in HostnameBasedLocalAddressProvider constructor
  * Replace Level.INFO with Level.FINE in LegacyLocalAddressProvider constructor

JIRA:
  [REEF-850](https://issues.apache.org/jira/browse/REEF-850)

Pull Request:
  This closes #