### PR TITLE
[REEF-851] Fix nondeterministic test bug in CommunicationGroupDriverI…

### DIFF
--- a/lang/java/reef-io/src/test/java/org/apache/reef/io/network/group/impl/driver/CommunicationGroupDriverImplTest.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/io/network/group/impl/driver/CommunicationGroupDriverImplTest.java
@@ -33,7 +33,7 @@ import org.apache.reef.tang.formats.AvroConfigurationSerializer;
 import org.apache.reef.task.Task;
 import org.apache.reef.wake.EStage;
 import org.apache.reef.wake.EventHandler;
-import org.apache.reef.wake.impl.ThreadPoolStage;
+import org.apache.reef.wake.impl.SyncStage;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -60,12 +60,12 @@ public final class CommunicationGroupDriverImplTest {
     final AtomicInteger numMsgs = new AtomicInteger(0);
 
     final EStage<GroupCommunicationMessage> senderStage =
-        new ThreadPoolStage<>(new EventHandler<GroupCommunicationMessage>() {
+        new SyncStage<>(new EventHandler<GroupCommunicationMessage>() {
           @Override
           public void onNext(final GroupCommunicationMessage msg) {
             numMsgs.getAndIncrement();
           }
-        }, 1);
+        });
 
     final CommunicationGroupDriverImpl communicationGroupDriver = new CommunicationGroupDriverImpl(
         GroupName.class, new AvroConfigurationSerializer(), senderStage,
@@ -143,12 +143,12 @@ public final class CommunicationGroupDriverImplTest {
     final AtomicInteger numMsgs = new AtomicInteger(0);
 
     final EStage<GroupCommunicationMessage> senderStage =
-        new ThreadPoolStage<>(new EventHandler<GroupCommunicationMessage>() {
+        new SyncStage<>(new EventHandler<GroupCommunicationMessage>() {
           @Override
           public void onNext(final GroupCommunicationMessage msg) {
             numMsgs.getAndIncrement();
           }
-        }, 1);
+        });
 
     final CommunicationGroupDriverImpl communicationGroupDriver = new CommunicationGroupDriverImpl(
         GroupName.class, new AvroConfigurationSerializer(), senderStage,


### PR DESCRIPTION
…mplTest

This addressed the issue by
* Replacing ThreadPoolStage with SyncStage to make test deterministic

JIRA: [REEF-851](https://issues.apache.org/jira/browse/REEF-851)