### PR TITLE
[REEF-848] updateIPartition<IEnumerable<T>> to IPartition<T>

### DIFF
--- a/lang/cs/Org.Apache.REEF.IO.TestClient/HadoopFilePartitionTest.cs
+++ b/lang/cs/Org.Apache.REEF.IO.TestClient/HadoopFilePartitionTest.cs
@@ -45,7 +45,7 @@ namespace Org.Apache.REEF.IO.TestClient
             string remoteFilePath2 = MakeRemoteTestFile(new byte[] { 114, 115, 116, 117 });
 
             var serializerConf = TangFactory.GetTang().NewConfigurationBuilder()
-                .BindImplementation<IFileDeSerializer<byte>, ByteSerializer>(GenericType<IFileDeSerializer<byte>>.Class,
+                .BindImplementation<IFileDeSerializer<IEnumerable<byte>>, ByteSerializer>(GenericType<IFileDeSerializer<IEnumerable<byte>>>.Class,
                     GenericType<ByteSerializer>.Class)
                 .Build();
             var serializerConfString = (new AvroConfigurationSerializer()).ToString(serializerConf);
@@ -134,7 +134,7 @@ namespace Org.Apache.REEF.IO.TestClient
         }
     }
 
-    internal class ByteSerializer : IFileDeSerializer<byte>
+    internal class ByteSerializer : IFileDeSerializer<IEnumerable<byte>>
     {
         [Inject]
         private ByteSerializer()

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestFilePartitionDataSet.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestFilePartitionDataSet.cs
@@ -234,7 +234,7 @@ namespace Org.Apache.REEF.IO.Tests
         {
             var serializerConf = TangFactory.GetTang().NewConfigurationBuilder()
                 .BindImplementation<IFileDeSerializer<IEnumerable<Row>>, RowSerializer>(
-                    GenericType < IFileDeSerializer<IEnumerable<Row>>>.Class,
+                    GenericType <IFileDeSerializer<IEnumerable<Row>>>.Class,
                     GenericType<RowSerializer>.Class)
                 .Build();
             return (new AvroConfigurationSerializer()).ToString(serializerConf);

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestFilePartitionDataSet.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestFilePartitionDataSet.cs
@@ -57,9 +57,11 @@ namespace Org.Apache.REEF.IO.Tests
             MakeLocalTestFile(sourceFilePath2, new byte[] { 114, 115, 116, 117 });
 
             var dataSet = TangFactory.GetTang()
-                .NewInjector(FileSystemPartitionConfiguration<byte>.ConfigurationModule
-                    .Set(FileSystemPartitionConfiguration<byte>.FilePathForPartitions, sourceFilePath1 + ";" + sourceFilePath2)
-                    .Set(FileSystemPartitionConfiguration<byte>.FileSerializerConfig, GetByteSerializerConfigString())
+                .NewInjector(FileSystemPartitionConfiguration<IEnumerable<byte>>.ConfigurationModule
+                    .Set(FileSystemPartitionConfiguration<IEnumerable<byte>>.FilePathForPartitions,
+                        sourceFilePath1 + ";" + sourceFilePath2)
+                    .Set(FileSystemPartitionConfiguration<IEnumerable<byte>>.FileSerializerConfig,
+                        GetByteSerializerConfigString())
                     .Build())
                 .GetInstance<IPartitionedDataSet>();
 
@@ -99,7 +101,8 @@ namespace Org.Apache.REEF.IO.Tests
             MakeLocalTestFile(sourceFilePath2, new byte[] { 114, 115, 116, 117 });
 
             var partitionConfig = TangFactory.GetTang().NewConfigurationBuilder()
-                .BindImplementation(GenericType<IPartitionedDataSet>.Class, GenericType<FileSystemPartitionDataSet<byte>>.Class)
+                .BindImplementation(GenericType<IPartitionedDataSet>.Class,
+                    GenericType<FileSystemPartitionDataSet<IEnumerable<byte>>>.Class)
                 .BindStringNamedParam<FileSerializerConfigString>(GetByteSerializerConfigString())
                 .BindSetEntry<FilePathsForPartitions, string>(GenericType<FilePathsForPartitions>.Class, sourceFilePath1)
                 .BindSetEntry<FilePathsForPartitions, string>(GenericType<FilePathsForPartitions>.Class, sourceFilePath2)
@@ -110,7 +113,6 @@ namespace Org.Apache.REEF.IO.Tests
                 .GetInstance<IPartitionedDataSet>();
 
             Assert.AreEqual(dataSet.Count, 2);
-
 
             foreach (var partitionDescriptor in dataSet)
             {
@@ -136,7 +138,7 @@ namespace Org.Apache.REEF.IO.Tests
             MakeLocalTestFile(sourceFilePath2, new byte[] { 114, 115, 116, 117 });
 
             var c = TangFactory.GetTang().NewConfigurationBuilder()
-                .BindImplementation(GenericType<IPartitionedDataSet>.Class, GenericType<FileSystemPartitionDataSet<byte>>.Class)
+                .BindImplementation(GenericType<IPartitionedDataSet>.Class, GenericType < FileSystemPartitionDataSet<IEnumerable<byte>>>.Class)
                 .BindStringNamedParam<FileSerializerConfigString>(GetByteSerializerConfigString())
                 .BindSetEntry<FilePathsForPartitions, string>(GenericType<FilePathsForPartitions>.Class, sourceFilePath1)
                 .BindSetEntry<FilePathsForPartitions, string>(GenericType<FilePathsForPartitions>.Class, sourceFilePath2)
@@ -155,7 +157,6 @@ namespace Org.Apache.REEF.IO.Tests
                         .GetInstance<IPartition<IEnumerable<byte>>>();
                 using (partition as IDisposable)
                 {
-
                     var e = partition.GetPartitionHandle();
                     foreach (var v in e)
                     {
@@ -177,10 +178,10 @@ namespace Org.Apache.REEF.IO.Tests
             MakeLocalTestFile(sourceFilePath2, new byte[] { 114, 115 });
 
             var dataSet = TangFactory.GetTang()
-                .NewInjector(FileSystemPartitionConfiguration<Row>.ConfigurationModule
-                    .Set(FileSystemPartitionConfiguration<Row>.FilePathForPartitions, sourceFilePath1)
-                    .Set(FileSystemPartitionConfiguration<Row>.FilePathForPartitions, sourceFilePath2)
-                    .Set(FileSystemPartitionConfiguration<Row>.FileSerializerConfig, GetRowSerializerConfigString())
+                .NewInjector(FileSystemPartitionConfiguration<IEnumerable<Row>>.ConfigurationModule
+                    .Set(FileSystemPartitionConfiguration<IEnumerable<Row>>.FilePathForPartitions, sourceFilePath1)
+                    .Set(FileSystemPartitionConfiguration<IEnumerable<Row>>.FilePathForPartitions, sourceFilePath2)
+                    .Set(FileSystemPartitionConfiguration<IEnumerable<Row>>.FileSerializerConfig, GetRowSerializerConfigString())
                     .Build())
                 .GetInstance<IPartitionedDataSet>();
 
@@ -222,8 +223,8 @@ namespace Org.Apache.REEF.IO.Tests
         private string GetByteSerializerConfigString()
         {
             var serializerConf = TangFactory.GetTang().NewConfigurationBuilder()
-                .BindImplementation<IFileDeSerializer<byte>, ByteSerializer>(
-                    GenericType<IFileDeSerializer<byte>>.Class,
+                .BindImplementation<IFileDeSerializer<IEnumerable<byte>>, ByteSerializer>(
+                    GenericType<IFileDeSerializer<IEnumerable<byte>>>.Class,
                     GenericType<ByteSerializer>.Class)
                 .Build();
             return (new AvroConfigurationSerializer()).ToString(serializerConf);
@@ -232,15 +233,15 @@ namespace Org.Apache.REEF.IO.Tests
         private string GetRowSerializerConfigString()
         {
             var serializerConf = TangFactory.GetTang().NewConfigurationBuilder()
-                .BindImplementation<IFileDeSerializer<Row>, RowSerializer>(
-                    GenericType<IFileDeSerializer<Row>>.Class,
+                .BindImplementation<IFileDeSerializer<IEnumerable<Row>>, RowSerializer>(
+                    GenericType < IFileDeSerializer<IEnumerable<Row>>>.Class,
                     GenericType<RowSerializer>.Class)
                 .Build();
             return (new AvroConfigurationSerializer()).ToString(serializerConf);
         }
     }
 
-    public class ByteSerializer : IFileDeSerializer<byte>
+    public class ByteSerializer : IFileDeSerializer<IEnumerable<byte>>
     {
         [Inject]
         public ByteSerializer()
@@ -282,7 +283,7 @@ namespace Org.Apache.REEF.IO.Tests
         }
     }
 
-    internal class RowSerializer : IFileDeSerializer<Row>
+    internal class RowSerializer : IFileDeSerializer<IEnumerable<Row>>
     {
         [Inject]
         private RowSerializer()

--- a/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FilePartitionDescriptor.cs
+++ b/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FilePartitionDescriptor.cs
@@ -53,7 +53,7 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
         public IConfiguration GetPartitionConfiguration()
         {
             var builder = TangFactory.GetTang().NewConfigurationBuilder()
-                .BindImplementation(GenericType<IPartition<IEnumerable<T>>>.Class, GenericType<FileSystemPartition<T>>.Class)
+                .BindImplementation(GenericType<IPartition<T>>.Class, GenericType<FileSystemPartition<T>>.Class)
                 .BindStringNamedParam<PartitionId>(_id);
 
             foreach (string p in _filePaths)

--- a/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemPartition.cs
+++ b/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemPartition.cs
@@ -30,7 +30,7 @@ using Org.Apache.REEF.Utilities.Logging;
 
 namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
 {
-    internal sealed class FileSystemPartition<T> : IPartition<IEnumerable<T>>, IDisposable
+    internal sealed class FileSystemPartition<T> : IPartition<T>, IDisposable
     {
         private static readonly Logger Logger = Logger.GetLogger(typeof(FileSystemPartition<T>));
 
@@ -78,7 +78,7 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
         /// provided by the Serializer
         /// </summary>
         /// <returns></returns>
-        public IEnumerable<T> GetPartitionHandle()
+        public T GetPartitionHandle()
         {
             if (!_isInitialized)
             {

--- a/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/IFileDeSerializer.cs
+++ b/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/IFileDeSerializer.cs
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-using System.Collections.Generic;
-
 namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
 {
     /// <summary>
@@ -29,11 +27,11 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
     {
         /// <summary>
         /// The input is a file folder which contains all input files in one partition.
-        /// The output is an IEnumerable of T which is defined by the client
+        /// The output is of type T which is defined by the client
         /// If there is any IO error, IOException could be thrown.
         /// </summary>
         /// <param name="fileFolder"></param>
         /// <returns></returns>
-        IEnumerable<T> Deserialize(string fileFolder);
+        T Deserialize(string fileFolder);
     }
 }


### PR DESCRIPTION
This PR uses T for the generic in IPartition.  Method GetPartitionHandle() also returns T.  It is up to the client to pass something like IEnumerable<U> for T.
Similarly, the return type from Deserialize() in FileDeSerializer also changed to T.
Test cases are updated as well.

JIRA: [REEF-848](https://issues.apache.org/jira/browse/REEF-848)

This closes #