### PR TITLE
[REEF-853] IIMRUClient does not return httpDriverEndPoint

### DIFF
--- a/lang/cs/Org.Apache.REEF.IMRU/API/IIMRUClient.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/API/IIMRUClient.cs
@@ -18,6 +18,8 @@
  */
 
 using System.Collections.Generic;
+using Org.Apache.REEF.Client.Common;
+using Org.Apache.REEF.Common.Attributes;
 
 namespace Org.Apache.REEF.IMRU.API
 {
@@ -32,5 +34,13 @@ namespace Org.Apache.REEF.IMRU.API
         /// <param name="jobDefinition">IMRU job definition</param>
         /// <returns>Result of IMRU</returns>
         IEnumerable<TResult> Submit<TMapInput, TMapOutput, TResult>(IMRUJobDefinition jobDefinition);
+
+        /// <summary>
+        /// DriverHttpEndPoint returned by IReefClient after job submission
+        /// returning null is a valid option for implementations that do not run on yarn or multi-core
+        /// For example: see InProcessIMRUCLient.cs
+        /// </summary>
+        [Unstable("0.13", "This depends on IREEFClient API which itself in unstable ")]
+        IDriverHttpEndpoint DriverHttpEndpoint { get; }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IMRU/InProcess/InProcessIMRUClient.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/InProcess/InProcessIMRUClient.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using Org.Apache.REEF.Client.Common;
 using Org.Apache.REEF.IMRU.API;
 using Org.Apache.REEF.IMRU.InProcess.Parameters;
 using Org.Apache.REEF.IO.PartitionedData;
@@ -44,7 +45,7 @@ namespace Org.Apache.REEF.IMRU.InProcess
     public class InProcessIMRUClient : IIMRUClient
     {
         private static readonly Logger Logger =
-            Logger.GetLogger(typeof (InProcessIMRUClient));
+            Logger.GetLogger(typeof(InProcessIMRUClient));
 
         private readonly int _numberOfMappers;
 
@@ -96,6 +97,14 @@ namespace Org.Apache.REEF.IMRU.InProcess
 
             var runner = injector.GetInstance<IMRURunner<TMapInput, TMapOutput, TResult>>();
             return runner.Run();
+        }
+
+        /// <summary>
+        /// DriverHttpEndPoint returned by IReefClient after job submission
+        /// </summary>
+        public IDriverHttpEndpoint DriverHttpEndpoint
+        {
+            get { return null; }
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Client/REEFIMRUClient.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Client/REEFIMRUClient.cs
@@ -21,6 +21,7 @@ using System.Data;
 using System.Globalization;
 using System.Linq;
 using Org.Apache.REEF.Client.API;
+using Org.Apache.REEF.Client.Common;
 using Org.Apache.REEF.Driver;
 using Org.Apache.REEF.IMRU.API;
 using Org.Apache.REEF.Driver.Bridge;
@@ -50,6 +51,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Client
         private readonly IREEFClient _reefClient;
         private readonly JobSubmissionBuilderFactory _jobSubmissionBuilderFactory;
         private readonly AvroConfigurationSerializer _configurationSerializer;
+        private IDriverHttpEndpoint _httpEndPoint;
 
         [Inject]
         private REEFIMRUClient(IREEFClient reefClient, AvroConfigurationSerializer configurationSerializer,
@@ -145,9 +147,17 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Client
                 .SetJobIdentifier(jobDefinition.JobName)
                 .Build();
 
-            _reefClient.SubmitAndGetDriverUrl(imruJobSubmission);
+            _httpEndPoint = _reefClient.SubmitAndGetDriverUrl(imruJobSubmission);
 
             return null;
+        }
+
+        /// <summary>
+        /// DriverHttpEndPoint returned by IReefClient after job submission
+        /// </summary>
+        public IDriverHttpEndpoint DriverHttpEndpoint
+        {
+            get { return _httpEndPoint; }
         }
     }
 }


### PR DESCRIPTION
This addressed the issue by
* Introducing a new member DriverHttpEndPoint in the IIMRUClient interface. This member/field is assigned after job is submitted.

JIRA:
[REEF-853](https://issues.apache.org/jira/browse/REEF-853)