### PR TITLE
[REEF-845] Make CommunicationGroupDriverImpl injectable

### DIFF
--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/CommunicationGroupDriver.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/CommunicationGroupDriver.java
@@ -23,7 +23,9 @@ import org.apache.reef.io.network.group.impl.config.BroadcastOperatorSpec;
 import org.apache.reef.io.network.group.impl.config.GatherOperatorSpec;
 import org.apache.reef.io.network.group.impl.config.ReduceOperatorSpec;
 import org.apache.reef.io.network.group.impl.config.ScatterOperatorSpec;
+import org.apache.reef.io.network.group.impl.driver.CommunicationGroupDriverImpl;
 import org.apache.reef.tang.Configuration;
+import org.apache.reef.tang.annotations.DefaultImplementation;
 import org.apache.reef.tang.annotations.Name;
 
 /**
@@ -33,6 +35,7 @@ import org.apache.reef.tang.annotations.Name;
  * to the Group Communication for a task in the comm group
  */
 @DriverSide
+@DefaultImplementation(CommunicationGroupDriverImpl.class)
 public interface CommunicationGroupDriver {
 
   /**

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/CommGroupMessageHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/CommGroupMessageHandler.java
@@ -24,9 +24,9 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
- * Message handler of the comm group.
+ * Name class of the comm group message handler.
  */
-@NamedParameter(doc = "Message handler of the comm group")
+@NamedParameter(doc = "Name class of the comm group message handler")
 public final class CommGroupMessageHandler implements Name<BroadcastingEventHandler<GroupCommunicationMessage>> {
   private CommGroupMessageHandler() {
   }

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/CommGroupMessageHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/CommGroupMessageHandler.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.io.network.group.impl.config.parameters;
+
+import org.apache.reef.io.network.group.impl.GroupCommunicationMessage;
+import org.apache.reef.io.network.group.impl.utils.BroadcastingEventHandler;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Message handler of comm group")
+public final class CommGroupMessageHandler implements Name<BroadcastingEventHandler<GroupCommunicationMessage>> {
+  private CommGroupMessageHandler() {
+  }
+}

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/CommGroupMessageHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/CommGroupMessageHandler.java
@@ -23,7 +23,10 @@ import org.apache.reef.io.network.group.impl.utils.BroadcastingEventHandler;
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
-@NamedParameter(doc = "Message handler of comm group")
+/**
+ * Message handler of the comm group.
+ */
+@NamedParameter(doc = "Message handler of the comm group")
 public final class CommGroupMessageHandler implements Name<BroadcastingEventHandler<GroupCommunicationMessage>> {
   private CommGroupMessageHandler() {
   }

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/CommGroupNameClass.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/CommGroupNameClass.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.io.network.group.impl.config.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Name class of the comm group")
+public final class CommGroupNameClass implements Name<Class<? extends Name<String>>> {
+  private CommGroupNameClass() {
+  }
+}

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/CommGroupNameClass.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/CommGroupNameClass.java
@@ -22,9 +22,9 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
- * Name class of the comm group.
+ * NamedParameter wrapper for the name class of the comm group.
  */
-@NamedParameter(doc = "Name class of the comm group")
+@NamedParameter(doc = "NamedParameter wrapper for the name class of the comm group")
 public final class CommGroupNameClass implements Name<Class<? extends Name<String>>> {
   private CommGroupNameClass() {
   }

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/CommGroupNameClass.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/CommGroupNameClass.java
@@ -21,6 +21,9 @@ package org.apache.reef.io.network.group.impl.config.parameters;
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
+/**
+ * Name class of the comm group.
+ */
 @NamedParameter(doc = "Name class of the comm group")
 public final class CommGroupNameClass implements Name<Class<? extends Name<String>>> {
   private CommGroupNameClass() {

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/CommGroupNumTask.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/CommGroupNumTask.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.io.network.group.impl.config.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Number of tasks in the comm group")
+public final class CommGroupNumTask implements Name<Integer> {
+  private CommGroupNumTask() {
+  }
+}

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/CommGroupNumTask.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/CommGroupNumTask.java
@@ -21,6 +21,9 @@ package org.apache.reef.io.network.group.impl.config.parameters;
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
+/**
+ * Number of tasks in the comm group.
+ */
 @NamedParameter(doc = "Number of tasks in the comm group")
 public final class CommGroupNumTask implements Name<Integer> {
   private CommGroupNumTask() {

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/CommGroupNumTask.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/CommGroupNumTask.java
@@ -22,9 +22,9 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
- * Number of tasks in the comm group.
+ * Name class of the number of tasks in the comm group.
  */
-@NamedParameter(doc = "Number of tasks in the comm group")
+@NamedParameter(doc = "Name class of the number of tasks in the comm group")
 public final class CommGroupNumTask implements Name<Integer> {
   private CommGroupNumTask() {
   }

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/GroupCommFailedEvalHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/GroupCommFailedEvalHandler.java
@@ -23,6 +23,9 @@ import org.apache.reef.io.network.group.impl.utils.BroadcastingEventHandler;
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
+/**
+ * Failed evaluator handler of group comm.
+ */
 @NamedParameter(doc = "Failed evaluator handler of group comm")
 public final class GroupCommFailedEvalHandler implements Name<BroadcastingEventHandler<FailedEvaluator>> {
   private GroupCommFailedEvalHandler() {

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/GroupCommFailedEvalHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/GroupCommFailedEvalHandler.java
@@ -24,9 +24,9 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
- * Failed evaluator handler of group comm.
+ * Name class of group comm failed evaluator handler.
  */
-@NamedParameter(doc = "Failed evaluator handler of group comm")
+@NamedParameter(doc = "Name class of group comm failed evaluator handler")
 public final class GroupCommFailedEvalHandler implements Name<BroadcastingEventHandler<FailedEvaluator>> {
   private GroupCommFailedEvalHandler() {
   }

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/GroupCommFailedEvalHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/GroupCommFailedEvalHandler.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.io.network.group.impl.config.parameters;
+
+import org.apache.reef.driver.evaluator.FailedEvaluator;
+import org.apache.reef.io.network.group.impl.utils.BroadcastingEventHandler;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Failed evaluator handler of group comm")
+public final class GroupCommFailedEvalHandler implements Name<BroadcastingEventHandler<FailedEvaluator>> {
+  private GroupCommFailedEvalHandler() {
+  }
+}

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/GroupCommFailedTaskHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/GroupCommFailedTaskHandler.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.io.network.group.impl.config.parameters;
+
+import org.apache.reef.driver.task.FailedTask;
+import org.apache.reef.io.network.group.impl.utils.BroadcastingEventHandler;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Failed task handler of group comm")
+public final class GroupCommFailedTaskHandler implements Name<BroadcastingEventHandler<FailedTask>> {
+  private GroupCommFailedTaskHandler() {
+  }
+}

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/GroupCommFailedTaskHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/GroupCommFailedTaskHandler.java
@@ -23,6 +23,9 @@ import org.apache.reef.io.network.group.impl.utils.BroadcastingEventHandler;
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
+/**
+ * Failed task handler of group comm.
+ */
 @NamedParameter(doc = "Failed task handler of group comm")
 public final class GroupCommFailedTaskHandler implements Name<BroadcastingEventHandler<FailedTask>> {
   private GroupCommFailedTaskHandler() {

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/GroupCommFailedTaskHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/GroupCommFailedTaskHandler.java
@@ -24,9 +24,9 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
- * Failed task handler of group comm.
+ * Name class of group comm failed task handler.
  */
-@NamedParameter(doc = "Failed task handler of group comm")
+@NamedParameter(doc = "Name class of group comm failed task handler")
 public final class GroupCommFailedTaskHandler implements Name<BroadcastingEventHandler<FailedTask>> {
   private GroupCommFailedTaskHandler() {
   }

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/GroupCommRunningTaskHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/GroupCommRunningTaskHandler.java
@@ -24,9 +24,9 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
- * Running task handler of group comm.
+ * Name class of group comm running task handler.
  */
-@NamedParameter(doc = "Running task handler of group comm")
+@NamedParameter(doc = "Name class of group comm running task handler")
 public final class GroupCommRunningTaskHandler implements Name<BroadcastingEventHandler<RunningTask>> {
   private GroupCommRunningTaskHandler() {
   }

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/GroupCommRunningTaskHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/GroupCommRunningTaskHandler.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.io.network.group.impl.config.parameters;
+
+import org.apache.reef.driver.task.RunningTask;
+import org.apache.reef.io.network.group.impl.utils.BroadcastingEventHandler;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Running task handler of group comm")
+public final class GroupCommRunningTaskHandler implements Name<BroadcastingEventHandler<RunningTask>> {
+  private GroupCommRunningTaskHandler() {
+  }
+}

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/GroupCommRunningTaskHandler.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/GroupCommRunningTaskHandler.java
@@ -23,6 +23,9 @@ import org.apache.reef.io.network.group.impl.utils.BroadcastingEventHandler;
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
+/**
+ * Running task handler of group comm.
+ */
 @NamedParameter(doc = "Running task handler of group comm")
 public final class GroupCommRunningTaskHandler implements Name<BroadcastingEventHandler<RunningTask>> {
   private GroupCommRunningTaskHandler() {

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/GroupCommSenderStage.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/GroupCommSenderStage.java
@@ -24,9 +24,9 @@ import org.apache.reef.tang.annotations.NamedParameter;
 import org.apache.reef.wake.EStage;
 
 /**
- * Sender stage of group comm.
+ * Name class of group comm sender stage.
  */
-@NamedParameter(doc = "Sender stage of group comm")
+@NamedParameter(doc = "Name class of group comm sender stage")
 public final class GroupCommSenderStage implements Name<EStage<GroupCommunicationMessage>> {
   private GroupCommSenderStage() {
   }

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/GroupCommSenderStage.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/GroupCommSenderStage.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.io.network.group.impl.config.parameters;
+
+import org.apache.reef.io.network.group.impl.GroupCommunicationMessage;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+import org.apache.reef.wake.EStage;
+
+@NamedParameter(doc = "Sender stage of group comm")
+public final class GroupCommSenderStage implements Name<EStage<GroupCommunicationMessage>> {
+  private GroupCommSenderStage() {
+  }
+}

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/GroupCommSenderStage.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/GroupCommSenderStage.java
@@ -23,6 +23,9 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 import org.apache.reef.wake.EStage;
 
+/**
+ * Sender stage of group comm.
+ */
 @NamedParameter(doc = "Sender stage of group comm")
 public final class GroupCommSenderStage implements Name<EStage<GroupCommunicationMessage>> {
   private GroupCommSenderStage() {

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/OperatorNameClass.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/OperatorNameClass.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.io.network.group.impl.config.parameters;
+
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+@NamedParameter(doc = "Name class of the operator")
+public final class OperatorNameClass implements Name<Class<? extends Name<String>>> {
+  private OperatorNameClass() {
+  }
+}

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/OperatorNameClass.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/OperatorNameClass.java
@@ -21,6 +21,9 @@ package org.apache.reef.io.network.group.impl.config.parameters;
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
+/**
+ * Name class of the operator.
+ */
 @NamedParameter(doc = "Name class of the operator")
 public final class OperatorNameClass implements Name<Class<? extends Name<String>>> {
   private OperatorNameClass() {

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/OperatorNameClass.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/OperatorNameClass.java
@@ -22,9 +22,9 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
- * Name class of the operator.
+ * NamedParameter wrapper for the name class of the operator.
  */
-@NamedParameter(doc = "Name class of the operator")
+@NamedParameter(doc = "NamedParameter wrapper for the name class of the operator")
 public final class OperatorNameClass implements Name<Class<? extends Name<String>>> {
   private OperatorNameClass() {
   }

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CommunicationGroupDriverFactory.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CommunicationGroupDriverFactory.java
@@ -18,13 +18,20 @@
  */
 package org.apache.reef.io.network.group.impl.driver;
 
+import org.apache.reef.driver.evaluator.FailedEvaluator;
+import org.apache.reef.driver.parameters.DriverIdentifier;
+import org.apache.reef.driver.task.FailedTask;
+import org.apache.reef.driver.task.RunningTask;
 import org.apache.reef.io.network.group.api.driver.CommunicationGroupDriver;
 import org.apache.reef.io.network.group.impl.GroupCommunicationMessage;
 import org.apache.reef.io.network.group.impl.config.parameters.*;
 import org.apache.reef.io.network.group.impl.utils.BroadcastingEventHandler;
 import org.apache.reef.tang.Injector;
+import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.tang.exceptions.InjectionException;
+import org.apache.reef.wake.EStage;
 
 import javax.inject.Inject;
 
@@ -37,8 +44,21 @@ public final class CommunicationGroupDriverFactory {
   private final Injector injector;
 
   @Inject
-  private CommunicationGroupDriverFactory(final Injector injector) {
-    this.injector = injector;
+  private CommunicationGroupDriverFactory(
+      @Parameter(DriverIdentifier.class) final String driverId,
+      @Parameter(GroupCommSenderStage.class) final EStage<GroupCommunicationMessage> senderStage,
+      @Parameter(GroupCommRunningTaskHandler.class)
+          final BroadcastingEventHandler<RunningTask> groupCommRunningTaskHandler,
+      @Parameter(GroupCommFailedTaskHandler.class)
+          final BroadcastingEventHandler<FailedTask> groupCommFailedTaskHandler,
+      @Parameter(GroupCommFailedEvalHandler.class)
+          final BroadcastingEventHandler<FailedEvaluator> groupCommFailedEvaluatorHandler) {
+    injector = Tang.Factory.getTang().newInjector();
+    injector.bindVolatileParameter(GroupCommSenderStage.class, senderStage);
+    injector.bindVolatileParameter(DriverIdentifier.class, driverId);
+    injector.bindVolatileParameter(GroupCommRunningTaskHandler.class, groupCommRunningTaskHandler);
+    injector.bindVolatileParameter(GroupCommFailedTaskHandler.class, groupCommFailedTaskHandler);
+    injector.bindVolatileParameter(GroupCommFailedEvalHandler.class, groupCommFailedEvaluatorHandler);
   }
 
   /**

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CommunicationGroupDriverFactory.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CommunicationGroupDriverFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.io.network.group.impl.driver;
+
+import org.apache.reef.io.network.group.api.driver.CommunicationGroupDriver;
+import org.apache.reef.io.network.group.impl.GroupCommunicationMessage;
+import org.apache.reef.io.network.group.impl.config.parameters.*;
+import org.apache.reef.io.network.group.impl.utils.BroadcastingEventHandler;
+import org.apache.reef.tang.Injector;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.exceptions.InjectionException;
+
+import javax.inject.Inject;
+
+/**
+ * A factory used to create CommunicationGroupDriver instance.
+ * Uses Tang to instantiate new object.
+ */
+public final class CommunicationGroupDriverFactory {
+
+  private final Injector injector;
+
+  @Inject
+  private CommunicationGroupDriverFactory(final Injector injector) {
+    this.injector = injector;
+  }
+
+  /**
+   * Instantiates a new CommunicationGroupDriver instance.
+   * @param groupName specified name of the communication group
+   * @param numberOfTasks minimum number of tasks needed in this group before start
+   * @param customFanOut fanOut for TreeTopology
+   * @return CommunicationGroupDriver instance
+   * @throws InjectionException
+   */
+  public CommunicationGroupDriver getNewInstance(
+      final Class<? extends Name<String>> groupName,
+      final BroadcastingEventHandler<GroupCommunicationMessage> commGroupMessageHandler,
+      final int numberOfTasks, final int customFanOut) throws InjectionException {
+
+    final Injector newInjector = injector.forkInjector();
+    newInjector.bindVolatileParameter(CommGroupNameClass.class, groupName);
+    newInjector.bindVolatileParameter(CommGroupMessageHandler.class, commGroupMessageHandler);
+    newInjector.bindVolatileParameter(CommGroupNumTask.class, numberOfTasks);
+    newInjector.bindVolatileParameter(TreeTopologyFanOut.class, customFanOut);
+    return newInjector.getInstance(CommunicationGroupDriver.class);
+  }
+}

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CommunicationGroupDriverFactory.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CommunicationGroupDriverFactory.java
@@ -52,7 +52,8 @@ public final class CommunicationGroupDriverFactory {
   public CommunicationGroupDriver getNewInstance(
       final Class<? extends Name<String>> groupName,
       final BroadcastingEventHandler<GroupCommunicationMessage> commGroupMessageHandler,
-      final int numberOfTasks, final int customFanOut) throws InjectionException {
+      final int numberOfTasks,
+      final int customFanOut) throws InjectionException {
 
     final Injector newInjector = injector.forkInjector();
     newInjector.bindVolatileParameter(CommGroupNameClass.class, groupName);

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CommunicationGroupDriverImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CommunicationGroupDriverImpl.java
@@ -33,9 +33,7 @@ import org.apache.reef.io.network.group.impl.config.BroadcastOperatorSpec;
 import org.apache.reef.io.network.group.impl.config.GatherOperatorSpec;
 import org.apache.reef.io.network.group.impl.config.ReduceOperatorSpec;
 import org.apache.reef.io.network.group.impl.config.ScatterOperatorSpec;
-import org.apache.reef.io.network.group.impl.config.parameters.CommunicationGroupName;
-import org.apache.reef.io.network.group.impl.config.parameters.OperatorName;
-import org.apache.reef.io.network.group.impl.config.parameters.SerializedOperConfigs;
+import org.apache.reef.io.network.group.impl.config.parameters.*;
 import org.apache.reef.io.network.group.impl.utils.BroadcastingEventHandler;
 import org.apache.reef.io.network.group.impl.utils.CountingSemaphore;
 import org.apache.reef.io.network.group.impl.utils.SetMap;
@@ -46,14 +44,17 @@ import org.apache.reef.tang.Injector;
 import org.apache.reef.tang.JavaConfigurationBuilder;
 import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.tang.formats.ConfigurationSerializer;
 import org.apache.reef.wake.EStage;
 
+import javax.inject.Inject;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 @DriverSide
@@ -68,9 +69,7 @@ public class CommunicationGroupDriverImpl implements CommunicationGroupDriver {
   private final Map<String, TaskState> perTaskState = new HashMap<>();
   private boolean finalised = false;
   private final ConfigurationSerializer confSerializer;
-  private final EStage<GroupCommunicationMessage> senderStage;
   private final String driverId;
-  private final int numberOfTasks;
 
   private final CountingSemaphore allTasksAdded;
 
@@ -83,33 +82,75 @@ public class CommunicationGroupDriverImpl implements CommunicationGroupDriver {
 
   private final SetMap<MsgKey, IndexedMsg> msgQue = new SetMap<>();
 
-  private final int fanOut;
+  private final TopologyFactory topologyFactory;
 
+  /**
+   * @Deprecated in 0.14. Use Tang to obtain an instance of this instead.
+   */
+  @Deprecated
   public CommunicationGroupDriverImpl(final Class<? extends Name<String>> groupName,
                                       final ConfigurationSerializer confSerializer,
                                       final EStage<GroupCommunicationMessage> senderStage,
-                                      final BroadcastingEventHandler<RunningTask> commGroupRunningTaskHandler,
-                                      final BroadcastingEventHandler<FailedTask> commGroupFailedTaskHandler,
-                                      final BroadcastingEventHandler<FailedEvaluator> commGroupFailedEvaluatorHandler,
+                                      final BroadcastingEventHandler<RunningTask> groupCommRunningTaskHandler,
+                                      final BroadcastingEventHandler<FailedTask> groupCommFailedTaskHandler,
+                                      final BroadcastingEventHandler<FailedEvaluator> groupCommFailedEvaluatorHandler,
                                       final BroadcastingEventHandler<GroupCommunicationMessage> commGroupMessageHandler,
                                       final String driverId, final int numberOfTasks, final int fanOut) {
     super();
     this.groupName = groupName;
-    this.numberOfTasks = numberOfTasks;
     this.driverId = driverId;
     this.confSerializer = confSerializer;
-    this.senderStage = senderStage;
-    this.fanOut = fanOut;
     this.allTasksAdded = new CountingSemaphore(numberOfTasks, getQualifiedName(), topologiesLock);
 
-    final TopologyRunningTaskHandler topologyRunningTaskHandler = new TopologyRunningTaskHandler(this);
-    commGroupRunningTaskHandler.addHandler(topologyRunningTaskHandler);
-    final TopologyFailedTaskHandler topologyFailedTaskHandler = new TopologyFailedTaskHandler(this);
-    commGroupFailedTaskHandler.addHandler(topologyFailedTaskHandler);
-    final TopologyFailedEvaluatorHandler topologyFailedEvaluatorHandler = new TopologyFailedEvaluatorHandler(this);
-    commGroupFailedEvaluatorHandler.addHandler(topologyFailedEvaluatorHandler);
-    final TopologyMessageHandler topologyMessageHandler = new TopologyMessageHandler(this);
-    commGroupMessageHandler.addHandler(topologyMessageHandler);
+    registerHandlers(groupCommRunningTaskHandler, groupCommFailedTaskHandler,
+        groupCommFailedEvaluatorHandler, commGroupMessageHandler);
+    final Injector injector = Tang.Factory.getTang().newInjector();
+    injector.bindVolatileParameter(CommGroupNameClass.class, groupName);
+    injector.bindVolatileParameter(GroupCommSenderStage.class, senderStage);
+    injector.bindVolatileParameter(DriverIdentifier.class, driverId);
+    injector.bindVolatileParameter(CommGroupNumTask.class, numberOfTasks);
+    injector.bindVolatileParameter(TreeTopologyFanOut.class, fanOut);
+    try {
+      topologyFactory = injector.getInstance(TopologyFactory.class);
+    } catch (final InjectionException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Inject
+  private CommunicationGroupDriverImpl(
+      @Parameter(CommGroupNameClass.class) final Class<? extends Name<String>> groupName,
+      final ConfigurationSerializer confSerializer,
+      @Parameter(GroupCommRunningTaskHandler.class)
+      final BroadcastingEventHandler<RunningTask> groupCommRunningTaskHandler,
+      @Parameter(GroupCommFailedTaskHandler.class)
+      final BroadcastingEventHandler<FailedTask> groupCommFailedTaskHandler,
+      @Parameter(GroupCommFailedEvalHandler.class)
+      final BroadcastingEventHandler<FailedEvaluator> groupCommFailedEvaluatorHandler,
+      @Parameter(CommGroupMessageHandler.class)
+      final BroadcastingEventHandler<GroupCommunicationMessage> commGroupMessageHandler,
+      @Parameter(DriverIdentifier.class) final String driverId,
+      @Parameter(CommGroupNumTask.class) final int numberOfTasks, final TopologyFactory topologyFactory) {
+    super();
+    this.groupName = groupName;
+    this.driverId = driverId;
+    this.confSerializer = confSerializer;
+    this.allTasksAdded = new CountingSemaphore(numberOfTasks, getQualifiedName(), topologiesLock);
+
+    registerHandlers(groupCommRunningTaskHandler, groupCommFailedTaskHandler,
+        groupCommFailedEvaluatorHandler, commGroupMessageHandler);
+    this.topologyFactory = topologyFactory;
+  }
+
+  private void registerHandlers(
+      final BroadcastingEventHandler<RunningTask> runningTaskHandler,
+      final BroadcastingEventHandler<FailedTask> failedTaskHandler,
+      final BroadcastingEventHandler<FailedEvaluator> failedEvaluatorHandler,
+      final BroadcastingEventHandler<GroupCommunicationMessage> groupCommMessageHandler) {
+    runningTaskHandler.addHandler(new TopologyRunningTaskHandler(this));
+    failedTaskHandler.addHandler(new TopologyFailedTaskHandler(this));
+    failedEvaluatorHandler.addHandler(new TopologyFailedEvaluatorHandler(this));
+    groupCommMessageHandler.addHandler(new TopologyMessageHandler(this));
   }
 
   @Override
@@ -121,7 +162,15 @@ public class CommunicationGroupDriverImpl implements CommunicationGroupDriver {
       throw new IllegalStateException("Can't add more operators to a finalised spec");
     }
     operatorSpecs.put(operatorName, spec);
-    final Topology topology = new TreeTopology(senderStage, groupName, operatorName, driverId, numberOfTasks, fanOut);
+
+    final Topology topology;
+    try {
+      topology = topologyFactory.getNewInstance(operatorName, TreeTopology.class);
+    } catch (final InjectionException e) {
+      LOG.log(Level.WARNING, "Cannot inject new topology named {0}", operatorName);
+      throw new RuntimeException(e);
+    }
+
     topology.setRootTask(spec.getSenderId());
     topology.setOperatorSpecification(spec);
     topologies.put(operatorName, topology);
@@ -140,7 +189,15 @@ public class CommunicationGroupDriverImpl implements CommunicationGroupDriver {
     }
     LOG.finer(getQualifiedName() + "Adding reduce operator to tree topology: " + spec);
     operatorSpecs.put(operatorName, spec);
-    final Topology topology = new TreeTopology(senderStage, groupName, operatorName, driverId, numberOfTasks, fanOut);
+
+    final Topology topology;
+    try {
+      topology = topologyFactory.getNewInstance(operatorName, TreeTopology.class);
+    } catch (final InjectionException e) {
+      LOG.log(Level.WARNING, "Cannot inject new topology named {0}", operatorName);
+      throw new RuntimeException(e);
+    }
+
     topology.setRootTask(spec.getReceiverId());
     topology.setOperatorSpecification(spec);
     topologies.put(operatorName, topology);
@@ -158,7 +215,15 @@ public class CommunicationGroupDriverImpl implements CommunicationGroupDriver {
       throw new IllegalStateException("Can't add more operators to a finalised spec");
     }
     operatorSpecs.put(operatorName, spec);
-    final Topology topology = new TreeTopology(senderStage, groupName, operatorName, driverId, numberOfTasks, fanOut);
+
+    final Topology topology;
+    try {
+      topology = topologyFactory.getNewInstance(operatorName, TreeTopology.class);
+    } catch (final InjectionException e) {
+      LOG.log(Level.WARNING, "Cannot inject new topology named {0}", operatorName);
+      throw new RuntimeException(e);
+    }
+
     topology.setRootTask(spec.getSenderId());
     topology.setOperatorSpecification(spec);
     topologies.put(operatorName, topology);
@@ -176,7 +241,15 @@ public class CommunicationGroupDriverImpl implements CommunicationGroupDriver {
       throw new IllegalStateException("Can't add more operators to a finalised spec");
     }
     operatorSpecs.put(operatorName, spec);
-    final Topology topology = new TreeTopology(senderStage, groupName, operatorName, driverId, numberOfTasks, fanOut);
+
+    final Topology topology;
+    try {
+      topology = topologyFactory.getNewInstance(operatorName, TreeTopology.class);
+    } catch (final InjectionException e) {
+      LOG.log(Level.WARNING, "Cannot inject new topology named {0}", operatorName);
+      throw new RuntimeException(e);
+    }
+
     topology.setRootTask(spec.getReceiverId());
     topology.setOperatorSpecification(spec);
     topologies.put(operatorName, topology);

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CommunicationGroupDriverImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CommunicationGroupDriverImpl.java
@@ -122,15 +122,16 @@ public class CommunicationGroupDriverImpl implements CommunicationGroupDriver {
       @Parameter(CommGroupNameClass.class) final Class<? extends Name<String>> groupName,
       final ConfigurationSerializer confSerializer,
       @Parameter(GroupCommRunningTaskHandler.class)
-      final BroadcastingEventHandler<RunningTask> groupCommRunningTaskHandler,
+          final BroadcastingEventHandler<RunningTask> groupCommRunningTaskHandler,
       @Parameter(GroupCommFailedTaskHandler.class)
-      final BroadcastingEventHandler<FailedTask> groupCommFailedTaskHandler,
+          final BroadcastingEventHandler<FailedTask> groupCommFailedTaskHandler,
       @Parameter(GroupCommFailedEvalHandler.class)
-      final BroadcastingEventHandler<FailedEvaluator> groupCommFailedEvaluatorHandler,
+          final BroadcastingEventHandler<FailedEvaluator> groupCommFailedEvaluatorHandler,
       @Parameter(CommGroupMessageHandler.class)
-      final BroadcastingEventHandler<GroupCommunicationMessage> commGroupMessageHandler,
+          final BroadcastingEventHandler<GroupCommunicationMessage> commGroupMessageHandler,
       @Parameter(DriverIdentifier.class) final String driverId,
-      @Parameter(CommGroupNumTask.class) final int numberOfTasks, final TopologyFactory topologyFactory) {
+      @Parameter(CommGroupNumTask.class) final int numberOfTasks,
+      final TopologyFactory topologyFactory) {
     super();
     this.groupName = groupName;
     this.driverId = driverId;

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/FlatTopology.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/FlatTopology.java
@@ -86,9 +86,9 @@ public class FlatTopology implements Topology {
 
   @Inject
   private FlatTopology(@Parameter(GroupCommSenderStage.class) final EStage<GroupCommunicationMessage> senderStage,
-                      @Parameter(CommGroupNameClass.class) final Class<? extends Name<String>> groupName,
-                      @Parameter(OperatorNameClass.class) final Class<? extends Name<String>> operatorName,
-                      @Parameter(DriverIdentifier.class) final String driverId) {
+                       @Parameter(CommGroupNameClass.class) final Class<? extends Name<String>> groupName,
+                       @Parameter(OperatorNameClass.class) final Class<? extends Name<String>> operatorName,
+                       @Parameter(DriverIdentifier.class) final String driverId) {
     this.senderStage = senderStage;
     this.groupName = groupName;
     this.operName = operatorName;

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/FlatTopology.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/FlatTopology.java
@@ -18,6 +18,7 @@
  */
 package org.apache.reef.io.network.group.impl.driver;
 
+import org.apache.reef.driver.parameters.DriverIdentifier;
 import org.apache.reef.io.network.group.api.operators.GroupCommOperator;
 import org.apache.reef.io.network.group.api.GroupChanges;
 import org.apache.reef.io.network.group.api.config.OperatorSpec;
@@ -30,9 +31,7 @@ import org.apache.reef.io.network.group.impl.config.BroadcastOperatorSpec;
 import org.apache.reef.io.network.group.impl.config.GatherOperatorSpec;
 import org.apache.reef.io.network.group.impl.config.ReduceOperatorSpec;
 import org.apache.reef.io.network.group.impl.config.ScatterOperatorSpec;
-import org.apache.reef.io.network.group.impl.config.parameters.DataCodec;
-import org.apache.reef.io.network.group.impl.config.parameters.ReduceFunctionParam;
-import org.apache.reef.io.network.group.impl.config.parameters.TaskVersion;
+import org.apache.reef.io.network.group.impl.config.parameters.*;
 import org.apache.reef.io.network.group.impl.operators.*;
 import org.apache.reef.io.network.group.impl.utils.Utils;
 import org.apache.reef.io.network.proto.ReefNetworkGroupCommProtos;
@@ -41,10 +40,12 @@ import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.JavaConfigurationBuilder;
 import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.wake.EStage;
 import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.impl.SingleThreadStage;
 
+import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -69,10 +70,25 @@ public class FlatTopology implements Topology {
   private TaskNode root;
   private final ConcurrentMap<String, TaskNode> nodes = new ConcurrentSkipListMap<>();
 
+  /**
+   * @Deprecated in 0.14. Use Tang to obtain an instance of this instead.
+   */
+  @Deprecated
   public FlatTopology(final EStage<GroupCommunicationMessage> senderStage,
                       final Class<? extends Name<String>> groupName,
                       final Class<? extends Name<String>> operatorName,
                       final String driverId, final int numberOfTasks) {
+    this.senderStage = senderStage;
+    this.groupName = groupName;
+    this.operName = operatorName;
+    this.driverId = driverId;
+  }
+
+  @Inject
+  private FlatTopology(@Parameter(GroupCommSenderStage.class) final EStage<GroupCommunicationMessage> senderStage,
+                      @Parameter(CommGroupNameClass.class) final Class<? extends Name<String>> groupName,
+                      @Parameter(OperatorNameClass.class) final Class<? extends Name<String>> operatorName,
+                      @Parameter(DriverIdentifier.class) final String driverId) {
     this.senderStage = senderStage;
     this.groupName = groupName;
     this.operName = operatorName;

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TopologyFactory.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TopologyFactory.java
@@ -18,11 +18,16 @@
  */
 package org.apache.reef.io.network.group.impl.driver;
 
+import org.apache.reef.driver.parameters.DriverIdentifier;
 import org.apache.reef.io.network.group.api.driver.Topology;
-import org.apache.reef.io.network.group.impl.config.parameters.OperatorNameClass;
+import org.apache.reef.io.network.group.impl.GroupCommunicationMessage;
+import org.apache.reef.io.network.group.impl.config.parameters.*;
 import org.apache.reef.tang.Injector;
+import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.tang.exceptions.InjectionException;
+import org.apache.reef.wake.EStage;
 
 import javax.inject.Inject;
 
@@ -35,8 +40,17 @@ public final class TopologyFactory {
   private final Injector injector;
 
   @Inject
-  private TopologyFactory(final Injector injector) {
-    this.injector = injector;
+  private TopologyFactory(@Parameter(GroupCommSenderStage.class) final EStage<GroupCommunicationMessage> senderStage,
+                          @Parameter(CommGroupNameClass.class) final Class<? extends Name<String>> groupName,
+                          @Parameter(DriverIdentifier.class) final String driverId,
+                          @Parameter(CommGroupNumTask.class) final int numberOfTasks,
+                          @Parameter(TreeTopologyFanOut.class) final int fanOut) {
+    injector = Tang.Factory.getTang().newInjector();
+    injector.bindVolatileParameter(GroupCommSenderStage.class, senderStage);
+    injector.bindVolatileParameter(CommGroupNameClass.class, groupName);
+    injector.bindVolatileParameter(DriverIdentifier.class, driverId);
+    injector.bindVolatileParameter(CommGroupNumTask.class, numberOfTasks);
+    injector.bindVolatileParameter(TreeTopologyFanOut.class, fanOut);
   }
 
   /**

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TopologyFactory.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TopologyFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.io.network.group.impl.driver;
+
+import org.apache.reef.io.network.group.api.driver.Topology;
+import org.apache.reef.io.network.group.impl.config.parameters.OperatorNameClass;
+import org.apache.reef.tang.Injector;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.exceptions.InjectionException;
+
+import javax.inject.Inject;
+
+/**
+ * A factory used to create Topology instance.
+ * Uses Tang to instantiate new object.
+ */
+public final class TopologyFactory {
+
+  private final Injector injector;
+
+  @Inject
+  private TopologyFactory(final Injector injector) {
+    this.injector = injector;
+  }
+
+  /**
+   * Instantiates a new Topology instance.
+   * @param operatorName specified name of the operator
+   * @param topologyClass specified topology type
+   * @return Topology instance
+   * @throws InjectionException
+   */
+  public Topology getNewInstance(final Class<? extends Name<String>> operatorName,
+                                 final Class<? extends Topology> topologyClass) throws InjectionException {
+    final Injector newInjector = injector.forkInjector();
+    newInjector.bindVolatileParameter(OperatorNameClass.class, operatorName);
+    return newInjector.getInstance(topologyClass);
+  }
+}

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TreeTopology.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TreeTopology.java
@@ -18,6 +18,7 @@
  */
 package org.apache.reef.io.network.group.impl.driver;
 
+import org.apache.reef.driver.parameters.DriverIdentifier;
 import org.apache.reef.io.network.group.api.operators.GroupCommOperator;
 import org.apache.reef.io.network.group.api.GroupChanges;
 import org.apache.reef.io.network.group.api.config.OperatorSpec;
@@ -30,9 +31,7 @@ import org.apache.reef.io.network.group.impl.config.BroadcastOperatorSpec;
 import org.apache.reef.io.network.group.impl.config.GatherOperatorSpec;
 import org.apache.reef.io.network.group.impl.config.ReduceOperatorSpec;
 import org.apache.reef.io.network.group.impl.config.ScatterOperatorSpec;
-import org.apache.reef.io.network.group.impl.config.parameters.DataCodec;
-import org.apache.reef.io.network.group.impl.config.parameters.ReduceFunctionParam;
-import org.apache.reef.io.network.group.impl.config.parameters.TaskVersion;
+import org.apache.reef.io.network.group.impl.config.parameters.*;
 import org.apache.reef.io.network.group.impl.operators.*;
 import org.apache.reef.io.network.group.impl.utils.Utils;
 import org.apache.reef.io.network.proto.ReefNetworkGroupCommProtos;
@@ -41,12 +40,14 @@ import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.JavaConfigurationBuilder;
 import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.Parameter;
 import org.apache.reef.tang.formats.AvroConfigurationSerializer;
 import org.apache.reef.tang.formats.ConfigurationSerializer;
 import org.apache.reef.wake.EStage;
 import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.impl.SingleThreadStage;
 
+import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -76,10 +77,28 @@ public class TreeTopology implements Topology {
   private final ConcurrentMap<String, TaskNode> nodes = new ConcurrentSkipListMap<>();
   private final ConfigurationSerializer confSer = new AvroConfigurationSerializer();
 
-
+  /**
+   * @Deprecated in 0.14. Use Tang to obtain an instance of this instead.
+   */
+  @Deprecated
   public TreeTopology(final EStage<GroupCommunicationMessage> senderStage,
-                      final Class<? extends Name<String>> groupName, final Class<? extends Name<String>> operatorName,
+                      final Class<? extends Name<String>> groupName,
+                      final Class<? extends Name<String>> operatorName,
                       final String driverId, final int numberOfTasks, final int fanOut) {
+    this.senderStage = senderStage;
+    this.groupName = groupName;
+    this.operName = operatorName;
+    this.driverId = driverId;
+    this.fanOut = fanOut;
+    LOG.config(getQualifiedName() + "Tree Topology running with a fan-out of " + fanOut);
+  }
+
+  @Inject
+  private TreeTopology(@Parameter(GroupCommSenderStage.class) final EStage<GroupCommunicationMessage> senderStage,
+                      @Parameter(CommGroupNameClass.class) final Class<? extends Name<String>> groupName,
+                      @Parameter(OperatorNameClass.class) final Class<? extends Name<String>> operatorName,
+                      @Parameter(DriverIdentifier.class) final String driverId,
+                      @Parameter(TreeTopologyFanOut.class) final int fanOut) {
     this.senderStage = senderStage;
     this.groupName = groupName;
     this.operName = operatorName;

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TreeTopology.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TreeTopology.java
@@ -95,10 +95,10 @@ public class TreeTopology implements Topology {
 
   @Inject
   private TreeTopology(@Parameter(GroupCommSenderStage.class) final EStage<GroupCommunicationMessage> senderStage,
-                      @Parameter(CommGroupNameClass.class) final Class<? extends Name<String>> groupName,
-                      @Parameter(OperatorNameClass.class) final Class<? extends Name<String>> operatorName,
-                      @Parameter(DriverIdentifier.class) final String driverId,
-                      @Parameter(TreeTopologyFanOut.class) final int fanOut) {
+                       @Parameter(CommGroupNameClass.class) final Class<? extends Name<String>> groupName,
+                       @Parameter(OperatorNameClass.class) final Class<? extends Name<String>> operatorName,
+                       @Parameter(DriverIdentifier.class) final String driverId,
+                       @Parameter(TreeTopologyFanOut.class) final int fanOut) {
     this.senderStage = senderStage;
     this.groupName = groupName;
     this.operName = operatorName;


### PR DESCRIPTION
This addressed the issue by
  * Make constructor of `CommunicationGroupDriverImpl`, `TreeTopology`, and `FlatTopology` injectable
  * Deprecate public constructors of `CommunicationGroupDriverImpl`, `TreeTopology`, and `FlatTopology`
  * Introduce `CommunicationGroupDriverFactory` and `TopologyFactory`
  * Fork injector to instantiate different communication groups and topologies

JIRA:
  [REEF-845](https://issues.apache.org/jira/browse/REEF-845)