### PR TITLE
[REEF-855] Improve Tang examples

### DIFF
--- a/lang/java/reef-tang/README.md
+++ b/lang/java/reef-tang/README.md
@@ -85,7 +85,7 @@ public class Timer {
     this.seconds = seconds;
   }
 
-  public void sleep() throws Exception {
+  public void sleep() throws InterruptedException {
     java.lang.Thread.sleep(seconds * 1000);
   }
 }
@@ -191,8 +191,8 @@ import org.apache.reef.tang.formats.OptionalParameter;
 public interface Timer {
   @NamedParameter(default_value="10",
       doc="Number of seconds to sleep", short_name="sec")
-  public static class Seconds implements Name<Integer> { }
-  public void sleep() throws Exception;
+  class Seconds implements Name<Integer> { }
+  void sleep() throws Exception;
 }
 
 public class TimerImpl implements Timer {
@@ -206,8 +206,8 @@ public class TimerImpl implements Timer {
     this.seconds = seconds;
   }
   @Override
-  public void sleep() throws Exception {
-    java.lang.Thread.sleep(seconds);
+  public void sleep() throws InterruptedException {
+    java.lang.Thread.sleep(seconds * 1000);
   }
 
 }
@@ -236,7 +236,7 @@ public class TimerMock implements Timer {
     System.out.println("Would have slept for " + seconds + "sec.");
   }
 
-  public static void main(String[] args) throws BindException, InjectionException, Exception {
+  public static void main(String[] args) throws BindException, InjectionException {
     Configuration c = TimerMock.CONF
       .set(TimerMockConf.MOCK_SLEEP_TIME, 1)
       .build();
@@ -546,7 +546,7 @@ InjectionPlan objects can be serialized to protocol buffers.  The following file
 
 https://github.com/apache/incubator-reef/blob/master/lang/java/reef-tang/tang/src/main/proto/injection_plan.proto
 
-### ClassHierachy
+### ClassHierarchy
 
 InjectionPlan explains what would happen if you asked Tang to take some action, but it doesn't provide much insight into Tang's view of the object hierarchy, parameter defaults and so on.  ClassHierarchy objects encode the state that Tang gets from .class files, including class inheritance relationships, parameter annotations, and so on.
 

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Tang.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Tang.java
@@ -138,7 +138,7 @@ public interface Tang {
   /**
    * A factory that returns the default implementation of the Tang interface.
    */
-  public final class Factory {
+  final class Factory {
     /**
      * Return an instance of the default implementation of Tang.
      *

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/examples/TimerV1.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/examples/TimerV1.java
@@ -41,7 +41,7 @@ public class TimerV1 {
 
   public static void main(final String[] args) throws BindException, InjectionException {
     final Tang tang = Tang.Factory.getTang();
-    final JavaConfigurationBuilder cb = (JavaConfigurationBuilder) tang.newConfigurationBuilder();
+    final JavaConfigurationBuilder cb = tang.newConfigurationBuilder();
     final Configuration conf = cb.build();
     final Injector injector = tang.newInjector(conf);
     final TimerV1 timer = injector.getInstance(TimerV1.class);

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/examples/timer/Timer.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/examples/timer/Timer.java
@@ -24,10 +24,10 @@ import org.apache.reef.tang.annotations.NamedParameter;
 
 @DefaultImplementation(TimerImpl.class)
 public interface Timer {
-  void sleep() throws Exception;
+  void sleep() throws InterruptedException;
 
   @NamedParameter(default_value = "10",
       doc = "Number of seconds to sleep", short_name = "sec")
-  public static class Seconds implements Name<Integer> {
+  class Seconds implements Name<Integer> {
   }
 }

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/examples/timer/TimerImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/examples/timer/TimerImpl.java
@@ -35,8 +35,8 @@ public class TimerImpl implements Timer {
   }
 
   @Override
-  public void sleep() throws Exception {
-    java.lang.Thread.sleep(seconds);
+  public void sleep() throws InterruptedException {
+    java.lang.Thread.sleep(seconds * 1000);
   }
 
 }

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/examples/timer/TimerMock.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/examples/timer/TimerMock.java
@@ -45,7 +45,7 @@ public class TimerMock implements Timer {
     this.seconds = seconds;
   }
 
-  public static void main(final String[] args) throws BindException, InjectionException, Exception {
+  public static void main(final String[] args) throws BindException, InjectionException, InterruptedException {
     final Configuration c = TimerMock.CONF
         .set(TimerMockConf.MOCK_SLEEP_TIME, 1)
         .build();
@@ -57,7 +57,7 @@ public class TimerMock implements Timer {
 
   @Override
   public void sleep() {
-    System.out.println("Would have slept for " + seconds + "sec.");
+    System.out.println("Would have slept for " + seconds + " sec.");
   }
 
   public static class TimerMockConf extends ConfigurationModuleBuilder {

--- a/website/src/site/markdown/tang.md
+++ b/website/src/site/markdown/tang.md
@@ -104,7 +104,7 @@ Suppose you are implementing a new class, and would like to automatically pass c
         this.seconds = seconds;
       }
     
-      public void sleep() throws Exception {
+      public void sleep() throws InterruptedException {
         java.lang.Thread.sleep(seconds * 1000);
       }
     }
@@ -151,7 +151,7 @@ In order for Tang to instantiate an object, we need to annotate the constructor 
         this.seconds = seconds;
       }
     
-      public void sleep() throws Exception {
+      public void sleep() throws InterruptedException {
         java.lang.Thread.sleep(seconds * 1000);
       }
     }
@@ -204,8 +204,8 @@ The process of instantiting an object with Tang is called _injection_.  As with 
     public interface Timer {
       @NamedParameter(default_value="10",
           doc="Number of seconds to sleep", short_name="sec")
-      public static class Seconds implements Name<Integer> { }
-      public void sleep() throws Exception;
+      class Seconds implements Name<Integer> { }
+      void sleep() throws InterruptedException;
     }
     
     public class TimerImpl implements Timer {
@@ -219,8 +219,8 @@ The process of instantiting an object with Tang is called _injection_.  As with 
         this.seconds = seconds;
       }
       @Override
-      public void sleep() throws Exception {
-        java.lang.Thread.sleep(seconds);
+      public void sleep() throws InterruptedException {
+        java.lang.Thread.sleep(seconds * 1000);
       }
     
     }
@@ -249,7 +249,7 @@ The process of instantiting an object with Tang is called _injection_.  As with 
         System.out.println("Would have slept for " + seconds + "sec.");
       }
     
-      public static void main(String[] args) throws BindException, InjectionException, Exception {
+      public static void main(String[] args) throws BindException, InjectionException, InterruptedException {
         Configuration c = TimerMock.CONF
           .set(TimerMockConf.MOCK_SLEEP_TIME, 1)
           .build();
@@ -270,7 +270,7 @@ Again, there are a few things going on here:
 `ConfigurationModule`s serve a number of purposes:
 
    - They allow application and library developers to encapsulate the details surrounding their code's instantiation.
-   - They provide Java APIs that expose `OptionalParameter`, `RequiredParameter`, `OptionalImplementation`, `RequiredImpementation` fields.  These fields tell users of the ConfigurationModule which subsystems of the application require which configuration parameters, and allow the author of the ConfigurationModule to use JavaDoc to document the parameters they export.
+   - They provide Java APIs that expose `OptionalParameter`, `RequiredParameter`, `OptionalImplementation`, `RequiredImplementation` fields.  These fields tell users of the ConfigurationModule which subsystems of the application require which configuration parameters, and allow the author of the ConfigurationModule to use JavaDoc to document the parameters they export.
    - Finally, because ConfigurationModule data structures are populated at class load time (before the application begins to run), they can be inspected by Tang's static analysis tools.
 
 These tools are provided by `org.apache.reef.tang.util.Tint`, which is included by default in all Tang builds.  As long as Tang is on the classpath, invoking:
@@ -453,3 +453,4 @@ ClassHierarchy objects can be serialized to protocol buffers.  The following fil
 The java interfaces are available in this package:
 
 [https://github.com/apache/incubator-reef/tree/master/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types](https://github.com/apache/incubator-reef/tree/master/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/types)
+


### PR DESCRIPTION
This PR addressed the followings:
  * Add a missing 1000 multiplier constant for seconds variable.
  * Use specific InterruptedException instead of Exception.
  * Remove redundant modifier in interface.
  * Fix some typos in markdown documents.

JIRA:
  [REEF-855](https://issues.apache.org/jira/browse/REEF-855)

Pull request:
  This closes #