### PR TITLE
[REEF-838] Enable checkstyle check for diamond operator

### DIFF
--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
@@ -142,7 +142,7 @@ public final class JobDriver {
   // We are holding on to following on bridge side.
   // Need to add references here so that GC does not collect them.
   private final HashMap<String, AllocatedEvaluatorBridge> allocatedEvaluatorBridges =
-      new HashMap<String, AllocatedEvaluatorBridge>();
+      new HashMap<>();
   private EvaluatorRequestorBridge evaluatorRequestorBridge;
 
 

--- a/lang/java/reef-common/src/main/resources/checkstyle-strict.xml
+++ b/lang/java/reef-common/src/main/resources/checkstyle-strict.xml
@@ -183,6 +183,11 @@
         <module name="MissingSwitchDefault"/>
         <module name="SimplifyBooleanExpression"/>
         <module name="SimplifyBooleanReturn"/>
+
+        <!-- Detects places in Java code where the diamond operator can be used -->
+        <!-- See REEF-838 -->
+        <module name="DiamondOperatorForVariableDefinition"/>
+
 	<module name="FinalParameters"/>
 
         <!-- Checks for class design                         -->

--- a/lang/java/reef-common/src/main/resources/checkstyle.xml
+++ b/lang/java/reef-common/src/main/resources/checkstyle.xml
@@ -184,6 +184,11 @@
         <module name="MissingSwitchDefault"/>
         <module name="SimplifyBooleanExpression"/>
         <module name="SimplifyBooleanReturn"/>
+
+        <!-- Detects places in Java code where the diamond operator can be used -->
+        <!-- See REEF-838 -->
+        <module name="DiamondOperatorForVariableDefinition" />
+
 	<module name="FinalParameters"/>
 
         <!-- Checks for class design                         -->

--- a/lang/java/reef-common/src/main/resources/packagenames.xml
+++ b/lang/java/reef-common/src/main/resources/packagenames.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE checkstyle-packages PUBLIC
+        "-//Puppy Crawl//DTD Package Names 1.0//EN"
+        "http://www.puppycrawl.com/dtds/packages_1_0.dtd">
+
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<checkstyle-packages>
+
+    <package name = "com.github.sevntu.checkstyle">
+            <package name = "checks">
+                <package name = "coding"/>
+            </package>
+    </package>
+
+</checkstyle-packages>

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/MasterTask.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/MasterTask.java
@@ -61,7 +61,7 @@ public class MasterTask implements Task {
   private final double lambda;
   private final int maxIters;
   private final ArrayList<Double> losses = new ArrayList<>();
-  private final Codec<ArrayList<Double>> lossCodec = new SerializableCodec<ArrayList<Double>>();
+  private final Codec<ArrayList<Double>> lossCodec = new SerializableCodec<>();
   private final Vector model;
 
   private boolean sendModel = true;

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/SuspendTestTask.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/SuspendTestTask.java
@@ -65,6 +65,7 @@ public class SuspendTestTask implements Task, TaskMessageSource {
   /**
    * Codec to serialize/deserialize checkpoint IDs for suspend/resume.
    */
+  @SuppressWarnings("checkstyle:diamondoperatorforvariabledefinition")
   private final ObjectWritableCodec<CheckpointID> codecCheckpoint =
       new ObjectWritableCodec<CheckpointID>(FSCheckpointID.class);
   /**

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/AbstractEvaluatorToPartitionStrategy.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/AbstractEvaluatorToPartitionStrategy.java
@@ -112,7 +112,7 @@ public abstract class AbstractEvaluatorToPartitionStrategy implements EvaluatorT
     for (int splitNum = 0; splitNum < splits.length; splitNum++) {
       LOG.log(Level.FINE, "Processing split: " + splitNum);
       final InputSplit split = splits[splitNum];
-      final NumberedSplit<InputSplit> numberedSplit = new NumberedSplit<InputSplit>(split, splitNum,
+      final NumberedSplit<InputSplit> numberedSplit = new NumberedSplit<>(split, splitNum,
           partitions[splitNum]);
       unallocatedSplits.add(numberedSplit);
       updateLocations(numberedSplit);

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/SingleDataCenterEvaluatorToPartitionStrategy.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/SingleDataCenterEvaluatorToPartitionStrategy.java
@@ -54,7 +54,7 @@ public final class SingleDataCenterEvaluatorToPartitionStrategy extends Abstract
       final InputSplit split = numberedSplit.getEntry();
       final String[] locations = split.getLocations();
       for (final String location : locations) {
-        BlockingQueue<NumberedSplit<InputSplit>> newSplitQue = new LinkedBlockingQueue<NumberedSplit<InputSplit>>();
+        BlockingQueue<NumberedSplit<InputSplit>> newSplitQue = new LinkedBlockingQueue<>();
         final BlockingQueue<NumberedSplit<InputSplit>> splitQue = locationToSplits.putIfAbsent(location, newSplitQue);
         if (splitQue != null) {
           newSplitQue = splitQue;

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/naming/NameClient.java
@@ -77,8 +77,8 @@ public final class NameClient implements NameResolver {
       final TransportFactory tpFactory) {
 
     final NameCache cache = new NameCache(timeout);
-    final BlockingQueue<NamingLookupResponse> replyLookupQueue = new LinkedBlockingQueue<NamingLookupResponse>();
-    final BlockingQueue<NamingRegisterResponse> replyRegisterQueue = new LinkedBlockingQueue<NamingRegisterResponse>();
+    final BlockingQueue<NamingLookupResponse> replyLookupQueue = new LinkedBlockingQueue<>();
+    final BlockingQueue<NamingRegisterResponse> replyRegisterQueue = new LinkedBlockingQueue<>();
     final Codec<NamingMessage> codec = NamingCodecFactory.createFullCodec(factory);
 
     this.transport = tpFactory.newInstance(localAddressProvider.getLocalAddress(), 0,

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/local/LocalScratchSpace.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/local/LocalScratchSpace.java
@@ -29,7 +29,7 @@ public class LocalScratchSpace implements ScratchSpace {
 
   private final String jobName;
   private final String evaluatorName;
-  private final Set<File> tempFiles = new ConcurrentSkipListSet<File>();
+  private final Set<File> tempFiles = new ConcurrentSkipListSet<>();
   /**
    * Zero denotes "unlimited".
    */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/ram/RamMap.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/ram/RamMap.java
@@ -34,7 +34,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
  */
 public class RamMap<T> implements ExternalMap<T> {
 
-  private final ConcurrentSkipListMap<CharSequence, T> map = new ConcurrentSkipListMap<CharSequence, T>();
+  private final ConcurrentSkipListMap<CharSequence, T> map = new ConcurrentSkipListMap<>();
 
   @Inject
   public RamMap(final RamStorageService ramStore) {

--- a/lang/java/reef-io/src/test/java/org/apache/reef/io/network/NetworkConnectionServiceTest.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/io/network/NetworkConnectionServiceTest.java
@@ -221,7 +221,7 @@ public class NetworkConnectionServiceTest {
   @Test
   public void testMessagingNetworkConnServiceRateDisjoint() throws Exception {
     LOG.log(Level.FINEST, name.getMethodName());
-    final BlockingQueue<Object> barrier = new LinkedBlockingQueue<Object>();
+    final BlockingQueue<Object> barrier = new LinkedBlockingQueue<>();
 
     final int numThreads = 4;
     final int size = 2000;

--- a/lang/java/reef-io/src/test/java/org/apache/reef/io/storage/MergingIteratorTest.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/io/storage/MergingIteratorTest.java
@@ -42,7 +42,7 @@ public class MergingIteratorTest {
         Arrays.asList(new Integer[]{2, 5, 8, 11}).iterator(),
         Arrays.asList(new Integer[]{3, 6, 9, 12}).iterator()
     };
-    MergingIterator<Integer> merge = new MergingIterator<Integer>(cmp, its);
+    MergingIterator<Integer> merge = new MergingIterator<>(cmp, its);
     int i = 1;
     while (merge.hasNext()) {
       Assert.assertEquals(i, (int) merge.next());

--- a/lang/java/reef-io/src/test/java/org/apache/reef/io/storage/SpoolFileTest.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/io/storage/SpoolFileTest.java
@@ -151,7 +151,7 @@ public class SpoolFileTest {
   @Test
   public void testFile() throws ServiceException {
     final LocalStorageService service = new LocalStorageService("spoolTest", "file");
-    final Spool<Integer> f = new SerializerFileSpool<Integer>(service, serializer,
+    final Spool<Integer> f = new SerializerFileSpool<>(service, serializer,
         deserializer);
     test(f);
     service.getScratchSpace().delete();
@@ -163,9 +163,9 @@ public class SpoolFileTest {
     final Codec<Integer> c = new IntegerCodec();
 
 
-    final CodecFileAccumulable<Integer, Codec<Integer>> f = new CodecFileAccumulable<Integer, Codec<Integer>>(
+    final CodecFileAccumulable<Integer, Codec<Integer>> f = new CodecFileAccumulable<>(
         service, c);
-    final CodecFileIterable<Integer, Codec<Integer>> g = new CodecFileIterable<Integer, Codec<Integer>>(
+    final CodecFileIterable<Integer, Codec<Integer>> g = new CodecFileIterable<>(
         new File(f.getName()), c);
     test(f, g);
     service.getScratchSpace().delete();

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationModuleBuilder.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationModuleBuilder.java
@@ -37,9 +37,9 @@ import java.util.Set;
 
 public abstract class ConfigurationModuleBuilder {
 
-  private static final Set<Class<?>> PARAM_BLACKLIST = new MonotonicHashSet<Class<?>>(
+  private static final Set<Class<?>> PARAM_BLACKLIST = new MonotonicHashSet<>(
       Param.class, Impl.class);
-  private static final Set<Class<?>> PARAM_TYPES = new MonotonicHashSet<Class<?>>(
+  private static final Set<Class<?>> PARAM_TYPES = new MonotonicHashSet<>(
       RequiredImpl.class, OptionalImpl.class, RequiredParameter.class,
       OptionalParameter.class);
   protected final JavaConfigurationBuilder b = Tang.Factory.getTang()

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/NonBlockingJoin.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/NonBlockingJoin.java
@@ -32,8 +32,8 @@ public class NonBlockingJoin implements StaticObservable {
 
   private final Observer<TupleEvent> out;
 
-  private final ConcurrentSkipListSet<TupleEvent> leftTable = new ConcurrentSkipListSet<TupleEvent>();
-  private final ConcurrentSkipListSet<TupleEvent> rightTable = new ConcurrentSkipListSet<TupleEvent>();
+  private final ConcurrentSkipListSet<TupleEvent> leftTable = new ConcurrentSkipListSet<>();
+  private final ConcurrentSkipListSet<TupleEvent> rightTable = new ConcurrentSkipListSet<>();
 
   public NonBlockingJoin(final Observer<TupleEvent> out) {
     this.out = out;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/HandlerContainer.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/HandlerContainer.java
@@ -56,9 +56,11 @@ final class HandlerContainer<T> implements EventHandler<RemoteEvent<byte[]>> {
     this.transport = transport;
   }
 
+  @SuppressWarnings("checkstyle:diamondoperatorforvariabledefinition")
   public AutoCloseable registerHandler(final RemoteIdentifier sourceIdentifier,
                                        final Class<? extends T> messageType,
                                        final EventHandler<? extends T> theHandler) {
+
 
     final Tuple2<RemoteIdentifier, Class<? extends T>> tuple =
         new Tuple2<RemoteIdentifier, Class<? extends T>>(sourceIdentifier, messageType);
@@ -120,6 +122,7 @@ final class HandlerContainer<T> implements EventHandler<RemoteEvent<byte[]>> {
    *
    * @param value
    */
+  @SuppressWarnings("checkstyle:diamondoperatorforvariabledefinition")
   @Override
   public synchronized void onNext(final RemoteEvent<byte[]> value) {
 

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestCombiner.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestCombiner.java
@@ -40,7 +40,7 @@ public class TestCombiner {
 
   @Test
   public void test() throws Exception {
-    final CombinerStage<Integer, Integer> stage = new CombinerStage<Integer, Integer>(
+    final CombinerStage<Integer, Integer> stage = new CombinerStage<>(
         new Combiner<Integer, Integer>() {
 
           @Override

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TransportTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TransportTest.java
@@ -72,7 +72,7 @@ public class TransportTest {
 
     // Codec<String>
     final ReceiverStage<String> stage =
-        new ReceiverStage<String>(new ObjectSerializableCodec<String>(), monitor, expected);
+        new ReceiverStage<>(new ObjectSerializableCodec<String>(), monitor, expected);
     final Transport transport = tpFactory.newInstance(hostAddress, port, stage, stage, 1, 10000);
 
     // sending side
@@ -104,7 +104,7 @@ public class TransportTest {
 
     // Codec<TestEvent>
     final ReceiverStage<TestEvent> stage =
-        new ReceiverStage<TestEvent>(new ObjectSerializableCodec<TestEvent>(), monitor, expected);
+        new ReceiverStage<>(new ObjectSerializableCodec<TestEvent>(), monitor, expected);
     final Transport transport = tpFactory.newInstance(hostAddress, port, stage, stage, 1, 10000);
 
     // sending side

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/RxTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/RxTest.java
@@ -35,7 +35,7 @@ public class RxTest {
   public void testRx() throws Exception {
     System.out.println(name.getMethodName());
 
-    final RxStage<TestEvent> stage = new RxThreadPoolStage<TestEvent>(new TestObserver("o1"), 1);
+    final RxStage<TestEvent> stage = new RxThreadPoolStage<>(new TestObserver("o1"), 1);
 
     int i = 0;
     try {

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/RxThreadPoolStageTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/RxThreadPoolStageTest.java
@@ -42,7 +42,7 @@ public class RxThreadPoolStageTest {
     System.out.println(name.getMethodName());
 
     final TestObserver to = new TestObserver("o1");
-    final RxStage<TestEvent> stage = new RxThreadPoolStage<TestEvent>(to, 1);
+    final RxStage<TestEvent> stage = new RxThreadPoolStage<>(to, 1);
 
     int i = 0;
     int sum = 0;
@@ -68,7 +68,7 @@ public class RxThreadPoolStageTest {
     System.out.println(name.getMethodName());
 
     final TestObserver to = new TestObserver("o1");
-    final RxStage<TestEvent> stage = new RxThreadPoolStage<TestEvent>(to, 11);
+    final RxStage<TestEvent> stage = new RxThreadPoolStage<>(to, 11);
 
     int i = 0;
     int sum = 0;
@@ -94,7 +94,7 @@ public class RxThreadPoolStageTest {
     System.out.println(name.getMethodName());
 
     final TestObserver to = new TestObserver("o1");
-    final RxStage<TestEvent> stage = new RxThreadPoolStage<TestEvent>(to, 11);
+    final RxStage<TestEvent> stage = new RxThreadPoolStage<>(to, 11);
 
     final int tn = 7;
     final ExecutorService taskmaster = Executors.newFixedThreadPool(tn);

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@ under the License.
         <jackson.version>1.9.13</jackson.version>
         <protobuf.version>2.5.0</protobuf.version>
         <maven-checkstyle-plugin.version>2.15</maven-checkstyle-plugin.version>
+        <sevntu.checkstyle.plugin.version>1.15.0</sevntu.checkstyle.plugin.version>
         <checkstyle.version>6.6</checkstyle.version>
         <findbugs.version>3.0.2</findbugs.version>
         <rootPath>${user.dir}</rootPath>
@@ -87,6 +88,14 @@ under the License.
     <prerequisites>
         <maven>3.0</maven>
     </prerequisites>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>sevntu-maven</id>
+            <name>sevntu-maven</name>
+            <url>http://sevntu-checkstyle.github.io/sevntu.checkstyle/maven2</url>
+        </pluginRepository>
+    </pluginRepositories>
 
     <build>
         <pluginManagement>
@@ -303,9 +312,15 @@ under the License.
                             <artifactId>checkstyle</artifactId>
                             <version>${checkstyle.version}</version>
                         </dependency>
+                        <dependency>
+                            <groupId>com.github.sevntu.checkstyle</groupId>
+                            <artifactId>sevntu-checkstyle-maven-plugin</artifactId>
+                            <version>${sevntu.checkstyle.plugin.version}</version>
+                        </dependency>
                     </dependencies>
                     <configuration>
                         <configLocation>lang/java/reef-common/src/main/resources/checkstyle.xml</configLocation>
+                        <packageNamesLocation>lang/java/reef-common/src/main/resources/packagenames.xml</packageNamesLocation>
                         <failOnViolation>true</failOnViolation>
                         <format>xml</format>
                         <format>html</format>


### PR DESCRIPTION
This patch:

 * Adds the 'sevntu.checkstyle' maven plugin as a build dependency
 * Adds 'packagenames.xml' to 'reef-common' resources to ease naming of the plugin's checks
 * Enables the DiamondOperatorForVariableDefinition check at the error level
 * Fixes the errors reported by this check
 * Suppresses the check's warnings if they are false positives

JIRA:
 [REEF-838] (https://issues.apache.org/jira/browse/REEF-838)