### PR TITLE
[REEF-859]:Debug c++ builds should target retail CRT.

### DIFF
--- a/lang/cs/Org.Apache.REEF.Bridge/Org.Apache.REEF.Bridge.vcxproj
+++ b/lang/cs/Org.Apache.REEF.Bridge/Org.Apache.REEF.Bridge.vcxproj
@@ -48,7 +48,7 @@ under the License.
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">    
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v120</PlatformToolset>
     <CLRSupport>true</CLRSupport>
@@ -82,6 +82,7 @@ under the License.
       <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <AdditionalIncludeDirectories>..\..\java\reef-bridge-java\target\classes;$(JAVA_HOME)\include;$(JAVA_HOME)\include\win32;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
This addressed the issue by changing the build file to target
retail CRT even for debug builds

JIRA: [REEF-859](https://issues.apache.org/jira/browse/REEF-859)

This closes #