### PR TITLE
 [REEF-576] Introduce IFileSystem in IUpdateFunction to write results  

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ git:
 
 jdk:
   - oraclejdk7
+  - oraclejdk8
 
 env: PATH=$PATH:$HOME/local/bin
 

--- a/lang/cs/Org.Apache.REEF.Bridge/InteropUtil.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/InteropUtil.cpp
@@ -133,3 +133,7 @@ JNIEnv* RetrieveEnv(JavaVM* jvm) {
   }
   return env;
 }
+
+String^ FormatJavaExceptionMessage(String^ errorMessage, Exception^ exception) {
+	return String::Concat(errorMessage, Environment::NewLine, exception->StackTrace);
+}

--- a/lang/cs/Org.Apache.REEF.Bridge/InteropUtil.h
+++ b/lang/cs/Org.Apache.REEF.Bridge/InteropUtil.h
@@ -63,6 +63,8 @@ jlongArray JavaLongArrayFromManagedLongArray(
 
 JNIEnv* RetrieveEnv(JavaVM* jvm);
 
+String^ FormatJavaExceptionMessage(String^ errorMessage, Exception^ exception);
+
 void HandleClr2JavaError(
   JNIEnv *env,
   String^ errorMessage,

--- a/lang/cs/Org.Apache.REEF.Bridge/JavaClrBridge.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/JavaClrBridge.cpp
@@ -131,9 +131,9 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemAl
     ClrSystemHandlerWrapper::Call_ClrSystemAllocatedEvaluatorHandler_OnNext(handle, allocatedEval);
   }
   catch (System::Exception^ ex) {
-    String^ errorMessage = "Exception in Call_clrSystemAllocatedEvaluatorHandler_OnNext";
+    String^ errorMessage = "Exception in Call_clrSystemAllocatedEvaluatorHandler_OnNext:";
     ManagedLog::LOGGER->LogError(errorMessage, ex);
-    allocatedEval -> OnError(errorMessage);
+    allocatedEval->OnError(FormatJavaExceptionMessage(errorMessage, ex));
   }
 }
 
@@ -145,14 +145,14 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemAl
 JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemActiveContextHandlerOnNext
 (JNIEnv *env, jclass cls, jlong handle, jobject jactiveContextBridge, jobject jlogger) {
   ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_clrSystemActiveContextHandlerOnNext");
-  ActiveContextClr2Java^ activeContextBrdige = gcnew ActiveContextClr2Java(env, jactiveContextBridge);
+  ActiveContextClr2Java^ activeContextBridge = gcnew ActiveContextClr2Java(env, jactiveContextBridge);
   try {
-    ClrSystemHandlerWrapper::Call_ClrSystemActiveContextHandler_OnNext(handle, activeContextBrdige);
+    ClrSystemHandlerWrapper::Call_ClrSystemActiveContextHandler_OnNext(handle, activeContextBridge);
   }
   catch (System::Exception^ ex) {
     String^ errorMessage = "Exception in Call_ClrSystemActiveContextHandler_OnNext";
     ManagedLog::LOGGER->LogError(errorMessage, ex);
-    activeContextBrdige -> OnError(errorMessage);
+    activeContextBridge->OnError(FormatJavaExceptionMessage(errorMessage, ex));
   }
 }
 
@@ -171,7 +171,7 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_ClrSystemEv
   catch (System::Exception^ ex) {
     String^ errorMessage = "Exception in Call_ClrSystemEvaluatorRequestor_OnNext";
     ManagedLog::LOGGER->LogError(errorMessage, ex);
-    evaluatorRequestorBridge -> OnError(errorMessage);
+    evaluatorRequestorBridge->OnError(FormatJavaExceptionMessage(errorMessage, ex));
   }
 }
 
@@ -191,7 +191,7 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemTa
   catch (System::Exception^ ex) {
     String^ errorMessage = "Exception in Call_ClrSystemTaskMessage_OnNext";
     ManagedLog::LOGGER->LogError(errorMessage, ex);
-    taskMesageBridge -> OnError(errorMessage);
+    taskMesageBridge->OnError(FormatJavaExceptionMessage(errorMessage, ex));
   }
 }
 
@@ -210,7 +210,7 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemFa
   catch (System::Exception^ ex) {
     String^ errorMessage = "Exception in Call_ClrSystemTaskMessage_OnNext";
     ManagedLog::LOGGER->LogError(errorMessage, ex);
-    failedTaskBridge -> OnError(errorMessage);
+    failedTaskBridge->OnError(FormatJavaExceptionMessage(errorMessage, ex));
   }
 }
 
@@ -229,7 +229,7 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemRu
   catch (System::Exception^ ex) {
     String^ errorMessage = "Exception in Call_ClrSystemRunningTask_OnNext";
     ManagedLog::LOGGER->LogError(errorMessage, ex);
-    runningTaskBridge -> OnError(errorMessage);
+    runningTaskBridge->OnError(FormatJavaExceptionMessage(errorMessage, ex));
   }
 }
 
@@ -248,7 +248,7 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemFa
   catch (System::Exception^ ex) {
     String^ errorMessage = "Exception in Call_ClrSystemFailedEvaluator_OnNext";
     ManagedLog::LOGGER->LogError(errorMessage, ex);
-    failedEvaluatorBridge -> OnError(errorMessage);
+    failedEvaluatorBridge->OnError(FormatJavaExceptionMessage(errorMessage, ex));
   }
 }
 
@@ -267,7 +267,7 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemHt
   catch (System::Exception^ ex) {
     String^ errorMessage = "Exception in Call_ClrSystemHttpServer_OnNext";
     ManagedLog::LOGGER->LogError(errorMessage, ex);
-    httpServerClr2Java -> OnError(errorMessage);
+    httpServerClr2Java->OnError(FormatJavaExceptionMessage(errorMessage, ex));
   }
 }
 
@@ -286,7 +286,7 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemCo
   catch (System::Exception^ ex) {
     String^ errorMessage = "Exception in Call_ClrSystemCompletedTask_OnNext";
     ManagedLog::LOGGER->LogError(errorMessage, ex);
-    completedTaskBridge -> OnError(errorMessage);
+    completedTaskBridge->OnError(FormatJavaExceptionMessage(errorMessage, ex));
   }
 }
 
@@ -351,7 +351,7 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemSu
   catch (System::Exception^ ex) {
     String^ errorMessage = "Exception in Call_ClrSystemSuspendedTask_OnNext";
     ManagedLog::LOGGER->LogError(errorMessage, ex);
-    suspendedTaskBridge -> OnError(errorMessage);
+    suspendedTaskBridge->OnError(FormatJavaExceptionMessage(errorMessage, ex));
   }
 }
 
@@ -370,7 +370,7 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemCo
   catch (System::Exception^ ex) {
     String^ errorMessage = "Exception in Call_ClrSystemCompletedEvaluator_OnNext";
     ManagedLog::LOGGER->LogError(errorMessage, ex);
-    completedEvaluatorBridge -> OnError(errorMessage);
+    completedEvaluatorBridge->OnError(FormatJavaExceptionMessage(errorMessage, ex));
   }
 }
 
@@ -389,7 +389,7 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemCl
   catch (System::Exception^ ex) {
     String^ errorMessage = "Exception in Call_ClrSystemClosedContext_OnNext";
     ManagedLog::LOGGER->LogError(errorMessage, ex);
-    closedContextBridge -> OnError(errorMessage);
+    closedContextBridge->OnError(FormatJavaExceptionMessage(errorMessage, ex));
   }
 }
 
@@ -408,7 +408,7 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemFa
   catch (System::Exception^ ex) {
     String^ errorMessage = "Exception in Call_ClrSystemFailedContext_OnNext";
     ManagedLog::LOGGER->LogError(errorMessage, ex);
-    failedContextBridge -> OnError(errorMessage);
+    failedContextBridge->OnError(FormatJavaExceptionMessage(errorMessage, ex));
   }
 }
 
@@ -427,7 +427,7 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemCo
   catch (System::Exception^ ex) {
     String^ errorMessage = "Exception in Call_ClrSystemContextMessage_OnNext";
     ManagedLog::LOGGER->LogError(errorMessage, ex);
-    contextMessageBridge -> OnError(errorMessage);
+    contextMessageBridge->OnError(FormatJavaExceptionMessage(errorMessage, ex));
   }
 }
 
@@ -462,14 +462,14 @@ JNIEXPORT jlongArray JNICALL Java_org_apache_reef_javabridge_NativeInterop_callC
 JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemDriverRestartActiveContextHandlerOnNext
 (JNIEnv *env, jclass cls, jlong handle, jobject jactiveContextBridge) {
   ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_clrSystemDriverRestartActiveContextHandlerOnNext");
-  ActiveContextClr2Java^ activeContextBrdige = gcnew ActiveContextClr2Java(env, jactiveContextBridge);
+  ActiveContextClr2Java^ activeContextBridge = gcnew ActiveContextClr2Java(env, jactiveContextBridge);
   try {
-    ClrSystemHandlerWrapper::Call_ClrSystemDriverRestartActiveContextHandler_OnNext(handle, activeContextBrdige);
+    ClrSystemHandlerWrapper::Call_ClrSystemDriverRestartActiveContextHandler_OnNext(handle, activeContextBridge);
   }
   catch (System::Exception^ ex) {
     String^ errorMessage = "Exception in Call_ClrSystemDriverRestartActiveContextHandler_OnNext";
     ManagedLog::LOGGER -> LogError(errorMessage, ex);
-    activeContextBrdige -> OnError(errorMessage);
+    activeContextBridge->OnError(FormatJavaExceptionMessage(errorMessage, ex));
   }
 }
 
@@ -488,7 +488,7 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemDr
   catch (System::Exception^ ex) {
     String^ errorMessage = "Exception in Call_ClrSystemDriverRestartRunningTask_OnNext";
     ManagedLog::LOGGER->LogError(errorMessage, ex);
-    runningTaskBridge -> OnError(errorMessage);
+    runningTaskBridge->OnError(FormatJavaExceptionMessage(errorMessage, ex));
   }
 }
 

--- a/lang/cs/Org.Apache.REEF.Bridge/JavaClrBridge.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/JavaClrBridge.cpp
@@ -57,6 +57,43 @@ static void MarshalErrorToJava (
   env->SetObjectField(jerrorInfo, fieldID, jexceptionString);
 }
 
+void populateJavaBridgeHandlerManager(JNIEnv * env, jobject jbridgeHandlerManager, BridgeHandlerManager^ bridgeHandlerManager) {
+    jclass cls = env->GetObjectClass(jbridgeHandlerManager);
+    jmethodID jsetAllocatedEvaluatorHandlerMid = env->GetMethodID(cls, "setAllocatedEvaluatorHandler", "(J)V");
+    env->CallVoidMethod(jbridgeHandlerManager, jsetAllocatedEvaluatorHandlerMid, bridgeHandlerManager->AllocatedEvaluatorHandler);
+    jmethodID jsetActiveContextHandlerMid = env->GetMethodID(cls, "setActiveContextHandler", "(J)V");
+    env->CallVoidMethod(jbridgeHandlerManager, jsetActiveContextHandlerMid, bridgeHandlerManager->ActiveContextHandler);
+    jmethodID jsetTaskMessageHandlerMid = env->GetMethodID(cls, "setTaskMessageHandler", "(J)V");
+    env->CallVoidMethod(jbridgeHandlerManager, jsetTaskMessageHandlerMid, bridgeHandlerManager->TaskMessageHandler);
+    jmethodID jsetFailedTaskHandlerMid = env->GetMethodID(cls, "setFailedTaskHandler", "(J)V");
+    env->CallVoidMethod(jbridgeHandlerManager, jsetFailedTaskHandlerMid, bridgeHandlerManager->FailedTaskHandler);
+    jmethodID jsetFailedEvaluatorHandlerMid = env->GetMethodID(cls, "setFailedEvaluatorHandler", "(J)V");
+    env->CallVoidMethod(jbridgeHandlerManager, jsetFailedEvaluatorHandlerMid, bridgeHandlerManager->FailedEvaluatorHandler);
+    jmethodID jsetHttpServerEventHandlerMid = env->GetMethodID(cls, "setHttpServerEventHandler", "(J)V");
+    env->CallVoidMethod(jbridgeHandlerManager, jsetHttpServerEventHandlerMid, bridgeHandlerManager->HttpServerHandler);
+    jmethodID jsetCompletedTaskHandlerMid = env->GetMethodID(cls, "setCompletedTaskHandler", "(J)V");
+    env->CallVoidMethod(jbridgeHandlerManager, jsetCompletedTaskHandlerMid, bridgeHandlerManager->CompletedTaskHandler);
+    jmethodID jsetRunningTaskHandlerMid = env->GetMethodID(cls, "setRunningTaskHandler", "(J)V");
+    env->CallVoidMethod(jbridgeHandlerManager, jsetRunningTaskHandlerMid, bridgeHandlerManager->RunningTaskHandler);
+    jmethodID jsetSuspendedTaskHandlerMid = env->GetMethodID(cls, "setSuspendedTaskHandler", "(J)V");
+    env->CallVoidMethod(jbridgeHandlerManager, jsetSuspendedTaskHandlerMid, bridgeHandlerManager->SuspendedTaskHandler);
+    jmethodID jsetCompletedEvaluatorHandlerMid = env->GetMethodID(cls, "setCompletedEvaluatorHandler", "(J)V");
+    env->CallVoidMethod(jbridgeHandlerManager, jsetCompletedEvaluatorHandlerMid, bridgeHandlerManager->CompletedEvaluatorHandler);
+    jmethodID jsetClosedContextHandlerMid = env->GetMethodID(cls, "setClosedContextHandler", "(J)V");
+    env->CallVoidMethod(jbridgeHandlerManager, jsetClosedContextHandlerMid, bridgeHandlerManager->ClosedContextHandler);
+    jmethodID jsetFailedContextHandlerMid = env->GetMethodID(cls, "setFailedContextHandler", "(J)V");
+    env->CallVoidMethod(jbridgeHandlerManager, jsetFailedContextHandlerMid, bridgeHandlerManager->FailedContextHandler);
+    jmethodID jsetContextMessageHandlerMid = env->GetMethodID(cls, "setContextMessageHandler", "(J)V");
+    env->CallVoidMethod(jbridgeHandlerManager, jsetContextMessageHandlerMid, bridgeHandlerManager->ContextMessageHandler);
+    jmethodID jsetDriverRestartActiveContextHandlerMid = env->GetMethodID(cls, "setDriverRestartActiveContextHandler", "(J)V");
+    env->CallVoidMethod(jbridgeHandlerManager, jsetDriverRestartActiveContextHandlerMid, bridgeHandlerManager->DriverRestartActiveContextHandler);
+    jmethodID jsetDriverRestartRunningTaskHandlerMid = env->GetMethodID(cls, "setDriverRestartRunningTaskHandler", "(J)V");
+    env->CallVoidMethod(jbridgeHandlerManager, jsetDriverRestartRunningTaskHandlerMid, bridgeHandlerManager->DriverRestartRunningTaskHandler);
+    jmethodID jsetDriverRestartCompletedHandlerMid = env->GetMethodID(cls, "setDriverRestartCompletedHandler", "(J)V");
+    env->CallVoidMethod(jbridgeHandlerManager, jsetDriverRestartCompletedHandlerMid, bridgeHandlerManager->DriverRestartCompletedHandler);
+    jmethodID jsetDriverRestartFailedEvaluatorHandlerMid = env->GetMethodID(cls, "setDriverRestartFailedEvaluatorHandler", "(J)V");
+    env->CallVoidMethod(jbridgeHandlerManager, jsetDriverRestartFailedEvaluatorHandlerMid, bridgeHandlerManager->DriverRestartFailedEvaluatorHandler);
+}
 
 // Loading Clr Assembly. Note that we do not use ManagerLogger in this method since the
 // logger assembly needs to be loaded by this method before it can be used.
@@ -97,10 +134,10 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_loadClrAsse
 /*
  * Class:     org_apache_reef_javabridge_NativeInterop
  * Method:    callClrSystemOnStartHandler
- * Signature: (Ljava/lang/String;Ljava/lang/String;Lorg/apache/reef/javabridge/EvaluatorRequestorBridge;)[J
+ * Signature: (Ljava/lang/String;Ljava/lang/String;Lorg/apache/reef/javabridge/BridgeHandlerManager;Lorg/apache/reef/javabridge/EvaluatorRequestorBridge;)V
  */
-JNIEXPORT jlongArray JNICALL Java_org_apache_reef_javabridge_NativeInterop_callClrSystemOnStartHandler
-(JNIEnv * env, jclass jclassx, jstring dateTimeString, jstring httpServerPort, jobject jevaluatorRequestorBridge) {
+JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_callClrSystemOnStartHandler
+(JNIEnv * env, jclass jclassx, jstring dateTimeString, jstring httpServerPort, jobject jbridgeHandlerManager, jobject jevaluatorRequestorBridge) {
   try {
     ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_callClrSystemOnStartHandler");
     DateTime dt = DateTime::Now;
@@ -108,13 +145,12 @@ JNIEXPORT jlongArray JNICALL Java_org_apache_reef_javabridge_NativeInterop_callC
 	String^ strPort = ManagedStringFromJavaString(env, httpServerPort);
 
 	EvaluatorRequestorClr2Java^ evaluatorRequestorBridge = gcnew EvaluatorRequestorClr2Java(env, jevaluatorRequestorBridge);
-	array<unsigned long long>^ handlers = ClrSystemHandlerWrapper::Call_ClrSystemStartHandler_OnStart(dt, strPort, evaluatorRequestorBridge);
-    return JavaLongArrayFromManagedLongArray(env, handlers);
+	BridgeHandlerManager^ handlerManager = ClrSystemHandlerWrapper::Call_ClrSystemStartHandler_OnStart(dt, strPort, evaluatorRequestorBridge);
+    populateJavaBridgeHandlerManager(env, jbridgeHandlerManager, handlerManager);
   }
   catch (System::Exception^ ex) {
     // we cannot get error back to java here since we don't have an object to call back (although we ideally should...)
     ManagedLog::LOGGER->LogError("Exceptions in Java_org_apache_reef_javabridge_NativeInterop_callClrSystemOnStartHandler", ex);
-    return NULL;
   }
 }
 
@@ -432,25 +468,24 @@ JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_clrSystemCo
 }
 
 /*
-* Class:     org_apache_reef_javabridge_NativeInterop
-* Method:    callClrSystemOnRestartHandler
-* Signature: (Ljava/lang/String;Lorg/apache/reef/javabridge/EvaluatorRequestorBridge;Lorg/apache/reef/javabridge/DriverRestartedBridge;)[J
-*/
-JNIEXPORT jlongArray JNICALL Java_org_apache_reef_javabridge_NativeInterop_callClrSystemOnRestartHandler
-(JNIEnv * env, jclass jclassx, jstring httpServerPort, jobject jevaluatorRequestorBridge, jobject jdriverRestartedBridge) {
+ * Class:     org_apache_reef_javabridge_NativeInterop
+ * Method:    callClrSystemOnRestartHandler
+ * Signature: (Ljava/lang/String;Lorg/apache/reef/javabridge/BridgeHandlerManager;Lorg/apache/reef/javabridge/EvaluatorRequestorBridge;Lorg/apache/reef/javabridge/DriverRestartedBridge;)V
+ */
+JNIEXPORT void JNICALL Java_org_apache_reef_javabridge_NativeInterop_callClrSystemOnRestartHandler
+(JNIEnv * env, jclass jclassx, jstring httpServerPort, jobject jbridgeHandlerManager, jobject jevaluatorRequestorBridge, jobject jdriverRestartedBridge) {
 	try {
 		ManagedLog::LOGGER->Log("+Java_org_apache_reef_javabridge_NativeInterop_callClrSystemOnRestartHandler");
 		String^ strPort = ManagedStringFromJavaString(env, httpServerPort);
 
 		EvaluatorRequestorClr2Java^ evaluatorRequestorBridge = gcnew EvaluatorRequestorClr2Java(env, jevaluatorRequestorBridge);
 		DriverRestartedClr2Java^ driverRestartedBridge = gcnew DriverRestartedClr2Java(env, jdriverRestartedBridge);
-		array<unsigned long long>^ handlers = ClrSystemHandlerWrapper::Call_ClrSystemRestartHandler_OnRestart(strPort, evaluatorRequestorBridge, driverRestartedBridge);
-		return JavaLongArrayFromManagedLongArray(env, handlers);
+        BridgeHandlerManager^ handlerManager = ClrSystemHandlerWrapper::Call_ClrSystemRestartHandler_OnRestart(strPort, evaluatorRequestorBridge, driverRestartedBridge);
+        populateJavaBridgeHandlerManager(env, jbridgeHandlerManager, handlerManager);
 	}
 	catch (System::Exception^ ex) {
 		// we cannot get error back to java here since we don't have an object to call back (although we ideally should...)
 		ManagedLog::LOGGER->LogError("Exceptions in Java_org_apache_reef_javabridge_NativeInterop_callClrSystemOnRestartHandler", ex);
-		return NULL;
 	}
 }
 
@@ -533,7 +568,7 @@ static JNINativeMethod methods[] = {
 
 	{ "clrBufferedLog", "(ILjava/lang/String;)V", (void*)&Java_org_apache_reef_javabridge_NativeInterop_clrBufferedLog },
 
-	{ "callClrSystemOnStartHandler", "(Ljava/lang/String;Ljava/lang/String;Lorg/apache/reef/javabridge/EvaluatorRequestorBridge;)[J",
+	{ "callClrSystemOnStartHandler", "(Ljava/lang/String;Ljava/lang/String;Lorg/apache/reef/javabridge/BridgeHandlerManager;Lorg/apache/reef/javabridge/EvaluatorRequestorBridge;)V",
 	(void*)&Java_org_apache_reef_javabridge_NativeInterop_callClrSystemOnStartHandler },
 
 	{ "clrSystemAllocatedEvaluatorHandlerOnNext", "(JLorg/apache/reef/javabridge/AllocatedEvaluatorBridge;Lorg/apache/reef/javabridge/InteropLogger;)V",
@@ -575,7 +610,7 @@ static JNINativeMethod methods[] = {
 	{ "clrSystemContextMessageHandlerOnNext", "(JLorg/apache/reef/javabridge/ContextMessageBridge;)V",
 	(void*)&Java_org_apache_reef_javabridge_NativeInterop_clrSystemContextMessageHandlerOnNext },
 
-	{ "callClrSystemOnRestartHandler", "(Ljava/lang/String;Lorg/apache/reef/javabridge/EvaluatorRequestorBridge;Lorg/apache/reef/javabridge/DriverRestartedBridge;)[J",
+	{ "callClrSystemOnRestartHandler", "(Ljava/lang/String;Lorg/apache/reef/javabridge/BridgeHandlerManager;Lorg/apache/reef/javabridge/EvaluatorRequestorBridge;Lorg/apache/reef/javabridge/DriverRestartedBridge;)V",
 	(void*)&Java_org_apache_reef_javabridge_NativeInterop_callClrSystemOnRestartHandler },
 
 	{ "clrSystemDriverRestartActiveContextHandlerOnNext", "(JLorg/apache/reef/javabridge/ActiveContextBridge;)V",

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/BridgeHandlerManager.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/BridgeHandlerManager.cs
@@ -1,0 +1,61 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Org.Apache.REEF.Driver.Bridge
+{
+    /// <summary>
+    /// A class that holds all .NET handles for Java InterOp calls.
+    /// </summary>
+    public sealed class BridgeHandlerManager
+    {
+        public ulong AllocatedEvaluatorHandler { get; internal set; }
+
+        public ulong TaskMessageHandler { get; internal set; }
+
+        public ulong ActiveContextHandler { get; internal set; }
+
+        public ulong FailedTaskHandler { get; internal set; }
+
+        public ulong RunningTaskHandler { get; internal set; }
+
+        public ulong CompletedTaskHandler { get; internal set; }
+
+        public ulong SuspendedTaskHandler { get; internal set; }
+
+        public ulong FailedEvaluatorHandler { get; internal set; }
+
+        public ulong CompletedEvaluatorHandler { get; internal set; }
+
+        public ulong ClosedContextHandler { get; internal set; }
+
+        public ulong FailedContextHandler { get; internal set; }
+
+        public ulong ContextMessageHandler { get; internal set; }
+
+        public ulong DriverRestartActiveContextHandler { get; internal set; }
+
+        public ulong DriverRestartRunningTaskHandler { get; internal set; }
+
+        public ulong DriverRestartCompletedHandler { get; internal set; }
+
+        public ulong DriverRestartFailedEvaluatorHandler { get; internal set; }
+
+        public ulong HttpServerHandler { get; internal set; }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/ClrSystemHandlerWrapper.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/ClrSystemHandlerWrapper.cs
@@ -230,20 +230,7 @@ namespace Org.Apache.REEF.Driver.Bridge
             }
         }
 
-        //Deprecate, remove after both Java and C# code gets checked in
-        public static ulong[] Call_ClrSystemStartHandler_OnStart(
-            DateTime startTime,
-            IEvaluatorRequestorClr2Java  evaluatorRequestorClr2Java)
-        {
-            IEvaluatorRequestor evaluatorRequestor = new EvaluatorRequestor(evaluatorRequestorClr2Java);
-            using (LOGGER.LogFunction("ClrSystemHandlerWrapper::Call_ClrSystemStartHandler_OnStart"))
-            {
-                LOGGER.Log(Level.Info, "*** Start time is " + startTime);
-                return GetHandlers(null, evaluatorRequestor);
-            }
-        }
-
-        public static ulong[] Call_ClrSystemStartHandler_OnStart(
+        public static BridgeHandlerManager Call_ClrSystemStartHandler_OnStart(
             DateTime startTime, 
             string httpServerPort,
             IEvaluatorRequestorClr2Java evaluatorRequestorClr2Java)
@@ -260,7 +247,7 @@ namespace Org.Apache.REEF.Driver.Bridge
             }   
         }
 
-        public static ulong[] Call_ClrSystemRestartHandler_OnRestart(
+        public static BridgeHandlerManager Call_ClrSystemRestartHandler_OnRestart(
             string httpServerPort,
             IEvaluatorRequestorClr2Java evaluatorRequestorClr2Java,
             IDriverRestartedClr2Java driverRestartedClr2Java)
@@ -277,7 +264,7 @@ namespace Org.Apache.REEF.Driver.Bridge
             }
         }
 
-        private static ulong[] GetHandlers(string httpServerPortNumber, IEvaluatorRequestor evaluatorRequestor)
+        private static BridgeHandlerManager GetHandlers(string httpServerPortNumber, IEvaluatorRequestor evaluatorRequestor)
         {
             var injector = BridgeConfigurationProvider.GetBridgeInjector(evaluatorRequestor);
 

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverBridge.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/DriverBridge.cs
@@ -203,9 +203,9 @@ namespace Org.Apache.REEF.Driver.Bridge
             _driverRestartFailedEvaluatorSubscriber = new ClrSystemHandler<IFailedEvaluator>();
         }
 
-        public ulong[] Subscribe()
+        public BridgeHandlerManager Subscribe()
         {
-            ulong[] handlers = Enumerable.Repeat(Constants.NullHandler, Constants.HandlersNumber).ToArray();
+            var bridgeHandlerManager = new BridgeHandlerManager();
 
             // subscribe to Allocated Evaluator
             foreach (var handler in _allocatedEvaluatorHandlers)
@@ -213,7 +213,7 @@ namespace Org.Apache.REEF.Driver.Bridge
                 _allocatedEvaluatorSubscriber.Subscribe(handler);
                 _logger.Log(Level.Verbose, "subscribed to IAllocatedEvaluator handler: " + handler);
             }
-            handlers[Constants.Handlers[Constants.AllocatedEvaluatorHandler]] = ClrHandlerHelper.CreateHandler(_allocatedEvaluatorSubscriber);
+            bridgeHandlerManager.AllocatedEvaluatorHandler = ClrHandlerHelper.CreateHandler(_allocatedEvaluatorSubscriber);
 
             // subscribe to TaskMessage
             foreach (var handler in _taskMessageHandlers)
@@ -221,7 +221,7 @@ namespace Org.Apache.REEF.Driver.Bridge
                 _taskMessageSubscriber.Subscribe(handler);
                 _logger.Log(Level.Verbose, "subscribed to ITaskMessage handler: " + handler);
             }
-            handlers[Constants.Handlers[Constants.TaskMessageHandler]] = ClrHandlerHelper.CreateHandler(_taskMessageSubscriber);
+            bridgeHandlerManager.TaskMessageHandler = ClrHandlerHelper.CreateHandler(_taskMessageSubscriber);
 
             // subscribe to Active Context
             foreach (var handler in _activeContextHandlers)
@@ -229,7 +229,7 @@ namespace Org.Apache.REEF.Driver.Bridge
                 _activeContextSubscriber.Subscribe(handler);
                 _logger.Log(Level.Verbose, "subscribed to IActiveContext handler: " + handler);
             }
-            handlers[Constants.Handlers[Constants.ActiveContextHandler]] = ClrHandlerHelper.CreateHandler(_activeContextSubscriber);
+            bridgeHandlerManager.ActiveContextHandler = ClrHandlerHelper.CreateHandler(_activeContextSubscriber);
 
             // subscribe to Failed Task
             foreach (var handler in _failedTaskHandlers)
@@ -237,7 +237,7 @@ namespace Org.Apache.REEF.Driver.Bridge
                 _failedTaskSubscriber.Subscribe(handler);
                 _logger.Log(Level.Verbose, "subscribed to IFailedTask handler: " + handler);
             }
-            handlers[Constants.Handlers[Constants.FailedTaskHandler]] = ClrHandlerHelper.CreateHandler(_failedTaskSubscriber);
+            bridgeHandlerManager.FailedTaskHandler = ClrHandlerHelper.CreateHandler(_failedTaskSubscriber);
 
             // subscribe to Running Task
             foreach (var handler in _runningTaskHandlers)
@@ -245,7 +245,7 @@ namespace Org.Apache.REEF.Driver.Bridge
                 _runningTaskSubscriber.Subscribe(handler);
                 _logger.Log(Level.Verbose, "subscribed to IRunningTask handler: " + handler);
             }
-            handlers[Constants.Handlers[Constants.RunningTaskHandler]] = ClrHandlerHelper.CreateHandler(_runningTaskSubscriber);
+            bridgeHandlerManager.RunningTaskHandler = ClrHandlerHelper.CreateHandler(_runningTaskSubscriber);
 
             // subscribe to Completed Task
             foreach (var handler in _completedTaskHandlers)
@@ -253,7 +253,7 @@ namespace Org.Apache.REEF.Driver.Bridge
                 _completedTaskSubscriber.Subscribe(handler);
                 _logger.Log(Level.Verbose, "subscribed to ICompletedTask handler: " + handler);
             }
-            handlers[Constants.Handlers[Constants.CompletedTaskHandler]] = ClrHandlerHelper.CreateHandler(_completedTaskSubscriber);
+            bridgeHandlerManager.CompletedTaskHandler = ClrHandlerHelper.CreateHandler(_completedTaskSubscriber);
 
             // subscribe to Suspended Task
             foreach (var handler in _suspendedTaskHandlers)
@@ -261,7 +261,7 @@ namespace Org.Apache.REEF.Driver.Bridge
                 _suspendedTaskSubscriber.Subscribe(handler);
                 _logger.Log(Level.Verbose, "subscribed to ISuspendedTask handler: " + handler);
             }
-            handlers[Constants.Handlers[Constants.SuspendedTaskHandler]] = ClrHandlerHelper.CreateHandler(_suspendedTaskSubscriber);
+            bridgeHandlerManager.SuspendedTaskHandler = ClrHandlerHelper.CreateHandler(_suspendedTaskSubscriber);
 
             // subscribe to Failed Evaluator
             foreach (var handler in _failedEvaluatorHandlers)
@@ -269,7 +269,7 @@ namespace Org.Apache.REEF.Driver.Bridge
                 _failedEvaluatorSubscriber.Subscribe(handler);
                 _logger.Log(Level.Verbose, "subscribed to IFailedEvaluator handler: " + handler);
             }
-            handlers[Constants.Handlers[Constants.FailedEvaluatorHandler]] = ClrHandlerHelper.CreateHandler(_failedEvaluatorSubscriber);
+            bridgeHandlerManager.FailedEvaluatorHandler = ClrHandlerHelper.CreateHandler(_failedEvaluatorSubscriber);
 
             // subscribe to Completed Evaluator
             foreach (var handler in _completedEvaluatorHandlers)
@@ -277,7 +277,7 @@ namespace Org.Apache.REEF.Driver.Bridge
                 _completedEvaluatorSubscriber.Subscribe(handler);
                 _logger.Log(Level.Verbose, "subscribed to ICompletedEvaluator handler: " + handler);
             }
-            handlers[Constants.Handlers[Constants.CompletedEvaluatorHandler]] = ClrHandlerHelper.CreateHandler(_completedEvaluatorSubscriber);
+            bridgeHandlerManager.CompletedEvaluatorHandler = ClrHandlerHelper.CreateHandler(_completedEvaluatorSubscriber);
 
             // subscribe to Closed Context
             foreach (var handler in _closedContextHandlers)
@@ -285,7 +285,7 @@ namespace Org.Apache.REEF.Driver.Bridge
                 _closedContextSubscriber.Subscribe(handler);
                 _logger.Log(Level.Verbose, "subscribed to IClosedContext handler: " + handler);
             }
-            handlers[Constants.Handlers[Constants.ClosedContextHandler]] = ClrHandlerHelper.CreateHandler(_closedContextSubscriber);
+            bridgeHandlerManager.ClosedContextHandler = ClrHandlerHelper.CreateHandler(_closedContextSubscriber);
 
             // subscribe to Failed Context
             foreach (var handler in _failedContextHandlers)
@@ -293,7 +293,7 @@ namespace Org.Apache.REEF.Driver.Bridge
                 _failedContextSubscriber.Subscribe(handler);
                 _logger.Log(Level.Verbose, "subscribed to IFailedContext handler: " + handler);
             }
-            handlers[Constants.Handlers[Constants.FailedContextHandler]] = ClrHandlerHelper.CreateHandler(_failedContextSubscriber);
+            bridgeHandlerManager.FailedContextHandler = ClrHandlerHelper.CreateHandler(_failedContextSubscriber);
 
             // subscribe to Context Message
             foreach (var handler in _contextMessageHandlers)
@@ -301,7 +301,7 @@ namespace Org.Apache.REEF.Driver.Bridge
                 _contextMessageSubscriber.Subscribe(handler);
                 _logger.Log(Level.Verbose, "subscribed to IContextMesage handler: " + handler);
             }
-            handlers[Constants.Handlers[Constants.ContextMessageHandler]] = ClrHandlerHelper.CreateHandler(_contextMessageSubscriber);
+            bridgeHandlerManager.ContextMessageHandler = ClrHandlerHelper.CreateHandler(_contextMessageSubscriber);
                 
             // subscribe to Active Context received during driver restart
             foreach (var handler in _driverRestartActiveContextHandlers)
@@ -309,7 +309,7 @@ namespace Org.Apache.REEF.Driver.Bridge
                 _driverRestartActiveContextSubscriber.Subscribe(handler);
                 _logger.Log(Level.Verbose, "subscribed to handler for IActiveContext received during driver restart: " + handler);
             }
-            handlers[Constants.Handlers[Constants.DriverRestartActiveContextHandler]] = ClrHandlerHelper.CreateHandler(_driverRestartActiveContextSubscriber);
+            bridgeHandlerManager.DriverRestartActiveContextHandler = ClrHandlerHelper.CreateHandler(_driverRestartActiveContextSubscriber);
 
             // subscribe to Running Task received during driver restart
             foreach (var handler in _driverRestartRunningTaskHandlers)
@@ -317,7 +317,7 @@ namespace Org.Apache.REEF.Driver.Bridge
                 _driverRestartRunningTaskSubscriber.Subscribe(handler);
                 _logger.Log(Level.Verbose, "subscribed to handler for IRunningTask received during driver restart: " + handler);
             }
-            handlers[Constants.Handlers[Constants.DriverRestartRunningTaskHandler]] = ClrHandlerHelper.CreateHandler(_driverRestartRunningTaskSubscriber);
+            bridgeHandlerManager.DriverRestartRunningTaskHandler = ClrHandlerHelper.CreateHandler(_driverRestartRunningTaskSubscriber);
 
             // subscribe to Restart Completed received during driver restart
             foreach (var handler in _driverRestartCompletedHandlers)
@@ -325,7 +325,7 @@ namespace Org.Apache.REEF.Driver.Bridge
                 _driverRestartCompletedSubscriber.Subscribe(handler);
                 _logger.Log(Level.Verbose, "subscribed to handler for IRestartCompleted received during driver restart: " + handler);
             }
-            handlers[Constants.Handlers[Constants.DriverRestartCompletedHandler]] = ClrHandlerHelper.CreateHandler(_driverRestartCompletedSubscriber);
+            bridgeHandlerManager.DriverRestartCompletedHandler = ClrHandlerHelper.CreateHandler(_driverRestartCompletedSubscriber);
 
             // subscribe to Failed Evaluator received during driver restart
             foreach (var handler in _driverRestartFailedEvaluatorHandlers)
@@ -333,14 +333,14 @@ namespace Org.Apache.REEF.Driver.Bridge
                 _driverRestartFailedEvaluatorSubscriber.Subscribe(handler);
                 _logger.Log(Level.Verbose, "subscribed to handler for IFailedEvaluator received during driver restart: " + handler);
             }
-            handlers[Constants.Handlers[Constants.DriverRestartFailedEvaluatorHandler]] = ClrHandlerHelper.CreateHandler(_driverRestartFailedEvaluatorSubscriber);
+            bridgeHandlerManager.DriverRestartFailedEvaluatorHandler = ClrHandlerHelper.CreateHandler(_driverRestartFailedEvaluatorSubscriber);
 
             // subscribe to Http message
             _httpServerEventSubscriber.Subscribe(_httpServerHandler);
             _logger.Log(Level.Verbose, "subscribed to IHttpMessage handler  :" + _httpServerHandler);
-            handlers[Constants.Handlers[Constants.HttpServerHandler]] = ClrHandlerHelper.CreateHandler(_httpServerEventSubscriber);
+            bridgeHandlerManager.HttpServerHandler = ClrHandlerHelper.CreateHandler(_httpServerEventSubscriber);
 
-            return handlers;
+            return bridgeHandlerManager;
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Driver/Constants.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Constants.cs
@@ -18,7 +18,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 
 namespace Org.Apache.REEF.Driver
 {
@@ -50,101 +49,6 @@ namespace Org.Apache.REEF.Driver
         /// The default memory granularity for evaluators.
         /// </summary>
         public const int DefaultMemoryGranularity = 1024;
-
-        /// <summary>
-        /// The number of handlers total. Tightly coupled with Java.
-        /// </summary>
-        public const int HandlersNumber = 18;
-
-        /// <summary>
-        /// The name for EvaluatorRequestorHandler. Tightly coupled with Java.
-        /// </summary>
-        public const string EvaluatorRequestorHandler = "EvaluatorRequestor";
-
-        /// <summary>
-        /// The name for AllocatedEvaluatorHandler. Tightly coupled with Java.
-        /// </summary>
-        public const string AllocatedEvaluatorHandler = "AllocatedEvaluator";
-
-        /// <summary>
-        /// The name for CompletedEvaluatorHandler. Tightly coupled with Java.
-        /// </summary>
-        public const string CompletedEvaluatorHandler = "CompletedEvaluator";
-
-        /// <summary>
-        /// The name for ActiveContextHandler. Tightly coupled with Java.
-        /// </summary>
-        public const string ActiveContextHandler = "ActiveContext";
-
-        /// <summary>
-        /// The name for ClosedContextHandler. Tightly coupled with Java.
-        /// </summary>
-        public const string ClosedContextHandler = "ClosedContext";
-
-        /// <summary>
-        /// The name for FailedContextHandler. Tightly coupled with Java.
-        /// </summary>
-        public const string FailedContextHandler = "FailedContext";
-        
-        /// <summary>
-        /// The name for ContextMessageHandler. Tightly coupled with Java.
-        /// </summary>
-        public const string ContextMessageHandler = "ContextMessage";
-
-        /// <summary>
-        /// The name for TaskMessageHandler. Tightly coupled with Java.
-        /// </summary>
-        public const string TaskMessageHandler = "TaskMessage";
-
-        /// <summary>
-        /// The name for FailedTaskHandler. Tightly coupled with Java.
-        /// </summary>
-        public const string FailedTaskHandler = "FailedTask";
-
-        /// <summary>
-        /// The name for RunningTaskHandler. Tightly coupled with Java.
-        /// </summary>
-        public const string RunningTaskHandler = "RunningTask";
-
-        /// <summary>
-        /// The name for FailedEvaluatorHandler. Tightly coupled with Java.
-        /// </summary>
-        public const string FailedEvaluatorHandler = "FailedEvaluator";
-
-        /// <summary>
-        /// The name for CompletedTaskHandler. Tightly coupled with Java.
-        /// </summary>
-        public const string CompletedTaskHandler = "CompletedTask";
-
-        /// <summary>
-        /// The name for SuspendedTaskHandler. Tightly coupled with Java.
-        /// </summary>
-        public const string SuspendedTaskHandler = "SuspendedTask";
-
-        /// <summary>
-        /// The name for HttpServerHandler. Tightly coupled with Java.
-        /// </summary>
-        public const string HttpServerHandler = "HttpServerHandler";
-
-        /// <summary>
-        /// The name for DriverRestartActiveContextHandler. Tightly coupled with Java.
-        /// </summary>
-        public const string DriverRestartActiveContextHandler = "DriverRestartActiveContext";
-
-        /// <summary>
-        /// The name for DriverRestartRunningTaskHandler. Tightly coupled with Java.
-        /// </summary>
-        public const string DriverRestartRunningTaskHandler = "DriverRestartRunningTask";
-
-        /// <summary>
-        /// The name for DriverRestartCompletedHandler. Tightly coupled with Java.
-        /// </summary>
-        public const string DriverRestartCompletedHandler = "DriverRestartCompleted";
-
-        /// <summary>
-        /// The name for DriverRestartFailedEvaluatorHandler. Tightly coupled with Java
-        /// </summary>
-        public const string DriverRestartFailedEvaluatorHandler = "DriverRestartFailedEvaluator";
 
         [Obsolete(message:"Use REEFFileNames instead.")]
         public const string DriverBridgeConfiguration = Common.Constants.ClrBridgeRuntimeConfiguration;
@@ -184,37 +88,5 @@ namespace Org.Apache.REEF.Driver
         /// Configuration for Java verbose logging.
         /// </summary>
         public const string JavaVerboseLoggingConfig = "-Djava.util.logging.config.class=org.apache.reef.util.logging.Config";
-
-        /// <summary>
-        /// A dictionary of handler constants to handler descriptors.
-        /// </summary>
-        public static Dictionary<string, int> Handlers
-        {
-            get
-            {
-                return
-                    new Dictionary<string, int>()
-                    {
-                        { EvaluatorRequestorHandler, 0 },
-                        { AllocatedEvaluatorHandler, 1 },
-                        { ActiveContextHandler, 2 },
-                        { TaskMessageHandler, 3 },
-                        { FailedTaskHandler, 4 },
-                        { FailedEvaluatorHandler, 5 },
-                        { HttpServerHandler, 6 },
-                        { CompletedTaskHandler, 7 },
-                        { RunningTaskHandler, 8 },
-                        { SuspendedTaskHandler, 9 },
-                        { CompletedEvaluatorHandler, 10 },
-                        { ClosedContextHandler, 11 },
-                        { FailedContextHandler, 12 },
-                        { ContextMessageHandler, 13 },
-                        { DriverRestartActiveContextHandler, 14 },
-                        { DriverRestartRunningTaskHandler, 15 },
-                        { DriverRestartCompletedHandler, 16 },
-                        { DriverRestartFailedEvaluatorHandler, 17 }
-                    };
-            }
-        }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/Org.Apache.REEF.Driver.csproj
+++ b/lang/cs/Org.Apache.REEF.Driver/Org.Apache.REEF.Driver.csproj
@@ -39,6 +39,7 @@ under the License.
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Bridge\BridgeConfigurationProvider.cs" />
+    <Compile Include="Bridge\BridgeHandlerManager.cs" />
     <Compile Include="Bridge\BridgeLogger.cs" />
     <Compile Include="Bridge\Clr2java\IActiveContextClr2Java.cs" />
     <Compile Include="Bridge\Clr2java\IAllocatedEvaluaotrClr2Java.cs" />

--- a/lang/cs/Org.Apache.REEF.Evaluator/Evaluator.cs
+++ b/lang/cs/Org.Apache.REEF.Evaluator/Evaluator.cs
@@ -339,8 +339,7 @@ namespace Org.Apache.REEF.Evaluator
         {
             var message = "Unhandled exception caught in Evaluator. Current files in the working directory: " +
                           GetDirectoryListing(Directory.GetCurrentDirectory());
-            _logger.Log(Level.Error, message, ex);
-            throw ex;
+            Utilities.Diagnostics.Exceptions.Throw(ex, message, _logger);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/MapperCount/MapperCount.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/MapperCount/MapperCount.cs
@@ -17,10 +17,16 @@
  * under the License.
  */
 
+using System;
 using System.Linq;
 using Org.Apache.REEF.IMRU.API;
+using Org.Apache.REEF.IMRU.OnREEF.Parameters;
+using Org.Apache.REEF.IMRU.OnREEF.ResultHandler;
+using Org.Apache.REEF.IO.FileSystem.Local;
 using Org.Apache.REEF.IO.PartitionedData.Random;
 using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Tang.Implementations.Tang;
+using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Wake.StreamingCodec.CommonStreamingCodecs;
 
@@ -43,7 +49,7 @@ namespace Org.Apache.REEF.IMRU.Examples.MapperCount
         /// Runs the actual mapper count job
         /// </summary>
         /// <returns>The number of MapFunction instances that are part of the job.</returns>
-        public int Run(int numberofMappers)
+        public int Run(int numberofMappers, string outputFile, IConfiguration fileSystemConfig)
         {
             var results = _imruClient.Submit<int, int, int>(
                 new IMRUJobDefinitionBuilder()
@@ -66,8 +72,16 @@ namespace Org.Apache.REEF.IMRU.Examples.MapperCount
                             GenericType<IntSumReduceFunction>.Class)
                         .Build())
                     .SetPartitionedDatasetConfiguration(
-                        RandomInputDataConfiguration.ConfigurationModule.Set(RandomInputDataConfiguration.NumberOfPartitions,
+                        RandomInputDataConfiguration.ConfigurationModule.Set(
+                            RandomInputDataConfiguration.NumberOfPartitions,
                             numberofMappers.ToString()).Build())
+                    .SetResultHandlerConfiguration(
+                        TangFactory.GetTang()
+                            .NewConfigurationBuilder(fileSystemConfig)
+                            .BindImplementation(GenericType<IIMRUResultHandler<int>>.Class,
+                                GenericType<WriteResultHandler<int>>.Class)
+                            .BindNamedParameter(typeof(ResultOutputLocation), outputFile)
+                            .Build())
                     .SetMapTaskCores(2)
                     .SetUpdateTaskCores(3)
                     .SetJobName("MapperCount")

--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/OnREEFIMRURunTimeConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/OnREEFIMRURunTimeConfiguration.cs
@@ -73,11 +73,9 @@ namespace Org.Apache.REEF.IMRU.Examples
             IConfiguration imruClientConfig =
                 REEFIMRUClientConfiguration.ConfigurationModule.Build();
 
-            var fileSystemConfig = HadoopFileSystemConfiguration.ConfigurationModule.Build();
-
             IConfiguration runtimeConfig =
                 YARNClientConfiguration.ConfigurationModule.Build();
-            return Configurations.Merge(runtimeConfig, imruClientConfig, fileSystemConfig);
+            return Configurations.Merge(runtimeConfig, imruClientConfig);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IMRU.Examples/Run.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Examples/Run.cs
@@ -21,10 +21,12 @@ using System;
 using System.Globalization;
 using System.Linq;
 using Org.Apache.REEF.Client.API;
+using Org.Apache.REEF.Client.Yarn;
 using Org.Apache.REEF.IMRU.Examples.PipelinedBroadcastReduce;
+using Org.Apache.REEF.IO.FileSystem.Hadoop;
+using Org.Apache.REEF.IO.FileSystem.Local;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
-using Org.Apache.REEF.Wake.Remote.Parameters;
 using Org.Apache.REEF.Utilities.Logging;
 
 namespace Org.Apache.REEF.IMRU.Examples
@@ -36,24 +38,27 @@ namespace Org.Apache.REEF.IMRU.Examples
     {
         private static readonly Logger Logger = Logger.GetLogger(typeof(Run));
 
-        private static void RunMapperTest(IConfiguration tcpPortConfig, bool runOnYarn, int numNodes)
+        private static void RunMapperTest(IConfiguration tcpPortConfig, bool runOnYarn, int numNodes, string filename)
         {
             IInjector injector;
+            IConfiguration fileSystemConfig;
 
             if (!runOnYarn)
             {
                 injector =
                     TangFactory.GetTang()
                         .NewInjector(OnREEFIMRURunTimeConfiguration<int, int, int>.GetLocalIMRUConfiguration(numNodes), tcpPortConfig);
+                fileSystemConfig = LocalFileSystemConfiguration.ConfigurationModule.Build();
             }
             else
             {
                 injector = TangFactory.GetTang()
                     .NewInjector(OnREEFIMRURunTimeConfiguration<int, int, int>.GetYarnIMRUConfiguration(), tcpPortConfig);
+                fileSystemConfig = HDFSConfigurationWithoutDriverBinding.ConfigurationModule.Build();
             }
 
             var mapperCountExample = injector.GetInstance<MapperCount.MapperCount>();
-            mapperCountExample.Run(numNodes - 1);
+            mapperCountExample.Run(numNodes - 1, filename, fileSystemConfig);
         }
 
         private static void RunBroadcastReduceTest(IConfiguration tcpPortConfig, bool runOnYarn, int numNodes, string[] args)
@@ -114,6 +119,7 @@ namespace Org.Apache.REEF.IMRU.Examples
             int numNodes = 2;
             int startPort = 8900;
             int portRange = 1000;
+            string resultFilename = " ";
 
             if (args != null)
             {
@@ -154,7 +160,11 @@ namespace Org.Apache.REEF.IMRU.Examples
             {
                 case "mappercount":
                     Logger.Log(Level.Info, "Running Mapper count");
-                    RunMapperTest(tcpPortConfig, runOnYarn, numNodes);
+                    if (args.Length > 5)
+                    {
+                        resultFilename = args[5];
+                    }
+                    RunMapperTest(tcpPortConfig, runOnYarn, numNodes, resultFilename);
                     Logger.Log(Level.Info, "Done Running Mapper count");
                     return;
 

--- a/lang/cs/Org.Apache.REEF.IMRU.Tests/MapperCountTest.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Tests/MapperCountTest.cs
@@ -46,7 +46,7 @@ namespace Org.Apache.REEF.IMRU.Tests
                             .Build()
                     )
                     .GetInstance<MapperCount>();
-            var result = tested.Run(NumberOfMappers);
+            var result = tested.Run(NumberOfMappers, "", TangFactory.GetTang().NewConfigurationBuilder().Build());
             Assert.AreEqual(NumberOfMappers, result, "The result of the run should be the number of Mappers.");
         }
     }

--- a/lang/cs/Org.Apache.REEF.IMRU/API/IIMRUResultHandler.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/API/IIMRUResultHandler.cs
@@ -18,6 +18,7 @@
  */
 
 using System;
+using Org.Apache.REEF.Common.Attributes;
 
 namespace Org.Apache.REEF.IMRU.API
 {
@@ -25,6 +26,7 @@ namespace Org.Apache.REEF.IMRU.API
     /// Interface defining how to handle the output of Update function in IMRU
     /// </summary>
     /// <typeparam name="T">Result type</typeparam>
+    [Unstable("0.14", "This API will change after introducing proper API for output in REEF.IO")]
     public interface IIMRUResultHandler<in T> : IDisposable
     {
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.IMRU/API/IIMRUResultHandler.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/API/IIMRUResultHandler.cs
@@ -1,0 +1,37 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System;
+
+namespace Org.Apache.REEF.IMRU.API
+{
+    /// <summary>
+    /// Interface defining how to handle the output of Update function in IMRU
+    /// </summary>
+    /// <typeparam name="T">Result type</typeparam>
+    public interface IIMRUResultHandler<in T> : IDisposable
+    {
+        /// <summary>
+        /// Handles the result of IMRU updata function.
+        /// For example, do nothing, write to file etc.
+        /// </summary>
+        /// <param name="result">The output of IMRU update function</param>
+        void HandleResult(T result);
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IMRU/API/IMRUJobDefinition.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/API/IMRUJobDefinition.cs
@@ -37,6 +37,7 @@ namespace Org.Apache.REEF.IMRU.API
         private readonly IConfiguration _mapOutputPipelineDataConverterConfiguration;
         private readonly IConfiguration _mapInputPipelineDataConverterConfiguration;
         private readonly IConfiguration _partitionedDatasetConfiguration;
+        private readonly IConfiguration _resultHandlerConfiguration;
         private readonly int _numberOfMappers;
         private readonly int _memoryPerMapper;
         private readonly int _updateTaskMemory;
@@ -60,6 +61,7 @@ namespace Org.Apache.REEF.IMRU.API
         /// PipelineDataConverter for TMapInput</param>
         /// <param name="partitionedDatasetConfiguration">Configuration of partitioned 
         /// dataset</param>
+        /// <param name="resultHandlerConfiguration">Configuration of result handler</param>
         /// <param name="perMapConfigGeneratorConfig">Per mapper configuration</param>
         /// <param name="numberOfMappers">Number of mappers</param>
         /// <param name="memoryPerMapper">Per Mapper memory.</param>
@@ -77,6 +79,7 @@ namespace Org.Apache.REEF.IMRU.API
             IConfiguration mapOutputPipelineDataConverterConfiguration,
             IConfiguration mapInputPipelineDataConverterConfiguration,
             IConfiguration partitionedDatasetConfiguration,
+            IConfiguration resultHandlerConfiguration,
             ISet<IConfiguration> perMapConfigGeneratorConfig,
             int numberOfMappers,
             int memoryPerMapper,
@@ -102,6 +105,7 @@ namespace Org.Apache.REEF.IMRU.API
             _updateTaskCores = updateTaskCores;
             _perMapConfigGeneratorConfig = perMapConfigGeneratorConfig;
             _invokeGC = invokeGC;
+            _resultHandlerConfiguration = resultHandlerConfiguration;
         }
 
         /// <summary>
@@ -234,6 +238,15 @@ namespace Org.Apache.REEF.IMRU.API
         internal bool InvokeGarbageCollectorAfterIteration
         {
             get { return _invokeGC; }
+        }
+
+        /// <summary>
+        /// Configuration of the result handler 
+        /// </summary>
+        /// <returns></returns>
+        internal IConfiguration ResultHandlerConfiguration
+        {
+            get { return _resultHandlerConfiguration; }
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IMRU/API/IMRUJobDefinitionBuilder.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/API/IMRUJobDefinitionBuilder.cs
@@ -52,6 +52,7 @@ namespace Org.Apache.REEF.IMRU.API
         private IConfiguration _mapOutputPipelineDataConverterConfiguration;
         private IConfiguration _mapInputPipelineDataConverterConfiguration;
         private IConfiguration _partitionedDatasetConfiguration;
+        private IConfiguration _resultHandlerConfiguration;
         private readonly ISet<IConfiguration> _perMapConfigGeneratorConfig;
         private bool _invokeGC;
 
@@ -66,6 +67,7 @@ namespace Org.Apache.REEF.IMRU.API
             _mapInputPipelineDataConverterConfiguration = EmptyConfiguration;
             _mapOutputPipelineDataConverterConfiguration = EmptyConfiguration;
             _partitionedDatasetConfiguration = EmptyConfiguration;
+            _resultHandlerConfiguration = EmptyConfiguration;
             _memoryPerMapper = 512;
             _updateTaskMemory = 512;
             _coresPerMapper = 1;
@@ -248,6 +250,17 @@ namespace Org.Apache.REEF.IMRU.API
         }
 
         /// <summary>
+        /// Sets Result handler Configuration
+        /// </summary>
+        /// <param name="resultHandlerConfig">Result handler config</param>
+        /// <returns></returns>
+        public IMRUJobDefinitionBuilder SetResultHandlerConfiguration(IConfiguration resultHandlerConfig)
+        {
+            _resultHandlerConfiguration = resultHandlerConfig;
+            return this;
+        }
+
+        /// <summary>
         /// Whether to invoke Garbage Collector after each IMRU iteration
         /// </summary>
         /// <param name="invokeGC">variable telling whether to invoke or not</param>
@@ -307,6 +320,7 @@ namespace Org.Apache.REEF.IMRU.API
                 _mapOutputPipelineDataConverterConfiguration,
                 _mapInputPipelineDataConverterConfiguration,
                 _partitionedDatasetConfiguration,
+                _resultHandlerConfiguration,
                 _perMapConfigGeneratorConfig,
                 _numberOfMappers,
                 _memoryPerMapper,

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Client/REEFIMRUClient.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Client/REEFIMRUClient.cs
@@ -128,6 +128,8 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Client
                     _configurationSerializer.ToString(jobDefinition.MapOutputPipelineDataConverterConfiguration))
                 .BindNamedParameter(typeof(SerializedReduceConfiguration),
                     _configurationSerializer.ToString(jobDefinition.ReduceFunctionConfiguration))
+                .BindNamedParameter(typeof(SerializedResultHandlerConfiguration),
+                    _configurationSerializer.ToString(jobDefinition.ResultHandlerConfiguration))
                 .BindNamedParameter(typeof(MemoryPerMapper),
                     jobDefinition.MapperMemory.ToString(CultureInfo.InvariantCulture))
                 .BindNamedParameter(typeof(MemoryForUpdateTask),

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/ConfigurationManager.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/ConfigurationManager.cs
@@ -39,6 +39,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         private readonly IConfiguration _updateFunctionConfiguration;
         private readonly IConfiguration _mapOutputPipelineDataConverterConfiguration;
         private readonly IConfiguration _mapInputPipelineDataConverterConfiguration;
+        private readonly IConfiguration _resultHandlerConfiguration;
 
         [Inject]
         private ConfigurationManager(
@@ -48,14 +49,17 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
             [Parameter(typeof(SerializedUpdateConfiguration))] string updateConfig,
             [Parameter(typeof(SerializedMapInputCodecConfiguration))] string mapInputCodecConfig,
             [Parameter(typeof(SerializedUpdateFunctionCodecsConfiguration))] string updateFunctionCodecsConfig,
-            [Parameter(typeof(SerializedMapOutputPipelineDataConverterConfiguration))] string mapOutputPipelineDataConverterConfiguration,
-            [Parameter(typeof(SerializedMapInputPipelineDataConverterConfiguration))] string mapInputPipelineDataConverterConfiguration)
+            [Parameter(typeof(SerializedMapOutputPipelineDataConverterConfiguration))] string
+                mapOutputPipelineDataConverterConfiguration,
+            [Parameter(typeof(SerializedMapInputPipelineDataConverterConfiguration))] string
+                mapInputPipelineDataConverterConfiguration,
+            [Parameter(typeof(SerializedResultHandlerConfiguration))] string resultHandlerConfiguration)
         {
             try
             {
                 _mapFunctionConfiguration = configurationSerializer.FromString(mapConfig);
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 Exceptions.Throw(e, "Unable to deserialize map function configuration", Logger);
             }
@@ -110,6 +114,17 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
             {
                 _mapInputPipelineDataConverterConfiguration =
                     configurationSerializer.FromString(mapInputPipelineDataConverterConfiguration);
+            }
+            catch (Exception e)
+            {
+                Exceptions.Throw(e, "Unable to deserialize map input pipeline data converter configuration", Logger);
+            }
+
+            try
+            {
+                _resultHandlerConfiguration =
+                    configurationSerializer.FromString(resultHandlerConfiguration);
+                Logger.Log(Level.Verbose,"Serialized result handler is " + resultHandlerConfiguration);
             }
             catch (Exception e)
             {
@@ -172,6 +187,14 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
         internal IConfiguration MapInputPipelineDataConverterConfiguration
         {
             get { return _mapInputPipelineDataConverterConfiguration; }
+        }
+
+        /// <summary>
+        /// Configuration of Result handler
+        /// </summary>
+        internal IConfiguration ResultHandlerConfiguration
+        {
+            get { return _resultHandlerConfiguration; }
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Driver/IMRUDriver.cs
@@ -18,7 +18,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using Org.Apache.REEF.Common.Tasks;
@@ -30,6 +29,7 @@ using Org.Apache.REEF.IMRU.API;
 using Org.Apache.REEF.IMRU.OnREEF.IMRUTasks;
 using Org.Apache.REEF.IMRU.OnREEF.MapInputWithControlMessage;
 using Org.Apache.REEF.IMRU.OnREEF.Parameters;
+using Org.Apache.REEF.IMRU.OnREEF.ResultHandler;
 using Org.Apache.REEF.IO.PartitionedData;
 using Org.Apache.REEF.Network.Group.Driver;
 using Org.Apache.REEF.Network.Group.Driver.Impl;
@@ -37,13 +37,13 @@ using Org.Apache.REEF.Network.Group.Pipelining;
 using Org.Apache.REEF.Network.Group.Pipelining.Impl;
 using Org.Apache.REEF.Network.Group.Topology;
 using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Tang.Exceptions;
 using Org.Apache.REEF.Tang.Implementations.Configuration;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Utilities.Diagnostics;
 using Org.Apache.REEF.Utilities.Logging;
-using Org.Apache.REEF.Wake.Remote.Parameters;
 
 namespace Org.Apache.REEF.IMRU.OnREEF.Driver
 {
@@ -168,10 +168,27 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Driver
                                 .Set(TaskConfiguration.Task,
                                     GenericType<UpdateTaskHost<TMapInput, TMapOutput, TResult>>.Class)
                                 .Build(),
-                            _configurationManager.UpdateFunctionConfiguration
+                            _configurationManager.UpdateFunctionConfiguration,
+                            _configurationManager.ResultHandlerConfiguration
                         })
                         .BindNamedParameter(typeof (InvokeGC), _invokeGC.ToString())
                         .Build();
+
+                try
+                {
+                    TangFactory.GetTang()
+                        .NewInjector(partialTaskConf, _configurationManager.UpdateFunctionCodecsConfiguration)
+                        .GetInstance<IIMRUResultHandler<TResult>>();
+                }
+                catch(InjectionException)
+                {
+                    partialTaskConf = TangFactory.GetTang().NewConfigurationBuilder(partialTaskConf)
+                        .BindImplementation(GenericType<IIMRUResultHandler<TResult>>.Class,
+                            GenericType<DefaultResultHandler<TResult>>.Class)
+                        .Build();
+                    Logger.Log(Level.Warning,
+                        "User has not given any way to handle IMRU result, defaulting to ignoring it");
+                }
 
                 _commGroup.AddTask(IMRUConstants.UpdateTaskName);
                 _groupCommTaskStarter.QueueTask(partialTaskConf, activeContext);

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/SerializedResultHandlerConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Parameters/SerializedResultHandlerConfiguration.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using Org.Apache.REEF.Tang.Annotations;
+
+namespace Org.Apache.REEF.IMRU.OnREEF.Parameters
+{
+    [NamedParameter("The serialized configuration for result handler.")]
+    internal sealed class SerializedResultHandlerConfiguration : Name<string>
+    {
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/ResultHandler/DefaultResultHandler.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/ResultHandler/DefaultResultHandler.cs
@@ -18,11 +18,13 @@
  */
 
 using System;
+using Org.Apache.REEF.Common.Attributes;
 using Org.Apache.REEF.IMRU.API;
 using Org.Apache.REEF.Tang.Annotations;
 
 namespace Org.Apache.REEF.IMRU.OnREEF.ResultHandler
 {
+    [Unstable("0.14", "This API will change after introducing proper API for output in REEF.IO")]
     internal class DefaultResultHandler<TResult> : IIMRUResultHandler<TResult>
     {
         [Inject]

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/ResultHandler/DefaultResultHandler.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/ResultHandler/DefaultResultHandler.cs
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System;
+using Org.Apache.REEF.IMRU.API;
+using Org.Apache.REEF.Tang.Annotations;
+
+namespace Org.Apache.REEF.IMRU.OnREEF.ResultHandler
+{
+    internal class DefaultResultHandler<TResult> : IIMRUResultHandler<TResult>
+    {
+        [Inject]
+        private DefaultResultHandler()
+        {
+        }
+
+        /// <summary>
+        /// Specifies how to handle the IMRU results from UpdateTask. Does nothing
+        /// </summary>
+        /// <param name="result">The result of IMRU</param>
+        public void HandleResult(TResult result)
+        {
+        }
+
+        /// <summary>
+        /// Handles what to do on completion
+        /// In this case do nothing
+        /// </summary>
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/ResultHandler/ResultOutputLocation.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/ResultHandler/ResultOutputLocation.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using Org.Apache.REEF.Tang.Annotations;
+
+namespace Org.Apache.REEF.IMRU.OnREEF.ResultHandler
+{
+    [NamedParameter("output location for writing result", "resultfile", " ")]
+    public sealed class ResultOutputLocation : Name<string>
+    {
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/ResultHandler/WriteResultHandler.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/ResultHandler/WriteResultHandler.cs
@@ -1,0 +1,117 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System;
+using System.IO;
+using Org.Apache.REEF.IMRU.API;
+using Org.Apache.REEF.IO.FileSystem;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Utilities.Diagnostics;
+using Org.Apache.REEF.Utilities.Logging;
+using Org.Apache.REEF.Wake.Remote.Impl;
+using Org.Apache.REEF.Wake.StreamingCodec;
+
+namespace Org.Apache.REEF.IMRU.OnREEF.ResultHandler
+{
+    /// <summary>
+    /// Writes IMRU result from Update task to a file
+    ///  </summary>
+    /// <typeparam name="TResult"></typeparam>
+    public class WriteResultHandler<TResult> : IIMRUResultHandler<TResult>
+    {
+        private static readonly Logger Logger = Logger.GetLogger(typeof (WriteResultHandler<>));
+
+        private readonly IStreamingCodec<TResult> _resultCodec;
+        private readonly IFileSystem _fileSystem;
+        private readonly string _remoteFileName;
+        private readonly string _localFilename;
+
+        [Inject]
+        private WriteResultHandler(
+            IStreamingCodec<TResult> resultCodec,
+            IFileSystem fileSystem,
+            [Parameter(typeof(ResultOutputLocation))] string fileName)
+        {
+            _resultCodec = resultCodec;
+            _fileSystem = fileSystem;
+            _remoteFileName = fileName;
+            _localFilename = GenerateLocalFilename();
+        }
+
+        /// <summary>
+        /// Specifies how to handle the IMRU results from the Update Task. Writes it to a location
+        /// </summary>
+        /// <param name="value">The result of IMRU from the UpdateTask</param>
+        public void HandleResult(TResult value)
+        {
+            if (string.IsNullOrWhiteSpace(_remoteFileName))
+            {
+                return;
+            }
+
+            WriteOutput(value);
+        }
+
+        /// <summary>
+        /// Handles what to do on completion
+        /// In this case write to remote location
+        /// </summary>
+        public void Dispose()
+        {
+            if (string.IsNullOrWhiteSpace(_remoteFileName))
+            {
+                return;
+            }
+
+            Uri remoteUri = _fileSystem.CreateUriForPath(_remoteFileName);
+
+            if (_fileSystem.Exists(remoteUri))
+            {
+                Exceptions.Throw(
+                    new Exception(string.Format("Output Uri: {0} already exists", remoteUri)), Logger);
+            }
+
+            _fileSystem.CopyFromLocal(_localFilename, remoteUri);
+        }
+
+        private string GenerateLocalFilename()
+        {
+            string localFileFolder = Path.GetTempPath() + "-partition-" + Guid.NewGuid().ToString("N").Substring(0, 8);
+            Directory.CreateDirectory(localFileFolder);
+            var localFilePath = String.Format("{0}\\{1}", localFileFolder, Guid.NewGuid().ToString("N").Substring(0, 8));
+
+            if (File.Exists(localFilePath))
+            {
+                File.Delete(localFilePath);
+                Logger.Log(Level.Warning, "localFile for output already exists, deleting it: " + localFilePath);
+            }
+
+            return localFilePath;
+        }
+
+        private void WriteOutput(TResult result)
+        {
+            using (FileStream stream = new FileStream(_localFilename, FileMode.Append, FileAccess.Write))
+            {
+                StreamDataWriter writer = new StreamDataWriter(stream);
+                _resultCodec.Write(result, writer);
+            }
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/ResultHandler/WriteResultHandler.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/ResultHandler/WriteResultHandler.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.IO;
+using Org.Apache.REEF.Common.Attributes;
 using Org.Apache.REEF.IMRU.API;
 using Org.Apache.REEF.IO.FileSystem;
 using Org.Apache.REEF.Tang.Annotations;
@@ -33,6 +34,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.ResultHandler
     /// Writes IMRU result from Update task to a file
     ///  </summary>
     /// <typeparam name="TResult"></typeparam>
+    [Unstable("0.14", "This API will change after introducing proper API for output in REEF.IO")]
     public class WriteResultHandler<TResult> : IIMRUResultHandler<TResult>
     {
         private static readonly Logger Logger = Logger.GetLogger(typeof (WriteResultHandler<>));

--- a/lang/cs/Org.Apache.REEF.IMRU/Org.Apache.REEF.IMRU.csproj
+++ b/lang/cs/Org.Apache.REEF.IMRU/Org.Apache.REEF.IMRU.csproj
@@ -45,6 +45,7 @@ under the License.
   </ItemGroup>
   <ItemGroup>
     <Compile Include="API\IIMRUClient.cs" />
+    <Compile Include="API\IIMRUResultHandler.cs" />
     <Compile Include="API\IMapFunction.cs" />
     <Compile Include="API\IMRUCodecConfiguration.cs" />
     <Compile Include="API\IMRUPipelineDataConverterConfiguration.cs" />
@@ -84,6 +85,7 @@ under the License.
     <Compile Include="OnREEF\Parameters\CoresPerMapper.cs" />
     <Compile Include="OnREEF\Parameters\MemoryForUpdateTask.cs" />
     <Compile Include="OnREEF\Parameters\MemoryPerMapper.cs" />
+    <Compile Include="OnREEF\Parameters\SerializedResultHandlerConfiguration.cs" />
     <Compile Include="OnREEF\Parameters\SerializedMapConfiguration.cs" />
     <Compile Include="OnREEF\Parameters\SerializedMapInputCodecConfiguration.cs" />
     <Compile Include="OnREEF\Parameters\SerializedMapInputPipelineDataConverterConfiguration.cs" />
@@ -91,6 +93,9 @@ under the License.
     <Compile Include="OnREEF\Parameters\SerializedReduceConfiguration.cs" />
     <Compile Include="OnREEF\Parameters\SerializedUpdateConfiguration.cs" />
     <Compile Include="OnREEF\Parameters\SerializedUpdateFunctionCodecsConfiguration.cs" />
+    <Compile Include="OnREEF\ResultHandler\DefaultResultHandler.cs" />
+    <Compile Include="OnREEF\ResultHandler\ResultOutputLocation.cs" />
+    <Compile Include="OnREEF\ResultHandler\WriteResultHandler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HDFSConfigurationWithoutDriverBinding.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HDFSConfigurationWithoutDriverBinding.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using Org.Apache.REEF.Common.Io;
+using Org.Apache.REEF.Common.Client.Parameters;
+using Org.Apache.REEF.IO.FileSystem.Hadoop.Parameters;
+using Org.Apache.REEF.Tang.Formats;
+using Org.Apache.REEF.Tang.Interface;
+using Org.Apache.REEF.Tang.Util;
+
+namespace Org.Apache.REEF.IO.FileSystem.Hadoop
+{
+    /// <summary>
+    /// Configuration Module for the (command based) Hadoop file system implementation of IFileSystem.
+    /// </summary>
+    /// <remarks>
+    /// This IFileSystem implementation is enormously slow as it spawns a new JVM per API call. Avoid if you have better means
+    /// of file system access.
+    /// Also, Stream-based operations are not supported.
+    /// </remarks>
+    public sealed class HDFSConfigurationWithoutDriverBinding : ConfigurationModuleBuilder
+    {
+        /// <summary>
+        /// The number of times each HDFS command will be retried. Defaults to 3.
+        /// </summary>
+        public static readonly OptionalParameter<int> CommandRetries = new OptionalParameter<int>();
+
+        /// <summary>
+        /// The timeout (in milliseconds) for HDFS commands. Defaults to 300000 (5 minutes).
+        /// </summary>
+        public static readonly OptionalParameter<int> CommandTimeOut = new OptionalParameter<int>();
+
+        /// <summary>
+        /// The folder in which Hadoop is installed. Defaults to %HADOOP_HOME%.
+        /// </summary>
+        public static readonly OptionalParameter<string> HadoopHome = new OptionalParameter<string>();
+
+        /// <summary>
+        /// Set all the parameters needed for injecting HadoopFileSystemConfigurationProvider.
+        /// </summary>
+        public static readonly ConfigurationModule ConfigurationModule = new HDFSConfigurationWithoutDriverBinding()
+            .BindImplementation(GenericType<IFileSystem>.Class, GenericType<HadoopFileSystem>.Class)
+            .BindNamedParameter(GenericType<NumberOfRetries>.Class, CommandRetries)
+            .BindNamedParameter(GenericType<CommandTimeOut>.Class, CommandTimeOut)
+            .BindNamedParameter(GenericType<HadoopHome>.Class, HadoopHome)
+            .Build();
+    }
+}

--- a/lang/cs/Org.Apache.REEF.IO/Org.Apache.REEF.IO.csproj
+++ b/lang/cs/Org.Apache.REEF.IO/Org.Apache.REEF.IO.csproj
@@ -42,6 +42,7 @@ under the License.
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FileSystem\Hadoop\CommandResult.cs" />
+    <Compile Include="FileSystem\Hadoop\HDFSConfigurationWithoutDriverBinding.cs" />
     <Compile Include="FileSystem\Hadoop\HadoopFileSystemConfiguration.cs" />
     <Compile Include="FileSystem\Hadoop\HadoopFileSystemConfigurationProvider.cs" />
     <Compile Include="FileSystem\Hadoop\HDFSCommandRunner.cs" />

--- a/lang/cs/Org.Apache.REEF.Utilities/Diagnostics/Exceptions.cs
+++ b/lang/cs/Org.Apache.REEF.Utilities/Diagnostics/Exceptions.cs
@@ -18,6 +18,7 @@
  */
 
 using System;
+using System.Runtime.ExceptionServices;
 using System.Text;
 using Org.Apache.REEF.Utilities.Logging;
 
@@ -51,7 +52,7 @@ namespace Org.Apache.REEF.Utilities.Diagnostics
             {
                 logger.Log(Level.Error, logMessage, exception);
             }
-            throw exception;
+            ExceptionDispatchInfo.Capture(exception).Throw();
         }
 
         /// <summary>
@@ -151,7 +152,7 @@ namespace Org.Apache.REEF.Utilities.Diagnostics
             {
                 logger.Log(level, logMessage, exception);
             }
-            throw exception;
+            ExceptionDispatchInfo.Capture(exception).Throw();
         }
 
         /// <summary>

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/BridgeHandlerManager.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/BridgeHandlerManager.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.javabridge;
+
+import org.apache.reef.annotations.audience.Private;
+
+/**
+ * A class that holds all handles to the .NET side.
+ * USED BY UNMANAGED CODE! PLEASE DO NOT CHANGE ANY FUNCTION SIGNATURES
+ * UNLESS YOU KNOW WHAT YOU ARE DOING!
+ */
+@Private
+public final class BridgeHandlerManager {
+  private long allocatedEvaluatorHandler = 0;
+  private long activeContextHandler = 0;
+  private long taskMessageHandler = 0;
+  private long failedTaskHandler = 0;
+  private long failedEvaluatorHandler = 0;
+  private long httpServerEventHandler = 0;
+  private long completedTaskHandler = 0;
+  private long runningTaskHandler = 0;
+  private long suspendedTaskHandler = 0;
+  private long completedEvaluatorHandler = 0;
+  private long closedContextHandler = 0;
+  private long failedContextHandler = 0;
+  private long contextMessageHandler = 0;
+  private long driverRestartActiveContextHandler = 0;
+  private long driverRestartRunningTaskHandler = 0;
+  private long driverRestartCompletedHandler = 0;
+  private long driverRestartFailedEvaluatorHandler = 0;
+
+  public BridgeHandlerManager() {
+  }
+
+  public long getAllocatedEvaluatorHandler() {
+    return allocatedEvaluatorHandler;
+  }
+
+  public void setAllocatedEvaluatorHandler(final long allocatedEvaluatorHandler) {
+    this.allocatedEvaluatorHandler = allocatedEvaluatorHandler;
+  }
+
+  public long getActiveContextHandler() {
+    return activeContextHandler;
+  }
+
+  public void setActiveContextHandler(final long activeContextHandler) {
+    this.activeContextHandler = activeContextHandler;
+  }
+
+  public long getTaskMessageHandler() {
+    return taskMessageHandler;
+  }
+
+  public void setTaskMessageHandler(final long taskMessageHandler) {
+    this.taskMessageHandler = taskMessageHandler;
+  }
+
+  public long getFailedTaskHandler() {
+    return failedTaskHandler;
+  }
+
+  public void setFailedTaskHandler(final long failedTaskHandler) {
+    this.failedTaskHandler = failedTaskHandler;
+  }
+
+  public long getFailedEvaluatorHandler() {
+    return failedEvaluatorHandler;
+  }
+
+  public void setFailedEvaluatorHandler(final long failedEvaluatorHandler) {
+    this.failedEvaluatorHandler = failedEvaluatorHandler;
+  }
+
+  public long getHttpServerEventHandler() {
+    return httpServerEventHandler;
+  }
+
+  public void setHttpServerEventHandler(final long httpServerEventHandler) {
+    this.httpServerEventHandler = httpServerEventHandler;
+  }
+
+  public long getCompletedTaskHandler() {
+    return completedTaskHandler;
+  }
+
+  public void setCompletedTaskHandler(final long completedTaskHandler) {
+    this.completedTaskHandler = completedTaskHandler;
+  }
+
+  public long getRunningTaskHandler() {
+    return runningTaskHandler;
+  }
+
+  public void setRunningTaskHandler(final long runningTaskHandler) {
+    this.runningTaskHandler = runningTaskHandler;
+  }
+
+  public long getSuspendedTaskHandler() {
+    return suspendedTaskHandler;
+  }
+
+  public void setSuspendedTaskHandler(final long suspendedTaskHandler) {
+    this.suspendedTaskHandler = suspendedTaskHandler;
+  }
+
+  public long getCompletedEvaluatorHandler() {
+    return completedEvaluatorHandler;
+  }
+
+  public void setCompletedEvaluatorHandler(final long completedEvaluatorHandler) {
+    this.completedEvaluatorHandler = completedEvaluatorHandler;
+  }
+
+  public long getClosedContextHandler() {
+    return closedContextHandler;
+  }
+
+  public void setClosedContextHandler(final long closedContextHandler) {
+    this.closedContextHandler = closedContextHandler;
+  }
+
+  public long getFailedContextHandler() {
+    return failedContextHandler;
+  }
+
+  public void setFailedContextHandler(final long failedContextHandler) {
+    this.failedContextHandler = failedContextHandler;
+  }
+
+  public long getContextMessageHandler() {
+    return contextMessageHandler;
+  }
+
+  public void setContextMessageHandler(final long contextMessageHandler) {
+    this.contextMessageHandler = contextMessageHandler;
+  }
+
+  public long getDriverRestartActiveContextHandler() {
+    return driverRestartActiveContextHandler;
+  }
+
+  public void setDriverRestartActiveContextHandler(final long driverRestartActiveContextHandler) {
+    this.driverRestartActiveContextHandler = driverRestartActiveContextHandler;
+  }
+
+  public long getDriverRestartRunningTaskHandler() {
+    return driverRestartRunningTaskHandler;
+  }
+
+  public void setDriverRestartRunningTaskHandler(final long driverRestartRunningTaskHandler) {
+    this.driverRestartRunningTaskHandler = driverRestartRunningTaskHandler;
+  }
+
+  public long getDriverRestartCompletedHandler() {
+    return driverRestartCompletedHandler;
+  }
+
+  public void setDriverRestartCompletedHandler(final long driverRestartCompletedHandler) {
+    this.driverRestartCompletedHandler = driverRestartCompletedHandler;
+  }
+
+  public long getDriverRestartFailedEvaluatorHandler() {
+    return driverRestartFailedEvaluatorHandler;
+  }
+
+  public void setDriverRestartFailedEvaluatorHandler(final long driverRestartFailedEvaluatorHandler) {
+    this.driverRestartFailedEvaluatorHandler = driverRestartFailedEvaluatorHandler;
+  }
+}

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/NativeInterop.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/NativeInterop.java
@@ -20,63 +20,21 @@ package org.apache.reef.javabridge;
 
 import org.apache.reef.javabridge.generic.DriverRestartCompletedBridge;
 
-import java.util.HashMap;
-
 /**
  * Java interfaces of CLR/Java bridge.
  * Implementations of the methods can be found at lang/cs/Org.Apache.REEF.Bridge/JavaClrBridge.cpp.
  */
 public final class NativeInterop {
-  public static final String CLASS_HIERARCHY_FILENAME = "clrClassHierarchy.bin";
   public static final String GLOBAL_LIBRARIES_FILENAME = "userSuppliedGlobalLibraries.txt";
-  public static final String ALLOCATED_EVALUATOR_KEY = "AllocatedEvaluator";
-  public static final String ACTIVE_CONTEXT_KEY = "ActiveContext";
-  public static final String TASK_MESSAGE_KEY = "TaskMessage";
-  public static final String FAILED_TASK_KEY = "FailedTask";
-  public static final String FAILED_EVALUATOR_KEY = "FailedEvaluator";
-  public static final String HTTP_SERVER_KEY = "HttpServerKey";
-  public static final String COMPLETED_TASK_KEY = "CompletedTask";
-  public static final String RUNNING_TASK_KEY = "RunningTask";
-  public static final String SUSPENDED_TASK_KEY = "SuspendedTask";
-  public static final String COMPLETED_EVALUATOR_KEY = "CompletedEvaluator";
-  public static final String CLOSED_CONTEXT_KEY = "ClosedContext";
-  public static final String FAILED_CONTEXT_KEY = "FailedContext";
-  public static final String CONTEXT_MESSAGE_KEY = "ContextMessage";
-  public static final String DRIVER_RESTART_ACTIVE_CONTEXT_KEY = "DriverRestartActiveContext";
-  public static final String DRIVER_RESTART_RUNNING_TASK_KEY = "DriverRestartRunningTask";
-  public static final String DRIVER_RESTART_COMPLETED_KEY = "DriverRestartCompleted";
-  public static final String DRIVER_RESTART_FAILED_EVALUATOR_KEY = "DriverRestartFailedEvaluator";
-  public static final HashMap<String, Integer> HANDLERS = new HashMap<String, Integer>() {
-    {
-      put(ALLOCATED_EVALUATOR_KEY, 1);
-      put(ACTIVE_CONTEXT_KEY, 2);
-      put(TASK_MESSAGE_KEY, 3);
-      put(FAILED_TASK_KEY, 4);
-      put(FAILED_EVALUATOR_KEY, 5);
-      put(HTTP_SERVER_KEY, 6);
-      put(COMPLETED_TASK_KEY, 7);
-      put(RUNNING_TASK_KEY, 8);
-      put(SUSPENDED_TASK_KEY, 9);
-      put(COMPLETED_EVALUATOR_KEY, 10);
-      put(CLOSED_CONTEXT_KEY, 11);
-      put(FAILED_CONTEXT_KEY, 12);
-      put(CONTEXT_MESSAGE_KEY, 13);
-      put(DRIVER_RESTART_ACTIVE_CONTEXT_KEY, 14);
-      put(DRIVER_RESTART_RUNNING_TASK_KEY, 15);
-      put(DRIVER_RESTART_COMPLETED_KEY, 16);
-      put(DRIVER_RESTART_FAILED_EVALUATOR_KEY, 17);
-    }
-  };
-
-  public static final int N_HANDLERS = 18;
 
   public static native void loadClrAssembly(final String filePath);
 
   public static native void clrBufferedLog(final int level, final String message);
 
-  public static native long[] callClrSystemOnStartHandler(
+  public static native void callClrSystemOnStartHandler(
       final String dateTime,
       final String httpServerPortNumber,
+      final BridgeHandlerManager bridgeHandlerManager,
       final EvaluatorRequestorBridge javaEvaluatorRequestorBridge);
 
   public static native void clrSystemAllocatedEvaluatorHandlerOnNext(
@@ -153,8 +111,9 @@ public final class NativeInterop {
       final ContextMessageBridge contextMessageBridge
   );
 
-  public static native long[] callClrSystemOnRestartHandler(
+  public static native void callClrSystemOnRestartHandler(
       final String httpServerPortNumber,
+      final BridgeHandlerManager bridgeHandlerManager,
       final EvaluatorRequestorBridge javaEvaluatorRequestorBridge,
       final DriverRestartedBridge driverRestartedBridge
   );

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/ClrHandlersInitializer.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/ClrHandlersInitializer.java
@@ -21,6 +21,7 @@ package org.apache.reef.javabridge.generic;
 import org.apache.reef.annotations.Unstable;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.javabridge.BridgeHandlerManager;
 import org.apache.reef.javabridge.EvaluatorRequestorBridge;
 
 /**
@@ -34,5 +35,5 @@ interface ClrHandlersInitializer {
   /**
    * Returns the set of CLR handles.
    */
-  long[] getClrHandlers(final String portNumber, final EvaluatorRequestorBridge evaluatorRequestorBridge);
+  BridgeHandlerManager getClrHandlers(final String portNumber, final EvaluatorRequestorBridge evaluatorRequestorBridge);
 }

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/DriverRestartClrHandlersInitializer.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/DriverRestartClrHandlersInitializer.java
@@ -22,6 +22,7 @@ import org.apache.reef.annotations.Unstable;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.driver.restart.DriverRestarted;
+import org.apache.reef.javabridge.BridgeHandlerManager;
 import org.apache.reef.javabridge.DriverRestartedBridge;
 import org.apache.reef.javabridge.EvaluatorRequestorBridge;
 import org.apache.reef.javabridge.NativeInterop;
@@ -41,9 +42,12 @@ final class DriverRestartClrHandlersInitializer implements ClrHandlersInitialize
   }
 
   @Override
-  public long[] getClrHandlers(final String portNumber, final EvaluatorRequestorBridge evaluatorRequestorBridge) {
-    return NativeInterop.callClrSystemOnRestartHandler(
-        portNumber,
-        evaluatorRequestorBridge, new DriverRestartedBridge(driverRestarted));
+  public BridgeHandlerManager getClrHandlers(final String portNumber,
+                                             final EvaluatorRequestorBridge evaluatorRequestorBridge) {
+    final BridgeHandlerManager bridgeHandlerManager = new BridgeHandlerManager();
+    NativeInterop.callClrSystemOnRestartHandler(portNumber, bridgeHandlerManager, evaluatorRequestorBridge,
+        new DriverRestartedBridge(driverRestarted));
+
+    return bridgeHandlerManager;
   }
 }

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/DriverStartClrHandlersInitializer.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/DriverStartClrHandlersInitializer.java
@@ -21,6 +21,7 @@ package org.apache.reef.javabridge.generic;
 import org.apache.reef.annotations.Unstable;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.javabridge.BridgeHandlerManager;
 import org.apache.reef.javabridge.EvaluatorRequestorBridge;
 import org.apache.reef.javabridge.NativeInterop;
 import org.apache.reef.wake.time.event.StartTime;
@@ -40,7 +41,12 @@ final class DriverStartClrHandlersInitializer implements ClrHandlersInitializer 
   }
 
   @Override
-  public long[] getClrHandlers(final String portNumber, final EvaluatorRequestorBridge evaluatorRequestorBridge) {
-    return NativeInterop.callClrSystemOnStartHandler(startTime.toString(), portNumber, evaluatorRequestorBridge);
+  public BridgeHandlerManager getClrHandlers(final String portNumber,
+                                             final EvaluatorRequestorBridge evaluatorRequestorBridge) {
+    BridgeHandlerManager bridgeHandlerManager = new BridgeHandlerManager();
+    NativeInterop.callClrSystemOnStartHandler(startTime.toString(), portNumber, bridgeHandlerManager,
+        evaluatorRequestorBridge);
+
+    return bridgeHandlerManager;
   }
 }

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
@@ -120,24 +120,7 @@ public final class JobDriver {
    */
   private final LoggingScopeFactory loggingScopeFactory;
 
-  private long allocatedEvaluatorHandler = 0;
-  private long activeContextHandler = 0;
-  private long taskMessageHandler = 0;
-  private long failedTaskHandler = 0;
-  private long failedEvaluatorHandler = 0;
-  private long httpServerEventHandler = 0;
-  private long completedTaskHandler = 0;
-  private long runningTaskHandler = 0;
-  private long suspendedTaskHandler = 0;
-  private long completedEvaluatorHandler = 0;
-  private long closedContextHandler = 0;
-  private long failedContextHandler = 0;
-  private long contextMessageHandler = 0;
-  private long driverRestartActiveContextHandler = 0;
-  private long driverRestartRunningTaskHandler = 0;
-  private long driverRestartCompletedHandler = 0;
-  private long driverRestartFailedEvaluatorHandler = 0;
-  private boolean clrBridgeSetup = false;
+  private BridgeHandlerManager handlerManager = null;
   private boolean isRestarted = false;
   // We are holding on to following on bridge side.
   // Need to add references here so that GC does not collect them.
@@ -211,42 +194,13 @@ public final class JobDriver {
 
       this.evaluatorRequestorBridge =
           new EvaluatorRequestorBridge(JobDriver.this.evaluatorRequestor, false, loggingScopeFactory);
-      final long[] handlers = initializer.getClrHandlers(portNumber, evaluatorRequestorBridge);
-      if (handlers != null) {
-        if (handlers.length != NativeInterop.N_HANDLERS) {
-          throw new RuntimeException(
-              String.format("%s handlers initialized in CLR while native bridge is expecting %s handlers",
-                  String.valueOf(handlers.length),
-                  String.valueOf(NativeInterop.N_HANDLERS)));
-        }
-        this.allocatedEvaluatorHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.ALLOCATED_EVALUATOR_KEY)];
-        this.activeContextHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.ACTIVE_CONTEXT_KEY)];
-        this.taskMessageHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.TASK_MESSAGE_KEY)];
-        this.failedTaskHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.FAILED_TASK_KEY)];
-        this.failedEvaluatorHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.FAILED_EVALUATOR_KEY)];
-        this.httpServerEventHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.HTTP_SERVER_KEY)];
-        this.completedTaskHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.COMPLETED_TASK_KEY)];
-        this.runningTaskHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.RUNNING_TASK_KEY)];
-        this.suspendedTaskHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.SUSPENDED_TASK_KEY)];
-        this.completedEvaluatorHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.COMPLETED_EVALUATOR_KEY)];
-        this.closedContextHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.CLOSED_CONTEXT_KEY)];
-        this.failedContextHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.FAILED_CONTEXT_KEY)];
-        this.contextMessageHandler = handlers[NativeInterop.HANDLERS.get(NativeInterop.CONTEXT_MESSAGE_KEY)];
-        this.driverRestartActiveContextHandler =
-            handlers[NativeInterop.HANDLERS.get(NativeInterop.DRIVER_RESTART_ACTIVE_CONTEXT_KEY)];
-        this.driverRestartRunningTaskHandler =
-            handlers[NativeInterop.HANDLERS.get(NativeInterop.DRIVER_RESTART_RUNNING_TASK_KEY)];
-        this.driverRestartCompletedHandler =
-            handlers[NativeInterop.HANDLERS.get(NativeInterop.DRIVER_RESTART_COMPLETED_KEY)];
-        this.driverRestartFailedEvaluatorHandler =
-            handlers[NativeInterop.HANDLERS.get(NativeInterop.DRIVER_RESTART_FAILED_EVALUATOR_KEY)];
-      }
+      JobDriver.this.handlerManager = initializer.getClrHandlers(portNumber, evaluatorRequestorBridge);
 
       try (final LoggingScope lp =
                this.loggingScopeFactory.getNewLoggingScope("setupBridge::clrSystemHttpServerHandlerOnNext")) {
         final HttpServerEventBridge httpServerEventBridge = new HttpServerEventBridge("SPEC");
-        NativeInterop.clrSystemHttpServerHandlerOnNext(this.httpServerEventHandler, httpServerEventBridge,
-            this.interopLogger);
+        NativeInterop.clrSystemHttpServerHandlerOnNext(JobDriver.this.handlerManager.getHttpServerEventHandler(),
+            httpServerEventBridge, this.interopLogger);
         final String specList = httpServerEventBridge.getUriSpecification();
         LOG.log(Level.INFO, "Starting http server, getUriSpecification: {0}", specList);
         if (specList != null) {
@@ -258,7 +212,6 @@ public final class JobDriver {
           }
         }
       }
-      this.clrBridgeSetup = true;
     }
     LOG.log(Level.INFO, "CLR Bridge setup.");
   }
@@ -277,14 +230,14 @@ public final class JobDriver {
       eval.setProcess(process);
       LOG.log(Level.INFO, "Allocated Evaluator: {0}, total running running {1}",
           new Object[]{eval.getId(), JobDriver.this.contexts.size()});
-      if (JobDriver.this.allocatedEvaluatorHandler == 0) {
+      if (JobDriver.this.handlerManager.getAllocatedEvaluatorHandler() == 0) {
         throw new RuntimeException("Allocated Evaluator Handler not initialized by CLR.");
       }
       final AllocatedEvaluatorBridge allocatedEvaluatorBridge =
           this.allocatedEvaluatorBridgeFactory.getAllocatedEvaluatorBridge(eval, this.nameServerInfo);
       allocatedEvaluatorBridges.put(allocatedEvaluatorBridge.getId(), allocatedEvaluatorBridge);
-      NativeInterop.clrSystemAllocatedEvaluatorHandlerOnNext(JobDriver.this.allocatedEvaluatorHandler,
-          allocatedEvaluatorBridge, this.interopLogger);
+      NativeInterop.clrSystemAllocatedEvaluatorHandlerOnNext(
+          JobDriver.this.handlerManager.getAllocatedEvaluatorHandler(), allocatedEvaluatorBridge, this.interopLogger);
     }
   }
 
@@ -302,9 +255,11 @@ public final class JobDriver {
         JobDriver.this.jobMessageObserver.sendMessageToClient(message.getBytes(StandardCharsets.UTF_8));
 
         if (isRestartFailed) {
-          evaluatorFailedHandlerWaitForCLRBridgeSetup(driverRestartFailedEvaluatorHandler, eval, isRestartFailed);
+          evaluatorFailedHandlerWaitForCLRBridgeSetup(
+              JobDriver.this.handlerManager.getDriverRestartFailedEvaluatorHandler(), eval, isRestartFailed);
         } else {
-          evaluatorFailedHandlerWaitForCLRBridgeSetup(failedEvaluatorHandler, eval, isRestartFailed);
+          evaluatorFailedHandlerWaitForCLRBridgeSetup(JobDriver.this.handlerManager.getFailedEvaluatorHandler(),
+              eval, isRestartFailed);
         }
       }
     }
@@ -314,7 +269,7 @@ public final class JobDriver {
                                                            final FailedEvaluator eval,
                                                            final boolean isRestartFailed) {
     if (handle == 0) {
-      if (JobDriver.this.clrBridgeSetup) {
+      if (JobDriver.this.handlerManager != null) {
         final String message = "No CLR FailedEvaluator handler was set, exiting now";
         LOG.log(Level.WARNING, message);
         JobDriver.this.jobMessageObserver.sendMessageToClient(message.getBytes(StandardCharsets.UTF_8));
@@ -322,7 +277,7 @@ public final class JobDriver {
         clock.scheduleAlarm(0, new EventHandler<Alarm>() {
           @Override
           public void onNext(final Alarm time) {
-            if (JobDriver.this.clrBridgeSetup) {
+            if (JobDriver.this.handlerManager != null) {
               handleFailedEvaluatorInCLR(eval, isRestartFailed);
             } else {
               LOG.log(Level.INFO, "Waiting for CLR bridge to be set up");
@@ -344,9 +299,12 @@ public final class JobDriver {
         JobDriver.this.isRestarted, loggingScopeFactory);
     if (isRestartFailed) {
       NativeInterop.clrSystemDriverRestartFailedEvaluatorHandlerOnNext(
-          JobDriver.this.driverRestartFailedEvaluatorHandler, failedEvaluatorBridge, JobDriver.this.interopLogger);
+          JobDriver.this.handlerManager.getDriverRestartFailedEvaluatorHandler(),
+          failedEvaluatorBridge, JobDriver.this.interopLogger);
     } else {
-      NativeInterop.clrSystemFailedEvaluatorHandlerOnNext(JobDriver.this.failedEvaluatorHandler, failedEvaluatorBridge,
+      NativeInterop.clrSystemFailedEvaluatorHandlerOnNext(
+          JobDriver.this.handlerManager.getDriverRestartFailedEvaluatorHandler(),
+          failedEvaluatorBridge,
           JobDriver.this.interopLogger);
     }
 
@@ -365,12 +323,12 @@ public final class JobDriver {
   private void submit(final ActiveContext context) {
     try {
       LOG.log(Level.INFO, "Send task to context: {0}", new Object[]{context});
-      if (JobDriver.this.activeContextHandler == 0) {
+      if (JobDriver.this.handlerManager.getActiveContextHandler() == 0) {
         throw new RuntimeException("Active Context Handler not initialized by CLR.");
       }
       final ActiveContextBridge activeContextBridge = activeContextBridgeFactory.getActiveContextBridge(context);
-      NativeInterop.clrSystemActiveContextHandlerOnNext(JobDriver.this.activeContextHandler, activeContextBridge,
-          JobDriver.this.interopLogger);
+      NativeInterop.clrSystemActiveContextHandlerOnNext(JobDriver.this.handlerManager.getActiveContextHandler(),
+          activeContextBridge, JobDriver.this.interopLogger);
     } catch (final Exception ex) {
       LOG.log(Level.SEVERE, "Fail to submit task to active context");
       context.close();
@@ -427,13 +385,13 @@ public final class JobDriver {
         }
         LOG.log(Level.INFO, "Return results to the client:\n{0}", result);
         JobDriver.this.jobMessageObserver.sendMessageToClient(JVM_CODEC.encode(result));
-        if (JobDriver.this.completedTaskHandler == 0) {
+        if (JobDriver.this.handlerManager.getCompletedTaskHandler() == 0) {
           LOG.log(Level.INFO, "No CLR handler bound to handle completed task.");
         } else {
           LOG.log(Level.INFO, "CLR CompletedTaskHandler handler set, handling things with CLR handler.");
           final CompletedTaskBridge completedTaskBridge = new CompletedTaskBridge(task, activeContextBridgeFactory);
-          NativeInterop.clrSystemCompletedTaskHandlerOnNext(JobDriver.this.completedTaskHandler, completedTaskBridge,
-              JobDriver.this.interopLogger);
+          NativeInterop.clrSystemCompletedTaskHandlerOnNext(JobDriver.this.handlerManager.getCompletedTaskHandler(),
+              completedTaskBridge, JobDriver.this.interopLogger);
         }
       }
     }
@@ -488,12 +446,11 @@ public final class JobDriver {
 
         final String requestString = httpSerializer.toString(avroHttpRequest);
         final byte[] requestBytes = requestString.getBytes(Charset.forName(AvroHttpSerializer.JSON_CHARSET));
-        //final byte[] requestBytes = httpSerializer.toBytes(avroHttpRequest);
 
         try {
           final HttpServerEventBridge httpServerEventBridge = new HttpServerEventBridge(requestBytes);
-          NativeInterop.clrSystemHttpServerHandlerOnNext(JobDriver.this.httpServerEventHandler, httpServerEventBridge,
-              JobDriver.this.interopLogger);
+          NativeInterop.clrSystemHttpServerHandlerOnNext(JobDriver.this.handlerManager.getHttpServerEventHandler(),
+              httpServerEventBridge, JobDriver.this.interopLogger);
           final String responseBody = new String(httpServerEventBridge.getQueryResponseData(), "UTF-8");
           response.getWriter().println(responseBody);
           LOG.log(Level.INFO, "HttpServerBridgeEventHandler onHttpRequest received response: {0}", responseBody);
@@ -512,14 +469,14 @@ public final class JobDriver {
     @Override
     public void onNext(final FailedTask task) throws RuntimeException {
       LOG.log(Level.SEVERE, "FailedTask received, will be handle in CLR handler, if set.");
-      if (JobDriver.this.failedTaskHandler == 0) {
+      if (JobDriver.this.handlerManager.getFailedTaskHandler() == 0) {
         LOG.log(Level.SEVERE, "Failed Task Handler not initialized by CLR, fail for real.");
         throw new RuntimeException("Failed Task Handler not initialized by CLR.");
       }
       try {
         final FailedTaskBridge failedTaskBridge = new FailedTaskBridge(task, activeContextBridgeFactory);
-        NativeInterop.clrSystemFailedTaskHandlerOnNext(JobDriver.this.failedTaskHandler, failedTaskBridge,
-            JobDriver.this.interopLogger);
+        NativeInterop.clrSystemFailedTaskHandlerOnNext(JobDriver.this.handlerManager.getFailedTaskHandler(),
+            failedTaskBridge, JobDriver.this.interopLogger);
       } catch (final Exception ex) {
         LOG.log(Level.SEVERE, "Fail to invoke CLR failed task handler");
         throw new RuntimeException(ex);
@@ -534,14 +491,14 @@ public final class JobDriver {
     @Override
     public void onNext(final RunningTask task) {
       try (final LoggingScope ls = loggingScopeFactory.taskRunning(task.getId())) {
-        if (JobDriver.this.runningTaskHandler == 0) {
+        if (JobDriver.this.handlerManager.getRunningTaskHandler() == 0) {
           LOG.log(Level.INFO, "RunningTask event received but no CLR handler was bound. Exiting handler.");
         } else {
           LOG.log(Level.INFO, "RunningTask will be handled by CLR handler. Task Id: {0}", task.getId());
           try {
             final RunningTaskBridge runningTaskBridge = new RunningTaskBridge(task, activeContextBridgeFactory);
-            NativeInterop.clrSystemRunningTaskHandlerOnNext(JobDriver.this.runningTaskHandler, runningTaskBridge,
-                JobDriver.this.interopLogger);
+            NativeInterop.clrSystemRunningTaskHandlerOnNext(JobDriver.this.handlerManager.getRunningTaskHandler(),
+                runningTaskBridge, JobDriver.this.interopLogger);
           } catch (final Exception ex) {
             LOG.log(Level.WARNING, "Fail to invoke CLR running task handler");
             throw new RuntimeException(ex);
@@ -561,11 +518,11 @@ public final class JobDriver {
         clock.scheduleAlarm(0, new EventHandler<Alarm>() {
           @Override
           public void onNext(final Alarm time) {
-            if (JobDriver.this.clrBridgeSetup) {
-              if (JobDriver.this.driverRestartRunningTaskHandler != 0) {
+            if (JobDriver.this.handlerManager != null) {
+              if (JobDriver.this.handlerManager.getDriverRestartRunningTaskHandler() != 0) {
                 LOG.log(Level.INFO, "CLR driver restart RunningTask handler implemented, now handle it in CLR.");
                 NativeInterop.clrSystemDriverRestartRunningTaskHandlerOnNext(
-                    JobDriver.this.driverRestartRunningTaskHandler,
+                    JobDriver.this.handlerManager.getDriverRestartRunningTaskHandler(),
                     new RunningTaskBridge(task, activeContextBridgeFactory));
               } else {
                 LOG.log(Level.WARNING, "No CLR driver restart RunningTask handler implemented, " +
@@ -594,11 +551,11 @@ public final class JobDriver {
         clock.scheduleAlarm(0, new EventHandler<Alarm>() {
           @Override
           public void onNext(final Alarm time) {
-            if (JobDriver.this.clrBridgeSetup) {
-              if (JobDriver.this.driverRestartActiveContextHandler != 0) {
+            if (JobDriver.this.handlerManager != null) {
+              if (JobDriver.this.handlerManager.getDriverRestartActiveContextHandler() != 0) {
                 LOG.log(Level.INFO, "CLR driver restart ActiveContext handler implemented, now handle it in CLR.");
                 NativeInterop.clrSystemDriverRestartActiveContextHandlerOnNext(
-                    JobDriver.this.driverRestartActiveContextHandler,
+                    JobDriver.this.handlerManager.getDriverRestartActiveContextHandler(),
                     activeContextBridgeFactory.getActiveContextBridge(context));
               } else {
                 LOG.log(Level.WARNING, "No CLR driver restart ActiveContext handler implemented, " +
@@ -660,11 +617,12 @@ public final class JobDriver {
           driverRestartCompleted.getCompletedTime());
       try (final LoggingScope ls = loggingScopeFactory.driverRestartCompleted(
           driverRestartCompleted.getCompletedTime().getTimeStamp())) {
-        if (JobDriver.this.driverRestartCompletedHandler != 0) {
+        if (JobDriver.this.handlerManager.getDriverRestartCompletedHandler() != 0) {
           LOG.log(Level.INFO, "CLR driver restart handler implemented, now handle it in CLR.");
 
           NativeInterop.clrSystemDriverRestartCompletedHandlerOnNext(
-              JobDriver.this.driverRestartCompletedHandler, new DriverRestartCompletedBridge(driverRestartCompleted));
+              JobDriver.this.handlerManager.getDriverRestartCompletedHandler(),
+              new DriverRestartCompletedBridge(driverRestartCompleted));
         } else {
           LOG.log(Level.WARNING, "No CLR driver restart handler implemented, done with DriverRestartCompletedHandler.");
         }
@@ -696,11 +654,11 @@ public final class JobDriver {
       final String msg = new String(taskMessage.get(), StandardCharsets.UTF_8);
       LOG.log(Level.INFO, "Received TaskMessage: {0} from CLR", msg);
       //try (LoggingScope ls = loggingScopeFactory.taskMessageReceived(new String(msg))) {
-      if (JobDriver.this.taskMessageHandler != 0) {
+      if (JobDriver.this.handlerManager.getTaskMessageHandler() != 0) {
         final TaskMessageBridge taskMessageBridge = new TaskMessageBridge(taskMessage);
         // if CLR implements the task message handler, handle the bytes in CLR handler
-        NativeInterop.clrSystemTaskMessageHandlerOnNext(JobDriver.this.taskMessageHandler, taskMessage.get(),
-            taskMessageBridge, JobDriver.this.interopLogger);
+        NativeInterop.clrSystemTaskMessageHandlerOnNext(JobDriver.this.handlerManager.getTaskMessageHandler(),
+            taskMessage.get(), taskMessageBridge, JobDriver.this.interopLogger);
       }
       //}
     }
@@ -715,11 +673,12 @@ public final class JobDriver {
       final String message = "Received notification that task [" + task.getId() + "] has been suspended.";
       LOG.log(Level.INFO, message);
       try (final LoggingScope ls = loggingScopeFactory.taskSuspended(task.getId())) {
-        if (JobDriver.this.suspendedTaskHandler != 0) {
+        if (JobDriver.this.handlerManager.getSuspendedTaskHandler() != 0) {
           final SuspendedTaskBridge suspendedTaskBridge = new SuspendedTaskBridge(task, activeContextBridgeFactory);
           // if CLR implements the suspended task handler, handle it in CLR
           LOG.log(Level.INFO, "Handling the event of suspended task in CLR bridge.");
-          NativeInterop.clrSystemSuspendedTaskHandlerOnNext(JobDriver.this.suspendedTaskHandler, suspendedTaskBridge);
+          NativeInterop.clrSystemSuspendedTaskHandlerOnNext(JobDriver.this.handlerManager.getSuspendedTaskHandler(),
+              suspendedTaskBridge);
         }
         JobDriver.this.jobMessageObserver.sendMessageToClient(JVM_CODEC.encode(message));
       }
@@ -734,11 +693,12 @@ public final class JobDriver {
     public void onNext(final CompletedEvaluator evaluator) {
       LOG.log(Level.INFO, " Completed Evaluator {0}", evaluator.getId());
       try (final LoggingScope ls = loggingScopeFactory.evaluatorCompleted(evaluator.getId())) {
-        if (JobDriver.this.completedEvaluatorHandler != 0) {
+        if (JobDriver.this.handlerManager.getCompletedEvaluatorHandler() != 0) {
           final CompletedEvaluatorBridge completedEvaluatorBridge = new CompletedEvaluatorBridge(evaluator);
           // if CLR implements the completed evaluator handler, handle it in CLR
           LOG.log(Level.INFO, "Handling the event of completed evaluator in CLR bridge.");
-          NativeInterop.clrSystemCompletedEvaluatorHandlerOnNext(completedEvaluatorHandler, completedEvaluatorBridge);
+          NativeInterop.clrSystemCompletedEvaluatorHandlerOnNext(
+              JobDriver.this.handlerManager.getCompletedEvaluatorHandler(), completedEvaluatorBridge);
           allocatedEvaluatorBridges.remove(completedEvaluatorBridge.getId());
         }
       }
@@ -755,11 +715,12 @@ public final class JobDriver {
     public void onNext(final ClosedContext context) {
       LOG.log(Level.INFO, "Completed Context: {0}", context.getId());
       try (final LoggingScope ls = loggingScopeFactory.closedContext(context.getId())) {
-        if (JobDriver.this.closedContextHandler != 0) {
+        if (JobDriver.this.handlerManager.getClosedContextHandler() != 0) {
           final ClosedContextBridge closedContextBridge = new ClosedContextBridge(context, activeContextBridgeFactory);
           // if CLR implements the closed context handler, handle it in CLR
           LOG.log(Level.INFO, "Handling the event of closed context in CLR bridge.");
-          NativeInterop.clrSystemClosedContextHandlerOnNext(JobDriver.this.closedContextHandler, closedContextBridge);
+          NativeInterop.clrSystemClosedContextHandlerOnNext(JobDriver.this.handlerManager.getClosedContextHandler(),
+              closedContextBridge);
         }
         synchronized (JobDriver.this) {
           JobDriver.this.contexts.remove(context.getId());
@@ -778,11 +739,12 @@ public final class JobDriver {
     public void onNext(final FailedContext context) {
       LOG.log(Level.SEVERE, "FailedContext", context);
       try (final LoggingScope ls = loggingScopeFactory.evaluatorFailed(context.getId())) {
-        if (JobDriver.this.failedContextHandler != 0) {
+        if (JobDriver.this.handlerManager.getFailedContextHandler() != 0) {
           final FailedContextBridge failedContextBridge = new FailedContextBridge(context, activeContextBridgeFactory);
           // if CLR implements the failed context handler, handle it in CLR
           LOG.log(Level.INFO, "Handling the event of failed context in CLR bridge.");
-          NativeInterop.clrSystemFailedContextHandlerOnNext(JobDriver.this.failedContextHandler, failedContextBridge);
+          NativeInterop.clrSystemFailedContextHandlerOnNext(JobDriver.this.handlerManager.getFailedContextHandler(),
+              failedContextBridge);
         }
         synchronized (JobDriver.this) {
           JobDriver.this.contexts.remove(context.getId());
@@ -804,11 +766,11 @@ public final class JobDriver {
       LOG.log(Level.SEVERE, "Received ContextMessage:", message.get());
       try (final LoggingScope ls =
                loggingScopeFactory.contextMessageReceived(new String(message.get(), StandardCharsets.UTF_8))) {
-        if (JobDriver.this.contextMessageHandler != 0) {
+        if (JobDriver.this.handlerManager.getContextMessageHandler() != 0) {
           final ContextMessageBridge contextMessageBridge = new ContextMessageBridge(message);
           // if CLR implements the context message handler, handle it in CLR
           LOG.log(Level.INFO, "Handling the event of context message in CLR bridge.");
-          NativeInterop.clrSystemContextMessageHandlerOnNext(JobDriver.this.contextMessageHandler,
+          NativeInterop.clrSystemContextMessageHandlerOnNext(JobDriver.this.handlerManager.getContextMessageHandler(),
               contextMessageBridge);
         }
       }

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/GroupCommDriver.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/GroupCommDriver.java
@@ -60,6 +60,22 @@ public interface GroupCommDriver {
       int customFanOut);
 
   /**
+   * Create a new communication group with the specified name, topology implementation,
+   * the minimum number of tasks needed in this group before
+   * communication can start, and a custom fanOut.
+   *
+   * @param groupName
+   * @param topologyClass
+   * @param numberOfTasks
+   * @param customFanOut
+   * @return
+   */
+  CommunicationGroupDriver newCommunicationGroup(Class<? extends Name<String>> groupName,
+                                                 Class<? extends Topology> topologyClass,
+                                                 int numberOfTasks,
+                                                 int customFanOut);
+
+  /**
    * Tests whether the activeContext is a context configured.
    * using the Group Communication Service
    *

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/TopologyClass.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/config/parameters/TopologyClass.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.io.network.group.impl.config.parameters;
+
+import org.apache.reef.io.network.group.api.driver.Topology;
+import org.apache.reef.tang.annotations.Name;
+import org.apache.reef.tang.annotations.NamedParameter;
+
+/**
+ * NamedParameter for topology implementation.
+ */
+@NamedParameter(doc = "NamedParameter for topology implementation")
+public final class TopologyClass implements Name<Class<? extends Topology>> {
+  private TopologyClass() {
+  }
+}

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CommunicationGroupDriverFactory.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CommunicationGroupDriverFactory.java
@@ -23,6 +23,7 @@ import org.apache.reef.driver.parameters.DriverIdentifier;
 import org.apache.reef.driver.task.FailedTask;
 import org.apache.reef.driver.task.RunningTask;
 import org.apache.reef.io.network.group.api.driver.CommunicationGroupDriver;
+import org.apache.reef.io.network.group.api.driver.Topology;
 import org.apache.reef.io.network.group.impl.GroupCommunicationMessage;
 import org.apache.reef.io.network.group.impl.config.parameters.*;
 import org.apache.reef.io.network.group.impl.utils.BroadcastingEventHandler;
@@ -64,6 +65,8 @@ public final class CommunicationGroupDriverFactory {
   /**
    * Instantiates a new CommunicationGroupDriver instance.
    * @param groupName specified name of the communication group
+   * @param topologyClass topology implementation
+   * @param commGroupMessageHandler message handler for the communication group
    * @param numberOfTasks minimum number of tasks needed in this group before start
    * @param customFanOut fanOut for TreeTopology
    * @return CommunicationGroupDriver instance
@@ -71,12 +74,14 @@ public final class CommunicationGroupDriverFactory {
    */
   public CommunicationGroupDriver getNewInstance(
       final Class<? extends Name<String>> groupName,
+      final Class<? extends Topology> topologyClass,
       final BroadcastingEventHandler<GroupCommunicationMessage> commGroupMessageHandler,
       final int numberOfTasks,
       final int customFanOut) throws InjectionException {
 
     final Injector newInjector = injector.forkInjector();
     newInjector.bindVolatileParameter(CommGroupNameClass.class, groupName);
+    newInjector.bindVolatileParameter(TopologyClass.class, topologyClass);
     newInjector.bindVolatileParameter(CommGroupMessageHandler.class, commGroupMessageHandler);
     newInjector.bindVolatileParameter(CommGroupNumTask.class, numberOfTasks);
     newInjector.bindVolatileParameter(TreeTopologyFanOut.class, customFanOut);

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CommunicationGroupDriverImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CommunicationGroupDriverImpl.java
@@ -83,6 +83,7 @@ public class CommunicationGroupDriverImpl implements CommunicationGroupDriver {
   private final SetMap<MsgKey, IndexedMsg> msgQue = new SetMap<>();
 
   private final TopologyFactory topologyFactory;
+  private final Class<? extends Topology> topologyClass;
 
   /**
    * @Deprecated in 0.14. Use Tang to obtain an instance of this instead.
@@ -115,6 +116,7 @@ public class CommunicationGroupDriverImpl implements CommunicationGroupDriver {
     } catch (final InjectionException e) {
       throw new RuntimeException(e);
     }
+    this.topologyClass = TreeTopology.class;
   }
 
   @Inject
@@ -131,7 +133,8 @@ public class CommunicationGroupDriverImpl implements CommunicationGroupDriver {
           final BroadcastingEventHandler<GroupCommunicationMessage> commGroupMessageHandler,
       @Parameter(DriverIdentifier.class) final String driverId,
       @Parameter(CommGroupNumTask.class) final int numberOfTasks,
-      final TopologyFactory topologyFactory) {
+      final TopologyFactory topologyFactory,
+      @Parameter(TopologyClass.class) final Class<? extends Topology> topologyClass) {
     super();
     this.groupName = groupName;
     this.driverId = driverId;
@@ -141,6 +144,7 @@ public class CommunicationGroupDriverImpl implements CommunicationGroupDriver {
     registerHandlers(groupCommRunningTaskHandler, groupCommFailedTaskHandler,
         groupCommFailedEvaluatorHandler, commGroupMessageHandler);
     this.topologyFactory = topologyFactory;
+    this.topologyClass = topologyClass;
   }
 
   private void registerHandlers(
@@ -166,7 +170,7 @@ public class CommunicationGroupDriverImpl implements CommunicationGroupDriver {
 
     final Topology topology;
     try {
-      topology = topologyFactory.getNewInstance(operatorName, TreeTopology.class);
+      topology = topologyFactory.getNewInstance(operatorName, topologyClass);
     } catch (final InjectionException e) {
       LOG.log(Level.WARNING, "Cannot inject new topology named {0}", operatorName);
       throw new RuntimeException(e);
@@ -193,7 +197,7 @@ public class CommunicationGroupDriverImpl implements CommunicationGroupDriver {
 
     final Topology topology;
     try {
-      topology = topologyFactory.getNewInstance(operatorName, TreeTopology.class);
+      topology = topologyFactory.getNewInstance(operatorName, topologyClass);
     } catch (final InjectionException e) {
       LOG.log(Level.WARNING, "Cannot inject new topology named {0}", operatorName);
       throw new RuntimeException(e);
@@ -219,7 +223,7 @@ public class CommunicationGroupDriverImpl implements CommunicationGroupDriver {
 
     final Topology topology;
     try {
-      topology = topologyFactory.getNewInstance(operatorName, TreeTopology.class);
+      topology = topologyFactory.getNewInstance(operatorName, topologyClass);
     } catch (final InjectionException e) {
       LOG.log(Level.WARNING, "Cannot inject new topology named {0}", operatorName);
       throw new RuntimeException(e);
@@ -245,7 +249,7 @@ public class CommunicationGroupDriverImpl implements CommunicationGroupDriver {
 
     final Topology topology;
     try {
-      topology = topologyFactory.getNewInstance(operatorName, TreeTopology.class);
+      topology = topologyFactory.getNewInstance(operatorName, topologyClass);
     } catch (final InjectionException e) {
       LOG.log(Level.WARNING, "Cannot inject new topology named {0}", operatorName);
       throw new RuntimeException(e);

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/ComparableIdentifier.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/ComparableIdentifier.java
@@ -20,8 +20,6 @@ package org.apache.reef.wake;
 
 /**
  * Identifier that can be totally ordered.
- *
- * @param <T> type
  */
 public interface ComparableIdentifier extends Identifier, Comparable<Identifier> {
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/Identifiable.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/Identifiable.java
@@ -18,6 +18,9 @@
  */
 package org.apache.reef.wake;
 
+/**
+ * This interface imposes that each object of the class that implements it has an identifier.
+ */
 public interface Identifiable {
 
   /**

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/Identifier.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/Identifier.java
@@ -18,13 +18,12 @@
  */
 package org.apache.reef.wake;
 
-/*
+/**
  * An identifier class for REEF.  Identifiers are a generic naming primitive
  * that carry some information about the type of the object they point to.
  * Typical examples are server sockets, filenames, and requests.
- * 
+ *
  * Identifier constructors should take zero arguments, or take a single string.
- * 
  */
 public interface Identifier {
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/IdentifierFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/IdentifierFactory.java
@@ -18,6 +18,9 @@
  */
 package org.apache.reef.wake;
 
+/**
+ * The factory interface for Wake.
+ */
 public interface IdentifierFactory {
 
   /**

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/StageConfiguration.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/StageConfiguration.java
@@ -29,38 +29,65 @@ import java.util.concurrent.ExecutorService;
  */
 public final class StageConfiguration {
 
+  /**
+   * The stage name.
+   */
   @NamedParameter(doc = "The stage name.")
   public static final class StageName implements Name<String> {
   }
 
+  /**
+   * The event handler for the stage.
+   */
   @NamedParameter(doc = "The event handler for the stage.")
   public static final class StageHandler implements Name<EventHandler<?>> {
   }
 
+  /**
+   * The error handler for the stage.
+   */
   @NamedParameter(doc = "The error handler for the stage.")
   public static final class ErrorHandler implements Name<EventHandler<Throwable>> {
   }
 
+  /**
+   * The number of threads for the stage.
+   */
   @NamedParameter(doc = "The number of threads for the stage.")
   public static final class NumberOfThreads implements Name<Integer> {
   }
 
+  /**
+   * The capacity for the stage.
+   */
   @NamedParameter(doc = "The capacity for the stage.")
   public static final class Capacity implements Name<Integer> {
   }
 
+  /**
+   * The executor service for the stage.
+   */
   @NamedParameter(doc = "The executor service for the stage.")
   public static final class StageExecutorService implements Name<ExecutorService> {
   }
 
+  /**
+   * The initial delay for periodic events of the timer stage.
+   */
   @NamedParameter(doc = "The initial delay for periodic events of the timer stage.")
   public static final class TimerInitialDelay implements Name<Long> {
   }
 
+  /**
+   * The period for periodic events of the timer stage.
+   */
   @NamedParameter(doc = "The period for periodic events of the timer stage.")
   public static final class TimerPeriod implements Name<Long> {
   }
 
+  /**
+   * The observer for the stage.
+   */
   @NamedParameter(doc = "The observer for the stage.")
   public static final class StageObserver implements Name<Observer<?>> {
   }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/WakeParameters.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/WakeParameters.java
@@ -21,8 +21,8 @@ package org.apache.reef.wake;
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
-/*
- * Default parameters for Wake
+/**
+ * Default parameters for Wake.
  */
 public final class WakeParameters {
 
@@ -32,15 +32,24 @@ public final class WakeParameters {
 
   public static final long REMOTE_EXECUTOR_SHUTDOWN_TIMEOUT = 10000;
 
-  @NamedParameter(doc = "Maximum frame length unit", default_value = "" + MAX_FRAME_LENGTH)
+  /**
+   * Maximum frame length unit.
+   */
+  @NamedParameter(doc = "Maximum frame length unit.", default_value = "" + MAX_FRAME_LENGTH)
   public static final class MaxFrameLength implements Name<Integer> {
   }
 
-  @NamedParameter(doc = "Executor shutdown timeout", default_value = "" + EXECUTOR_SHUTDOWN_TIMEOUT)
+  /**
+   * Executor shutdown timeout.
+   */
+  @NamedParameter(doc = "Executor shutdown timeout.", default_value = "" + EXECUTOR_SHUTDOWN_TIMEOUT)
   public static final class ExecutorShutdownTimeout implements Name<Integer> {
   }
 
-  @NamedParameter(doc = "Remote send timeout", default_value = "" + REMOTE_EXECUTOR_SHUTDOWN_TIMEOUT)
+  /**
+   * Remote send timeout.
+   */
+  @NamedParameter(doc = "Remote send timeout.", default_value = "" + REMOTE_EXECUTOR_SHUTDOWN_TIMEOUT)
   public static final class RemoteSendTimeout implements Name<Integer> {
   }
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/accumulate/CombinerStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/accumulate/CombinerStage.java
@@ -25,6 +25,12 @@ import org.apache.reef.wake.rx.Observer;
 import java.util.Map;
 import java.util.concurrent.ConcurrentSkipListMap;
 
+/**
+ * key-value pair Combiner stage.
+ *
+ * @param <K> key
+ * @param <V> value
+ */
 public class CombinerStage<K extends Comparable<K>, V> implements Stage {
 
   private final Combiner<K, V> c;
@@ -87,10 +93,22 @@ public class CombinerStage<K extends Comparable<K>, V> implements Stage {
     worker.join();
   }
 
+  /**
+   * key-value pair Combiner Interface.
+   *
+   * @param <K> key
+   * @param <V> value
+   */
   public interface Combiner<K extends Comparable<K>, V> {
     V combine(K key, V old, V cur);
   }
 
+  /**
+   * A comparable key-value pair.
+   *
+   * @param <K> key
+   * @param <V> value
+   */
   public static class Pair<K extends Comparable<K>, V> implements Map.Entry<K, V>, Comparable<Map.Entry<K, V>> {
     private final K k;
     private final V v;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/accumulate/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/accumulate/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * A key-value combiner example.
  */
 package org.apache.reef.wake.examples.accumulate;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/BlockingJoin.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/BlockingJoin.java
@@ -23,7 +23,9 @@ import org.apache.reef.wake.rx.StaticObservable;
 
 import java.util.concurrent.ConcurrentSkipListSet;
 
-
+/**
+ * Blocking join.
+ */
 public class BlockingJoin implements StaticObservable {
   private final Observer<TupleEvent> out;
   private final ConcurrentSkipListSet<TupleEvent> left = new ConcurrentSkipListSet<>();

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/EventPrinter.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/EventPrinter.java
@@ -20,6 +20,11 @@ package org.apache.reef.wake.examples.join;
 
 import org.apache.reef.wake.rx.Observer;
 
+/**
+ * Event printer.
+ *
+ * @param <T> the type of the event
+ */
 public class EventPrinter<T> implements Observer<T> {
 
   @Override

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/NonBlockingJoin.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/NonBlockingJoin.java
@@ -24,7 +24,9 @@ import org.apache.reef.wake.rx.StaticObservable;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-
+/**
+ * Non-blocking Join.
+ */
 public class NonBlockingJoin implements StaticObservable {
   private final AtomicBoolean leftDone = new AtomicBoolean(false);
   private final AtomicBoolean completed = new AtomicBoolean(false);

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/TupleEvent.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/TupleEvent.java
@@ -18,7 +18,9 @@
  */
 package org.apache.reef.wake.examples.join;
 
-
+/**
+ * A tuple event consisting key and value pair.
+ */
 public class TupleEvent implements Comparable<TupleEvent> {
   private final int key;
   private final String val;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/TupleSource.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/TupleSource.java
@@ -22,6 +22,9 @@ import org.apache.reef.wake.Stage;
 import org.apache.reef.wake.rx.Observer;
 import org.apache.reef.wake.rx.StaticObservable;
 
+/**
+ * A source class generating TupleEvent.
+ */
 public class TupleSource implements StaticObservable, Stage {
   private final Thread[] threads;
   private final Observer<TupleEvent> out;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Blocking and non-blocking join example.
  */
 package org.apache.reef.wake.examples.join;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Wake examples.
  */
 package org.apache.reef.wake.examples;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/exception/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/exception/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Wake exceptions.
  */
 package org.apache.reef.wake.exception;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/IndependentIterationsThreadPoolStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/IndependentIterationsThreadPoolStage.java
@@ -31,10 +31,6 @@ import java.util.logging.Logger;
  * This stage uses a thread pool to schedule events in parallel.
  * Should be used when input events are already materialized in a List and
  * can be fired in any order.
- *
- * @param numThreads  fixed number of threads available in the pool
- * @param granularity maximum number of events executed serially.
- *                    The right choice will balance task spawn overhead with parallelism.
  */
 public class IndependentIterationsThreadPoolStage<T> extends AbstractEStage<List<T>> {
 
@@ -42,6 +38,14 @@ public class IndependentIterationsThreadPoolStage<T> extends AbstractEStage<List
   private EventHandler<T> handler;
   private ExecutorService executor;
 
+  /**
+   * Create a thread pool with fixed threads.
+   *
+   * @param handler     an event handler
+   * @param numThreads  fixed number of threads available in the pool
+   * @param granularity maximum number of events executed serially.
+   *                    The right choice will balance task spawn overhead with parallelism.
+   */
   public IndependentIterationsThreadPoolStage(
       final EventHandler<T> handler, final int numThreads, final int granularity) {
     super(handler.getClass().getName());

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/MergingEventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/MergingEventHandler.java
@@ -60,7 +60,7 @@ public final class MergingEventHandler<L, R> {
     reset();
   }
 
-  /*
+  /**
    * Not thread safe. Must be externally synchronized.
    */
   private void reset() {
@@ -68,6 +68,12 @@ public final class MergingEventHandler<L, R> {
     leftEvent = null;
   }
 
+  /**
+   * A pair having two independent typed items.
+   *
+   * @param <S1> a type of first item
+   * @param <S2> a type of second item
+   */
   public static final class Pair<S1, S2> {
     private final S1 first;
     private final S2 second;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/WakeSharedPool.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/WakeSharedPool.java
@@ -34,17 +34,19 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 
-// This implementation uses the fork join framework to reduce the cost of spawning
-// events in stages. For two participating stages back to back, the pool allows
-// for the thread in the first stage to execute the event it submits to the second stage.
-// These choices are made by the ForkJoinPool.
-// 
-// So, this does sort of go against the reason for stages, but doesn't eliminate them
-// and raises the level of abstraction that Wake sees above threads. 
-//
-// this will only be deadlock free if blocking synchronization done by events is safe.
-// That is no event submitted to the pool can have a producer/consumer dependency
-// on another event submitted to the pool
+/**
+ * This implementation uses the fork join framework to reduce the cost of spawning
+ * events in stages. For two participating stages back to back, the pool allows
+ * for the thread in the first stage to execute the event it submits to the second stage.
+ * These choices are made by the ForkJoinPool.
+ *
+ * So, this does sort of go against the reason for stages, but doesn't eliminate them
+ * and raises the level of abstraction that Wake sees above threads.
+ *
+ * this will only be deadlock free if blocking synchronization done by events is safe.
+ * That is no event submitted to the pool can have a producer/consumer dependency
+ * on another event submitted to the pool
+ */
 public class WakeSharedPool implements Stage {
   private static final Logger LOG = Logger.getLogger(WakeSharedPool.class.getName());
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Wake's implementation.
  */
 package org.apache.reef.wake.impl;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Implementations of standard latency and throughput instrumentation.
  */
 package org.apache.reef.wake.metrics;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Public interfaces and factories for Wake's core API.
  */
 package org.apache.reef.wake;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/Vertex.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/Vertex.java
@@ -30,7 +30,6 @@ public class Vertex<T> {
   private final String name;
   private final ConstructorDef<T> constructorDef;
   private final Vertex<?>[] constructorArguments;
-//  private final Set<Object> referencesToThisObject = new MonotonicHashSet<>();
 
   public Vertex(final T object, final String name, final ConstructorDef<T> constructorDef,
                 final Vertex<?>[] constructorArguments) {
@@ -73,12 +72,6 @@ public class Vertex<T> {
     this.constructorArguments = null;
   }
 
-  //  public void addReference(Vertex<?> v) {
-//    referencesToThisObject.add(v);
-//  }
-//  public Vertex<?>[] getInEdges() {
-//    return referencesToThisObject.toArray(new Vertex[0]);
-//  }
   public ConstructorDef<T> getConstructorDef() {
     return this.constructorDef;
   }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/WakeProfiler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/WakeProfiler.java
@@ -35,6 +35,9 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Logger;
 
+/**
+ * A graphical profiler class that instruments Tang-based Wake applications.
+ */
 public class WakeProfiler implements Aspect {
   private static final Logger LOG = Logger.getLogger(WakeProfiler.class.toString());
   private final Map<Object, Vertex<?>> vertexObject = new MonotonicHashMap<>();
@@ -69,7 +72,7 @@ public class WakeProfiler implements Aspect {
   @SuppressWarnings("unchecked")
   private <T> Vertex<?> newSetVertex(final Set<T> s) {
     if (vertexObject.containsKey(s)) {
-      return (Vertex<Set<T>>) vertexObject.get(s);
+      return vertexObject.get(s);
     }
     if (s.size() > 1) {
       LOG.fine("new set of size " + s.size());
@@ -95,7 +98,6 @@ public class WakeProfiler implements Aspect {
   @Override
   public <T> T inject(final ConstructorDef<T> constructorDef, final Constructor<T> constructor, final Object[] args)
       throws InvocationTargetException, IllegalAccessException, IllegalArgumentException, InstantiationException {
-//    LOG.info("inject" + constructor + "->" + args.length);
     final Vertex<?>[] vArgs = new Vertex[args.length];
     for (int i = 0; i < args.length; i++) {
       final Object o = args[i];
@@ -130,7 +132,6 @@ public class WakeProfiler implements Aspect {
 
             if (method.getName().equals("onNext")) {
               final long start = System.nanoTime();
-//              LOG.info(object + "." + method.getName() + " called");
               final Object o = methodProxy.invokeSuper(object, args);
               final long stop = System.nanoTime();
 
@@ -233,8 +234,6 @@ public class WakeProfiler implements Aspect {
         LOG.warning("Set of size " + ((Set<?>) o).size() + " with " + v.getOutEdges().length + " out edges");
         s = "{...}";
         tooltip = null;
-////      } else if(false && (o instanceof EventHandler || o instanceof Stage)) {
-////        s = jsonEscape(v.getObject().toString());
       } else {
         final Stats stat = stats.get(o);
         if (stat != null) {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * A graphical profiler that automatically instruments Tang-based Wake applications.
  */
 package org.apache.reef.wake.profiler;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/Decoder.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/Decoder.java
@@ -29,7 +29,7 @@ public interface Decoder<T> {
   /**
    * Decodes the given byte array into an object.
    *
-   * @param buf
+   * @param data the data to be decoded
    * @return the decoded object
    */
   T decode(byte[] data);

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/Encoder.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/Encoder.java
@@ -29,7 +29,7 @@ public interface Encoder<T> {
   /**
    * Encodes the given object into a Byte Array.
    *
-   * @param obj
+   * @param obj an object to be encoded
    * @return a byte[] representation of the object
    */
   byte[] encode(T obj);

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteConfiguration.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteConfiguration.java
@@ -31,54 +31,84 @@ import org.apache.reef.wake.remote.impl.TransportEvent;
  */
 public final class RemoteConfiguration {
 
+  /**
+   * The name of the remote manager.
+   */
   @NamedParameter(short_name = "rm_name", doc = "The name of the remote manager.", default_value = "REEF_CLIENT")
   public static final class ManagerName implements Name<String> {
     // Intentionally empty
   }
 
+  /**
+   * The host address to be used for messages.
+   */
   @NamedParameter(short_name = "rm_host", doc = "The host address to be used for messages.",
       default_value = "##UNKNOWN##")
   public static final class HostAddress implements Name<String> {
     // Intentionally empty
   }
 
+  /**
+   * The port to be used for messages.
+   */
   @NamedParameter(short_name = "rm_port", doc = "The port to be used for messages.", default_value = "0")
   public static final class Port implements Name<Integer> {
     // Intentionally empty
   }
 
+  /**
+   * The codec to be used for messages.
+   */
   @NamedParameter(doc = "The codec to be used for messages.", default_class = ObjectSerializableCodec.class)
   public static final class MessageCodec implements Name<Codec<?>> {
     // Intentionally empty
   }
 
-  @NamedParameter(doc = "The event handler to be used for throwables", default_class = DefaultErrorHandler.class)
+  /**
+   * The event handler to be used for throwables.
+   */
+  @NamedParameter(doc = "The event handler to be used for throwables.", default_class = DefaultErrorHandler.class)
   public static final class ErrorHandler implements Name<EventHandler<Throwable>> {
     // Intentionally empty
   }
 
+  /**
+   * Whether or not to use the message ordering guarantee.
+   */
   @NamedParameter(short_name = "rm_order",
-      doc = "Whether or not to use the message ordering guarantee", default_value = "true")
+      doc = "Whether or not to use the message ordering guarantee.", default_value = "true")
   public static final class OrderingGuarantee implements Name<Boolean> {
     // Intentionally empty
   }
 
-  @NamedParameter(doc = "The number of tries", default_value = "3")
+  /**
+   * The number of tries.
+   */
+  @NamedParameter(doc = "The number of tries.", default_value = "3")
   public static final class NumberOfTries implements Name<Integer> {
     // Intentionally empty    
   }
 
-  @NamedParameter(doc = "The timeout of connection retrying", default_value = "10000")
+  /**
+   * The timeout of connection retrying.
+   */
+  @NamedParameter(doc = "The timeout of connection retrying.", default_value = "10000")
   public static final class RetryTimeout implements Name<Integer> {
     // Intentionally empty       
   }
 
-  @NamedParameter(doc = "Client stage for messaging transport", default_class = DefaultTransportEStage.class)
+  /**
+   * Client stage for messaging transport.
+   */
+  @NamedParameter(doc = "Client stage for messaging transport.", default_class = DefaultTransportEStage.class)
   public static final class RemoteClientStage implements Name<EStage<TransportEvent>> {
     // Intentionally empty
   }
 
-  @NamedParameter(doc = "Server stage for messaging transport", default_class = DefaultTransportEStage.class)
+  /**
+   * Server stage for messaging transport.
+   */
+  @NamedParameter(doc = "Server stage for messaging transport.", default_class = DefaultTransportEStage.class)
   public static final class RemoteServerStage implements Name<EStage<TransportEvent>> {
     // Intentionally empty
   }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/exception/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/exception/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Wake remote exceptions.
  */
 package org.apache.reef.wake.remote.exception;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/ConnectFutureTask.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/ConnectFutureTask.java
@@ -23,6 +23,11 @@ import org.apache.reef.wake.EventHandler;
 import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
 
+/**
+ * FutureTask for network connection.
+ *
+ * @param <T> type
+ */
 public class ConnectFutureTask<T> extends FutureTask<T> {
 
   private final EventHandler<ConnectFutureTask<T>> handler;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteIdentifierFactoryImplementation.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteIdentifierFactoryImplementation.java
@@ -26,6 +26,9 @@ import org.apache.reef.wake.remote.RemoteIdentifierFactory;
 import javax.inject.Inject;
 import java.util.Map;
 
+/**
+ * A default implementation for RemoteIdentifierFactory interface.
+ */
 public class DefaultRemoteIdentifierFactoryImplementation extends DefaultIdentifierFactory
     implements RemoteIdentifierFactory {
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultTransportEStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultTransportEStage.java
@@ -22,6 +22,9 @@ import org.apache.reef.wake.EStage;
 
 import javax.inject.Inject;
 
+/**
+ * A default event-based message transporting stage for both client and server.
+ */
 public class DefaultTransportEStage implements EStage<TransportEvent> {
 
   @Inject

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/MultiCodec.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/MultiCodec.java
@@ -30,7 +30,7 @@ import java.util.Map.Entry;
  * Codec using the WakeTuple protocol buffer.
  * (class name and bytes)
  *
- * @param <T>
+ * @param <T> type
  */
 public class MultiCodec<T> implements Codec<T> {
 
@@ -40,7 +40,7 @@ public class MultiCodec<T> implements Codec<T> {
   /**
    * Constructs a codec that encodes/decodes an object to/from bytes based on the class name.
    *
-   * @param clazzToDecoderMap
+   * @param clazzToCodecMap a map of codec for class
    */
   public MultiCodec(final Map<Class<? extends T>, Codec<? extends T>> clazzToCodecMap) {
     final Map<Class<? extends T>, Encoder<? extends T>> clazzToEncoderMap = new HashMap<>();
@@ -56,7 +56,7 @@ public class MultiCodec<T> implements Codec<T> {
   /**
    * Encodes an object to a byte array.
    *
-   * @param obj
+   * @param obj object to be encoded
    */
   @Override
   public byte[] encode(final T obj) {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/MultiDecoder.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/MultiDecoder.java
@@ -37,7 +37,7 @@ public class MultiDecoder<T> implements Decoder<T> {
   /**
    * Constructs a decoder that decodes bytes based on the class name.
    *
-   * @param clazzToDecoderMap
+   * @param clazzToDecoderMap a map of decoder for class
    */
   public MultiDecoder(final Map<Class<? extends T>, Decoder<? extends T>> clazzToDecoderMap) {
     this.clazzToDecoderMap = clazzToDecoderMap;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/MultiEncoder.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/MultiEncoder.java
@@ -29,7 +29,7 @@ import java.util.Map;
  * Encoder using the WakeTuple protocol buffer.
  * (class name and bytes)
  *
- * @param <T>
+ * @param <T> type
  */
 public class MultiEncoder<T> implements Encoder<T> {
 
@@ -38,7 +38,7 @@ public class MultiEncoder<T> implements Encoder<T> {
   /**
    * Constructs an encoder that encodes an object to bytes based on the class name.
    *
-   * @param clazzToEncoderMap
+   * @param clazzToEncoderMap a map of encoder for class
    */
   public MultiEncoder(final Map<Class<? extends T>, Encoder<? extends T>> clazzToEncoderMap) {
     this.clazzToEncoderMap = clazzToEncoderMap;
@@ -47,7 +47,7 @@ public class MultiEncoder<T> implements Encoder<T> {
   /**
    * Encodes an object to a byte array.
    *
-   * @param obj
+   * @param obj an object to be encoded
    */
   @Override
   public byte[] encode(final T obj) {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/ObjectSerializableCodec.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/ObjectSerializableCodec.java
@@ -27,7 +27,7 @@ import java.io.*;
 /**
  * Codec that uses Java serialization.
  *
- * @param <T>
+ * @param <T> type
  */
 public class ObjectSerializableCodec<T> implements Codec<T> {
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/OrderedRemoteReceiverStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/OrderedRemoteReceiverStage.java
@@ -47,7 +47,7 @@ public class OrderedRemoteReceiverStage implements EStage<TransportEvent> {
   private final ThreadPoolStage<OrderedEventStream> pullStage;
 
   /**
-   * Constructs a ordered remote receiver stage.
+   * Constructs an ordered remote receiver stage.
    *
    * @param handler      the handler of remote events
    * @param errorHandler the exception handler
@@ -119,7 +119,7 @@ class OrderedPushEventHandler implements EventHandler<TransportEvent> {
 
   OrderedPushEventHandler(final ConcurrentMap<SocketAddress, OrderedEventStream> streamMap,
                           final ThreadPoolStage<OrderedEventStream> pullStage) {
-    this.codec = new RemoteEventCodec<byte[]>(new ByteCodec());
+    this.codec = new RemoteEventCodec<>(new ByteCodec());
     this.streamMap = streamMap;
     this.pullStage = pullStage;
   }
@@ -180,7 +180,7 @@ class OrderedEventStream {
   private long nextSeq; // the number of the next event to consume
 
   OrderedEventStream() {
-    queue = new PriorityBlockingQueue<RemoteEvent<byte[]>>(11, new RemoteEventComparator<byte[]>());
+    queue = new PriorityBlockingQueue<>(11, new RemoteEventComparator<byte[]>());
     nextSeq = 0;
   }
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteSeqNumGenerator.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteSeqNumGenerator.java
@@ -32,7 +32,7 @@ public class RemoteSeqNumGenerator {
   private final ConcurrentMap<SocketAddress, AtomicLong> seqMap;
 
   public RemoteSeqNumGenerator() {
-    seqMap = new ConcurrentHashMap<SocketAddress, AtomicLong>();
+    seqMap = new ConcurrentHashMap<>();
   }
 
   public long getNextSeq(final SocketAddress addr) {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Implementations for Wake's remote communication.
  */
 package org.apache.reef.wake.remote.impl;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Wake's remote communication.
  */
 package org.apache.reef.wake.remote;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/TcpPortProvider.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/TcpPortProvider.java
@@ -24,7 +24,7 @@ import java.util.Iterator;
 
 /**
  * Provides an iterator that returns port numbers.
-*/
+ */
 @DefaultImplementation(RangeTcpPortProvider.class)
 public interface TcpPortProvider extends Iterable<Integer> {
   /**

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * TCP port providers.
  */
 package org.apache.reef.wake.remote.ports;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/parameters/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/parameters/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Parameters for TCP port selection.
  */
 package org.apache.reef.wake.remote.ports.parameters;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/exception/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/exception/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Wake remote transport exceptions.
  */
 package org.apache.reef.wake.remote.transport.exception;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/ChunkedReadWriteHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/ChunkedReadWriteHandler.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 import java.util.logging.Logger;
 
 /**
- * Thin wrapper around ChunkedWriteHandler
+ * Thin wrapper around ChunkedWriteHandler.
  * <p/>
  * ChunkedWriteHandler only handles the down stream parts
  * and just emits the chunks up stream. So we add an upstream
@@ -177,8 +177,8 @@ public class ChunkedReadWriteHandler extends ChunkedWriteHandler {
     return ret;
   }
 
-  /*
-   * Release Bytebuf when the stream closes
+  /**
+   * Release Bytebuf when the stream closes.
    */
   private class ByteBufCloseableStream extends ByteBufInputStream {
     private final ByteBuf buffer;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/LinkReference.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/LinkReference.java
@@ -22,6 +22,10 @@ import org.apache.reef.wake.remote.transport.Link;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * A reference for a link.
+ * When channel became active, LinkReference is created and mapped with remote address.
+ */
 final class LinkReference {
 
   private final AtomicInteger connectInProgress = new AtomicInteger(0);

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyChannelHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyChannelHandler.java
@@ -27,7 +27,9 @@ import io.netty.util.ReferenceCountUtil;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-
+/**
+ * Netty channel handler for channel status(active/inactive) and incoming data.
+ */
 class NettyChannelHandler extends ChannelInboundHandlerAdapter {
 
   private static final Logger LOG = Logger.getLogger(NettyChannelHandler.class.getName());
@@ -60,7 +62,6 @@ class NettyChannelHandler extends ChannelInboundHandlerAdapter {
   @Override
   public void channelRead(
       final ChannelHandlerContext ctx, final Object msg) throws Exception {
-    //LOG.log(Level.FINEST, "Read {0} {1}", new Object[]{ctx.channel(), msg});
     try {
       this.listener.channelRead(ctx, msg);
     } finally {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyChannelInitializer.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyChannelInitializer.java
@@ -27,11 +27,11 @@ import io.netty.handler.codec.bytes.ByteArrayEncoder;
 
 /**
  * Netty channel initializer for Transport.
- * <p/>
- * MAXFRAMELENGTH : the buffer size of the frame decoder
  */
 class NettyChannelInitializer extends ChannelInitializer<SocketChannel> {
-
+  /**
+   * the buffer size of the frame decoder.
+   */
   public static final int MAXFRAMELENGTH = 10 * 1024 * 1024;
   private final NettyChannelHandlerFactory handlerFactory;
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyClientEventListener.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyClientEventListener.java
@@ -28,6 +28,9 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * A Netty event listener for server.
+ */
 final class NettyClientEventListener extends AbstractNettyEventListener {
 
   private static final Logger LOG = Logger.getLogger(NettyClientEventListener.class.getName());

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyLink.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyLink.java
@@ -31,7 +31,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Link implementation with Netty
+ * Link implementation with Netty.
  *
  * If you set a LinkListener<T>, it keeps message until writeAndFlush operation completes
  * and notifies whether the sent message transferred successfully through the listener.

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyServerEventListener.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyServerEventListener.java
@@ -28,6 +28,9 @@ import java.net.SocketAddress;
 import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
 
+/**
+ * A Netty event listener for server side.
+ */
 final class NettyServerEventListener extends AbstractNettyEventListener {
 
   public NettyServerEventListener(

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Netty-based remote transport implementation.
  */
 package org.apache.reef.wake.remote.transport.netty;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Wake's remote transportation.
  */
 package org.apache.reef.wake.remote.transport;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/exception/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/exception/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * RX-style communication exceptions.
  */
 package org.apache.reef.wake.rx.exception;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/TimeoutSubject.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/TimeoutSubject.java
@@ -23,6 +23,11 @@ import org.apache.reef.wake.rx.Subject;
 
 import java.util.concurrent.TimeoutException;
 
+/**
+ * A class implementing Subject<T> with timeout.
+ *
+ * @param <T>
+ */
 public class TimeoutSubject<T> implements Subject<T, T> {
   private Thread timeBomb;
   private Observer<T> destination;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Wake's RX-style communication implementation.
  */
 package org.apache.reef.wake.rx.impl;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Wake's RX-style communication.
  */
 package org.apache.reef.wake.rx;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/storage/FileIdentifier.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/storage/FileIdentifier.java
@@ -22,6 +22,9 @@ import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+/**
+ * An identifier has a File URI.
+ */
 public class FileIdentifier implements StorageIdentifier {
   private final File f;
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/Clock.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/Clock.java
@@ -81,34 +81,34 @@ public interface Clock extends Runnable, AutoCloseable {
    * Bind this to an event handler to statically subscribe to the StartTime Event.
    */
   @NamedParameter(default_class = MissingStartHandlerHandler.class, doc = "Will be called upon the start event")
-  public class StartHandler implements Name<Set<EventHandler<StartTime>>> {
+  class StartHandler implements Name<Set<EventHandler<StartTime>>> {
   }
 
   /**
    * Bind this to an event handler to statically subscribe to the StopTime Event.
    */
   @NamedParameter(default_class = LoggingEventHandler.class, doc = "Will be called upon the stop event")
-  public class StopHandler implements Name<Set<EventHandler<StopTime>>> {
+  class StopHandler implements Name<Set<EventHandler<StopTime>>> {
   }
 
   /**
    * Bind this to an event handler to statically subscribe to the RuntimeStart Event.
    */
   @NamedParameter(default_class = LoggingEventHandler.class, doc = "Will be called upon the runtime start event")
-  public class RuntimeStartHandler implements Name<Set<EventHandler<RuntimeStart>>> {
+  class RuntimeStartHandler implements Name<Set<EventHandler<RuntimeStart>>> {
   }
 
   /**
    * Bind this to an event handler to statically subscribe to the RuntimeStart Event.
    */
   @NamedParameter(default_class = LoggingEventHandler.class, doc = "Will be called upon the runtime stop event")
-  public class RuntimeStopHandler implements Name<Set<EventHandler<RuntimeStop>>> {
+  class RuntimeStopHandler implements Name<Set<EventHandler<RuntimeStop>>> {
   }
 
   /**
    * Bind this to an event handler to statically subscribe to the IdleClock Event.
    */
   @NamedParameter(default_class = LoggingEventHandler.class, doc = "Will be called upon the Idle event")
-  public class IdleHandler implements Name<Set<EventHandler<IdleClock>>> {
+  class IdleHandler implements Name<Set<EventHandler<IdleClock>>> {
   }
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/event/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/event/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Time-based events (start/stop/alarm).
  */
 package org.apache.reef.wake.time.event;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Clock and time-based events(start/stop/alarm) implementation.
  */
 package org.apache.reef.wake.time;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/LogicalTimer.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/LogicalTimer.java
@@ -20,6 +20,9 @@ package org.apache.reef.wake.time.runtime;
 
 import javax.inject.Inject;
 
+/**
+ * Logical timer.
+ */
 public final class LogicalTimer implements Timer {
 
   private long current = 0;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RealTimer.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RealTimer.java
@@ -20,6 +20,9 @@ package org.apache.reef.wake.time.runtime;
 
 import javax.inject.Inject;
 
+/**
+ * A system-time based Timer.
+ */
 public final class RealTimer implements Timer {
 
   @Inject

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RuntimeClock.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RuntimeClock.java
@@ -35,6 +35,13 @@ import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * Default implementation of clock.
+ *
+ * After invoking `RuntimeStart` and `StartTime` events initially,
+ * this invokes scheduled events on time. If there is no scheduled event,
+ * `IdleClock` event is invoked.
+ */
 public final class RuntimeClock implements Clock {
 
   private static final Logger LOG = Logger.getLogger(Clock.class.toString());

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/Timer.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/Timer.java
@@ -20,6 +20,9 @@ package org.apache.reef.wake.time.runtime;
 
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
+/**
+ * An interface for Timer.
+ */
 @DefaultImplementation(RealTimer.class)
 public interface Timer {
   long getCurrent();

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/ClientAlarm.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/ClientAlarm.java
@@ -21,6 +21,9 @@ package org.apache.reef.wake.time.runtime.event;
 import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.time.event.Alarm;
 
+/**
+ * An event for client-created alarm.
+ */
 public final class ClientAlarm extends Alarm {
 
   public ClientAlarm(final long timestamp, final EventHandler<Alarm> handler) {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/IdleClock.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/IdleClock.java
@@ -20,6 +20,9 @@ package org.apache.reef.wake.time.runtime.event;
 
 import org.apache.reef.wake.time.Time;
 
+/**
+ * An event when there is no scheduled event.
+ */
 public final class IdleClock extends Time {
 
   public IdleClock(final long timestamp) {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/RuntimeAlarm.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/RuntimeAlarm.java
@@ -21,6 +21,9 @@ package org.apache.reef.wake.time.runtime.event;
 import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.time.event.Alarm;
 
+/**
+ * An event for non-client alarm.
+ */
 public final class RuntimeAlarm extends Alarm {
 
   public RuntimeAlarm(final long timestamp, final EventHandler<Alarm> handler) {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/RuntimeStart.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/RuntimeStart.java
@@ -20,6 +20,9 @@ package org.apache.reef.wake.time.runtime.event;
 
 import org.apache.reef.wake.time.Time;
 
+/**
+ * An event for a runtime started.
+ */
 public final class RuntimeStart extends Time {
 
   public RuntimeStart(final long timestamp) {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/RuntimeStop.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/RuntimeStop.java
@@ -20,6 +20,9 @@ package org.apache.reef.wake.time.runtime.event;
 
 import org.apache.reef.wake.time.Time;
 
+/**
+ * An event for a runtime stopped.
+ */
 public class RuntimeStop extends Time {
 
   private final Throwable exception;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Runtime-related Wake events.
  */
 package org.apache.reef.wake.time.runtime.event;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/BlockingEventHandlerTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/BlockingEventHandlerTest.java
@@ -27,6 +27,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+/**
+ * Blocking event handler test.
+ */
 public class BlockingEventHandlerTest {
 
   @Test

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/BlockingSignalEventHandlerTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/BlockingSignalEventHandlerTest.java
@@ -27,6 +27,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+/**
+ * Blocking signal event handler test.
+ */
 public class BlockingSignalEventHandlerTest {
 
   @Test

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/ForkPoolStageTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/ForkPoolStageTest.java
@@ -31,6 +31,9 @@ import org.junit.rules.TestName;
 import java.util.*;
 
 
+/**
+ * ForkPool stage test.
+ */
 public class ForkPoolStageTest {
 
   private static final String LOG_PREFIX = "TEST ";

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/IndependentIterationsThreadPoolStageTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/IndependentIterationsThreadPoolStageTest.java
@@ -30,6 +30,9 @@ import java.util.logging.Logger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+/**
+ * IndependentIterationsThreadPoolStage test.
+ */
 public class IndependentIterationsThreadPoolStageTest {
 
   @Test

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/MergingEventHandlerTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/MergingEventHandlerTest.java
@@ -29,6 +29,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * Merging event handler tests.
+ */
 public class MergingEventHandlerTest {
 
   @Test

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/MetricsTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/MetricsTest.java
@@ -27,6 +27,9 @@ import org.junit.rules.TestName;
 
 import java.util.Random;
 
+/**
+ * Metrics tests.
+ */
 public class MetricsTest {
 
   private static final String LOG_PREFIX = "TEST ";

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/PubSubThreadPoolStageTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/PubSubThreadPoolStageTest.java
@@ -35,6 +35,9 @@ import java.util.HashSet;
 import java.util.Set;
 
 
+/**
+ * Publish/subscribe event handler tests.
+ */
 public class PubSubThreadPoolStageTest {
 
   private static final String LOG_PREFIX = "TEST ";

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/StageManagerTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/StageManagerTest.java
@@ -24,6 +24,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 
+/**
+ * Stage manager tests.
+ */
 public class StageManagerTest {
   @Rule
   public TestName name = new TestName();

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/SyncStageTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/SyncStageTest.java
@@ -30,6 +30,9 @@ import org.junit.rules.TestName;
 import java.util.*;
 
 
+/**
+ * Sync stage tests.
+ */
 public class SyncStageTest {
 
   private static final String LOG_PREFIX = "TEST ";

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/ThreadPoolStageTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/ThreadPoolStageTest.java
@@ -31,6 +31,9 @@ import org.junit.rules.TestName;
 import java.util.*;
 
 
+/**
+ * Thread pool stage tests.
+ */
 public class ThreadPoolStageTest {
 
   private static final String LOG_PREFIX = "TEST ";

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/TimerStageTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/TimerStageTest.java
@@ -31,6 +31,9 @@ import org.junit.rules.TestName;
 import java.util.concurrent.atomic.AtomicInteger;
 
 
+/**
+ * Timer stage tests.
+ */
 public class TimerStageTest {
 
   private static final String LOG_PREFIX = "TEST ";

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/SkipListTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/SkipListTest.java
@@ -23,6 +23,9 @@ import org.junit.Assert;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * Tests for ConcurrentSkipListMap.
+ */
 public class SkipListTest {
 
   public static void main(final String[] arg) {

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestBlockingJoin.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestBlockingJoin.java
@@ -24,7 +24,9 @@ import org.apache.reef.wake.examples.join.TupleEvent;
 import org.apache.reef.wake.examples.join.TupleSource;
 import org.junit.Test;
 
-
+/**
+ * Tests for BlockingJoin.
+ */
 public class TestBlockingJoin {
   @Test
   public void testJoin() throws Exception {

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestCombiner.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestCombiner.java
@@ -27,6 +27,9 @@ import java.util.Map.Entry;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * Tests for CombinerStage.
+ */
 public class TestCombiner {
 
   private static final int BUCKET_COUNT = 1000;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestJoin.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestJoin.java
@@ -25,6 +25,9 @@ import org.apache.reef.wake.examples.join.TupleSource;
 import org.junit.Test;
 
 
+/**
+ * Tests for NonBlockingJoin.
+ */
 public class TestJoin {
   @Test
   public void testJoin() throws Exception {

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestTupleSource.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestTupleSource.java
@@ -24,6 +24,9 @@ import org.apache.reef.wake.examples.join.TupleSource;
 import org.junit.Test;
 
 
+/**
+ * Tests for TupleSource.
+ */
 public class TestTupleSource {
   @Test
   public void testOneThread() throws Exception {

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/package-info.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Tests for org.apache.reef.wake.examples package.
  */
 package org.apache.reef.wake.test.examples;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/package-info.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Tests for org.apache.reef.wake package.
  */
 package org.apache.reef.wake.test;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/RemoteIdentifierFactoryTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/RemoteIdentifierFactoryTest.java
@@ -36,6 +36,9 @@ import org.junit.rules.TestName;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Tests for RemoteIdentifierFactory.
+ */
 public class RemoteIdentifierFactoryTest {
   @Rule
   public final TestName name = new TestName();

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/RemoteManagerTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/RemoteManagerTest.java
@@ -49,6 +49,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 
+/**
+ * Tests for RemoteManagerFactory.
+ */
 public class RemoteManagerTest {
 
   private final LocalAddressProvider localAddressProvider;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/RemoteTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/RemoteTest.java
@@ -47,6 +47,9 @@ import java.net.UnknownHostException;
 import java.util.*;
 import java.util.logging.Level;
 
+/**
+ * Tests for remote event.
+ */
 public class RemoteTest {
   private final LocalAddressProvider localAddressProvider;
   private final TransportFactory tpFactory;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/SmallMessagesTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/SmallMessagesTest.java
@@ -43,6 +43,9 @@ import org.junit.rules.TestName;
 import java.util.*;
 import java.util.logging.Level;
 
+/**
+ * Test transferring small messages.
+ */
 public class SmallMessagesTest {
   private final LocalAddressProvider localAddressProvider;
   private final TransportFactory tpFactory;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/StartEvent.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/StartEvent.java
@@ -18,6 +18,9 @@
  */
 package org.apache.reef.wake.test.remote;
 
+/**
+ * A simplest test event.
+ */
 public class StartEvent implements java.io.Serializable {
 
   private static final long serialVersionUID = 1L;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestEvent.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestEvent.java
@@ -20,6 +20,9 @@ package org.apache.reef.wake.test.remote;
 
 import java.io.Serializable;
 
+/**
+ * A test event having two data; message and load.
+ */
 public class TestEvent implements Serializable {
 
   private static final long serialVersionUID = 1L;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestEvent1.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestEvent1.java
@@ -18,6 +18,9 @@
  */
 package org.apache.reef.wake.test.remote;
 
+/**
+ * A test event extending other event.
+ */
 public class TestEvent1 extends TestEvent {
 
   private static final long serialVersionUID = 1L;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestEvent2.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestEvent2.java
@@ -18,6 +18,9 @@
  */
 package org.apache.reef.wake.test.remote;
 
+/**
+ * Another test event extending other event.
+ */
 public class TestEvent2 extends TestEvent {
 
   private static final long serialVersionUID = 1L;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestRemote.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestRemote.java
@@ -29,6 +29,9 @@ import org.apache.reef.wake.remote.impl.DefaultRemoteIdentifierFactoryImplementa
 import javax.inject.Inject;
 import java.net.UnknownHostException;
 
+/**
+ * An app to test Wake's remote implementation.
+ */
 public class TestRemote implements Runnable {
   private final RemoteManagerFactory remoteManagerFactory;
   private final LocalAddressProvider localAddressProvider;
@@ -69,6 +72,9 @@ public class TestRemote implements Runnable {
   }
 }
 
+/**
+ * An event handler to receive an event, TestEvent.
+ */
 class TestEventHandler implements EventHandler<RemoteMessage<TestEvent>> {
 
   private final EventHandler<TestEvent> proxy;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestRemoteIdentifier.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestRemoteIdentifier.java
@@ -20,6 +20,9 @@ package org.apache.reef.wake.test.remote;
 
 import org.apache.reef.wake.remote.RemoteIdentifier;
 
+/**
+ * A test remote identifier.
+ */
 public class TestRemoteIdentifier implements RemoteIdentifier {
   private final String str;
 

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TransportRaceTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TransportRaceTest.java
@@ -42,6 +42,9 @@ import java.net.InetSocketAddress;
 import java.util.logging.Level;
 
 
+/**
+ * Tests the race condition during transporting events.
+ */
 public class TransportRaceTest {
   private final LocalAddressProvider localAddressProvider;
   private final TransportFactory tpFactory;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TransportTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TransportTest.java
@@ -44,6 +44,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 
 
+/**
+ * Tests for Transport.
+ */
 public class TransportTest {
   private final LocalAddressProvider localAddressProvider;
   private final TransportFactory tpFactory;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/package-info.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Tests for org.apache.reef.wake.remote package.
  */
 package org.apache.reef.wake.test.remote;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/RxTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/RxTest.java
@@ -26,6 +26,9 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 
 
+/**
+ * Tests for Rx-style communication.
+ */
 public class RxTest {
 
   @Rule

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/RxThreadPoolStageTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/RxThreadPoolStageTest.java
@@ -32,6 +32,9 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 
+/**
+ * Tests for RxThreadPoolStage.
+ */
 public class RxThreadPoolStageTest {
 
   @Rule

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/TimeoutSubjectTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/TimeoutSubjectTest.java
@@ -31,6 +31,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.*;
 
+/**
+ * Tests for TimeoutSubject.
+ */
 public class TimeoutSubjectTest {
 
   @Test

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/package-info.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Tests for org.apache.reef.wake.rx package.
  */
 package org.apache.reef.wake.test.rx;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/ClockTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/ClockTest.java
@@ -40,6 +40,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
+/**
+ * Tests for Clock.
+ */
 public class ClockTest {
 
   private static RuntimeClock buildClock() throws Exception {

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/package-info.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Tests for org.apache.reef.wake.time package.
  */
 package org.apache.reef.wake.test.time;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/util/Monitor.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/util/Monitor.java
@@ -20,6 +20,9 @@ package org.apache.reef.wake.test.util;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+/**
+ * A monitor used in tests.
+ */
 public class Monitor {
   private AtomicBoolean finished = new AtomicBoolean(false);
 

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/util/PassThroughEncoder.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/util/PassThroughEncoder.java
@@ -21,7 +21,7 @@ package org.apache.reef.wake.test.util;
 import org.apache.reef.wake.remote.Encoder;
 
 /**
- *
+ * A simple encoder which does nothing, i.e., returns the original value.
  */
 public class PassThroughEncoder implements Encoder<byte[]> {
 

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/util/TimeoutHandler.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/util/TimeoutHandler.java
@@ -21,6 +21,9 @@ package org.apache.reef.wake.test.util;
 import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.impl.PeriodicEvent;
 
+/**
+ * A timeout handler using monitor.
+ */
 public class TimeoutHandler implements EventHandler<PeriodicEvent> {
 
   private final Monitor monitor;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/util/package-info.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/util/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Tests for org.apache.reef.wake.util package.
  */
 package org.apache.reef.wake.test.util;


### PR DESCRIPTION
This addressed the issue by
* Using IObserver<TResult> that specifies what to do with the result. It is injected in UpdateTaskHost
* allowing users to specify the Result Handler using IMRUJobDefinition interface
* providing two common implementations: DeafultResultHandler (do nothing with result), WriteResuktHandler (Write result to distributed or local filesystem usinf IFilesystem interface)
* updating MapperCount example to enable it to write output

JIRA:
[REEF-576](https://issues.apache.org/jira/browse/REEF-576)