### PR TITLE
[REEF-873] fix FileSystemPartitionInputDataSet id issue

### DIFF
--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestFilePartitionInputDataSet.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestFilePartitionInputDataSet.cs
@@ -49,10 +49,11 @@ namespace Org.Apache.REEF.IO.Tests
         [TestMethod]
         public void TestDataSetId()
         {
+            string filePaths = string.Format(CultureInfo.CurrentCulture, "{0};{1};{2};{3}", "/tmp/abc", "tmp//cde.txt", "efg", "tmp\\hhh");
+
             var dataSet = TangFactory.GetTang()
                 .NewInjector(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.ConfigurationModule
-                    .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.FilePathForPartitions,
-                        "/tmp/abc" + ";" + "tmp//cde.txt" + ";" + "efg" +";" + "tmp\\hhh")
+                    .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.FilePathForPartitions, filePaths)
                     .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.FileSerializerConfig,
                         GetByteSerializerConfigString())
                     .Build())

--- a/lang/cs/Org.Apache.REEF.IO.Tests/TestFilePartitionInputDataSet.cs
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/TestFilePartitionInputDataSet.cs
@@ -46,6 +46,21 @@ namespace Org.Apache.REEF.IO.Tests
         string sourceFilePath1 = Path.Combine(Path.GetTempPath(), tempFileName1);
         string sourceFilePath2 = Path.Combine(Path.GetTempPath(), tempFileName2);
 
+        [TestMethod]
+        public void TestDataSetId()
+        {
+            var dataSet = TangFactory.GetTang()
+                .NewInjector(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.ConfigurationModule
+                    .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.FilePathForPartitions,
+                        "/tmp/abc" + ";" + "tmp//cde.txt" + ";" + "efg" +";" + "tmp\\hhh")
+                    .Set(FileSystemInputPartitionConfiguration<IEnumerable<byte>>.FileSerializerConfig,
+                        GetByteSerializerConfigString())
+                    .Build())
+                .GetInstance<IPartitionedInputDataSet>();
+
+            Assert.AreEqual(dataSet.Id, "FileSystemDataSet-hhh");
+        }
+
         /// <remarks>
         /// This test creates IPartitionDataSet with FileSystemInputPartitionConfiguration module.
         /// It then instantiates each IInputPartition using the IConfiguration provided by the IPartitionDescriptor.

--- a/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemPartitionInputDataSet.cs
+++ b/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemPartitionInputDataSet.cs
@@ -43,6 +43,7 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
         private readonly Dictionary<string, IPartitionDescriptor> _partitions;
         private readonly int _count ;
         private const string StringSeparators = ";";
+        private const string FolderSeparators = "/";
         private const string IdPrefix = "FileSystemDataSet-";
         private readonly string _id;
         
@@ -55,7 +56,7 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
             )
         {
             _count = filePaths.Count;
-            _id = IdPrefix + Guid.NewGuid().ToString("N").Substring(0, 8);
+            _id = FormId(filePaths);
 
             _partitions = new Dictionary<string, IPartitionDescriptor>(_count);
 
@@ -115,6 +116,21 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
         IEnumerator IEnumerable.GetEnumerator()
         {
             return _partitions.Values.GetEnumerator();
+        }
+
+        private static string FormId(ISet<string> filePaths)
+        {
+            string id = "";
+            if (filePaths != null && filePaths.Count > 0)
+            {
+                var path = filePaths.First();
+                var paths = path.Split(new string[] { FolderSeparators }, StringSplitOptions.None);
+                if (paths.Length > 0)
+                {
+                    id = paths[paths.Length - 1];
+                }
+            }
+            return "myId" + id;
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemPartitionInputDataSet.cs
+++ b/lang/cs/Org.Apache.REEF.IO/PartitionedData/FileSystem/FileSystemPartitionInputDataSet.cs
@@ -55,7 +55,8 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
             )
         {
             _count = filePaths.Count;
-            _id = FormId(filePaths);
+            _id = IdPrefix + Guid.NewGuid().ToString("N").Substring(0, 8);
+
             _partitions = new Dictionary<string, IPartitionDescriptor>(_count);
 
             var fileSerializerConfig = 
@@ -114,25 +115,6 @@ namespace Org.Apache.REEF.IO.PartitionedData.FileSystem
         IEnumerator IEnumerable.GetEnumerator()
         {
             return _partitions.Values.GetEnumerator();
-        }
-
-        private string FormId(ISet<string> filePaths)
-        {
-            string id = "";
-            if (filePaths != null && filePaths.Count > 0)
-            {
-                var path = filePaths.First();
-                var paths = path.Split(new string[] {StringSeparators}, StringSplitOptions.None);
-                if (paths.Length > 0)
-                {
-                    FileInfo fInfo = new FileInfo(paths[0]);
-                    if (fInfo.Directory != null)
-                    {
-                        id = fInfo.Directory.Name;
-                    }
-                }
-            }
-            return IdPrefix + id;
         }
     }
 }


### PR DESCRIPTION
This PR is to change the way to generate id for FileSystemPartitionInputDataSet. Original way was trying to derive the id from the input file name so that to make it easy to recognize. Given the fact that the input file name itself is can be random number, and the long file name may cause errors in parsing it, we would like to choose a simpler way to generate the id.

JIRA: [REEF-873](https://issues.apache.org/jira/browse/REEF-873)

This closes #