### PR TITLE
[REEF-874] return application status after job is submitted

### DIFF
--- a/lang/cs/Org.Apache.REEF.Client.Tests/MultipleRMUrlProviderTests.cs
+++ b/lang/cs/Org.Apache.REEF.Client.Tests/MultipleRMUrlProviderTests.cs
@@ -1,0 +1,117 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.Globalization;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Org.Apache.REEF.Client.Yarn.RestClient;
+using Org.Apache.REEF.Client.YARN.RestClient;
+using Org.Apache.REEF.Tang.Exceptions;
+using Org.Apache.REEF.Tang.Implementations.Tang;
+using Org.Apache.REEF.Tang.Util;
+
+namespace Org.Apache.REEF.Client.Tests
+{
+    [TestClass]
+    public class MultipleRMUrlProviderTests
+    {
+        private const string HadoopConfDirEnvVariable = "HADOOP_CONF_DIR";
+        private const string YarnConfigFileName = "yarn-site.xml";
+        private const string AnyHttpAddressConfig = @"anyhost:8088";
+        private const string AnyHttpAddressConfigUpdated = @"anyhost1:8088";
+        private const string AnyHttpsAddressConfig = @"anyotherhost:9088";
+
+        private const string YarnConfigurationXmlContent = @"<?xml version=""1.0""?>
+<?xml-stylesheet type=""text/xsl"" href=""configuration.xsl""?>
+<!-- Put site-specific property overrides in this file. -->
+<configuration xmlns:xi=""http://www.w3.org/2001/XInclude"">
+  <property>
+    <name>yarn.resourcemanager.webapp.address.rm1</name>
+    <value>" + AnyHttpAddressConfig + @"</value>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.webapp.address.rm2</name>
+    <value>" + AnyHttpAddressConfigUpdated + @"</value>
+  </property>
+  <property>
+    <name>yarn.nodemanager.local-dirs</name>
+    <value>C:\hdpdata\hadoop\local</value>
+  </property>
+</configuration>";
+
+        [TestMethod]
+        public void UrlProviderReadsEnvVarConfiguredConfigFileAndParsesCorrectHttpUrl()
+        {
+            string tempFile = Path.GetTempFileName();
+            string tempDir = Path.GetDirectoryName(tempFile);
+            string yarnConfigFile = Path.Combine(tempDir, YarnConfigFileName);
+
+            using (new YarnConfigurationUrlProviderTests.TempFileWriter(yarnConfigFile, YarnConfigurationXmlContent))
+            using (new YarnConfigurationUrlProviderTests.TemporaryOverrideEnvironmentVariable(HadoopConfDirEnvVariable, tempDir))
+            {
+                IUrlProvider urlProvider = GetYarnConfigurationUrlProvider();
+                var url = urlProvider.GetUrlAsync().GetAwaiter().GetResult();
+
+                int i = 0;
+                foreach (var u in url)
+                {
+                    i++;
+                    Assert.AreEqual("http", u.Scheme);
+                    if (i == 1)
+                    {
+                        Assert.AreEqual(AnyHttpAddressConfig.Split(':')[0], u.Host);
+                        Assert.AreEqual(AnyHttpAddressConfig.Split(':')[1],
+                            u.Port.ToString(CultureInfo.InvariantCulture));
+                    }
+                    else
+                    {
+                        Assert.AreEqual(AnyHttpAddressConfigUpdated.Split(':')[0], u.Host);
+                        Assert.AreEqual(AnyHttpAddressConfigUpdated.Split(':')[1],
+                            u.Port.ToString(CultureInfo.InvariantCulture));
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void CannotFindHadoopConfigDirThrowsArgumentException()
+        {
+            using (new YarnConfigurationUrlProviderTests.TemporaryOverrideEnvironmentVariable(HadoopConfDirEnvVariable, string.Empty))
+            {
+                try
+                {
+                    IUrlProvider urlProviderNotUsed = GetYarnConfigurationUrlProvider();
+                    Assert.Fail("Should throw exception");
+                }
+                catch (InjectionException injectionException)
+                {
+                    Assert.IsTrue(injectionException.GetBaseException() is ArgumentException);
+                }
+            }
+        }
+
+        private IUrlProvider GetYarnConfigurationUrlProvider()
+        {
+            var builder = TangFactory.GetTang().NewConfigurationBuilder()
+                .BindImplementation(GenericType<IUrlProvider>.Class, GenericType<MultipleRMUrlProvider>.Class)
+                .Build();
+
+            return TangFactory.GetTang().NewInjector(builder).GetInstance<IUrlProvider>();
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Client.Tests/Org.Apache.REEF.Client.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Client.Tests/Org.Apache.REEF.Client.Tests.csproj
@@ -47,6 +47,7 @@ under the License.
     <Reference Include="System.ServiceProcess" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MultipleRMUrlProviderTests.cs" />
     <Compile Include="WindowsHadoopEmulatorYarnClientTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="YarnClientTests.cs" />

--- a/lang/cs/Org.Apache.REEF.Client.Tests/YarnConfigurationUrlProviderTests.cs
+++ b/lang/cs/Org.Apache.REEF.Client.Tests/YarnConfigurationUrlProviderTests.cs
@@ -16,10 +16,14 @@
 // under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Client.Yarn.RestClient;
+using Org.Apache.REEF.Client.YARN.RestClient;
 using Org.Apache.REEF.Tang.Exceptions;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 
@@ -83,9 +87,9 @@ namespace Org.Apache.REEF.Client.Tests
                 YarnConfigurationUrlProvider urlProvider = GetYarnConfigurationUrlProvider();
                 var url = urlProvider.GetUrlAsync().GetAwaiter().GetResult();
 
-                Assert.AreEqual("http", url.Scheme);
-                Assert.AreEqual(AnyHttpAddressConfig.Split(':')[0], url.Host);
-                Assert.AreEqual(AnyHttpAddressConfig.Split(':')[1], url.Port.ToString(CultureInfo.InvariantCulture));
+                Assert.AreEqual("http", url.First().Scheme);
+                Assert.AreEqual(AnyHttpAddressConfig.Split(':')[0], url.First().Host);
+                Assert.AreEqual(AnyHttpAddressConfig.Split(':')[1], url.First().Port.ToString(CultureInfo.InvariantCulture));
             }
         }
 
@@ -100,11 +104,11 @@ namespace Org.Apache.REEF.Client.Tests
             using (new TemporaryOverrideEnvironmentVariable(HadoopConfDirEnvVariable, tempDir))
             {
                 YarnConfigurationUrlProvider urlProvider = GetYarnConfigurationUrlProvider(useHttps: true);
-                var url = urlProvider.GetUrlAsync().GetAwaiter().GetResult();
+                IEnumerable<Uri> url = urlProvider.GetUrlAsync().GetAwaiter().GetResult();
 
-                Assert.AreEqual("https", url.Scheme);
-                Assert.AreEqual(AnyHttpsAddressConfig.Split(':')[0], url.Host);
-                Assert.AreEqual(AnyHttpsAddressConfig.Split(':')[1], url.Port.ToString(CultureInfo.InvariantCulture));
+                Assert.AreEqual("https", url.First().Scheme);
+                Assert.AreEqual(AnyHttpsAddressConfig.Split(':')[0], url.First().Host);
+                Assert.AreEqual(AnyHttpsAddressConfig.Split(':')[1], url.First().Port.ToString(CultureInfo.InvariantCulture));
             }
         }
 
@@ -122,9 +126,9 @@ namespace Org.Apache.REEF.Client.Tests
                     useHttps: true);
                 var url = urlProvider.GetUrlAsync().GetAwaiter().GetResult();
 
-                Assert.AreEqual("https", url.Scheme);
-                Assert.AreEqual(AnyHttpsAddressConfig.Split(':')[0], url.Host);
-                Assert.AreEqual(AnyHttpsAddressConfig.Split(':')[1], url.Port.ToString(CultureInfo.InvariantCulture));
+                Assert.AreEqual("https", url.First().Scheme);
+                Assert.AreEqual(AnyHttpsAddressConfig.Split(':')[0], url.First().Host);
+                Assert.AreEqual(AnyHttpsAddressConfig.Split(':')[1], url.First().Port.ToString(CultureInfo.InvariantCulture));
             }
         }
 
@@ -165,7 +169,7 @@ namespace Org.Apache.REEF.Client.Tests
         /// even in the case of failure.
         /// Other tests in the assembly will see changed env var
         /// </summary>
-        private class TemporaryOverrideEnvironmentVariable : IDisposable
+        internal class TemporaryOverrideEnvironmentVariable : IDisposable
         {
             private readonly string _variableName;
             private readonly string _oldValue;
@@ -188,7 +192,7 @@ namespace Org.Apache.REEF.Client.Tests
         /// even in the case of failures.
         /// It is a shame we are writing to disk in unit test
         /// </summary>
-        private class TempFileWriter : IDisposable
+        internal class TempFileWriter : IDisposable
         {
             private readonly string _filePath;
 

--- a/lang/cs/Org.Apache.REEF.Client/API/IREEFClient.cs
+++ b/lang/cs/Org.Apache.REEF.Client/API/IREEFClient.cs
@@ -18,7 +18,9 @@
  */
 
 using System;
+using System.Threading.Tasks;
 using Org.Apache.REEF.Client.Common;
+using Org.Apache.REEF.Client.YARN.RestClient.DataModel;
 using Org.Apache.REEF.Common.Attributes;
 
 namespace Org.Apache.REEF.Client.API
@@ -37,11 +39,19 @@ namespace Org.Apache.REEF.Client.API
 
         /// <summary>
         /// Submit the job described in jobSubmission to the cluster.
-        /// Expect IDriverHttpEndpoint returned after the call.
+        /// Expect IJobSubmissionResult returned after the call.
         /// </summary>
         /// <param name="jobSubmission"></param>
-        /// <returns>IDriverHttpEndpoint</returns>
+        /// <returns>IJobSubmissionResult</returns>
         [Unstable("0.13", "Working in progress for what to return after submit")]
-        IDriverHttpEndpoint SubmitAndGetDriverUrl(IJobSubmission jobSubmission);
+        IJobSubmissionResult SubmitAndGetJobStatus(IJobSubmission jobSubmission);
+
+        /// <summary>
+        /// Returns the application status in running the job
+        /// </summary>
+        /// <param name="appId"></param>
+        /// <returns></returns>
+        [Unstable("0.14", "Working in progress for rest API status returned")]
+        Task<FinalState> GetJobFinalStatus(string appId);
     }
 }

--- a/lang/cs/Org.Apache.REEF.Client/Common/IJobSubmissionResult.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/IJobSubmissionResult.cs
@@ -17,15 +17,35 @@
  * under the License.
  */
 
+using Org.Apache.REEF.Client.YARN.RestClient.DataModel;
 using Org.Apache.REEF.Common.Attributes;
 
 namespace Org.Apache.REEF.Client.Common
 {
-    [Unstable("0.13", "Working in progress for what to return after submit")]
-    public interface IDriverHttpEndpoint
+    [Unstable("0.13", "Working in progress. For local runtime, some of the property, such as FinalState and AppId are not implemented yet.")]
+    public interface IJobSubmissionResult
     {
+        /// <summary>
+        /// Get http response for the given url
+        /// </summary>
+        /// <param name="url"></param>
+        /// <returns></returns>
         string GetUrlResult(string url);
 
+        /// <summary>
+        /// This method returns the url of http server running inside the driver.
+        /// e.g. http://hostname:port/
+        /// </summary>
         string DriverUrl { get; }
+
+        /// <summary>
+        /// Get Application final state
+        /// </summary>
+        FinalState FinalState { get; }
+
+        /// <summary>
+        /// Get Yarn application id after Job is submited
+        /// </summary>
+        string AppId { get; }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Client/Local/LocalJobSubmissionResult.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Local/LocalJobSubmissionResult.cs
@@ -1,0 +1,84 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System.IO;
+using System.Threading;
+using Org.Apache.REEF.Client.API;
+using Org.Apache.REEF.Client.Common;
+using Org.Apache.REEF.Utilities.Logging;
+
+namespace Org.Apache.REEF.Client.Local
+{
+    internal class LocalJobSubmissionResult : JobSubmissionResult
+    {
+        private static readonly Logger LOGGER = Logger.GetLogger(typeof(LocalJobSubmissionResult));
+
+        /// <summary>
+        /// Time interval between the pulling of data from the http end point file
+        /// </summary>
+        private const int PullInterval = 1000;
+
+        private const string UriTemplate = @"http://{0}/";
+
+        internal LocalJobSubmissionResult(IREEFClient reefClient, string filePath) 
+            : base(reefClient, filePath)
+        {
+        }
+
+        protected override string GetDriverUrl(string filepath)
+        {
+            return GetDriverUrlForLocalRuntime(filepath);
+        }
+
+        private string GetDriverUrlForLocalRuntime(string filePath)
+        {
+            string fullDriverUrl = null;
+            for (int i = 0; i < 10; i++)
+            {
+                var driverUrl = TryReadHttpServerIpAndPortFromFile(filePath);
+                if (!string.IsNullOrEmpty(driverUrl))
+                {
+                    fullDriverUrl = string.Format(UriTemplate, driverUrl); 
+                    break;
+                }
+                Thread.Sleep(PullInterval);
+            }
+            return fullDriverUrl;
+        }
+
+        private string TryReadHttpServerIpAndPortFromFile(string fileName)
+        {
+            string httpServerIpAndPort = null;
+            try
+            {
+                LOGGER.Log(Level.Info, "try open " + fileName);
+                using (var rdr = new StreamReader(File.OpenRead(fileName)))
+                {
+                    httpServerIpAndPort = rdr.ReadLine();
+                    LOGGER.Log(Level.Info, "httpServerIpAndPort is " + httpServerIpAndPort);
+                }
+            }
+            catch (FileNotFoundException)
+            {
+                LOGGER.Log(Level.Info, "File does not exist: " + fileName);
+            }
+            return httpServerIpAndPort;
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
+++ b/lang/cs/Org.Apache.REEF.Client/Org.Apache.REEF.Client.csproj
@@ -74,11 +74,12 @@ under the License.
     <Compile Include="Common\ClientConstants.cs" />
     <Compile Include="Common\DriverFolderPreparationHelper.cs" />
     <Compile Include="Common\FileSets.cs" />
-    <Compile Include="Common\HttpClientHelper.cs" />
-    <Compile Include="Common\IDriverHttpEndpoint.cs" />
+    <Compile Include="Common\JobSubmissionResult.cs" />
+    <Compile Include="Common\IJobSubmissionResult.cs" />
     <Compile Include="Common\JavaClientLauncher.cs" />
     <Compile Include="Common\ResourceHelper.cs" />
     <Compile Include="Local\LocalClient.cs" />
+    <Compile Include="Local\LocalJobSubmissionResult.cs" />
     <Compile Include="Local\LocalRuntimeClientConfiguration.cs" />
     <Compile Include="Local\Parameters\LocalRuntimeDirectory.cs" />
     <Compile Include="Local\Parameters\NumberOfEvaluators.cs" />
@@ -87,6 +88,7 @@ under the License.
     <Compile Include="YARN\Parameters\SecurityTokenParameters.cs" />
     <Compile Include="YARN\RestClient\DataModel\Acls.cs" />
     <Compile Include="YARN\RestClient\DataModel\AmContainerSpec.cs" />
+    <Compile Include="YARN\RestClient\DataModel\ApplicationFinalState.cs" />
     <Compile Include="YARN\RestClient\DataModel\ApplicationTag.cs" />
     <Compile Include="YARN\RestClient\DataModel\Commands.cs" />
     <Compile Include="YARN\RestClient\DataModel\Credentials.cs" />
@@ -98,7 +100,9 @@ under the License.
     <Compile Include="YARN\RestClient\DataModel\Tokens.cs" />
     <Compile Include="YARN\RestClient\IRestRequestExecutor.cs" />
     <Compile Include="YARN\RestClient\IUrlProvider.cs" />
+    <Compile Include="YARN\RestClient\MultipleRMUrlProvider.cs" />
     <Compile Include="YARN\RestClient\RestJsonSerializer.cs" />
+    <Compile Include="YARN\YarnJobSubmissionResult.cs" />
     <Compile Include="YARN\YARNREEFClient.cs" />
     <Compile Include="YARN\RestClient\IRestClientFactory.cs" />
     <Compile Include="YARN\RestClient\RestRequestExecutor.cs" />

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/Application.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/Application.cs
@@ -39,7 +39,7 @@ namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 
         public State State { get; set; }
 
-        public string FinalStatus { get; set; }
+        public FinalState FinalStatus { get; set; }
 
         public float Progress { get; set; }
 

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/ApplicationFinalState.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/DataModel/ApplicationFinalState.cs
@@ -5,9 +5,9 @@
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
-//
+// 
 //   http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -15,20 +15,22 @@
 // specific language governing permissions and limitations
 // under the License.
 
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Org.Apache.REEF.Tang.Annotations;
-
-namespace Org.Apache.REEF.Client.Yarn.RestClient
+namespace Org.Apache.REEF.Client.YARN.RestClient.DataModel
 {
-    [DefaultImplementation(typeof(YarnConfigurationUrlProvider))]
-    public interface IUrlProvider
+    /// <summary>
+    /// Class generated based on schema provided in
+    /// <see cref="!:http://hadoop.apache.org/docs/r2.6.0/hadoop-yarn/hadoop-yarn-site/WebServicesIntro.html">
+    /// Hadoop RM REST API </see> documentation.
+    /// </summary>
+    // valid values are members of the YarnApplicationState enum
+    public enum FinalState
     {
-        /// <summary>
-        /// Returns available Yarn resourcemanager web address for the environment
-        /// </summary>
-        /// <returns></returns>
-        Task<IEnumerable<Uri>> GetUrlAsync();
+        UNDEFINED,
+
+        SUCCEEDED,
+
+        FAILED,
+
+        KILLED
     }
 }

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/MultipleRMUrlProvider.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/MultipleRMUrlProvider.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Org.Apache.REEF.Client.Yarn.RestClient;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Utilities.Logging;
+
+namespace Org.Apache.REEF.Client.YARN.RestClient
+{
+    public class MultipleRMUrlProvider : IUrlProvider
+    {
+        private const string RmConfigKeyPrefix = "yarn.resourcemanager.webapp.address.rm";
+        private static readonly string HadoopConfDirEnvVariable = "HADOOP_CONF_DIR";
+        private static readonly string YarnConfigFileName = "yarn-site.xml";
+        private static readonly Logger Logger = Logger.GetLogger(typeof(MultipleRMUrlProvider));
+        private IList<Uri> _yarnRmUri;
+
+        [Inject]
+        private MultipleRMUrlProvider()
+        {
+            var hadoopConfigDir = Environment.GetEnvironmentVariable(HadoopConfDirEnvVariable);
+
+            if (string.IsNullOrEmpty(hadoopConfigDir) || !Directory.Exists(hadoopConfigDir))
+            {
+                throw new ArgumentException(HadoopConfDirEnvVariable + " is not configured or does not exist.",
+                    "hadoopConfigDir");
+            }
+
+            Logger.Log(Level.Verbose, "Using {0} as hadoop configuration directory", hadoopConfigDir);
+            string yarnConfigurationFile = Path.Combine(hadoopConfigDir, YarnConfigFileName);
+            LoadYarnConfiguration(yarnConfigurationFile);
+        }
+
+        public Task<IEnumerable<Uri>> GetUrlAsync()
+        {
+            return Task.FromResult((IEnumerable<Uri>)_yarnRmUri);
+        }
+
+        private void LoadYarnConfiguration(string yarnConfigurationFile)
+        {
+            var configRoot = XElement.Load(yarnConfigurationFile);
+            var address = configRoot.Elements("property")
+                .Where(x =>
+                    ((string) x.Element("name")).ToUpper().StartsWith(RmConfigKeyPrefix.ToUpper()))
+                .Select(x => (string) x.Element("value"));
+            _yarnRmUri =
+                address.Select(x => x.TrimEnd('/') + @"/")
+                    .Select(x => string.Format("http://{0}", x))
+                    .Where(x => Uri.IsWellFormedUriString(x, UriKind.Absolute))
+                    .Select(x => new Uri(x))
+                    .ToList();
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnConfigurationUrlProvider.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/RESTClient/YarnConfigurationUrlProvider.cs
@@ -16,6 +16,7 @@
 // under the License.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -42,7 +43,7 @@ namespace Org.Apache.REEF.Client.Yarn.RestClient
         private static readonly string YarnRmWebappHttpsAddressPropertyName = "yarn.resourcemanager.webapp.https.address";
         private static readonly string YarnRmWebappHttpAddressPropertyName = "yarn.resourcemanager.webapp.address";
         private static readonly Logger Logger = Logger.GetLogger(typeof(YarnConfigurationUrlProvider));
-        private Uri _yarnRmUri;
+        private IList<Uri> _yarnRmUri;
 
         [Inject]
         private YarnConfigurationUrlProvider(
@@ -69,9 +70,9 @@ namespace Org.Apache.REEF.Client.Yarn.RestClient
             LoadYarnConfiguration(yarnConfigurationFile, useHttps);
         }
 
-        public Task<Uri> GetUrlAsync()
+        public Task<IEnumerable<Uri>> GetUrlAsync()
         {
-            return Task.FromResult(_yarnRmUri);
+            return Task.FromResult((IEnumerable<Uri>)_yarnRmUri);
         }
 
         private void LoadYarnConfiguration(string yarnConfigurationFile, bool useHttps)
@@ -91,7 +92,7 @@ namespace Org.Apache.REEF.Client.Yarn.RestClient
 
             address = address.TrimEnd('/') + @"/";
 
-            _yarnRmUri = new Uri(string.Format("{0}://{1}", prefix, address));
+            _yarnRmUri = new List<Uri> { new Uri(string.Format("{0}://{1}", prefix, address)) };
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Client/YARN/YarnJobSubmissionResult.cs
+++ b/lang/cs/Org.Apache.REEF.Client/YARN/YarnJobSubmissionResult.cs
@@ -1,0 +1,55 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System;
+using System.IO;
+using Org.Apache.REEF.Client.API;
+using Org.Apache.REEF.Client.Common;
+using Org.Apache.REEF.Utilities.Logging;
+
+namespace Org.Apache.REEF.Client.YARN
+{
+    internal class YarnJobSubmissionResult : JobSubmissionResult
+    {
+        internal YarnJobSubmissionResult(IREEFClient reefClient, string filePath) 
+            : base(reefClient, filePath)
+        {
+        }
+
+        protected override string GetDriverUrl(string filepath)
+        {
+            return GetTrackingUrlAppId(filepath);
+        }
+
+        private string GetTrackingUrlAppId(string filepath)
+        {
+            if (!File.Exists(filepath))
+            {
+                throw new ApplicationException(string.Format("File {0} deosn't exist while trying to get tracking Uri", filepath));
+            }
+
+            using (var sr = new StreamReader(File.Open(filepath, FileMode.Open, FileAccess.Read, FileShare.Read)))
+            {
+                _appId = sr.ReadLine();
+                var trackingUrl = sr.ReadLine();
+                return "http://" + trackingUrl + "/";
+            }
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Examples.AllHandlers/AllHandlers.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.AllHandlers/AllHandlers.cs
@@ -51,7 +51,7 @@ namespace Org.Apache.REEF.Examples.AllHandlers
             _jobSubmissionBuilderFactory = jobSubmissionBuilderFactory;
         }
 
-        private IDriverHttpEndpoint Run()
+        private IJobSubmissionResult Run()
         {
             var helloDriverConfiguration = DriverConfiguration.ConfigurationModule
                 .Set(DriverConfiguration.OnEvaluatorAllocated, GenericType<HelloAllocatedEvaluatorHandler>.Class)
@@ -84,8 +84,8 @@ namespace Org.Apache.REEF.Examples.AllHandlers
                 .SetJobIdentifier("HelloDriver")
                 .Build();
 
-            IDriverHttpEndpoint driverHttpEndpoint = _reefClient.SubmitAndGetDriverUrl(helloJobSubmission);
-            return driverHttpEndpoint;
+            IJobSubmissionResult jobSubmissionResult = _reefClient.SubmitAndGetJobStatus(helloJobSubmission);
+            return jobSubmissionResult;
         }
 
         /// <summary></summary>
@@ -125,12 +125,12 @@ namespace Org.Apache.REEF.Examples.AllHandlers
         /// args[0] specify either running local or YARN. Default is local
         /// args[1] specify running folder. Default is REEF_LOCAL_RUNTIME
         /// </remarks>
-        public static IDriverHttpEndpoint Run(string[] args)
+        public static IJobSubmissionResult Run(string[] args)
         {
             string runOnYarn = args.Length > 0 ? args[0] : Local;
             string runtimeFolder = args.Length > 1 ? args[1] : "REEF_LOCAL_RUNTIME";
-            IDriverHttpEndpoint driverEndPoint = TangFactory.GetTang().NewInjector(GetRuntimeConfiguration(runOnYarn, runtimeFolder)).GetInstance<AllHandlers>().Run();
-            return driverEndPoint;
+            IJobSubmissionResult jobSubmissionResult = TangFactory.GetTang().NewInjector(GetRuntimeConfiguration(runOnYarn, runtimeFolder)).GetInstance<AllHandlers>().Run();
+            return jobSubmissionResult;
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Examples.DriverRestart/DriverRestart.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.DriverRestart/DriverRestart.cs
@@ -76,7 +76,7 @@ namespace Org.Apache.REEF.Examples.DriverRestart
                 .SetJobIdentifier("DriverRestart")
                 .Build();
 
-            _reefClient.SubmitAndGetDriverUrl(restartJobSubmission);
+            _reefClient.SubmitAndGetJobStatus(restartJobSubmission);
         }
 
         public static void Main(string[] args)

--- a/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEF.cs
+++ b/lang/cs/Org.Apache.REEF.Examples.HelloREEF/HelloREEF.cs
@@ -26,6 +26,7 @@ using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
+using Org.Apache.REEF.Utilities.Logging;
 
 namespace Org.Apache.REEF.Examples.HelloREEF
 {
@@ -34,6 +35,7 @@ namespace Org.Apache.REEF.Examples.HelloREEF
     /// </summary>
     public sealed class HelloREEF
     {
+        private static readonly Logger Logger = Logger.GetLogger(typeof(HelloREEF));
         private const string Local = "local";
         private const string YARN = "yarn";
         private readonly IREEFClient _reefClient;
@@ -63,7 +65,7 @@ namespace Org.Apache.REEF.Examples.HelloREEF
                 .SetJobIdentifier("HelloREEF")
                 .Build();
 
-            _reefClient.SubmitAndGetDriverUrl(helloJobSubmission);
+            _reefClient.SubmitAndGetJobStatus(helloJobSubmission);
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.IMRU/API/IIMRUClient.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/API/IIMRUClient.cs
@@ -41,6 +41,6 @@ namespace Org.Apache.REEF.IMRU.API
         /// For example: see InProcessIMRUCLient.cs
         /// </summary>
         [Unstable("0.13", "This depends on IREEFClient API which itself in unstable ")]
-        IDriverHttpEndpoint DriverHttpEndpoint { get; }
+        IJobSubmissionResult JobSubmissionResult { get; }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IMRU/InProcess/InProcessIMRUClient.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/InProcess/InProcessIMRUClient.cs
@@ -102,7 +102,7 @@ namespace Org.Apache.REEF.IMRU.InProcess
         /// <summary>
         /// DriverHttpEndPoint returned by IReefClient after job submission
         /// </summary>
-        public IDriverHttpEndpoint DriverHttpEndpoint
+        public IJobSubmissionResult JobSubmissionResult
         {
             get { return null; }
         }

--- a/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Client/REEFIMRUClient.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU/OnREEF/Client/REEFIMRUClient.cs
@@ -51,7 +51,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Client
         private readonly IREEFClient _reefClient;
         private readonly JobSubmissionBuilderFactory _jobSubmissionBuilderFactory;
         private readonly AvroConfigurationSerializer _configurationSerializer;
-        private IDriverHttpEndpoint _httpEndPoint;
+        private IJobSubmissionResult _jobSubmissionResult;
 
         [Inject]
         private REEFIMRUClient(IREEFClient reefClient, AvroConfigurationSerializer configurationSerializer,
@@ -149,7 +149,7 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Client
                 .SetJobIdentifier(jobDefinition.JobName)
                 .Build();
 
-            _httpEndPoint = _reefClient.SubmitAndGetDriverUrl(imruJobSubmission);
+            _jobSubmissionResult = _reefClient.SubmitAndGetJobStatus(imruJobSubmission);
 
             return null;
         }
@@ -157,9 +157,9 @@ namespace Org.Apache.REEF.IMRU.OnREEF.Client
         /// <summary>
         /// DriverHttpEndPoint returned by IReefClient after job submission
         /// </summary>
-        public IDriverHttpEndpoint DriverHttpEndpoint
+        public IJobSubmissionResult JobSubmissionResult
         {
-            get { return _httpEndPoint; }
+            get { return _jobSubmissionResult; }
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HadoopFileSystem.cs
+++ b/lang/cs/Org.Apache.REEF.IO/FileSystem/Hadoop/HadoopFileSystem.cs
@@ -61,6 +61,7 @@ namespace Org.Apache.REEF.IO.FileSystem.Hadoop
         /// <returns></returns>
         public Uri CreateUriForPath(string path)
         {
+            Logger.Log(Level.Info, string.Format(CultureInfo.CurrentCulture, "CreateUriForPath with path: {0}, _uriPrefix: {1}.", path, _uriPrefix));
             if (path == null)
             {
                 throw new ArgumentException("null path passed in CreateUriForPath");
@@ -70,18 +71,12 @@ namespace Org.Apache.REEF.IO.FileSystem.Hadoop
             try
             {
                 uri = new Uri(path);
-                var preFix = string.Format(CultureInfo.CurrentCulture,
-                    string.Format(PrefixTemplate, uri.Scheme, uri.Authority));
-                Logger.Log(Level.Info, string.Format(CultureInfo.CurrentCulture, "preFix in the path: {0}.", preFix));
-
-                if (!preFix.Equals(_uriPrefix))
-                {
-                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "Wrong prefix in the path {0} provided.", path));
-                }
+                Logger.Log(Level.Info, string.Format(CultureInfo.CurrentCulture, "Uri {0} created in CreateUriForPath.", uri));
             }
             catch (UriFormatException)
             {
-                uri = new Uri(_uriPrefix + path); 
+                uri = new Uri(_uriPrefix + path);
+                Logger.Log(Level.Info, string.Format(CultureInfo.CurrentCulture, "Uri {0} created in CreateUriForPath with prefix added.", uri));
             }
 
             return uri;

--- a/lang/cs/Org.Apache.REEF.Network.Examples.Client/BroadcastAndReduceClient.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Examples.Client/BroadcastAndReduceClient.cs
@@ -105,7 +105,7 @@ namespace Org.Apache.REEF.Network.Examples.Client
                 .SetJobIdentifier(jobIdentifier)
                 .Build();
 
-            reefClient.SubmitAndGetDriverUrl(jobSubmission);
+            reefClient.SubmitAndGetJobStatus(jobSubmission);
         }
 
         internal static IConfiguration GetRuntimeConfiguration(string runOnYarn, int numberOfEvaluator, string runtimeFolder)

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestBridgeClient.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestBridgeClient.cs
@@ -66,13 +66,13 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         private async void RunClrBridgeClient(bool runOnYarn, string testRuntimeFolder)
         {
             string[] a = new[] { runOnYarn ? "yarn" : "local", testRuntimeFolder };
-            IDriverHttpEndpoint driverHttpEndpoint = AllHandlers.Run(a);
+            IJobSubmissionResult driverHttpEndpoint = AllHandlers.Run(a);
 
             var uri = driverHttpEndpoint.DriverUrl + "NRT/status?a=1&b=2";
             var strStatus = driverHttpEndpoint.GetUrlResult(uri);
             Assert.IsTrue(strStatus.Equals("Byte array returned from HelloHttpHandler in CLR!!!\r\n"));
 
-            await ((HttpClientHelper)driverHttpEndpoint).TryUntilNoConnection(uri);
+            await ((JobSubmissionResult)driverHttpEndpoint).TryUntilNoConnection(uri);
 
             ValidateSuccessForLocalRuntime(2, testRuntimeFolder);
 

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSimpleEventHandlers.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSimpleEventHandlers.cs
@@ -48,7 +48,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         [Timeout(180 * 1000)]
         public void RunSimpleEventHandlerOnLocalRuntime()
         {
-            string testFolder = DefaultRuntimeFolder + TestNumber++;
+            string testFolder = DefaultRuntimeFolder + Guid.NewGuid().ToString("N").Substring(4);
             CleanUp(testFolder);
             TestRun(DriverConfigurations(), typeof(HelloSimpleEventHandlers), 2, "simpleHandler", "local", testFolder);
             ValidateSuccessForLocalRuntime(1, testFolder);

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
@@ -270,7 +270,7 @@ namespace Org.Apache.REEF.Tests.Functional
                 .SetJobIdentifier(jobIdentifier)
                 .Build();
 
-            reefClient.SubmitAndGetDriverUrl(jobSubmission);
+            reefClient.SubmitAndGetJobStatus(jobSubmission);
         }
 
         private IConfiguration GetRuntimeConfiguration(string runOnYarn, int numberOfEvaluator, string runtimeFolder)


### PR DESCRIPTION
*This PR added  GetJobStatus() in IREEFClient and Yarn implementations
*Added named parameter YarnRmWebappHttpsAddressPropertyName for YarnConfigurationUrlProvider so tha tclient can configure it with the values set for the env

JIRA: [REEF-874](https://issues.apache.org/jira/browse/REEF-874)

This closes #