### PR TITLE
[REEF-882] Properly report the message of an Exception causing a failure on YARN to the RM

### DIFF
--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RuntimeClock.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RuntimeClock.java
@@ -114,7 +114,7 @@ public final class RuntimeClock implements Clock {
       this.schedule.add(new StopTime(timer.getCurrent()));
       this.schedule.notifyAll();
       this.closed = true;
-      if (this.stoppedOnException != null) {
+      if (this.stoppedOnException == null) {
         this.stoppedOnException = stopOnException;
       }
     }


### PR DESCRIPTION
This addressed the issue by
  * Inverting null check in RuntimeClock to assign when uninitialized.
  * Changing assumptions of unregistering YARN application as REEF failure when there are Driver Exceptions.

JIRA:
  [REEF-882](https://issues.apache.org/jira/browse/REEF-882)