### PR TITLE
[REEF-819] Add software quality reporting tools for Java code

### DIFF
--- a/lang/java/reef-common/src/main/resources/checkstyle-suppress.xml
+++ b/lang/java/reef-common/src/main/resources/checkstyle-suppress.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+        "-//Puppy Crawl//DTD Suppressions 1.0//EN"
+        "http://www.puppycrawl.com/dtds/suppressions_1_0.dtd">
+
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<suppressions>
+    <suppress checks=".*" files=".*\\target\\generated-sources\\.*" />
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -320,6 +320,7 @@ under the License.
                     </dependencies>
                     <configuration>
                         <configLocation>lang/java/reef-common/src/main/resources/checkstyle.xml</configLocation>
+                        <suppressionsLocation>lang/java/reef-common/src/main/resources/checkstyle-suppress.xml</suppressionsLocation>
                         <packageNamesLocation>lang/java/reef-common/src/main/resources/packagenames.xml</packageNamesLocation>
                         <failOnViolation>true</failOnViolation>
                         <format>xml</format>
@@ -368,6 +369,22 @@ under the License.
                                 </fileMappers>
                             </transformationSet>
                         </transformationSets>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>cobertura-maven-plugin</artifactId>
+                    <version>2.7</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-pmd-plugin</artifactId>
+                    <version>3.5</version>
+                    <configuration>
+                        <targetJdk>1.7</targetJdk>
+                        <excludes>
+                            <exclude>*/target/generated-sources/*</exclude>
+                        </excludes>
                     </configuration>
                 </plugin>
             </plugins>
@@ -448,6 +465,28 @@ under the License.
                         <phase>compile</phase>
                         <goals>
                             <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <configuration>
+                    <instrumentation>
+                        <excludes>
+                            <exclude>org/apache/reef/examples/**/*.class</exclude>
+                            <exclude>org/apache/reef/tang/examples/**/*.class</exclude>
+                            <exclude>org/apache/reef/vortex/examples/**/*.class</exclude>
+                            <exclude>org/apache/reef/wake/examples/**/*.class</exclude>
+                        </excludes>
+                    </instrumentation>
+                    <aggregate>true</aggregate>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>clean</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -808,4 +847,5 @@ under the License.
             </build>
         </profile>
     </profiles>
+
 </project>


### PR DESCRIPTION
This change:
 * configures Cobertura as standalone plugin (mvn cobertura:cobertura)
 * configures PMD and PMD-CPD as standalone plugin (mvn pmd:pmd and mvn pmd:cpd)
 * excludes Java files generated from Avro schemes from Checkstyle check

JIRA:
  [REEF-819](https://issues.apache.org/jira/browse/REEF-819)

Pull request:
  This closes #