### PR TITLE
[REEF-892] Add javadocs and remove redundant modifiers in Wake

### DIFF
--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/ComparableIdentifier.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/ComparableIdentifier.java
@@ -20,8 +20,6 @@ package org.apache.reef.wake;
 
 /**
  * Identifier that can be totally ordered.
- *
- * @param <T> type
  */
 public interface ComparableIdentifier extends Identifier, Comparable<Identifier> {
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/Identifiable.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/Identifiable.java
@@ -18,6 +18,9 @@
  */
 package org.apache.reef.wake;
 
+/**
+ * Identifier that can have id.
+ */
 public interface Identifiable {
 
   /**

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/Identifier.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/Identifier.java
@@ -18,13 +18,12 @@
  */
 package org.apache.reef.wake;
 
-/*
+/**
  * An identifier class for REEF.  Identifiers are a generic naming primitive
  * that carry some information about the type of the object they point to.
  * Typical examples are server sockets, filenames, and requests.
- * 
+ *
  * Identifier constructors should take zero arguments, or take a single string.
- * 
  */
 public interface Identifier {
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/IdentifierFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/IdentifierFactory.java
@@ -18,6 +18,9 @@
  */
 package org.apache.reef.wake;
 
+/**
+ * The factory interface for Wake.
+ */
 public interface IdentifierFactory {
 
   /**

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/StageConfiguration.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/StageConfiguration.java
@@ -29,38 +29,65 @@ import java.util.concurrent.ExecutorService;
  */
 public final class StageConfiguration {
 
+  /**
+   * The stage name.
+   */
   @NamedParameter(doc = "The stage name.")
   public static final class StageName implements Name<String> {
   }
 
+  /**
+   * The event handler for the stage.
+   */
   @NamedParameter(doc = "The event handler for the stage.")
   public static final class StageHandler implements Name<EventHandler<?>> {
   }
 
+  /**
+   * The error handler for the stage.
+   */
   @NamedParameter(doc = "The error handler for the stage.")
   public static final class ErrorHandler implements Name<EventHandler<Throwable>> {
   }
 
+  /**
+   * The number of threads for the stage.
+   */
   @NamedParameter(doc = "The number of threads for the stage.")
   public static final class NumberOfThreads implements Name<Integer> {
   }
 
+  /**
+   * The capacity for the stage.
+   */
   @NamedParameter(doc = "The capacity for the stage.")
   public static final class Capacity implements Name<Integer> {
   }
 
+  /**
+   * The executor service for the stage.
+   */
   @NamedParameter(doc = "The executor service for the stage.")
   public static final class StageExecutorService implements Name<ExecutorService> {
   }
 
+  /**
+   * The initial delay for periodic events of the timer stage.
+   */
   @NamedParameter(doc = "The initial delay for periodic events of the timer stage.")
   public static final class TimerInitialDelay implements Name<Long> {
   }
 
+  /**
+   * The period for periodic events of the timer stage.
+   */
   @NamedParameter(doc = "The period for periodic events of the timer stage.")
   public static final class TimerPeriod implements Name<Long> {
   }
 
+  /**
+   * The observer for the stage.
+   */
   @NamedParameter(doc = "The observer for the stage.")
   public static final class StageObserver implements Name<Observer<?>> {
   }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/WakeParameters.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/WakeParameters.java
@@ -21,8 +21,8 @@ package org.apache.reef.wake;
 import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
-/*
- * Default parameters for Wake
+/**
+ * Default parameters for Wake.
  */
 public final class WakeParameters {
 
@@ -32,15 +32,24 @@ public final class WakeParameters {
 
   public static final long REMOTE_EXECUTOR_SHUTDOWN_TIMEOUT = 10000;
 
-  @NamedParameter(doc = "Maximum frame length unit", default_value = "" + MAX_FRAME_LENGTH)
+  /**
+   * Maximum frame length unit.
+   */
+  @NamedParameter(doc = "Maximum frame length unit.", default_value = "" + MAX_FRAME_LENGTH)
   public static final class MaxFrameLength implements Name<Integer> {
   }
 
-  @NamedParameter(doc = "Executor shutdown timeout", default_value = "" + EXECUTOR_SHUTDOWN_TIMEOUT)
+  /**
+   * Executor shutdown timeout.
+   */
+  @NamedParameter(doc = "Executor shutdown timeout.", default_value = "" + EXECUTOR_SHUTDOWN_TIMEOUT)
   public static final class ExecutorShutdownTimeout implements Name<Integer> {
   }
 
-  @NamedParameter(doc = "Remote send timeout", default_value = "" + REMOTE_EXECUTOR_SHUTDOWN_TIMEOUT)
+  /**
+   * Remote send timeout.
+   */
+  @NamedParameter(doc = "Remote send timeout.", default_value = "" + REMOTE_EXECUTOR_SHUTDOWN_TIMEOUT)
   public static final class RemoteSendTimeout implements Name<Integer> {
   }
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/accumulate/CombinerStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/accumulate/CombinerStage.java
@@ -25,6 +25,12 @@ import org.apache.reef.wake.rx.Observer;
 import java.util.Map;
 import java.util.concurrent.ConcurrentSkipListMap;
 
+/**
+ * key-value pair Combiner stage.
+ *
+ * @param <K> key
+ * @param <V> value
+ */
 public class CombinerStage<K extends Comparable<K>, V> implements Stage {
 
   private final Combiner<K, V> c;
@@ -87,10 +93,22 @@ public class CombinerStage<K extends Comparable<K>, V> implements Stage {
     worker.join();
   }
 
+  /**
+   * key-value pair Combiner Interface.
+   *
+   * @param <K> key
+   * @param <V> value
+   */
   public interface Combiner<K extends Comparable<K>, V> {
     V combine(K key, V old, V cur);
   }
 
+  /**
+   * A comparable key-value pair.
+   *
+   * @param <K> key
+   * @param <V> value
+   */
   public static class Pair<K extends Comparable<K>, V> implements Map.Entry<K, V>, Comparable<Map.Entry<K, V>> {
     private final K k;
     private final V v;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/accumulate/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/accumulate/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * A key-value combiner example.
  */
 package org.apache.reef.wake.examples.accumulate;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/BlockingJoin.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/BlockingJoin.java
@@ -23,7 +23,9 @@ import org.apache.reef.wake.rx.StaticObservable;
 
 import java.util.concurrent.ConcurrentSkipListSet;
 
-
+/**
+ * Blocking join.
+ */
 public class BlockingJoin implements StaticObservable {
   private final Observer<TupleEvent> out;
   private final ConcurrentSkipListSet<TupleEvent> left = new ConcurrentSkipListSet<>();

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/EventPrinter.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/EventPrinter.java
@@ -20,6 +20,11 @@ package org.apache.reef.wake.examples.join;
 
 import org.apache.reef.wake.rx.Observer;
 
+/**
+ * Event printer.
+ *
+ * @param <T> the type of the event
+ */
 public class EventPrinter<T> implements Observer<T> {
 
   @Override

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/NonBlockingJoin.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/NonBlockingJoin.java
@@ -24,7 +24,9 @@ import org.apache.reef.wake.rx.StaticObservable;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-
+/**
+ * Non-blocking Join.
+ */
 public class NonBlockingJoin implements StaticObservable {
   private final AtomicBoolean leftDone = new AtomicBoolean(false);
   private final AtomicBoolean completed = new AtomicBoolean(false);

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/TupleEvent.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/TupleEvent.java
@@ -18,7 +18,9 @@
  */
 package org.apache.reef.wake.examples.join;
 
-
+/**
+ * A tuple event consisting key and value pair.
+ */
 public class TupleEvent implements Comparable<TupleEvent> {
   private final int key;
   private final String val;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/TupleSource.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/TupleSource.java
@@ -22,6 +22,9 @@ import org.apache.reef.wake.Stage;
 import org.apache.reef.wake.rx.Observer;
 import org.apache.reef.wake.rx.StaticObservable;
 
+/**
+ * A source class generating TupleEvent.
+ */
 public class TupleSource implements StaticObservable, Stage {
   private final Thread[] threads;
   private final Observer<TupleEvent> out;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/join/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Blocking and non-blocking join example.
  */
 package org.apache.reef.wake.examples.join;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Wake examples.
  */
 package org.apache.reef.wake.examples;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/exception/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/exception/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Wake exceptions.
  */
 package org.apache.reef.wake.exception;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/IndependentIterationsThreadPoolStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/IndependentIterationsThreadPoolStage.java
@@ -31,10 +31,6 @@ import java.util.logging.Logger;
  * This stage uses a thread pool to schedule events in parallel.
  * Should be used when input events are already materialized in a List and
  * can be fired in any order.
- *
- * @param numThreads  fixed number of threads available in the pool
- * @param granularity maximum number of events executed serially.
- *                    The right choice will balance task spawn overhead with parallelism.
  */
 public class IndependentIterationsThreadPoolStage<T> extends AbstractEStage<List<T>> {
 
@@ -42,6 +38,14 @@ public class IndependentIterationsThreadPoolStage<T> extends AbstractEStage<List
   private EventHandler<T> handler;
   private ExecutorService executor;
 
+  /**
+   * Create a thread pool with fixed threads.
+   *
+   * @param handler     an event handler
+   * @param numThreads  fixed number of threads available in the pool
+   * @param granularity maximum number of events executed serially.
+   *                    The right choice will balance task spawn overhead with parallelism.
+   */
   public IndependentIterationsThreadPoolStage(
       final EventHandler<T> handler, final int numThreads, final int granularity) {
     super(handler.getClass().getName());

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/MergingEventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/MergingEventHandler.java
@@ -60,7 +60,7 @@ public final class MergingEventHandler<L, R> {
     reset();
   }
 
-  /*
+  /**
    * Not thread safe. Must be externally synchronized.
    */
   private void reset() {
@@ -68,6 +68,12 @@ public final class MergingEventHandler<L, R> {
     leftEvent = null;
   }
 
+  /**
+   * A pair having two independent typed items.
+   *
+   * @param <S1> a type of first item
+   * @param <S2> a type of second item
+   */
   public static final class Pair<S1, S2> {
     private final S1 first;
     private final S2 second;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/WakeSharedPool.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/WakeSharedPool.java
@@ -34,17 +34,19 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 
-// This implementation uses the fork join framework to reduce the cost of spawning
-// events in stages. For two participating stages back to back, the pool allows
-// for the thread in the first stage to execute the event it submits to the second stage.
-// These choices are made by the ForkJoinPool.
-// 
-// So, this does sort of go against the reason for stages, but doesn't eliminate them
-// and raises the level of abstraction that Wake sees above threads. 
-//
-// this will only be deadlock free if blocking synchronization done by events is safe.
-// That is no event submitted to the pool can have a producer/consumer dependency
-// on another event submitted to the pool
+/**
+ * This implementation uses the fork join framework to reduce the cost of spawning
+ * events in stages. For two participating stages back to back, the pool allows
+ * for the thread in the first stage to execute the event it submits to the second stage.
+ * These choices are made by the ForkJoinPool.
+ *
+ * So, this does sort of go against the reason for stages, but doesn't eliminate them
+ * and raises the level of abstraction that Wake sees above threads.
+ *
+ * this will only be deadlock free if blocking synchronization done by events is safe.
+ * That is no event submitted to the pool can have a producer/consumer dependency
+ * on another event submitted to the pool
+ */
 public class WakeSharedPool implements Stage {
   private static final Logger LOG = Logger.getLogger(WakeSharedPool.class.getName());
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Wake's implementation.
  */
 package org.apache.reef.wake.impl;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Implementations of standard latency and throughput instrumentation.
  */
 package org.apache.reef.wake.metrics;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Public interfaces and factories for Wake's core API.
  */
 package org.apache.reef.wake;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/Vertex.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/Vertex.java
@@ -30,7 +30,6 @@ public class Vertex<T> {
   private final String name;
   private final ConstructorDef<T> constructorDef;
   private final Vertex<?>[] constructorArguments;
-//  private final Set<Object> referencesToThisObject = new MonotonicHashSet<>();
 
   public Vertex(final T object, final String name, final ConstructorDef<T> constructorDef,
                 final Vertex<?>[] constructorArguments) {
@@ -73,12 +72,6 @@ public class Vertex<T> {
     this.constructorArguments = null;
   }
 
-  //  public void addReference(Vertex<?> v) {
-//    referencesToThisObject.add(v);
-//  }
-//  public Vertex<?>[] getInEdges() {
-//    return referencesToThisObject.toArray(new Vertex[0]);
-//  }
   public ConstructorDef<T> getConstructorDef() {
     return this.constructorDef;
   }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/WakeProfiler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/WakeProfiler.java
@@ -35,6 +35,9 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Logger;
 
+/**
+ * A graphical profiler class that instruments Tang-based Wake applications.
+ */
 public class WakeProfiler implements Aspect {
   private static final Logger LOG = Logger.getLogger(WakeProfiler.class.toString());
   private final Map<Object, Vertex<?>> vertexObject = new MonotonicHashMap<>();
@@ -69,7 +72,7 @@ public class WakeProfiler implements Aspect {
   @SuppressWarnings("unchecked")
   private <T> Vertex<?> newSetVertex(final Set<T> s) {
     if (vertexObject.containsKey(s)) {
-      return (Vertex<Set<T>>) vertexObject.get(s);
+      return vertexObject.get(s);
     }
     if (s.size() > 1) {
       LOG.fine("new set of size " + s.size());
@@ -95,7 +98,6 @@ public class WakeProfiler implements Aspect {
   @Override
   public <T> T inject(final ConstructorDef<T> constructorDef, final Constructor<T> constructor, final Object[] args)
       throws InvocationTargetException, IllegalAccessException, IllegalArgumentException, InstantiationException {
-//    LOG.info("inject" + constructor + "->" + args.length);
     final Vertex<?>[] vArgs = new Vertex[args.length];
     for (int i = 0; i < args.length; i++) {
       final Object o = args[i];
@@ -130,7 +132,6 @@ public class WakeProfiler implements Aspect {
 
             if (method.getName().equals("onNext")) {
               final long start = System.nanoTime();
-//              LOG.info(object + "." + method.getName() + " called");
               final Object o = methodProxy.invokeSuper(object, args);
               final long stop = System.nanoTime();
 
@@ -233,8 +234,6 @@ public class WakeProfiler implements Aspect {
         LOG.warning("Set of size " + ((Set<?>) o).size() + " with " + v.getOutEdges().length + " out edges");
         s = "{...}";
         tooltip = null;
-////      } else if(false && (o instanceof EventHandler || o instanceof Stage)) {
-////        s = jsonEscape(v.getObject().toString());
       } else {
         final Stats stat = stats.get(o);
         if (stat != null) {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/profiler/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * A graphical profiler that automatically instruments Tang-based Wake applications.
  */
 package org.apache.reef.wake.profiler;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/Decoder.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/Decoder.java
@@ -29,7 +29,7 @@ public interface Decoder<T> {
   /**
    * Decodes the given byte array into an object.
    *
-   * @param buf
+   * @param data the data to be decoded
    * @return the decoded object
    */
   T decode(byte[] data);

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/Encoder.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/Encoder.java
@@ -29,7 +29,7 @@ public interface Encoder<T> {
   /**
    * Encodes the given object into a Byte Array.
    *
-   * @param obj
+   * @param obj an object to be encoded
    * @return a byte[] representation of the object
    */
   byte[] encode(T obj);

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteConfiguration.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteConfiguration.java
@@ -31,54 +31,84 @@ import org.apache.reef.wake.remote.impl.TransportEvent;
  */
 public final class RemoteConfiguration {
 
+  /**
+   * The name of the remote manager.
+   */
   @NamedParameter(short_name = "rm_name", doc = "The name of the remote manager.", default_value = "REEF_CLIENT")
   public static final class ManagerName implements Name<String> {
     // Intentionally empty
   }
 
+  /**
+   * The host address to be used for messages.
+   */
   @NamedParameter(short_name = "rm_host", doc = "The host address to be used for messages.",
       default_value = "##UNKNOWN##")
   public static final class HostAddress implements Name<String> {
     // Intentionally empty
   }
 
+  /**
+   * The port to be used for messages.
+   */
   @NamedParameter(short_name = "rm_port", doc = "The port to be used for messages.", default_value = "0")
   public static final class Port implements Name<Integer> {
     // Intentionally empty
   }
 
+  /**
+   * The codec to be used for messages.
+   */
   @NamedParameter(doc = "The codec to be used for messages.", default_class = ObjectSerializableCodec.class)
   public static final class MessageCodec implements Name<Codec<?>> {
     // Intentionally empty
   }
 
-  @NamedParameter(doc = "The event handler to be used for throwables", default_class = DefaultErrorHandler.class)
+  /**
+   * The event handler to be used for throwables.
+   */
+  @NamedParameter(doc = "The event handler to be used for throwables.", default_class = DefaultErrorHandler.class)
   public static final class ErrorHandler implements Name<EventHandler<Throwable>> {
     // Intentionally empty
   }
 
+  /**
+   * Whether or not to use the message ordering guarantee.
+   */
   @NamedParameter(short_name = "rm_order",
-      doc = "Whether or not to use the message ordering guarantee", default_value = "true")
+      doc = "Whether or not to use the message ordering guarantee.", default_value = "true")
   public static final class OrderingGuarantee implements Name<Boolean> {
     // Intentionally empty
   }
 
-  @NamedParameter(doc = "The number of tries", default_value = "3")
+  /**
+   * The number of tries.
+   */
+  @NamedParameter(doc = "The number of tries.", default_value = "3")
   public static final class NumberOfTries implements Name<Integer> {
     // Intentionally empty    
   }
 
-  @NamedParameter(doc = "The timeout of connection retrying", default_value = "10000")
+  /**
+   * The timeout of connection retrying.
+   */
+  @NamedParameter(doc = "The timeout of connection retrying.", default_value = "10000")
   public static final class RetryTimeout implements Name<Integer> {
     // Intentionally empty       
   }
 
-  @NamedParameter(doc = "Client stage for messaging transport", default_class = DefaultTransportEStage.class)
+  /**
+   * Client stage for messaging transport.
+   */
+  @NamedParameter(doc = "Client stage for messaging transport.", default_class = DefaultTransportEStage.class)
   public static final class RemoteClientStage implements Name<EStage<TransportEvent>> {
     // Intentionally empty
   }
 
-  @NamedParameter(doc = "Server stage for messaging transport", default_class = DefaultTransportEStage.class)
+  /**
+   * Server stage for messaging transport.
+   */
+  @NamedParameter(doc = "Server stage for messaging transport.", default_class = DefaultTransportEStage.class)
   public static final class RemoteServerStage implements Name<EStage<TransportEvent>> {
     // Intentionally empty
   }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/exception/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/exception/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Wake remote exceptions.
  */
 package org.apache.reef.wake.remote.exception;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/ConnectFutureTask.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/ConnectFutureTask.java
@@ -23,6 +23,11 @@ import org.apache.reef.wake.EventHandler;
 import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
 
+/**
+ * FutureTask for network connection.
+ *
+ * @param <T> type
+ */
 public class ConnectFutureTask<T> extends FutureTask<T> {
 
   private final EventHandler<ConnectFutureTask<T>> handler;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteIdentifierFactoryImplementation.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultRemoteIdentifierFactoryImplementation.java
@@ -26,6 +26,9 @@ import org.apache.reef.wake.remote.RemoteIdentifierFactory;
 import javax.inject.Inject;
 import java.util.Map;
 
+/**
+ * A default implementation for RemoteIdentifierFactory interface.
+ */
 public class DefaultRemoteIdentifierFactoryImplementation extends DefaultIdentifierFactory
     implements RemoteIdentifierFactory {
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultTransportEStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/DefaultTransportEStage.java
@@ -22,6 +22,9 @@ import org.apache.reef.wake.EStage;
 
 import javax.inject.Inject;
 
+/**
+ * A default event-based message transporting stage for both client and server.
+ */
 public class DefaultTransportEStage implements EStage<TransportEvent> {
 
   @Inject

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/MultiCodec.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/MultiCodec.java
@@ -30,7 +30,7 @@ import java.util.Map.Entry;
  * Codec using the WakeTuple protocol buffer.
  * (class name and bytes)
  *
- * @param <T>
+ * @param <T> type
  */
 public class MultiCodec<T> implements Codec<T> {
 
@@ -40,7 +40,7 @@ public class MultiCodec<T> implements Codec<T> {
   /**
    * Constructs a codec that encodes/decodes an object to/from bytes based on the class name.
    *
-   * @param clazzToDecoderMap
+   * @param clazzToCodecMap a map of codec for class
    */
   public MultiCodec(final Map<Class<? extends T>, Codec<? extends T>> clazzToCodecMap) {
     final Map<Class<? extends T>, Encoder<? extends T>> clazzToEncoderMap = new HashMap<>();
@@ -56,7 +56,7 @@ public class MultiCodec<T> implements Codec<T> {
   /**
    * Encodes an object to a byte array.
    *
-   * @param obj
+   * @param obj object to be encoded
    */
   @Override
   public byte[] encode(final T obj) {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/MultiDecoder.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/MultiDecoder.java
@@ -37,7 +37,7 @@ public class MultiDecoder<T> implements Decoder<T> {
   /**
    * Constructs a decoder that decodes bytes based on the class name.
    *
-   * @param clazzToDecoderMap
+   * @param clazzToDecoderMap a map of decoder for class
    */
   public MultiDecoder(final Map<Class<? extends T>, Decoder<? extends T>> clazzToDecoderMap) {
     this.clazzToDecoderMap = clazzToDecoderMap;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/MultiEncoder.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/MultiEncoder.java
@@ -29,7 +29,7 @@ import java.util.Map;
  * Encoder using the WakeTuple protocol buffer.
  * (class name and bytes)
  *
- * @param <T>
+ * @param <T> type
  */
 public class MultiEncoder<T> implements Encoder<T> {
 
@@ -38,7 +38,7 @@ public class MultiEncoder<T> implements Encoder<T> {
   /**
    * Constructs an encoder that encodes an object to bytes based on the class name.
    *
-   * @param clazzToEncoderMap
+   * @param clazzToEncoderMap a map of encoder for class
    */
   public MultiEncoder(final Map<Class<? extends T>, Encoder<? extends T>> clazzToEncoderMap) {
     this.clazzToEncoderMap = clazzToEncoderMap;
@@ -47,7 +47,7 @@ public class MultiEncoder<T> implements Encoder<T> {
   /**
    * Encodes an object to a byte array.
    *
-   * @param obj
+   * @param obj an object to be encode
    */
   @Override
   public byte[] encode(final T obj) {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/ObjectSerializableCodec.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/ObjectSerializableCodec.java
@@ -27,7 +27,7 @@ import java.io.*;
 /**
  * Codec that uses Java serialization.
  *
- * @param <T>
+ * @param <T> type
  */
 public class ObjectSerializableCodec<T> implements Codec<T> {
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/OrderedRemoteReceiverStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/OrderedRemoteReceiverStage.java
@@ -47,7 +47,7 @@ public class OrderedRemoteReceiverStage implements EStage<TransportEvent> {
   private final ThreadPoolStage<OrderedEventStream> pullStage;
 
   /**
-   * Constructs a ordered remote receiver stage.
+   * Constructs an ordered remote receiver stage.
    *
    * @param handler      the handler of remote events
    * @param errorHandler the exception handler
@@ -119,7 +119,7 @@ class OrderedPushEventHandler implements EventHandler<TransportEvent> {
 
   OrderedPushEventHandler(final ConcurrentMap<SocketAddress, OrderedEventStream> streamMap,
                           final ThreadPoolStage<OrderedEventStream> pullStage) {
-    this.codec = new RemoteEventCodec<byte[]>(new ByteCodec());
+    this.codec = new RemoteEventCodec<>(new ByteCodec());
     this.streamMap = streamMap;
     this.pullStage = pullStage;
   }
@@ -180,7 +180,7 @@ class OrderedEventStream {
   private long nextSeq; // the number of the next event to consume
 
   OrderedEventStream() {
-    queue = new PriorityBlockingQueue<RemoteEvent<byte[]>>(11, new RemoteEventComparator<byte[]>());
+    queue = new PriorityBlockingQueue<>(11, new RemoteEventComparator<byte[]>());
     nextSeq = 0;
   }
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteSeqNumGenerator.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteSeqNumGenerator.java
@@ -32,7 +32,7 @@ public class RemoteSeqNumGenerator {
   private final ConcurrentMap<SocketAddress, AtomicLong> seqMap;
 
   public RemoteSeqNumGenerator() {
-    seqMap = new ConcurrentHashMap<SocketAddress, AtomicLong>();
+    seqMap = new ConcurrentHashMap<>();
   }
 
   public long getNextSeq(final SocketAddress addr) {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Implementations for Wake's remote communication.
  */
 package org.apache.reef.wake.remote.impl;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Wake's remote communication.
  */
 package org.apache.reef.wake.remote;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/TcpPortProvider.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/TcpPortProvider.java
@@ -24,7 +24,7 @@ import java.util.Iterator;
 
 /**
  * Provides an iterator that returns port numbers.
-*/
+ */
 @DefaultImplementation(RangeTcpPortProvider.class)
 public interface TcpPortProvider extends Iterable<Integer> {
   /**

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * TCP port providers.
  */
 package org.apache.reef.wake.remote.ports;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/parameters/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/parameters/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Parameters for TCP port selection.
  */
 package org.apache.reef.wake.remote.ports.parameters;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/exception/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/exception/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Wake remote transport exceptions.
  */
 package org.apache.reef.wake.remote.transport.exception;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/ChunkedReadWriteHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/ChunkedReadWriteHandler.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 import java.util.logging.Logger;
 
 /**
- * Thin wrapper around ChunkedWriteHandler
+ * Thin wrapper around ChunkedWriteHandler.
  * <p/>
  * ChunkedWriteHandler only handles the down stream parts
  * and just emits the chunks up stream. So we add an upstream
@@ -177,8 +177,8 @@ public class ChunkedReadWriteHandler extends ChunkedWriteHandler {
     return ret;
   }
 
-  /*
-   * Release Bytebuf when the stream closes
+  /**
+   * Release Bytebuf when the stream closes.
    */
   private class ByteBufCloseableStream extends ByteBufInputStream {
     private final ByteBuf buffer;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/LinkReference.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/LinkReference.java
@@ -22,6 +22,10 @@ import org.apache.reef.wake.remote.transport.Link;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * A reference for a link.
+ * When channel became active, LinkReference is created and mapped with remote address.
+ */
 final class LinkReference {
 
   private final AtomicInteger connectInProgress = new AtomicInteger(0);

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyChannelHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyChannelHandler.java
@@ -27,7 +27,9 @@ import io.netty.util.ReferenceCountUtil;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-
+/**
+ * Netty channel handler for channel status(active/inactive) and incoming data.
+ */
 class NettyChannelHandler extends ChannelInboundHandlerAdapter {
 
   private static final Logger LOG = Logger.getLogger(NettyChannelHandler.class.getName());
@@ -60,7 +62,6 @@ class NettyChannelHandler extends ChannelInboundHandlerAdapter {
   @Override
   public void channelRead(
       final ChannelHandlerContext ctx, final Object msg) throws Exception {
-    //LOG.log(Level.FINEST, "Read {0} {1}", new Object[]{ctx.channel(), msg});
     try {
       this.listener.channelRead(ctx, msg);
     } finally {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyChannelInitializer.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyChannelInitializer.java
@@ -27,11 +27,11 @@ import io.netty.handler.codec.bytes.ByteArrayEncoder;
 
 /**
  * Netty channel initializer for Transport.
- * <p/>
- * MAXFRAMELENGTH : the buffer size of the frame decoder
  */
 class NettyChannelInitializer extends ChannelInitializer<SocketChannel> {
-
+  /**
+   * the buffer size of the frame decoder.
+   */
   public static final int MAXFRAMELENGTH = 10 * 1024 * 1024;
   private final NettyChannelHandlerFactory handlerFactory;
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyClientEventListener.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyClientEventListener.java
@@ -28,6 +28,9 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * A Netty event listener for server.
+ */
 final class NettyClientEventListener extends AbstractNettyEventListener {
 
   private static final Logger LOG = Logger.getLogger(NettyClientEventListener.class.getName());

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyLink.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyLink.java
@@ -31,7 +31,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Link implementation with Netty
+ * Link implementation with Netty.
  *
  * If you set a LinkListener<T>, it keeps message until writeAndFlush operation completes
  * and notifies whether the sent message transferred successfully through the listener.

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyServerEventListener.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyServerEventListener.java
@@ -28,6 +28,9 @@ import java.net.SocketAddress;
 import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
 
+/**
+ * A Netty event listener for server side.
+ */
 final class NettyServerEventListener extends AbstractNettyEventListener {
 
   public NettyServerEventListener(

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Netty-based remote transport implementation.
  */
 package org.apache.reef.wake.remote.transport.netty;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Wake's remote transportation.
  */
 package org.apache.reef.wake.remote.transport;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/exception/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/exception/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * RX-style communication exceptions.
  */
 package org.apache.reef.wake.rx.exception;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/TimeoutSubject.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/TimeoutSubject.java
@@ -23,6 +23,11 @@ import org.apache.reef.wake.rx.Subject;
 
 import java.util.concurrent.TimeoutException;
 
+/**
+ * A class implementing Subject<T> with timeout.
+ *
+ * @param <T>
+ */
 public class TimeoutSubject<T> implements Subject<T, T> {
   private Thread timeBomb;
   private Observer<T> destination;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Wake's RX-style communication implementation.
  */
 package org.apache.reef.wake.rx.impl;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Wake's RX-style communication.
  */
 package org.apache.reef.wake.rx;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/storage/FileIdentifier.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/storage/FileIdentifier.java
@@ -22,6 +22,9 @@ import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+/**
+ * An identifier has a File URI.
+ */
 public class FileIdentifier implements StorageIdentifier {
   private final File f;
 

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/Clock.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/Clock.java
@@ -81,34 +81,34 @@ public interface Clock extends Runnable, AutoCloseable {
    * Bind this to an event handler to statically subscribe to the StartTime Event.
    */
   @NamedParameter(default_class = MissingStartHandlerHandler.class, doc = "Will be called upon the start event")
-  public class StartHandler implements Name<Set<EventHandler<StartTime>>> {
+  class StartHandler implements Name<Set<EventHandler<StartTime>>> {
   }
 
   /**
    * Bind this to an event handler to statically subscribe to the StopTime Event.
    */
   @NamedParameter(default_class = LoggingEventHandler.class, doc = "Will be called upon the stop event")
-  public class StopHandler implements Name<Set<EventHandler<StopTime>>> {
+  class StopHandler implements Name<Set<EventHandler<StopTime>>> {
   }
 
   /**
    * Bind this to an event handler to statically subscribe to the RuntimeStart Event.
    */
   @NamedParameter(default_class = LoggingEventHandler.class, doc = "Will be called upon the runtime start event")
-  public class RuntimeStartHandler implements Name<Set<EventHandler<RuntimeStart>>> {
+  class RuntimeStartHandler implements Name<Set<EventHandler<RuntimeStart>>> {
   }
 
   /**
    * Bind this to an event handler to statically subscribe to the RuntimeStart Event.
    */
   @NamedParameter(default_class = LoggingEventHandler.class, doc = "Will be called upon the runtime stop event")
-  public class RuntimeStopHandler implements Name<Set<EventHandler<RuntimeStop>>> {
+  class RuntimeStopHandler implements Name<Set<EventHandler<RuntimeStop>>> {
   }
 
   /**
    * Bind this to an event handler to statically subscribe to the IdleClock Event.
    */
   @NamedParameter(default_class = LoggingEventHandler.class, doc = "Will be called upon the Idle event")
-  public class IdleHandler implements Name<Set<EventHandler<IdleClock>>> {
+  class IdleHandler implements Name<Set<EventHandler<IdleClock>>> {
   }
 }

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/event/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/event/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * A time-based events (start/stop/alarm).
  */
 package org.apache.reef.wake.time.event;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Clock and time-based events(start/stop/alarm) implementation.
  */
 package org.apache.reef.wake.time;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/LogicalTimer.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/LogicalTimer.java
@@ -20,6 +20,9 @@ package org.apache.reef.wake.time.runtime;
 
 import javax.inject.Inject;
 
+/**
+ * Logical timer.
+ */
 public final class LogicalTimer implements Timer {
 
   private long current = 0;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RealTimer.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RealTimer.java
@@ -20,6 +20,9 @@ package org.apache.reef.wake.time.runtime;
 
 import javax.inject.Inject;
 
+/**
+ * A system-time based Timer.
+ */
 public final class RealTimer implements Timer {
 
   @Inject

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RuntimeClock.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/RuntimeClock.java
@@ -35,6 +35,13 @@ import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * Default implementation of clock.
+ *
+ * After invoking `RuntimeStart` and `StartTime` events initially,
+ * this invokes scheduled events on time. If there is no scheduled event,
+ * `IdleClock` event is invoked.
+ */
 public final class RuntimeClock implements Clock {
 
   private static final Logger LOG = Logger.getLogger(Clock.class.toString());

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/Timer.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/Timer.java
@@ -20,6 +20,9 @@ package org.apache.reef.wake.time.runtime;
 
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
+/**
+ * An interface for Timer.
+ */
 @DefaultImplementation(RealTimer.class)
 public interface Timer {
   long getCurrent();

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/ClientAlarm.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/ClientAlarm.java
@@ -21,6 +21,9 @@ package org.apache.reef.wake.time.runtime.event;
 import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.time.event.Alarm;
 
+/**
+ * An event for client-created alarm.
+ */
 public final class ClientAlarm extends Alarm {
 
   public ClientAlarm(final long timestamp, final EventHandler<Alarm> handler) {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/IdleClock.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/IdleClock.java
@@ -20,6 +20,9 @@ package org.apache.reef.wake.time.runtime.event;
 
 import org.apache.reef.wake.time.Time;
 
+/**
+ * A event when there is no scheduled event.
+ */
 public final class IdleClock extends Time {
 
   public IdleClock(final long timestamp) {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/RuntimeAlarm.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/RuntimeAlarm.java
@@ -21,6 +21,9 @@ package org.apache.reef.wake.time.runtime.event;
 import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.time.event.Alarm;
 
+/**
+ * An event for non-client alarm.
+ */
 public final class RuntimeAlarm extends Alarm {
 
   public RuntimeAlarm(final long timestamp, final EventHandler<Alarm> handler) {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/RuntimeStart.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/RuntimeStart.java
@@ -20,6 +20,9 @@ package org.apache.reef.wake.time.runtime.event;
 
 import org.apache.reef.wake.time.Time;
 
+/**
+ * An event for a runtime started.
+ */
 public final class RuntimeStart extends Time {
 
   public RuntimeStart(final long timestamp) {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/RuntimeStop.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/RuntimeStop.java
@@ -20,6 +20,9 @@ package org.apache.reef.wake.time.runtime.event;
 
 import org.apache.reef.wake.time.Time;
 
+/**
+ * An event for a runtime stopped.
+ */
 public class RuntimeStop extends Time {
 
   private final Throwable exception;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/package-info.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/time/runtime/event/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Runtime-related Wake events.
  */
 package org.apache.reef.wake.time.runtime.event;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/BlockingEventHandlerTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/BlockingEventHandlerTest.java
@@ -27,6 +27,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+/**
+ * Blocking event handler test.
+ */
 public class BlockingEventHandlerTest {
 
   @Test

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/BlockingSignalEventHandlerTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/BlockingSignalEventHandlerTest.java
@@ -27,6 +27,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+/**
+ * Blocking signal event handler test.
+ */
 public class BlockingSignalEventHandlerTest {
 
   @Test

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/ForkPoolStageTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/ForkPoolStageTest.java
@@ -31,6 +31,9 @@ import org.junit.rules.TestName;
 import java.util.*;
 
 
+/**
+ * ForkPool stage test.
+ */
 public class ForkPoolStageTest {
 
   private static final String LOG_PREFIX = "TEST ";

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/IndependentIterationsThreadPoolStageTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/IndependentIterationsThreadPoolStageTest.java
@@ -30,6 +30,9 @@ import java.util.logging.Logger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+/**
+ * IndependentIterationsThreadPoolStage test.
+ */
 public class IndependentIterationsThreadPoolStageTest {
 
   @Test

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/MergingEventHandlerTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/MergingEventHandlerTest.java
@@ -29,6 +29,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * Merging event handler tests.
+ */
 public class MergingEventHandlerTest {
 
   @Test

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/MetricsTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/MetricsTest.java
@@ -27,6 +27,9 @@ import org.junit.rules.TestName;
 
 import java.util.Random;
 
+/**
+ * Metrics tests.
+ */
 public class MetricsTest {
 
   private static final String LOG_PREFIX = "TEST ";

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/PubSubThreadPoolStageTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/PubSubThreadPoolStageTest.java
@@ -35,6 +35,9 @@ import java.util.HashSet;
 import java.util.Set;
 
 
+/**
+ * Publish/subscribe event handler tests.
+ */
 public class PubSubThreadPoolStageTest {
 
   private static final String LOG_PREFIX = "TEST ";

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/StageManagerTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/StageManagerTest.java
@@ -24,6 +24,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 
+/**
+ * Stage manager tests.
+ */
 public class StageManagerTest {
   @Rule
   public TestName name = new TestName();

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/SyncStageTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/SyncStageTest.java
@@ -30,6 +30,9 @@ import org.junit.rules.TestName;
 import java.util.*;
 
 
+/**
+ * Sync stage tests.
+ */
 public class SyncStageTest {
 
   private static final String LOG_PREFIX = "TEST ";

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/ThreadPoolStageTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/ThreadPoolStageTest.java
@@ -31,6 +31,9 @@ import org.junit.rules.TestName;
 import java.util.*;
 
 
+/**
+ * Thread pool stage tests.
+ */
 public class ThreadPoolStageTest {
 
   private static final String LOG_PREFIX = "TEST ";

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/TimerStageTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/TimerStageTest.java
@@ -31,6 +31,9 @@ import org.junit.rules.TestName;
 import java.util.concurrent.atomic.AtomicInteger;
 
 
+/**
+ * Timer stage tests.
+ */
 public class TimerStageTest {
 
   private static final String LOG_PREFIX = "TEST ";

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/SkipListTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/SkipListTest.java
@@ -23,6 +23,9 @@ import org.junit.Assert;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * Tests for ConcurrentSkipListMap.
+ */
 public class SkipListTest {
 
   public static void main(final String[] arg) {

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestBlockingJoin.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestBlockingJoin.java
@@ -24,7 +24,9 @@ import org.apache.reef.wake.examples.join.TupleEvent;
 import org.apache.reef.wake.examples.join.TupleSource;
 import org.junit.Test;
 
-
+/**
+ * Tests for BlockingJoin.
+ */
 public class TestBlockingJoin {
   @Test
   public void testJoin() throws Exception {

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestCombiner.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestCombiner.java
@@ -27,6 +27,9 @@ import java.util.Map.Entry;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * Tests for CombinerStage.
+ */
 public class TestCombiner {
 
   private static final int BUCKET_COUNT = 1000;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestJoin.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestJoin.java
@@ -25,6 +25,9 @@ import org.apache.reef.wake.examples.join.TupleSource;
 import org.junit.Test;
 
 
+/**
+ * Tests for NonBlockingJoin.
+ */
 public class TestJoin {
   @Test
   public void testJoin() throws Exception {

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestTupleSource.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/TestTupleSource.java
@@ -24,6 +24,9 @@ import org.apache.reef.wake.examples.join.TupleSource;
 import org.junit.Test;
 
 
+/**
+ * Tests for TupleSource.
+ */
 public class TestTupleSource {
   @Test
   public void testOneThread() throws Exception {

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/package-info.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/examples/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Tests for org.apache.reef.wake.examples package.
  */
 package org.apache.reef.wake.test.examples;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/package-info.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Tests for org.apache.reef.wake package.
  */
 package org.apache.reef.wake.test;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/RemoteIdentifierFactoryTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/RemoteIdentifierFactoryTest.java
@@ -36,6 +36,9 @@ import org.junit.rules.TestName;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Tests for RemoteIdentifierFactory.
+ */
 public class RemoteIdentifierFactoryTest {
   @Rule
   public final TestName name = new TestName();

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/RemoteManagerTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/RemoteManagerTest.java
@@ -49,6 +49,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 
+/**
+ * Tests for RemoteManagerFactory.
+ */
 public class RemoteManagerTest {
 
   private final LocalAddressProvider localAddressProvider;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/RemoteTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/RemoteTest.java
@@ -47,6 +47,9 @@ import java.net.UnknownHostException;
 import java.util.*;
 import java.util.logging.Level;
 
+/**
+ * Tests for remote event.
+ */
 public class RemoteTest {
   private final LocalAddressProvider localAddressProvider;
   private final TransportFactory tpFactory;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/SmallMessagesTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/SmallMessagesTest.java
@@ -43,6 +43,9 @@ import org.junit.rules.TestName;
 import java.util.*;
 import java.util.logging.Level;
 
+/**
+ * Test transferring small messages.
+ */
 public class SmallMessagesTest {
   private final LocalAddressProvider localAddressProvider;
   private final TransportFactory tpFactory;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/StartEvent.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/StartEvent.java
@@ -18,6 +18,9 @@
  */
 package org.apache.reef.wake.test.remote;
 
+/**
+ * A simplest test event.
+ */
 public class StartEvent implements java.io.Serializable {
 
   private static final long serialVersionUID = 1L;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestEvent.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestEvent.java
@@ -20,6 +20,9 @@ package org.apache.reef.wake.test.remote;
 
 import java.io.Serializable;
 
+/**
+ * A test event having two data; message and load.
+ */
 public class TestEvent implements Serializable {
 
   private static final long serialVersionUID = 1L;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestEvent1.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestEvent1.java
@@ -18,6 +18,9 @@
  */
 package org.apache.reef.wake.test.remote;
 
+/**
+ * A test event extending other event.
+ */
 public class TestEvent1 extends TestEvent {
 
   private static final long serialVersionUID = 1L;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestEvent2.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestEvent2.java
@@ -18,6 +18,9 @@
  */
 package org.apache.reef.wake.test.remote;
 
+/**
+ * Another test event extending other event.
+ */
 public class TestEvent2 extends TestEvent {
 
   private static final long serialVersionUID = 1L;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestRemote.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestRemote.java
@@ -29,6 +29,9 @@ import org.apache.reef.wake.remote.impl.DefaultRemoteIdentifierFactoryImplementa
 import javax.inject.Inject;
 import java.net.UnknownHostException;
 
+/**
+ * An app to test Wake's remote implementation.
+ */
 public class TestRemote implements Runnable {
   private final RemoteManagerFactory remoteManagerFactory;
   private final LocalAddressProvider localAddressProvider;
@@ -69,6 +72,9 @@ public class TestRemote implements Runnable {
   }
 }
 
+/**
+ * An event handler to receive an event, TestEvent.
+ */
 class TestEventHandler implements EventHandler<RemoteMessage<TestEvent>> {
 
   private final EventHandler<TestEvent> proxy;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestRemoteIdentifier.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TestRemoteIdentifier.java
@@ -20,6 +20,9 @@ package org.apache.reef.wake.test.remote;
 
 import org.apache.reef.wake.remote.RemoteIdentifier;
 
+/**
+ * A test remote identifier.
+ */
 public class TestRemoteIdentifier implements RemoteIdentifier {
   private final String str;
 

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TransportRaceTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TransportRaceTest.java
@@ -42,6 +42,9 @@ import java.net.InetSocketAddress;
 import java.util.logging.Level;
 
 
+/**
+ * Tests the race condition during transporting events.
+ */
 public class TransportRaceTest {
   private final LocalAddressProvider localAddressProvider;
   private final TransportFactory tpFactory;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TransportTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/TransportTest.java
@@ -44,6 +44,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 
 
+/**
+ * Tests for Transport.
+ */
 public class TransportTest {
   private final LocalAddressProvider localAddressProvider;
   private final TransportFactory tpFactory;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/package-info.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/remote/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Tests for org.apache.reef.wake.remote package.
  */
 package org.apache.reef.wake.test.remote;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/RxTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/RxTest.java
@@ -26,6 +26,9 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 
 
+/**
+ * Tests for Rx-style communication.
+ */
 public class RxTest {
 
   @Rule

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/RxThreadPoolStageTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/RxThreadPoolStageTest.java
@@ -32,6 +32,9 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 
+/**
+ * Tests for RxThreadPoolStage.
+ */
 public class RxThreadPoolStageTest {
 
   @Rule

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/TimeoutSubjectTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/TimeoutSubjectTest.java
@@ -31,6 +31,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.*;
 
+/**
+ * Tests for TimeoutSubject.
+ */
 public class TimeoutSubjectTest {
 
   @Test

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/package-info.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/rx/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Tests for org.apache.reef.wake.rx package.
  */
 package org.apache.reef.wake.test.rx;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/ClockTest.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/ClockTest.java
@@ -40,6 +40,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
+/**
+ * Tests for Clock.
+ */
 public class ClockTest {
 
   private static RuntimeClock buildClock() throws Exception {

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/package-info.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/time/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Tests for org.apache.reef.wake.time package.
  */
 package org.apache.reef.wake.test.time;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/util/Monitor.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/util/Monitor.java
@@ -20,6 +20,9 @@ package org.apache.reef.wake.test.util;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+/**
+ * A monitor used in tests.
+ */
 public class Monitor {
   private AtomicBoolean finished = new AtomicBoolean(false);
 

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/util/PassThroughEncoder.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/util/PassThroughEncoder.java
@@ -21,7 +21,7 @@ package org.apache.reef.wake.test.util;
 import org.apache.reef.wake.remote.Encoder;
 
 /**
- *
+ * A simple encoder do nothing, i.e., return the original value.
  */
 public class PassThroughEncoder implements Encoder<byte[]> {
 

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/util/TimeoutHandler.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/util/TimeoutHandler.java
@@ -21,6 +21,9 @@ package org.apache.reef.wake.test.util;
 import org.apache.reef.wake.EventHandler;
 import org.apache.reef.wake.impl.PeriodicEvent;
 
+/**
+ * A timeout handler using monitor.
+ */
 public class TimeoutHandler implements EventHandler<PeriodicEvent> {
 
   private final Monitor monitor;

--- a/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/util/package-info.java
+++ b/lang/java/reef-wake/wake/src/test/java/org/apache/reef/wake/test/util/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- *
+ * Tests for org.apache.reef.wake.util package.
  */
 package org.apache.reef.wake.test.util;


### PR DESCRIPTION
This PR:
  * Adds javadocs in Wake
  * Removes redundant `public` in inner classes of `Clock` interface.
  * Replace a few statemes to use diamond expressions
  * Remove a few comment-out codes

JIRA:
  [REEF-892](https://issues.apache.org/jira/browse/REEF-892)

Pull request:
  This closes #