### PR TITLE
[REEF-895] Exceptions.CaughtAndThrow does not preserve stack trace of the original Exception

### DIFF
--- a/lang/cs/Org.Apache.REEF.Evaluator/Evaluator.cs
+++ b/lang/cs/Org.Apache.REEF.Evaluator/Evaluator.cs
@@ -339,8 +339,7 @@ namespace Org.Apache.REEF.Evaluator
         {
             var message = "Unhandled exception caught in Evaluator. Current files in the working directory: " +
                           GetDirectoryListing(Directory.GetCurrentDirectory());
-            _logger.Log(Level.Error, message, ex);
-            throw ex;
+            Utilities.Diagnostics.Exceptions.Throw(ex, message, _logger);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Utilities/Diagnostics/Exceptions.cs
+++ b/lang/cs/Org.Apache.REEF.Utilities/Diagnostics/Exceptions.cs
@@ -18,6 +18,7 @@
  */
 
 using System;
+using System.Runtime.ExceptionServices;
 using System.Text;
 using Org.Apache.REEF.Utilities.Logging;
 
@@ -51,7 +52,7 @@ namespace Org.Apache.REEF.Utilities.Diagnostics
             {
                 logger.Log(Level.Error, logMessage, exception);
             }
-            throw exception;
+            ExceptionDispatchInfo.Capture(exception).Throw();
         }
 
         /// <summary>
@@ -151,7 +152,7 @@ namespace Org.Apache.REEF.Utilities.Diagnostics
             {
                 logger.Log(level, logMessage, exception);
             }
-            throw exception;
+            ExceptionDispatchInfo.Capture(exception).Throw();
         }
 
         /// <summary>


### PR DESCRIPTION
This addressed the issue by
  * Use ``ExceptionDispatchInfo.Capture(ex).Throw()``.
  * Replace occurrences of throw ex.

JIRA:
  [REEF-895](https://issues.apache.org/jira/browse/REEF-895)