### PR TITLE
[REEF-905] Increase timeout for GroupCommunicationMessageCodecTest

### DIFF
--- a/lang/java/reef-io/src/test/java/org/apache/reef/io/network/group/GroupCommunicationMessageCodecTest.java
+++ b/lang/java/reef-io/src/test/java/org/apache/reef/io/network/group/GroupCommunicationMessageCodecTest.java
@@ -48,14 +48,14 @@ public class GroupCommunicationMessageCodecTest {
   class OperName implements Name<String> {
   }
 
-  @Test(timeout = 100)
+  @Test(timeout = 1000)
   public final void testInstantiation() throws InjectionException {
     final GroupCommunicationMessageCodec codec =
         Tang.Factory.getTang().newInjector().getInstance(GroupCommunicationMessageCodec.class);
     Assert.assertNotNull("tang.getInstance(GroupCommunicationMessageCodec.class): ", codec);
   }
 
-  @Test(timeout = 100)
+  @Test(timeout = 1000)
   public final void testEncodeDecode() {
     final Random r = new Random();
     final byte[] data = new byte[100];


### PR DESCRIPTION
This PR increases the timeout of two testcases from 100ms to 1000ms
in order to prevent failures on slow machines.

JIRA:
  [REEF-905](https://issues.apache.org/jira/browse/REEF-905)

Pull Request:
  This closes #