### PR TITLE
[REEF-912] Make Javadoc-generation work with Java 8

### DIFF
--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/TaskletExecutionRequest.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/TaskletExecutionRequest.java
@@ -42,7 +42,7 @@ public final class TaskletExecutionRequest<TInput extends Serializable, TOutput 
   }
 
   /**
-   * Vortex Master -> Vortex Worker request to execute a tasklet.
+   * Request from Vortex Master to Vortex Worker to execute a tasklet.
    */
   public TaskletExecutionRequest(final int taskletId,
                                  final VortexFunction<TInput, TOutput> userFunction,

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/VortexRequest.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/VortexRequest.java
@@ -23,7 +23,7 @@ import org.apache.reef.annotations.Unstable;
 import java.io.Serializable;
 
 /**
- * Master -> Worker protocol.
+ * Master-to-Worker protocol.
  */
 @Unstable
 public interface VortexRequest extends Serializable {

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/WorkerReport.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/common/WorkerReport.java
@@ -23,7 +23,7 @@ import org.apache.reef.annotations.Unstable;
 import java.io.Serializable;
 
 /**
- * Worker -> Master protocol.
+ * Worker-to-Master protocol.
  */
 @Unstable
 public interface WorkerReport extends Serializable {

--- a/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/evaluator/VortexWorker.java
+++ b/lang/java/reef-applications/reef-vortex/src/main/java/org/apache/reef/vortex/evaluator/VortexWorker.java
@@ -63,7 +63,7 @@ public final class VortexWorker implements Task, TaskMessageSource {
   }
 
   /**
-   * Starts the scheduler & executor and waits until termination.
+   * Starts the scheduler and executor and waits until termination.
    */
   @Override
   public byte[] call(final byte[] memento) throws Exception {

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/LocalRuntimeDriverConfigurationGenerator.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/LocalRuntimeDriverConfigurationGenerator.java
@@ -63,7 +63,7 @@ final class LocalRuntimeDriverConfigurationGenerator {
    * @param jobFolder The folder in which the job is staged.
    * @param jobId id of the job to be submitted
    * @param clientRemoteId
-   * @return
+   * @return the configuration
    * @throws IOException
    */
   public Configuration writeConfiguration(final File jobFolder,

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/LocalSubmissionFromCS.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/LocalSubmissionFromCS.java
@@ -37,7 +37,7 @@ import java.util.ArrayList;
 
 /**
  * Represents a job submission from the CS code.
- * <p/>
+ * <p>
  * This class exists mostly to parse and validate the command line parameters provided by the C# class
  * `Org.Apache.REEF.Client.Local.LocalClient`
  */
@@ -131,7 +131,7 @@ final class LocalSubmissionFromCS {
 
   /**
    * Gets parameters from C#:
-   * <p/>
+   * <p>
    * args[0]: Driver folder.
    * args[1]: Job ID.
    * args[2]: Number of Evaluators.

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/YarnJobSubmissionClient.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/YarnJobSubmissionClient.java
@@ -95,7 +95,7 @@ public final class YarnJobSubmissionClient {
 
   /**
    * @param driverFolder the folder containing the `reef` folder. Only that `reef` folder will be in the JAR.
-   * @return
+   * @return the jar file
    * @throws IOException
    */
   private File makeJar(final File driverFolder) throws IOException {

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/YarnSubmissionFromCS.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/YarnSubmissionFromCS.java
@@ -39,7 +39,7 @@ import java.util.List;
 
 /**
  * Represents a job submission from the CS code.
- * <p/>
+ * <p>
  * This class exists mostly to parse and validate the command line parameters provided by the C# class
  * `Org.Apache.REEF.Client.YARN.YARNClient`
  */

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/util/logging/CLRBufferedLogHandler.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/util/logging/CLRBufferedLogHandler.java
@@ -32,7 +32,7 @@ import java.util.logging.SimpleFormatter;
 /**
  * Logging Handler to intercept java logs and transfer them
  * to the CLR side via the reef-bridge.
- * <p/>
+ * <p>
  * Logs are buffered to avoid the cost of reef-bridge function calls.
  * A thread is also scheduled to flush the log buffer at a certain interval,
  * in case the log buffer remains unfilled for an extended period of time.
@@ -68,7 +68,7 @@ public class CLRBufferedLogHandler extends Handler {
 
   /**
    * Called whenever a log message is received on the java side.
-   * <p/>
+   * <p>
    * Adds the log record to the log buffer. If the log buffer is full and
    * the driver has already been initialized, flush the buffer of the logs.
    */
@@ -110,7 +110,7 @@ public class CLRBufferedLogHandler extends Handler {
 
   /**
    * Starts a thread to flush the log buffer on an interval.
-   * <p/>
+   * <p>
    * This will ensure that logs get flushed periodically, even
    * if the log buffer is not full.
    */

--- a/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/CheckpointService.java
+++ b/lang/java/reef-checkpoint/src/main/java/org/apache/reef/io/checkpoint/CheckpointService.java
@@ -24,14 +24,14 @@ import java.nio.channels.WritableByteChannel;
 
 /**
  * The CheckpointService provides a simple API to store and retrieve the state of a task.
- * <p/>
+ * <p>
  * Checkpoints are atomic, single-writer, write-once, multiple-readers, ready-many type of objects.
  * This is provided by releasing the CheckpointID for a checkpoint only upon commit of the checkpoint,
  * and by preventing a checkpoint to be re-opened for writes.
- * <p/>
+ * <p>
  * Non-functional properties such as durability, availability, compression, garbage collection,
  * quotas are left to the implementation.
- * <p/>
+ * <p>
  * This API is envisioned as the basic building block for a checkpoint service, on top of which richer
  * interfaces can be layered (e.g., frameworks providing object-serialization, checkpoint metadata and
  * provenance, etc.)

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverConfiguration.java
@@ -178,7 +178,7 @@ public final class DriverConfiguration extends ConfigurationModuleBuilder {
   public static final OptionalImpl<EventHandler<ContextMessage>> ON_CONTEXT_MESSAGE = new OptionalImpl<>();
 
   /**
-   * @see {@link ProgressProvider}
+   * Progress provider. See {@link ProgressProvider}.
    */
   public static final OptionalImpl<ProgressProvider> PROGRESS_PROVIDER = new OptionalImpl<>();
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverLauncher.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverLauncher.java
@@ -35,11 +35,11 @@ import java.util.logging.Logger;
 
 /**
  * A launcher for REEF Drivers.
- * <p/>
+ * <p>
  * It can be instantiated using a configuration that can create a REEF instance.
  * For example, the local resourcemanager and the YARN resourcemanager can do this.
- * <p/>
- * {@see org.apache.reef.examples.hello.HelloREEF} for a demo use case.
+ * <p>
+ * See {@link org.apache.reef.examples.hello} package for a demo use case.
  */
 @Public
 @Provided

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverServiceConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/DriverServiceConfiguration.java
@@ -39,7 +39,7 @@ import org.apache.reef.wake.time.event.StopTime;
 
 /**
  * Use this ConfigurationModule to configure Services to be run in the Driver.
- * <p/>
+ * <p>
  * A service is a set of event handlers that are informed of events in addition to * the event handlers defined in
  * DriverConfiguration. However, most services will treat the events as read-only. Doing differently should be
  * documented clearly in the Service documentation.

--- a/lang/java/reef-common/src/main/java/org/apache/reef/client/REEF.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/client/REEF.java
@@ -26,7 +26,7 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
 
 /**
  * The main entry point into the REEF resourcemanager.
- * <p/>
+ * <p>
  * Every REEF resourcemanager provides an implementation of this interface. That
  * instance is used to submitTask the Driver class for execution to REEF. As with
  * all submissions in REEF, this is done in the form of a TANG Configuration
@@ -45,7 +45,7 @@ public interface REEF extends AutoCloseable {
 
   /**
    * Submits the Driver set up in the given Configuration for execution.
-   * <p/>
+   * <p>
    * The Configuration needs to bind the Driver interface to an actual
    * implementation of that interface for the job at hand.
    *

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/ContextAndTaskSubmittable.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/ContextAndTaskSubmittable.java
@@ -32,11 +32,11 @@ import org.apache.reef.tang.Configuration;
 public interface ContextAndTaskSubmittable {
   /**
    * Submit a Context and a Task.
-   * <p/>
+   * <p>
    * The semantics of this call are the same as first submitting the context and then, on the fired ActiveContext event
    * to submit the Task. The performance of this will be better, though as it potentially saves some roundtrips on
    * the network.
-   * <p/>
+   * <p>
    * REEF will not fire an ActiveContext as a result of this. Instead, it will fire a TaskRunning event.
    *
    * @param contextConfiguration the Configuration of the EvaluatorContext. See ContextConfiguration for details.
@@ -46,11 +46,11 @@ public interface ContextAndTaskSubmittable {
 
   /**
    * Submit a Context with Services and a Task.
-   * <p/>
+   * <p>
    * The semantics of this call are the same as first submitting the context and services and then, on the fired
    * ActiveContext event to submit the Task. The performance of this will be better, though as it potentially saves
    * some roundtrips on the network.
-   * <p/>
+   * <p>
    * REEF will not fire an ActiveContext as a result of this. Instead, it will fire a TaskRunning event.
    *
    * @param contextConfiguration

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/FlexiblePreemptionEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/FlexiblePreemptionEvent.java
@@ -27,12 +27,12 @@ import java.util.Set;
 
 /**
  * Represents a flexible preemption request: It contains:
- * <p/>
+ * <p>
  * <ol>
  * <li>a set of EvaluatorRequests that the resource manager wants to have satisfied and also</li>
  * <li>a set of Evaluators it will choose to kill if the request isn't satisfied otherwise.</li>
  * </ol>
- * <p/>
+ * <p>
  * NOTE: This currently not implemented. Consider it a preview of the API.
  */
 @Private

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/PreemptionEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/PreemptionEvent.java
@@ -25,11 +25,11 @@ import org.apache.reef.annotations.audience.Public;
 
 /**
  * Represents Preemption requests issued by the underlying resource manager.
- * <p/>
+ * <p>
  * REEF exposes two kinds of preemption requests: Strict ones merely inform the Driver about machines that are about to
  * be preempted. Flexible ones provide that list, but also expose the resource request that the underlying resource
  * manager wants to satisfy, thereby giving the Driver a chance to satisfy it in another way.
- * <p/>
+ * <p>
  * NOTE: This currently not implemented. Consider it a preview of the API.
  */
 @DriverSide

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/StrictPreemptionEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/StrictPreemptionEvent.java
@@ -26,7 +26,7 @@ import org.apache.reef.annotations.audience.Public;
 /**
  * Represents a strict preemption event: It contains the set of Evaluators that the underlying resource manager will
  * take away from the Driver.
- * <p/>
+ * <p>
  * NOTE: This currently not implemented. Consider it a preview of the API.
  */
 @Unstable

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/catalog/ResourceCatalog.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/catalog/ResourceCatalog.java
@@ -24,10 +24,10 @@ import java.util.Collection;
 
 /**
  * A catalog of the resources available to a REEF instance.
- * <p/>
+ * <p>
  * This catalog contains static information about the resources and does not
  * reflect that dynamic availability of resources. In other words: Its entries
- * are an upper bound to what is available to a REEF {@link Driver} at any given
+ * are an upper bound to what is available to a REEF Driver at any given
  * moment in time.
  */
 @Unstable

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/client/JobMessageObserver.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/client/JobMessageObserver.java
@@ -25,7 +25,7 @@ import org.apache.reef.annotations.audience.Public;
 
 /**
  * The driver uses this interface to communicate with the job client.
- * <p/>
+ * <p>
  * Note that as of REEF 0.4, the presence of a client is no longer guaranteed, depending on the deployment environment.
  */
 @Public

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/ActiveContext.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/ActiveContext.java
@@ -28,16 +28,16 @@ import org.apache.reef.tang.Configuration;
 
 /**
  * Represents an active context on an Evaluator.
- * <p/>
+ * <p>
  * A context consists of two configurations:
  * <ol>
  * <li>ContextConfiguration: Its visibility is limited to the context itself and tasks spawned from it.</li>
  * <li>ServiceConfiguration: This is "inherited" by child context spawned.</li>
  * </ol>
- * <p/>
+ * <p>
  * Contexts have identifiers. A context is instantiated on a single Evaluator. Contexts are either created on an
  * AllocatedEvaluator (for what is called the "root Context") or by forming sub-Contexts.
- * <p/>
+ * <p>
  * Contexts form a stack. Only the topmost context is active. Child Contexts or Tasks can be submitted to the
  * active Context. Contexts can be closed, in which case their parent becomes active.
  * In the case of the root context, closing is equivalent to releasing the Evaluator. A child context "sees" all

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/FailedContext.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/context/FailedContext.java
@@ -27,7 +27,7 @@ import org.apache.reef.util.Optional;
 /**
  * Represents Context that failed.
  * A typical case would be that its ContextStartHandler threw an exception.
- * <p/>
+ * <p>
  * The underlying Evaluator is still accessible and a new context can be established. Note that REEF can't guarantee
  * consistency of the Evaluator for all applications. It is up to the application to decide whether it is safe to keep
  * using the Evaluator.

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/AllocatedEvaluator.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/AllocatedEvaluator.java
@@ -42,7 +42,6 @@ public interface AllocatedEvaluator
    * Puts the given file into the working directory of the Evaluator.
    *
    * @param file the file to be copied
-   * @throws java.io.IOException if the copy fails.
    */
   void addFile(final File file);
 
@@ -50,7 +49,6 @@ public interface AllocatedEvaluator
    * Puts the given file into the working directory of the Evaluator and adds it to its classpath.
    *
    * @param file the file to be copied
-   * @throws java.io.IOException if the copy fails.
    */
   void addLibrary(final File file);
 
@@ -75,7 +73,7 @@ public interface AllocatedEvaluator
 
   /**
    * Submits the given Task for execution.
-   * <p/>
+   * <p>
    * This generates a ContextConfiguration for the root context with a generated ID derived from the EvaluatorId.
    *
    * @param taskConfiguration the Configuration. See TaskConfiguration for details.

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequest.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequest.java
@@ -52,6 +52,8 @@ public final class EvaluatorRequest {
   }
 
   /**
+   * Get a new builder.
+   *
    * @return a new EvaluatorRequest Builder.
    */
   public static Builder newBuilder() {
@@ -59,6 +61,8 @@ public final class EvaluatorRequest {
   }
 
   /**
+   * Get a new builder from the existing request.
+   *
    * @return a new EvaluatorRequest Builder with settings initialized
    * from an existing request.
    */
@@ -85,6 +89,8 @@ public final class EvaluatorRequest {
   }
 
   /**
+   * Access the number of memory requested.
+   *
    * @return the minimum size of Evaluator requested.
    */
   public int getMegaBytes() {
@@ -92,6 +98,8 @@ public final class EvaluatorRequest {
   }
 
   /**
+   * Access the preferred node.
+   *
    * @return the node names that we prefer the Evaluator to run on
    */
   public List<String> getNodeNames() {
@@ -99,6 +107,8 @@ public final class EvaluatorRequest {
   }
 
   /**
+   * Access the preferred rack name.
+   *
    * @return the rack names that we prefer the Evaluator to run on
    */
   public List<String> getRackNames() {
@@ -122,8 +132,8 @@ public final class EvaluatorRequest {
     /**
      * Pre-populates the builder with the values extracted from the request.
      *
-     * @param request
-     *          the request
+     * @param request the request
+     * @return this Builder
      */
     private Builder(final EvaluatorRequest request) {
       setNumber(request.getNumber());
@@ -138,6 +148,8 @@ public final class EvaluatorRequest {
     }
 
     /**
+     * Set the amount of memory.
+     *
      * @param megaBytes the amount of megabytes to request for the Evaluator.
      * @return this builder
      */
@@ -148,10 +160,10 @@ public final class EvaluatorRequest {
     }
 
     /**
-     * set number of cores.
+     * Set number of cores.
      *
      * @param cores the number of cores
-     * @return
+     * @return this Builder.
      */
     @SuppressWarnings("checkstyle:hiddenfield")
     public Builder setNumberOfCores(final int cores) {
@@ -162,7 +174,7 @@ public final class EvaluatorRequest {
     /**
      * Set the number of Evaluators requested.
      *
-     * @param n
+     * @param n the number of evaluators
      * @return this Builder.
      */
     @SuppressWarnings("checkstyle:hiddenfield")
@@ -175,6 +187,9 @@ public final class EvaluatorRequest {
      * Adds a node name.It is the preferred location where the evaluator should
      * run on. If the node is available, the RM will try to allocate the
      * evaluator there
+     *
+     * @param nodeName a preferred node name
+     * @return this Builder.
      */
     public Builder addNodeName(final String nodeName) {
       this.nodeNames.add(nodeName);
@@ -186,6 +201,9 @@ public final class EvaluatorRequest {
      * run on. If the rack is available, the RM will try to allocate the
      * evaluator in one of its nodes. The RM will try to match node names first,
      * and then fallback to rack names
+     *
+     * @param rackName a preferred rack name
+     * @return this Builder.
      */
     public Builder addRackName(final String rackName) {
       this.rackNames.add(rackName);

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRuntimeRestartManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/restart/DriverRuntimeRestartManager.java
@@ -38,9 +38,9 @@ import java.util.Set;
 @DefaultImplementation(DefaultDriverRuntimeRestartMangerImpl.class)
 public interface DriverRuntimeRestartManager {
   /**
-   * @return > 0 if the driver has been restarted as reported by the resource manager. 0 otherwise.
+   * @return positive if the driver has been restarted as reported by the resource manager. 0 otherwise.
    * Note that this is different from whether the driver is in the process of restarting.
-   * This returns > 0 both on when the driver is in the restart process or has already finished restarting.
+   * This returns positive both on when the driver is in the restart process or has already finished restarting.
    * The default implementation always returns 0.
    */
   int getResubmissionAttempts();

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/FailedTask.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/task/FailedTask.java
@@ -59,10 +59,10 @@ public final class FailedTask extends AbstractFailure {
 
   /**
    * Access the context the task ran (and crashed) on, if it could be recovered.
-   * <p/>
+   * <p>
    * An ActiveContext is given when the task fails but the context remains alive.
    * On context failure, the context also fails and is surfaced via the FailedContext event.
-   * <p/>
+   * <p>
    * Note that receiving an ActiveContext here is no guarantee that the context (and evaluator)
    * are in a consistent state. Application developers need to investigate the reason available
    * via getCause() to make that call.

--- a/lang/java/reef-common/src/main/java/org/apache/reef/exception/DriverException.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/exception/DriverException.java
@@ -21,7 +21,7 @@ package org.apache.reef.exception;
 import java.util.concurrent.ExecutionException;
 
 /**
- * Thrown by the {@link Driver} and to the clients of {@link REEF}.
+ * Thrown by the Driver and to the clients of REEF.
  */
 public class DriverException extends ExecutionException {
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/exception/evaluator/ServiceException.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/exception/evaluator/ServiceException.java
@@ -20,7 +20,7 @@ package org.apache.reef.exception.evaluator;
 
 /**
  * The base class for exceptions thrown by REEF libraries and services.
- * <p/>
+ * <p>
  * Rules of thumb for exception handling in REEF:
  * <ul>
  * <li>When possible, throw a subclass of ServiceException, with the following exceptions (no pun intended)</li>

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/ExternalMap.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/ExternalMap.java
@@ -64,11 +64,11 @@ public interface ExternalMap<T> {
    * removed. (The map can contain at most one such mapping.) Returns the
    * value to which this map previously associated the key, or null if the map
    * contained no mapping for the key.
-   * <p/>
+   * <p>
    * If this map permits null values, then a return value of null does not
    * necessarily indicate that the map contained no mapping for the key; it's
    * also possible that the map explicitly mapped the key to null.
-   * <p/>
+   * <p>
    * The map will not contain a mapping for the specified key once the call
    * returns.
    *

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/Spool.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/Spool.java
@@ -33,21 +33,20 @@ public interface Spool<T> extends Iterable<T>, Accumulable<T> {
 
   /**
    * Returns an Iterable over the spool file.
-   * <p/>
+   * <p>
    * Depending on the implementation, this method may be called only once per
    * Spool instance, or it may be called repeatedly. Similarly, with some Spool
    * implementations, attempts to append to the SpoolFile after calling
    * iterator() may fail fast with a ConcurrentModificationException.
    *
    * @return An Iterator over the SpoolFile, in the order data was inserted.
-   * @throws Exception
    */
   @Override
   Iterator<T> iterator();
 
   /**
    * Returns an Accumulator for the spool file.
-   * <p/>
+   * <p>
    * Depending on the implementation, this method may be called only once per
    * Spool instance, or it may be called repeatedly. Similarly, with some Spool
    * implementations, attempts to append to the SpoolFile after calling

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/TempFileCreator.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/TempFileCreator.java
@@ -34,9 +34,9 @@ public interface TempFileCreator {
   /**
    * Creates a temporary file.
    *
-   * @param prefix
-   * @param suffix
-   * @return
+   * @param prefix the prefix for the file
+   * @param suffix the suffix for the file
+   * @return the created file.
    * @throws IOException
    */
   File createTempFile(final String prefix, final String suffix) throws IOException;
@@ -44,9 +44,9 @@ public interface TempFileCreator {
   /**
    * Creates a temporary folder.
    *
-   * @param prefix
-   * @param attrs
-   * @return
+   * @param prefix the prefix for the file
+   * @param attrs the attributes for the file
+   * @return the created folder.
    * @throws IOException
    */
   File createTempDirectory(final String prefix, final FileAttribute<?> attrs) throws IOException;
@@ -55,8 +55,8 @@ public interface TempFileCreator {
   /**
    * Create a temporary folder.
    *
-   * @param prefix
-   * @return
+   * @param prefix the prefix for the folder
+   * @return the created folder
    * @throws IOException
    */
   File createTempDirectory(final String prefix) throws IOException;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/naming/NamingLookup.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/naming/NamingLookup.java
@@ -33,8 +33,8 @@ public interface NamingLookup {
   /**
    * Lookup an Address for a given Identifier.
    *
-   * @param id
-   * @return
+   * @param id the identifier to be searched
+   * @return the Inet address
    * @throws java.io.IOException
    */
   InetSocketAddress lookup(final Identifier id) throws Exception;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/package-info.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/package-info.java
@@ -17,7 +17,8 @@
  * under the License.
  */
 /**
- * APIs for I/O in REEF: {@link org.apache.reef.io.Codec}s and {@link org.apache.reef.io.Serializer}s.
+ * APIs for I/O in REEF: {@link org.apache.reef.io.serialization.Codec}s and
+ * {@link org.apache.reef.io.serialization.Serializer}s.
  */
 @Unstable
 package org.apache.reef.io;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/io/serialization/SerializableCodec.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/io/serialization/SerializableCodec.java
@@ -24,7 +24,7 @@ import java.util.logging.Logger;
 
 /**
  * A {@link Codec} for {@link Serializable} objects.
- * <p/>
+ * <p>
  * It uses java serialization, use with caution.
  *
  * @param <T> The type of objects Serialized

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/REEFLauncher.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/REEFLauncher.java
@@ -148,8 +148,7 @@ public final class REEFLauncher {
   /**
    * Launches a REEF client process (Driver or Evaluator).
    *
-   * @param args
-   * @throws Exception
+   * @param args command-line args
    */
   public static void main(final String[] args) {
     LOG.log(Level.INFO, "Entering REEFLauncher.main().");

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeRestartConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeRestartConfiguration.java
@@ -26,7 +26,7 @@ import org.apache.reef.tang.formats.*;
 
 /**
  * The base configuration module for driver restart configurations of all runtimes.
- * <p/>
+ * <p>
  */
 @Private
 @ClientSide

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeStartHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/DriverRuntimeStartHandler.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
 
 /**
  * The RuntimeStart handler of the Driver.
- * <p/>
+ * <p>
  * This instantiates the DriverSingletons upon construction. Upon onNext(), it sets the resource manager status and
  * wires up the remote event handler connections to the client and the evaluators.
  */

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceLaunchEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceLaunchEvent.java
@@ -28,7 +28,7 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
 import java.util.Set;
 
 /**
- * Event from Driver Process -> Driver Runtime.
+ * Event from Driver Process to Driver Runtime.
  * A request to the Driver Runtime to launch an Evaluator on the allocated Resource
  */
 @RuntimeAuthor

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceReleaseEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceReleaseEvent.java
@@ -23,7 +23,7 @@ import org.apache.reef.annotations.audience.RuntimeAuthor;
 import org.apache.reef.tang.annotations.DefaultImplementation;
 
 /**
- * Event from Driver Process -> Driver Runtime.
+ * Event from Driver Process to Driver Runtime.
  * A request to the Driver Runtime to release this resource
  */
 @RuntimeAuthor

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEvent.java
@@ -26,7 +26,7 @@ import org.apache.reef.util.Optional;
 import java.util.List;
 
 /**
- * Event from Driver Process -> Driver Runtime.
+ * Event from Driver Process to Driver Runtime.
  * A request to the Driver Runtime to allocate resources with the given specification
  */
 @RuntimeAuthor

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEventImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/api/ResourceRequestEventImpl.java
@@ -131,7 +131,7 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
 
     /**
      * Add a list of node names.
-     * @see {@link ResourceRequestEventImpl.Builder#addNodeName}
+     * @see ResourceRequestEventImpl.Builder#addNodeName
      */
     public Builder addNodeNames(final List<String> nodeNames) {
       for (final String nodeName : nodeNames) {
@@ -141,8 +141,8 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
     }
 
     /**
-     * Add an entry to rackNameList.
-     * @see ResourceRequestEvent#getRackNameList()
+     * Add a list of rack names.
+     * @see ResourceRequestEventImpl.Builder#addRackName
      */
     public Builder addRackName(final String rackName) {
       this.rackNameList.add(rackName);
@@ -150,8 +150,8 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
     }
 
     /**
-     * Add a list of rack names.
-     * @see {@link ResourceRequestEventImpl.Builder#addRackName}
+     * Add an entry to rackNameList.
+     * @see ResourceRequestEvent#getRackNameList
      */
     public Builder addRackNames(final List<String> rackNames) {
       for (final String rackName : rackNames) {
@@ -161,7 +161,7 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
     }
 
     /**
-     * @see ResourceRequestEvent#getMemorySize()
+     * @see ResourceRequestEvent#getMemorySize
      */
     public Builder setMemorySize(final int memorySize) {
       this.memorySize = memorySize;
@@ -169,7 +169,7 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
     }
 
     /**
-     * @see ResourceRequestEvent#getPriority()
+     * @see ResourceRequestEvent#getPriority
      */
     public Builder setPriority(final int priority) {
       this.priority = priority;
@@ -177,7 +177,7 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
     }
 
     /**
-     * @see ResourceRequestEvent#getVirtualCores()
+     * @see ResourceRequestEvent#getVirtualCores
      */
     public Builder setVirtualCores(final int virtualCores) {
       this.virtualCores = virtualCores;
@@ -185,7 +185,7 @@ public final class ResourceRequestEventImpl implements ResourceRequestEvent {
     }
 
     /**
-     * @see ResourceRequestEvent#getRelaxLocality()
+     * @see ResourceRequestEvent#getRelaxLocality
      */
     public Builder setRelaxLocality(final boolean relaxLocality) {
       this.relaxLocality = relaxLocality;

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
@@ -68,12 +68,12 @@ import java.util.logging.Logger;
 /**
  * Manages a single Evaluator instance including all lifecycle instances:
  * (AllocatedEvaluator, CompletedEvaluator, FailedEvaluator).
- * <p/>
- * A (periodic) heartbeat channel is established EvaluatorRuntime -> EvaluatorManager.
+ * <p>
+ * A (periodic) heartbeat channel is established from EvaluatorRuntime to EvaluatorManager.
  * The EvaluatorRuntime will (periodically) send (status) messages to the EvaluatorManager using this
  * heartbeat channel.
- * <p/>
- * A (push-based) EventHandler channel is established EvaluatorManager -> EvaluatorRuntime.
+ * <p>
+ * A (push-based) EventHandler channel is established from EvaluatorManager to EvaluatorRuntime.
  * The EvaluatorManager uses this to forward Driver messages, launch Tasks, and initiate
  * control information (e.g., shutdown, suspend).
  */

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/Evaluators.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/Evaluators.java
@@ -96,7 +96,7 @@ public final class Evaluators implements AutoCloseable {
 
   /**
    * Create new EvaluatorManager and add it to the collection.
-   * <p/>
+   * <p>
    * FIXME: This method is a temporary fix for the race condition
    * described in issues #828 and #839.
    *

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/NodeDescriptorEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/NodeDescriptorEvent.java
@@ -24,7 +24,7 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
 import org.apache.reef.util.Optional;
 
 /**
- * Event from Driver Runtime -> Driver Process.
+ * Event from Driver Runtime to Driver Process.
  * Description of a node in the cluster
  */
 @RuntimeAuthor

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceAllocationEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceAllocationEvent.java
@@ -22,7 +22,7 @@ import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.annotations.audience.RuntimeAuthor;
 
 /**
- * Event from Driver Runtime -> Driver Process
+ * Event from Driver Runtime to Driver Process
  * A Resource allocated by the Driver Runtime. In response to a ResourceRequestEvent.
  */
 @RuntimeAuthor

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceStatusEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceStatusEvent.java
@@ -25,7 +25,7 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
 import org.apache.reef.util.Optional;
 
 /**
- * Event from Driver Runtime -> Driver Process.
+ * Event from Driver Runtime to Driver Process.
  * Status of a resource in the cluster
  */
 @RuntimeAuthor

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/RuntimeStatusEvent.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/RuntimeStatusEvent.java
@@ -27,7 +27,7 @@ import org.apache.reef.util.Optional;
 import java.util.List;
 
 /**
- * Event from Driver Runtime -> Driver Process.
+ * Event from Driver Runtime to Driver Process.
  * A status update from the Driver Runtime to the Driver Process
  */
 @RuntimeAuthor

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/ContextManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/ContextManager.java
@@ -136,7 +136,7 @@ public final class ContextManager implements AutoCloseable {
 
   /**
    * Processes the given ContextControlProto to launch / close / suspend Tasks and Contexts.
-   * <p/>
+   * <p>
    * This also triggers the HeartBeatManager to send a heartbeat with the result of this operation.
    *
    * @param controlMessage the message to process

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/ContextRuntime.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/ContextRuntime.java
@@ -133,7 +133,7 @@ public final class ContextRuntime {
 
   /**
    * Spawns a new context.
-   * <p/>
+   * <p>
    * The new context will have a serviceInjector that is created by forking the one in this object with the given
    * serviceConfiguration. The contextConfiguration is used to fork the contextInjector from that new serviceInjector.
    *
@@ -187,7 +187,7 @@ public final class ContextRuntime {
 
   /**
    * Spawns a new context without services of its own.
-   * <p/>
+   * <p>
    * The new context will have a serviceInjector that is created by forking the one in this object. The
    * contextConfiguration is used to fork the contextInjector from that new serviceInjector.
    *
@@ -307,7 +307,7 @@ public final class ContextRuntime {
 
   /**
    * Deliver the given message to the Task.
-   * <p/>
+   * <p>
    * Note that due to races, the task might have already ended. In that case, we drop this call and leave a WARNING
    * in the log.
    *
@@ -325,7 +325,7 @@ public final class ContextRuntime {
 
   /**
    * Issue a close call to the Task
-   * <p/>
+   * <p>
    * Note that due to races, the task might have already ended. In that case, we drop this call and leave a WARNING
    * in the log.
    *
@@ -343,7 +343,7 @@ public final class ContextRuntime {
 
   /**
    * Deliver a message to the Task
-   * <p/>
+   * <p>
    * Note that due to races, the task might have already ended. In that case, we drop this call and leave a WARNING
    * in the log.
    *

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/RootContextLauncher.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/context/RootContextLauncher.java
@@ -93,7 +93,7 @@ final class RootContextLauncher {
 
   /**
    * Instantiates the root context.
-   * <p/>
+   * <p>
    * This also launches the initial task if there is any.
    *
    * @param injector

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/parameters/ApplicationIdentifier.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/parameters/ApplicationIdentifier.java
@@ -23,7 +23,7 @@ import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
  * The RM application/job identifier.
- * <p/>
+ * <p>
  * In YARN, this is the applicationID assigned by the resource manager.
  */
 @NamedParameter(doc = "The RM application/job identifier.")

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/defaults/DefaultCloseHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/defaults/DefaultCloseHandler.java
@@ -25,7 +25,7 @@ import org.apache.reef.wake.EventHandler;
 import javax.inject.Inject;
 
 /**
- * Default implementation for EventHandler<CloseEvent>.
+ * Default implementation for {@code EventHandler<CloseEvent>}.
  */
 @Private
 public final class DefaultCloseHandler implements EventHandler<CloseEvent> {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/defaults/DefaultDriverMessageHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/task/defaults/DefaultDriverMessageHandler.java
@@ -25,7 +25,7 @@ import org.apache.reef.wake.EventHandler;
 import javax.inject.Inject;
 
 /**
- * A default implementation of EventHandler<DriverMessage>.
+ * A default implementation of {@code EventHandler<DriverMessage>}.
  */
 @Private
 public final class DefaultDriverMessageHandler implements EventHandler<DriverMessage> {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/REEFFileNames.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/files/REEFFileNames.java
@@ -169,7 +169,7 @@ public final class REEFFileNames {
 
   /**
    * The prefix used whenever REEF is asked to create a job folder, on (H)DFS or locally.
-   * <p/>
+   * <p>
    * This prefix is also used with JAR files created to represent a job.
    */
   public String getJobFolderPrefix() {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/REEFUncaughtExceptionHandler.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/REEFUncaughtExceptionHandler.java
@@ -28,10 +28,10 @@ import java.util.logging.Logger;
 
 /**
  * This is used as the Exception handler for REEF client processes (Driver, Evaluator).
- * <p/>
+ * <p>
  * It catches all exceptions and sends them to the controlling process.
  * For Evaluators, that is the Driver. For the Driver, that is the Client.
- * <p/>
+ * <p>
  * After sending the exception, this shuts down the JVM, as this JVM is then officially dead.
  */
 public final class REEFUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/task/HeartBeatTriggerManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/task/HeartBeatTriggerManager.java
@@ -28,10 +28,11 @@ import javax.inject.Inject;
 /**
  * Helper class for immediately sending heartbeat messages.
  * This can be used together with TaskMessageSource to push urgent messages to the Driver.
- * <p/>
+ * <p>
  * CAUTION: Do not overuse as the Driver can be saturated with heartbeats.
  *
- * @see https://issues.apache.org/jira/browse/REEF-33 for the ongoing discussion of alternatives to this design.
+ * @see <a href="https://issues.apache.org/jira/browse/REEF-33">REEF-33</a> for the ongoing discussion of
+ * alternatives to this design.
  */
 @TaskSide
 @Public

--- a/lang/java/reef-common/src/main/java/org/apache/reef/task/Task.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/task/Task.java
@@ -23,9 +23,9 @@ import org.apache.reef.annotations.audience.TaskSide;
 
 /**
  * The interface for Tasks.
- * <p/>
+ * <p>
  * This interface is to be implemented for Tasks.
- * <p/>
+ * <p>
  * The main entry point for a Task is the call() method inherited from
  * {@link java.util.concurrent.Callable}. The REEF Evaluator will call this method in order to run
  * the Task. The byte[] returned by it will be pushed to the Job Driver.

--- a/lang/java/reef-common/src/main/java/org/apache/reef/task/TaskMessageSource.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/task/TaskMessageSource.java
@@ -24,7 +24,7 @@ import org.apache.reef.util.Optional;
 
 /**
  * Message source for control flow messages from a task to the Driver.
- * <p/>
+ * <p>
  * The getMessage() method in an Implementation of this interface will be called by the Evaluator resourcemanager
  * whenever it is about to communicate with the Driver anyway.
  * Hence, this can be used for occasional status updates etc.

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/BuilderUtils.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/BuilderUtils.java
@@ -24,6 +24,9 @@ package org.apache.reef.util;
 public final class BuilderUtils {
   /**
    * Throws a runtime exception if the parameter is null.
+   * @param <T> a type of parameter
+   * @param parameter
+   * @return the parameter if it is not null
    */
   public static <T> T notNull(final T parameter) {
     if (parameter == null) {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/CollectionUtils.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/CollectionUtils.java
@@ -32,6 +32,7 @@ public final class CollectionUtils {
 
   /**
    * Checks if the collection is null or empty.
+   * @param <T> a type of element of collection
    * @param parameter the collection
    * @return true if the collection is null or empty
    */
@@ -41,9 +42,9 @@ public final class CollectionUtils {
 
   /**
    * Checks if the collection is not null and not empty.
+   * @param <T> a type of element of collection
    * @param parameter the collection
    * @return true if the collection is not null nor empty
-   *
    */
   public static <T> boolean isNotEmpty(final Collection<T> parameter) {
     return !isEmpty(parameter);

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/EnvironmentUtils.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/EnvironmentUtils.java
@@ -56,6 +56,7 @@ public final class EnvironmentUtils {
    * Get a set of all classpath entries EXCEPT of those under excludeEnv directories.
    * Every excludeEnv entry is an environment variable name.
    *
+   * @param excludeEnv A set of environments to be excluded.
    * @return A set of classpath entries as strings.
    */
   public static Set<String> getAllClasspathJars(final String... excludeEnv) {
@@ -113,7 +114,7 @@ public final class EnvironmentUtils {
   }
 
   /**
-   * @param clazz
+   * @param clazz class
    * @return the location (JAR or .class file) where the given class is located.
    */
   public static String getClassLocation(final Class<?> clazz) {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/Exceptions.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/Exceptions.java
@@ -28,8 +28,8 @@ public final class Exceptions {
   /**
    * Walks the .getCause() chain till it hits the leaf node.
    *
-   * @param throwable
-   * @return
+   * @param throwable a throwable object
+   * @return the most inner cause
    */
   public static Throwable getUltimateCause(final Throwable throwable) {
     if (throwable.getCause() == null) {

--- a/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/ThreadLogFormatter.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/util/logging/ThreadLogFormatter.java
@@ -30,9 +30,9 @@ import java.util.logging.LogRecord;
 
 /**
  * A denser logging format for REEF that is similar to the standard SimpleFormatter.
- * <p/>
+ * <p>
  * The following config properties are available:
- * <p/>
+ * <p>
  * * `org.apache.reef.util.logging.ThreadLogFormatter.format`
  * is a format string for String.format() that takes same arguments and in
  * the same order as the standard SimpleFormatter, plus the thread name:
@@ -43,7 +43,7 @@ import java.util.logging.LogRecord;
  * 5. message
  * 6. stack trace
  * 7. thread name
- * <p/>
+ * <p>
  * * `org.apache.reef.util.logging.ThreadLogFormatter.dropPrefix`
  * contains a comma-separated list of package name prefixes that should be
  * removed from the class name for logging. e.g. value `com.microsoft.,org.apache.`

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/data/loading/package-info.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/data/loading/package-info.java
@@ -17,6 +17,8 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * A line counter example using data loading service.
+ *
+ * Data loading service easily loads data either from HDFS or the local file system
  */
 package org.apache.reef.examples.data.loading;

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/BGDClient.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/BGDClient.java
@@ -67,7 +67,6 @@ public class BGDClient {
    *
    * @param runtimeConfiguration the runtime to run on.
    * @param jobName              the name of the job on the runtime.
-   * @return
    */
   public void submit(final Configuration runtimeConfiguration, final String jobName) throws Exception {
     final Configuration driverConfiguration = getDriverConfiguration(jobName);

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/data/Example.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/data/Example.java
@@ -36,7 +36,7 @@ public interface Example extends Serializable {
 
   /**
    * Computes the prediction for this Example, given the model w.
-   * <p/>
+   * <p>
    * w.dot(this.getFeatures())
    *
    * @param w the model

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/data/package-info.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/data/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Interface for example data instance for linear models.
  */
 package org.apache.reef.examples.group.bgd.data;

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/data/parser/package-info.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/data/parser/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * A parser interface and implementation for SVMLight records.
  */
 package org.apache.reef.examples.group.bgd.data.parser;

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/loss/package-info.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/loss/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Loss Functions for BGD.
  */
 package org.apache.reef.examples.group.bgd.loss;

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/package-info.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Runs BGD on the given runtime.
  */
 package org.apache.reef.examples.group.bgd;

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/package-info.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/parameters/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Parameters for BGD.
  */
 package org.apache.reef.examples.group.bgd.parameters;

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/utils/package-info.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/bgd/utils/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Utility functions for BGD.
  */
 package org.apache.reef.examples.group.bgd.utils;

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/package-info.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Broadcast Group Communication example.
  */
 package org.apache.reef.examples.group.broadcast;

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/parameters/package-info.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/broadcast/parameters/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Parameters for Broadcast group communication.
  */
 package org.apache.reef.examples.group.broadcast.parameters;

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/AbstractVector.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/AbstractVector.java
@@ -20,7 +20,7 @@ package org.apache.reef.examples.group.utils.math;
 
 /**
  * Abstract base class for {@link Vector} implementations.
- * <p/>
+ * <p>
  * The only methods to be implemented by subclasses are get, set and size.
  */
 public abstract class AbstractVector extends AbstractImmutableVector implements Vector {

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/Window.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/Window.java
@@ -23,7 +23,9 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-// TODO: Document
+/**
+ * Maintaining a fixed-size queue for sliding window operation.
+ */
 public class Window {
 
   private final int maxSize;

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/package-info.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/math/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Math utilities for Group Communication.
  */
 package org.apache.reef.examples.group.utils.math;

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/timer/package-info.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/group/utils/timer/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Timer for Group Communication.
  */
 package org.apache.reef.examples.group.utils.timer;

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/library/package-info.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/library/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * A library for distributed shell example.
  */
 package org.apache.reef.examples.library;

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/SuspendClient.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/suspend/SuspendClient.java
@@ -130,7 +130,7 @@ public class SuspendClient {
 
   /**
    * Receive notification from the driver that the job had failed.
-   * <p/>
+   * <p>
    * FailedJob is a proxy for the failed job driver
    * (contains job ID and exception thrown from the driver).
    */

--- a/lang/java/reef-examples/src/main/java/org/apache/reef/examples/utils/wake/package-info.java
+++ b/lang/java/reef-examples/src/main/java/org/apache/reef/examples/utils/wake/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Logging and Blocking event handlers.
  */
 package org.apache.reef.examples.utils.wake;

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/api/DataLoader.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/api/DataLoader.java
@@ -55,7 +55,7 @@ import java.util.logging.Logger;
  * the ones that need data loading have a context stacked
  * that enables a task to get access to Data via the
  * {@link DataSet}.
- * <p/>
+ * <p>
  * TODO: Add timeouts
  */
 @DriverSide

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/api/DataSet.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/api/DataSet.java
@@ -25,12 +25,12 @@ import org.apache.reef.io.network.util.Pair;
  * A view of the data set to be loaded
  * at an evaluator as an iterable of
  * key value pairs.
- * <p/>
+ * <p>
  * Implementations need not materialize
  * and clients should not assume that the
  * data is materialized. Any such thing
  * is left as a post-processing step.
- * <p/>
+ * <p>
  * Client also can't assume that the iterator
  * returned here can be restarted
  *

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/api/EvaluatorToPartitionStrategy.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/api/EvaluatorToPartitionStrategy.java
@@ -25,7 +25,7 @@ import org.apache.reef.driver.catalog.NodeDescriptor;
 import org.apache.reef.io.data.loading.impl.NumberedSplit;
 
 /**
- * Interface that tracks the mapping between evaluators & the data partitions
+ * Interface that tracks the mapping between evaluators and the data partitions
  * assigned to those evaluators. Its part of the implementation of a
  * {@link org.apache.reef.io.data.loading.api.DataLoadingService} that uses the
  * Hadoop {@link org.apache.hadoop.mapred.InputFormat} to partition the data and

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/api/package-info.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/api/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Data Loading Service API.
  */
 package org.apache.reef.io.data.loading.api;

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/AbstractEvaluatorToPartitionStrategy.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/AbstractEvaluatorToPartitionStrategy.java
@@ -161,7 +161,7 @@ public abstract class AbstractEvaluatorToPartitionStrategy implements EvaluatorT
 
   /**
    * Get an input split to be assigned to this evaluator.
-   * <p/>
+   * <p>
    * Allocates one if its not already allocated
    *
    * @param evaluatorId

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/InputFormatDataSet.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/InputFormatDataSet.java
@@ -33,7 +33,7 @@ import java.util.Iterator;
 /**
  * An implementation of {@link DataSet} that reads records using a RecordReader
  * encoded inside an InputSplit.
- * <p/>
+ * <p>
  * The input split is injected through an external constructor by deserializing
  * the input split assigned to this evaluator.
  *

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/InputFormatLoadingService.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/InputFormatLoadingService.java
@@ -43,10 +43,10 @@ import java.util.logging.Logger;
 /**
  * An implementation of {@link DataLoadingService}
  * that uses the Hadoop {@link org.apache.hadoop.mapred.InputFormat} to find
- * partitions of data & request resources.
- * <p/>
+ * partitions of data and request resources.
+ * <p>
  * The InputFormat is taken from the job configurations
- * <p/>
+ * <p>
  * The {@link EvaluatorToPartitionStrategy} is injected via Tang,
  * in order to support different ways to map evaluators to data
  */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/NumberedSplit.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/NumberedSplit.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang.Validate;
 
 /**
  * A tuple of an object of type E and an integer index.
- * Used inside {@link EvaluatorToPartitionStrategy} implementations to
+ * Used inside {@link org.apache.reef.io.data.loading.api.EvaluatorToPartitionStrategy} implementations to
  * mark the partitions associated with each {@link org.apache.hadoop.mapred.InputSplit}
  *
  * @param <E>

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/WritableSerializer.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/WritableSerializer.java
@@ -29,7 +29,7 @@ import java.io.*;
 /**
  * A serializer class that serializes {@link Writable}s
  * into String using the below {@link Codec} that
- * encodes & decodes {@link Writable}s
+ * encodes and decodes {@link Writable}s
  * By default this stores the class name in the serialized
  * form so that the specific type can be instantiated on
  * de-serialization. However, this also needs the jobconf

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/package-info.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/data/loading/impl/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Implementations of Data Loading Service.
  */
 package org.apache.reef.io.data.loading.impl;

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/NetworkConnectionService.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/NetworkConnectionService.java
@@ -28,21 +28,23 @@ import org.apache.reef.wake.remote.transport.LinkListener;
 
 /**
  * NetworkConnectionService.
- *
+ * <p>
  * NetworkConnectionService is a service which is designed for communicating messages with each other.
  * It creates multiple ConnectionFactories, which create multiple connections.
- *
+ * <p>
  * Flow of message transfer:
- * [Downstream]: connection.write(message) -> ConnectionFactory
- * -> src NetworkConnectionService (encode) -> dest NetworkConnectionService.
- * [Upstream]: message -> dest NetworkConnectionService (decode) -> ConnectionFactory -> EventHandler.
- *
+ * <ul>
+ * <li>[Downstream]: {@code connection.write(message) -> ConnectionFactory
+ * -> src NetworkConnectionService (encode) -> dest NetworkConnectionService}.</li>
+ * <li>[Upstream]: {@code message -> dest NetworkConnectionService (decode) -> ConnectionFactory -> EventHandler}.</li>
+ * </ul>
+ * <p>
  * Users can register a ConnectionFactory by registering their Codec, EventHandler, LinkListener and end point id.
  * When users send messages via connections created by the ConnectionFactory,
- *
+ * <p>
  * NetworkConnectionService encodes the messages according to the Codec
  * registered in the ConnectionFactory and sends them to the destination NetworkConnectionService.
- *
+ * <p>
  * Also, it receives the messages by decoding the messages and forwarding them
  * to the corresponding EventHandler registered in the ConnectionFactory.
  */
@@ -58,8 +60,8 @@ public interface NetworkConnectionService extends AutoCloseable {
    * is the contact point, which is registered to NameServer through this method.
    *
    * @param connectionFactoryId a connection factory id
-   * @param codec a codec for type <T>
-   * @param eventHandler an event handler for type <T>
+   * @param codec a codec for type T
+   * @param eventHandler an event handler for type T
    * @param linkListener a link listener
    * @param localEndPointId a local end point id
    * @return the registered connection factory

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/exception/package-info.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/exception/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Network service exceptions.
  */
 package org.apache.reef.io.network.exception;

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/config/OperatorSpec.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/config/OperatorSpec.java
@@ -31,7 +31,7 @@ import org.apache.reef.io.serialization.Codec;
 public interface OperatorSpec {
 
   /**
-   * @return The codec class to be used to serialize & deserialize data
+   * @return The codec class to be used to serialize and deserialize data
    * in the group communication operators.
    */
   Class<? extends Codec> getDataCodecClass();

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/CommunicationGroupDriver.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/CommunicationGroupDriver.java
@@ -30,7 +30,7 @@ import org.apache.reef.tang.annotations.Name;
 
 /**
  * The driver side interface of a Communication Group
- * Lets one add opertaors and tasks.
+ * Lets one add operators and tasks.
  * Main function is to extract the configuration related
  * to the Group Communication for a task in the comm group
  */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/TaskNodeStatus.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/driver/TaskNodeStatus.java
@@ -50,7 +50,7 @@ public interface TaskNodeStatus {
    * To be called before sending a ctrl msg to the task
    * represented by this node. All ctrl msgs sent to this
    * node need to be ACKed.
-   * Ctrl msgs will be sent        from a src &
+   * Ctrl msgs will be sent        from a src and
    * ACK sent from the task will be for a src.
    * As this is called from the TaskNodeImpl use srcId of msg
    * In TaskNodeImpl while processMsg        use dstId of msg

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/AllGather.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/AllGather.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 /**
  * MPI AllGather Operator.
- * <p/>
+ * <p>
  * Each task applies this operator on an element of type T. The result will be
  * a list of elements constructed using the elements all-gathered at each
  * task.

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Broadcast.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Broadcast.java
@@ -25,9 +25,9 @@ import org.apache.reef.tang.annotations.DefaultImplementation;
 
 /**
  * MPI Broadcast operator.
- * <p/>
+ * <p>
  * The sender or root send's an element that is received by all the receivers or other tasks.
- * <p/>
+ * <p>
  * This is an asymmetric operation and hence the differentiation b/w Sender and Receiver.
  */
 public interface Broadcast {

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Gather.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Gather.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 /**
  * MPI Gather Operator.
- * <p/>
+ * <p>
  * This is an operator where the root is a receiver and there are multiple senders.
  * The root or receiver gathers all the elements sent by the senders in a List.
  */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Reduce.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Reduce.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 /**
  * MPI Reduce operator.
- * <p/>
+ * <p>
  * This is another operator with root being receiver All senders send an element
  * to the receiver. These elements are passed through a reduce function and its
  * result is made available at the root

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/ReduceScatter.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/ReduceScatter.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 /**
  * MPI Reduce Scatter operator.
- * <p/>
+ * <p>
  * Each task has a list of elements. Assume that each task reduces
  * each element in the list to form a list of reduced elements at a dummy root.
  * The dummy root then keeps the portion of the list assigned to it and
@@ -36,7 +36,7 @@ public interface ReduceScatter<T> extends GroupCommOperator {
   /**
    * Apply this operation on elements where counts specify the distribution of
    * elements to each task. Ordering is assumed to be default.
-   * <p/>
+   * <p>
    * Here counts is of the same size as the entire group not just children.
    *
    * @return List of values that result from applying reduce function on
@@ -48,7 +48,7 @@ public interface ReduceScatter<T> extends GroupCommOperator {
   /**
    * Apply this operation on elements where counts specify the distribution of
    * elements to each task. Ordering is specified using order
-   * <p/>
+   * <p>
    * Here counts is of the same size as the entire group not just children
    *
    * @return List of values that result from applying reduce function on

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Scatter.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/Scatter.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 /**
  * MPI Scatter operator
- * <p/>
+ * <p>
  * Scatter a list of elements to the receivers The receivers will receive a
  * sub-list of elements targeted for them. Supports non-uniform distribution
  * through the specification of counts

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/package-info.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/operators/package-info.java
@@ -23,9 +23,9 @@
  * for symmetric operations unlike MPI which provides symmetric operations
  * for all operations.
  *
- * The interface is asymmetric in the sense that Senders & Receivers are
+ * The interface is asymmetric in the sense that Senders and Receivers are
  * separated out for operations like Scatter and Gather. All participants
- * do not execute the same function. A sender sends & a receiver receives.
+ * do not execute the same function. A sender sends and a receiver receives.
  *
  * The interface only concentrates on the data part because we are on the
  * data-plane of things in REEF. The control information is embedded in the
@@ -39,7 +39,7 @@
  * One thing implicit in MPI operations is the ordering of processors based
  * on their ranks which determines the order of operations. For ex., if we
  * scatter an array of 10 elements into 10 processors, then which processor
- * gets the 1st entry & so on is based on the rank.
+ * gets the 1st entry and so on is based on the rank.
  *
  * In our case we do not have any ranks associated with tasks. Instead,
  * by default we use the lexicographic order of the task ids. These can

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/package-info.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Elastic Group Communications API.
  */
 package org.apache.reef.io.network.group.api;

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/GroupCommClient.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/GroupCommClient.java
@@ -34,7 +34,7 @@ import org.apache.reef.tang.annotations.Name;
 public interface GroupCommClient {
 
   /**
-   * @param string
+   * @param groupName a group name
    * @return The communication group client with the given name that gives access
    * to the operators configured on it that will be used to do group communication
    */

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/NodeStruct.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/NodeStruct.java
@@ -23,10 +23,10 @@ import org.apache.reef.io.network.group.impl.GroupCommunicationMessage;
 /**
  * The actual node that is part of the operator topology
  *
- * Receives data from the handlers & provides them to the
+ * Receives data from the handlers and provides them to the
  * operators/OperatorTopologyStruct when they need it.
  *
- * This implementation decouples the send & receive.
+ * This implementation decouples the send and receive.
  */
 public interface NodeStruct {
 

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/OperatorTopology.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/OperatorTopology.java
@@ -28,18 +28,18 @@ import java.util.Map;
 
 /**
  * Represents the local topology of tasks for an operator. It
- * provides methods to send/rcv from parents & children
- * <p/>
- * Every operator is an EventHandler<GroupCommunicationMessage>
+ * provides methods to send/rcv from parents and children
+ * <p>
+ * Every operator is an {@code EventHandler<GroupCommunicationMessage>}
  * and it will use an instance of this type to delegate the
  * handling of the message and also uses it to communicate
  * with its parents and children
- * <p/>
+ * <p>
  * This is an operator facing interface. The actual topology is
  * maintained in OperatorTopologyStruct. Current strategy is to
  * maintain two versions of the topology and current operations
  * are always delegated to effectiveTopology and the baseTopology
- * is updated while initialization & when user calls updateTopology.
+ * is updated while initialization and when user calls updateTopology.
  * So this is only a wrapper around the two versions of topologies
  * and manages when to create/update them based on the messages from
  * the driver.

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/OperatorTopologyStruct.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/api/task/OperatorTopologyStruct.java
@@ -33,7 +33,7 @@ import java.util.Set;
  * The actual local topology maintaining the
  * children and parent that reacts to update
  * and data msgs. The actual nodes are represented
- * by NodeStruct and it handles receiving &
+ * by NodeStruct and it handles receiving and
  * providing data
  */
 public interface OperatorTopologyStruct {

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CommunicationGroupDriverImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/CommunicationGroupDriverImpl.java
@@ -87,7 +87,7 @@ public class CommunicationGroupDriverImpl implements CommunicationGroupDriver {
   private final Class<? extends Topology> topologyClass;
 
   /**
-   * @Deprecated in 0.14. Use Tang to obtain an instance of this instead.
+   * @deprecated in 0.14. Use Tang to obtain an instance of this instead.
    */
   @Deprecated
   public CommunicationGroupDriverImpl(final Class<? extends Name<String>> groupName,

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/GroupCommDriverImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/GroupCommDriverImpl.java
@@ -71,8 +71,8 @@ import java.util.logging.Logger;
 /**
  * Sets up various stages to handle REEF events and adds the per communication
  * group stages to them whenever a new communication group is created.
- * <p/>
- * Also starts the NameService & the NetworkService on the driver
+ * <p>
+ * Also starts the NameService and the NetworkService on the driver
  */
 public class GroupCommDriverImpl implements GroupCommServiceDriver {
   private static final Logger LOG = Logger.getLogger(GroupCommDriverImpl.class.getName());

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TaskNodeStatusImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/TaskNodeStatusImpl.java
@@ -110,7 +110,7 @@ public class TaskNodeStatusImpl implements TaskNodeStatus {
   /**
    * This needs to happen in line rather than in a stage because we need to note.
    * the messages we send to the tasks before we start processing msgs from the
-   * nodes.(Acks & Topology msgs)
+   * nodes.(Acks and Topology msgs)
    */
   @Override
   public void expectAckFor(final Type msgType, final String srcId) {

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/package-info.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/driver/package-info.java
@@ -27,7 +27,7 @@
  * specified.
  *
  * After the GroupCommDriver is configured the driver would want to submit
- * tasks with the Communication Groups & their operators configured. To do
+ * tasks with the Communication Groups and their operators configured. To do
  * that the user has to create a partial task configuration containing his
  * set of configurations and add it to the relevant communication group.
  * Based on whether the given task is a Master/Slave different roles for

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/package-info.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Implementations for Elastic Group Communications.
  */
 package org.apache.reef.io.network.group.impl;

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/OperatorTopologyImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/OperatorTopologyImpl.java
@@ -103,18 +103,18 @@ public class OperatorTopologyImpl implements OperatorTopology {
    * received TopologySetup but not yet created the effectiveTopology.
    * Most times the msgs in the deletionDeltas will be discarded as stale
    * msgs
-   * <p/>
+   * <p>
    * No synchronization is needed while handling *Dead messages.
-   * There 2 states: UpdatingTopo & NotUpdatingTopo
+   * There 2 states: UpdatingTopo and NotUpdatingTopo
    * If UpdatingTopo, deltas.put still takes care of adding this msg to effTop through baseTopo changes.
    * If not, we add to effTopo. So we are good.
-   * <p/>
+   * <p>
    * However, for data msgs synchronization is needed. Look at doc of
    * DataHandlingStage
-   * <p/>
+   * <p>
    * Adding to deletionDeltas should be outside
    * effTopo!=null block. There is a rare possibility that during initialization
-   * just after baseTopo is created(so deltas will be ignored) & just before
+   * just after baseTopo is created(so deltas will be ignored) and just before
    * effTopo is created(so effTopo will be null) where we can miss a deletion
    * msg if not added to deletionDelta because this method is synchronized
    */
@@ -296,7 +296,7 @@ public class OperatorTopologyImpl implements OperatorTopology {
   /**
    * Blocking method that waits till the base topology is updated Unblocks when.
    * we receive a TopologySetup msg from driver
-   * <p/>
+   * <p>
    * Will also update the effective topology when the base topology is updated
    * so that creation of effective topology is limited to just this method and
    * refresh will only refresh the effective topology with deletion msgs from

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/OperatorTopologyStructImpl.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/task/OperatorTopologyStructImpl.java
@@ -450,7 +450,7 @@ public class OperatorTopologyStructImpl implements OperatorTopologyStruct {
    * Updates the topology structure with the received
    * message. Does not make assumptions about msg order
    * Tries to handle OOS msgs
-   * <p/>
+   * <p>
    * Expects only control messages
    */
   @Override

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/ConcurrentCountingMap.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/ConcurrentCountingMap.java
@@ -28,7 +28,7 @@ import java.util.logging.Logger;
 /**
  * Utility map class that wraps a CountingMap.
  * in a ConcurrentMap
- * Equivalent to Map<K,Map<V,Integer>>
+ * Equivalent to {@code Map<K,Map<V,Integer>>}
  */
 public class ConcurrentCountingMap<K, V> {
   private static final Logger LOG = Logger.getLogger(ConcurrentCountingMap.class.getName());

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/SetMap.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/network/group/impl/utils/SetMap.java
@@ -23,7 +23,7 @@ import org.apache.reef.io.network.group.impl.driver.MsgKey;
 import java.util.*;
 
 /**
- * Map from K to Set<V>.
+ * Map from K to {@code Set<V>}.
  */
 public class SetMap<K, V> {
   private final Map<K, Set<V>> map = new HashMap<>();

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/local/package-info.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/local/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Implementations for local filesystem-based storage service.
  */
 package org.apache.reef.io.storage.local;

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/package-info.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * APIs for Storage Service.
  */
 package org.apache.reef.io.storage;

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/ram/RamSpool.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/ram/RamSpool.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 /**
  * A SpoolFile implementation that is backed by RAM.
- * <p/>
+ * <p>
  * It uses an ArrayList to store the objects in.
  */
 public final class RamSpool<T> implements Spool<T> {

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/ram/package-info.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/ram/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Implementations for RAM-based storage service.
  */
 package org.apache.reef.io.storage.ram;

--- a/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/util/package-info.java
+++ b/lang/java/reef-io/src/main/java/org/apache/reef/io/storage/util/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Utilities for storage services.
  */
 package org.apache.reef.io.storage.util;

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/HDInsightDriverConfiguration.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/HDInsightDriverConfiguration.java
@@ -51,16 +51,16 @@ import org.apache.reef.tang.formats.RequiredParameter;
 public final class HDInsightDriverConfiguration extends ConfigurationModuleBuilder {
 
   /**
-   * @see org.apache.reef.runtime.yarn.driver.parameters.JobSubmissionDirectory
+   * @see org.apache.reef.driver.parameters.JobSubmissionDirectory
    */
   public static final RequiredParameter<String> JOB_SUBMISSION_DIRECTORY = new RequiredParameter<>();
   /**
-   * @see org.apache.reef.runtime.yarn.driver.parameters.YarnHeartbeatPeriod.class
+   * @see org.apache.reef.runtime.yarn.driver.parameters.YarnHeartbeatPeriod
    */
   public static final OptionalParameter<Integer> YARN_HEARTBEAT_INTERVAL = new OptionalParameter<>();
 
   /**
-   * @see JobIdentifier.class
+   * @see JobIdentifier
    */
   public static final RequiredParameter<String> JOB_IDENTIFIER = new RequiredParameter<>();
 

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/UnsafeHDInsightRuntimeConfiguration.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/UnsafeHDInsightRuntimeConfiguration.java
@@ -88,7 +88,7 @@ public final class UnsafeHDInsightRuntimeConfiguration extends ConfigurationModu
    * @return the RuntimeConfiguration that is stored in a file refered to by the environment
    * variable HDInsightRuntimeConfiguration.HDINSIGHT_CONFIGURATION_FILE_ENVIRONMENT_VARIABLE.
    * @throws IOException
-   * @see HDInsightRuntimeConfiguration.HDINSIGHT_CONFIGURATION_FILE_ENVIRONMENT_VARIABLE
+   * @see HDInsightRuntimeConfiguration#HDINSIGHT_CONFIGURATION_FILE_ENVIRONMENT_VARIABLE
    */
   public static Configuration fromEnvironment() throws IOException {
 

--- a/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/sslhacks/UnsafeTrustManager.java
+++ b/lang/java/reef-runtime-hdinsight/src/main/java/org/apache/reef/runtime/hdinsight/client/sslhacks/UnsafeTrustManager.java
@@ -25,7 +25,7 @@ import java.security.cert.X509Certificate;
 
 /**
  * A TrustManager that trusts all certificates. Basically the "GOTO FAIL" bug implemented in Java.
- * <p/>
+ * <p>
  * Hence: DO NOT USE THIS CLASS UNLESS DEBUGGING.
  */
 final class UnsafeTrustManager implements X509TrustManager {

--- a/lang/java/reef-runtime-hdinsight/src/test/java/org/apache/reef/runtime/hdinsight/TestHDInsightRESTJsonSerialization.java
+++ b/lang/java/reef-runtime-hdinsight/src/test/java/org/apache/reef/runtime/hdinsight/TestHDInsightRESTJsonSerialization.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/LocalClasspathProvider.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/LocalClasspathProvider.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 /**
  * RuntimeClasspathProvider for the local runtime.
- * <p/>
+ * <p>
  * The prefix for the local runtime is empty, the suffix is the classpath of the current JVM. That classpath is filtered
  * to not contain subfolders of JAVA_HOME. Also, duplicates are removed.
  */

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/DriverFiles.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/DriverFiles.java
@@ -32,7 +32,7 @@ import java.util.logging.Logger;
 
 /**
  * Represents the files added to a driver.
- * <p/>
+ * <p>
  * This class is constructed via the from() method that instantiates it based on a JobSubmissionProto
  */
 final class DriverFiles {
@@ -120,7 +120,7 @@ final class DriverFiles {
 
   /**
    * Copies this set of files to the destination folder given.
-   * <p/>
+   * <p>
    * Will attempt to create symbolic links for the files to the destination
    * folder.  If the filesystem does not support symbolic links or the user
    * does not have appropriate permissions, the entire file will be copied instead.

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/FileSet.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/FileSet.java
@@ -39,9 +39,9 @@ final class FileSet {
 
   /**
    * Add a file to the FileSet.
-   * <p/>
+   * <p>
    * If the file is a directory, it is turned into a JAR and the resulting JAR is added.
-   * <p/>
+   * <p>
    * Files already added will be ignored.
    *
    * @param file the file to be added.

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/LocalRuntimeConfiguration.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/LocalRuntimeConfiguration.java
@@ -51,7 +51,7 @@ public class LocalRuntimeConfiguration extends ConfigurationModuleBuilder {
    * The folder in which the sub-folders, one per Node, will be created. Those will contain one folder per
    * Evaluator instantiated on the virtual node. Those inner folders will be named by the time when the Evaluator was
    * launched.
-   * <p/>
+   * <p>
    * If none is given, a folder "REEF_LOCAL_RUNTIME" will be created in the local directory.
    */
   public static final OptionalParameter<String> RUNTIME_ROOT_FOLDER = new OptionalParameter<>();

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/package-info.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * client-side event handlers for the local resourcemanager.
+ * Client-side event handlers for the local resourcemanager.
  */
 package org.apache.reef.runtime.local.client;

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/Container.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/Container.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 /**
  * Represents a Container: A slice of a machine.
- * <p/>
+ * <p>
  * In the case of the local resourcemanager, this slice is always the one of the machine where the job was submitted.
  */
 @Private

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ResourceManager.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/driver/ResourceManager.java
@@ -112,7 +112,7 @@ public final class ResourceManager {
 
   /**
    * Receives a resource request.
-   * <p/>
+   * <p>
    * If the request can be met, it will also be satisfied immediately.
    *
    * @param resourceRequest the resource request to be handled.

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/client/package-info.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/client/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Client-side event handlers for Mesos resourcemanager.
  */
 package org.apache.reef.runtime.mesos.client;

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/client/parameters/package-info.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/client/parameters/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Client-side parameters for Mesos job submission.
  */
 package org.apache.reef.runtime.mesos.client.parameters;

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosDriverConfiguration.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/MesosDriverConfiguration.java
@@ -45,7 +45,7 @@ import org.apache.reef.wake.impl.SingleThreadStage;
  */
 public final class MesosDriverConfiguration extends ConfigurationModuleBuilder {
   /**
-   * @see JobIdentifier.class
+   * @see JobIdentifier
    */
   public static final RequiredParameter<String> JOB_IDENTIFIER = new RequiredParameter<>();
 

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/package-info.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Driver-side event handlers for Mesos resourcemanager.
  */
 package org.apache.reef.runtime.mesos.driver;

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/parameters/package-info.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/parameters/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Driver-side parameters for Mesos job submission.
  */
 package org.apache.reef.runtime.mesos.driver.parameters;

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/evaluator/package-info.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/evaluator/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Evaluator-side event handlers for Mesos resourcemanager.
  */
 package org.apache.reef.runtime.mesos.evaluator;

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/evaluator/parameters/package-info.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/evaluator/parameters/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Evaluator-side parameters for Mesos job.
  */
 package org.apache.reef.runtime.mesos.evaluator.parameters;

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/package-info.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * An YARN implementation of REEF that uses Mesos slaves for execution.
  */
 package org.apache.reef.runtime.mesos;

--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/util/package-info.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/util/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Utility for Mesos runtime.
  */
 package org.apache.reef.runtime.mesos.util;

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/ClassPathBuilder.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/ClassPathBuilder.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 /**
  * A helper class to assemble a class path.
- * <p/>
+ * <p>
  * It uses a TreeSet internally for both a prefix and a suffix of the classpath. This makes sure that duplicate entries
  * are avoided.
  */

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/YarnSubmissionHelper.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/YarnSubmissionHelper.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -232,7 +232,7 @@ public final class YarnSubmissionHelper implements Closeable{
 
   /**
    * Extract the desired driver memory from jobSubmissionProto.
-   * <p/>
+   * <p>
    * returns maxMemory if that desired amount is more than maxMemory
    */
   private int getMemory(final int requestedMemory) {

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/package-info.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Client-side event handlers for YARN resourcemanager.
  */
 package org.apache.reef.runtime.yarn.client;

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/parameters/JobPriority.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/parameters/JobPriority.java
@@ -22,7 +22,7 @@ import org.apache.reef.tang.annotations.Name;
 import org.apache.reef.tang.annotations.NamedParameter;
 
 /**
- * The prioroty of the submitted job.
+ * The priority of the submitted job.
  */
 @NamedParameter(doc = "The job priority.", default_value = "0", short_name = "yarn_priority")
 public final class JobPriority implements Name<Integer> {

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/parameters/package-info.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/parameters/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Client-side parameters for YARN job submission.
  */
 package org.apache.reef.runtime.yarn.client.parameters;

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/uploader/JobFolder.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/uploader/JobFolder.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/uploader/JobUploader.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/uploader/JobUploader.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/uploader/package-info.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/client/uploader/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Uploader to copy job resource files to YARN.
  */
 package org.apache.reef.runtime.yarn.client.uploader;

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/DefaultRackNameFormatter.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/DefaultRackNameFormatter.java
@@ -38,7 +38,7 @@ public final class DefaultRackNameFormatter implements RackNameFormatter {
   }
 
   /**
-   * @see {@link RackNameFormatter#getRackName(Container)}.
+   * @see RackNameFormatter#getRackName(Container)
    */
   @Override
   public String getRackName(final Container container) {

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverConfiguration.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverConfiguration.java
@@ -40,21 +40,21 @@ import org.apache.reef.tang.formats.*;
  */
 public class YarnDriverConfiguration extends ConfigurationModuleBuilder {
   /**
-   * @see org.apache.reef.runtime.yarn.driver.parameters.JobSubmissionDirectory
+   * @see org.apache.reef.driver.parameters.JobSubmissionDirectory
    */
   public static final RequiredParameter<String> JOB_SUBMISSION_DIRECTORY = new RequiredParameter<>();
   /**
-   * @see org.apache.reef.runtime.yarn.driver.parameters.YarnHeartbeatPeriod.class
+   * @see org.apache.reef.runtime.yarn.driver.parameters.YarnHeartbeatPeriod
    */
   public static final OptionalParameter<Integer> YARN_HEARTBEAT_INTERVAL = new OptionalParameter<>();
 
   /**
-   * @see JobIdentifier.class
+   * @see JobIdentifier
    */
   public static final RequiredParameter<String> JOB_IDENTIFIER = new RequiredParameter<>();
 
   /**
-   * @see {@link RackNameFormatter}
+   * @see RackNameFormatter
    */
   public static final OptionalImpl<RackNameFormatter> RACK_NAME_FORMATTER = new OptionalImpl<>();
 

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRestartConfiguration.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRestartConfiguration.java
@@ -32,7 +32,7 @@ import org.apache.reef.tang.formats.OptionalImpl;
 
 /**
  * Use this ConfigurationModule to configure YARN-specific Restart options for the driver.
- * <p/>
+ * <p>
  */
 @ClientSide
 @Public

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRuntimeRestartManager.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/YarnDriverRuntimeRestartManager.java
@@ -88,7 +88,7 @@ public final class YarnDriverRuntimeRestartManager implements DriverRuntimeResta
    * variable provided by YARN. If that fails, determine whether the application master is a restart
    * based on the number of previous containers reported by YARN. In the failure scenario, returns 1 if restart, 0
    * otherwise.
-   * @return > 0 if the application master is a restarted instance, 0 otherwise.
+   * @return positive value if the application master is a restarted instance, 0 otherwise.
    */
   @Override
   public int getResubmissionAttempts() {

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/parameters/package-info.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/parameters/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Driver-side parameters of YARN job submission.
  */
 package org.apache.reef.runtime.yarn.driver.parameters;

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/package-info.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * An YARN implementation of REEF that uses YARN container for execution.
  */
 package org.apache.reef.runtime.yarn;

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/util/package-info.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/util/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Utility for YARN runtime.
  */
 package org.apache.reef.runtime.yarn.util;

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Aspect.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Aspect.java
@@ -29,18 +29,19 @@ import java.lang.reflect.InvocationTargetException;
  * design patterns by interposing wrapper objects at injection time.  It
  * can also be used for more mundane purposes, such as tracking the
  * relationship between the objects that are instantiated at runtime.
- * <p/>
+ * <p>
  * The Wake project contains a full-featured implementation of this API that
  * may serve as a useful example.
  */
 public interface Aspect {
   /**
    * Inject an object of type T.
-   * <p/>
+   * <p>
    * Note that it is never OK to return an instance of ExternalConstructor.
    * Typical implementations check to see if they are about to return an
    * instance of ExternalConstructor.  If so, they return ret.newInstance()
    * instead.
+   * It throws a number of exceptions which are passed-through from the wrapped call to newInstance().
    *
    * @param def         information about the constructor to be invoked.  This is
    *                    mostly useful because it contains references to any relevant named
@@ -51,7 +52,10 @@ public interface Aspect {
    * @param args        The parameters to be passed into constructor.newInstance(), in the correct order.
    * @return A new instance of T.
    * Note, it is inject()'s responsibility to call <tt>ret.getInstance() if ret instanceof ExternalConstructor</tt>.
-   * @throws A number of exceptions which are passed-through from the wrapped call to newInstance().
+   * @throws InvocationTargetException
+   * @throws IllegalAccessException
+   * @throws IllegalArgumentException
+   * @throws InstantiationException
    */
   <T> T inject(ConstructorDef<T> def, Constructor<T> constructor, Object[] args)
       throws InvocationTargetException, IllegalAccessException, IllegalArgumentException, InstantiationException;

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/BindLocation.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/BindLocation.java
@@ -20,7 +20,7 @@ package org.apache.reef.tang;
 
 /**
  * This interface is used to track the source of configuration bindings.
- * <p/>
+ * <p>
  * This can be explicitly set (such as by configuration file parsers), or be
  * implicitly bound to the stack trace of bind() invocation.
  */

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/ClassHierarchy.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/ClassHierarchy.java
@@ -26,11 +26,11 @@ import org.apache.reef.tang.types.Node;
  * ClassHierarchy objects store information about the interfaces
  * and implementations that are available in a particular runtime
  * environment.
- * <p/>
+ * <p>
  * When Tang is running inside the same environment as the injected
  * objects, ClassHierarchy is simply a read-only representation of
  * information that is made available via language reflection.
- * <p/>
+ * <p>
  * If Tang is set up to perform remote injection, then the ClassHierarchy
  * it runs against is backed by a flat file, or other summary of the
  * libraries that will be available during injection.
@@ -42,11 +42,15 @@ public interface ClassHierarchy {
    * @param fullName The full name of the class that will be looked up.
    * @return A non-null reference to a ClassNode or a NamedParameterNode.
    * @throws NameResolutionException If the class is not found.
-   * @throws ClassHierarchyException If the class does not pass Tang's static analysis.
+   * @throws org.apache.reef.tang.exceptions.ClassHierarchyException If the class does not pass Tang's static analysis.
    */
   Node getNode(String fullName) throws NameResolutionException;
 
   /**
+   * Return whether the impl is a subclass of inter.
+   *
+   * @param inter a interface class
+   * @param impl a implementation class
    * @return true if impl is a subclass of inter.
    */
   boolean isImplementation(ClassNode<?> inter, ClassNode<?> impl);
@@ -60,9 +64,12 @@ public interface ClassHierarchy {
    * objects.  The Configuration API transparently invokes merge as necessary,
    * allowing applications to combine configurations that were built against
    * differing classpaths.
-   * <p/>
+   * <p>
    * ClassHierarchies derived from applications written in different languages
    * cannot be merged.
+   *
+   * @param ch a class hierarchy to be merged
+   * @return the merged class hierarchy
    */
   ClassHierarchy merge(ClassHierarchy ch);
 
@@ -74,7 +81,7 @@ public interface ClassHierarchy {
    * There is no way to provide an interface that enumerates known claases
    * without exposing this fact; therefore, the Node returned by this method
    * can change over time.
-   * <p/>
+   * <p>
    * Normal callers (all use cases except ClassHierarchy serialization)
    * should use getNode(String) to lookup classes, since getNamespace() can
    * not support lazy loading of unknown classes.

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/ClassHierarchySerializer.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/ClassHierarchySerializer.java
@@ -50,6 +50,7 @@ public interface ClassHierarchySerializer {
    * Serializes a ClassHierarchy as a byte[].
    *
    * @param classHierarchy the ClassHierarchy to store
+   * @return the byte array containing the serialized class hierarchy
    * @throws IOException if there is an error in the process
    */
   byte[] toByteArray(final ClassHierarchy classHierarchy) throws IOException;
@@ -58,6 +59,7 @@ public interface ClassHierarchySerializer {
    * Serializes a ClassHierarchy as a String.
    *
    * @param classHierarchy the ClassHierarchy to store
+   * @return the string containing the serialized class hierarchy
    * @throws IOException if there is an error in the process
    */
   String toString(final ClassHierarchy classHierarchy) throws IOException;
@@ -66,6 +68,7 @@ public interface ClassHierarchySerializer {
    * Loads a ClassHierarchy from a file created with toFile().
    *
    * @param file the File to read from
+   * @return the class hierarchy
    * @throws IOException if the File can't be read or parsed
    */
   ClassHierarchy fromFile(final File file) throws IOException;
@@ -74,6 +77,7 @@ public interface ClassHierarchySerializer {
    * Loads a ClassHierarchy from a text file created with toTextFile().
    *
    * @param file the File to read from
+   * @return the class hierarchy
    * @throws IOException if the File can't be read or parsed
    */
   ClassHierarchy fromTextFile(final File file) throws IOException;
@@ -82,6 +86,7 @@ public interface ClassHierarchySerializer {
    * Deserializes a ClassHierarchy from a byte[] created with toByteArray().
    *
    * @param theBytes the byte[] to deserialize
+   * @return the class hierarchy
    * @throws IOException if the byte[] can't be read or parsed
    */
   ClassHierarchy fromByteArray(final byte[] theBytes) throws IOException;
@@ -90,6 +95,7 @@ public interface ClassHierarchySerializer {
    * Deserializes a ClassHierarchy from a String created with toString().
    *
    * @param theString the String to deserialize
+   * @return the class hierarchy
    * @throws IOException if the String can't be read or parsed
    */
   ClassHierarchy fromString(final String theString) throws IOException;

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Configuration.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Configuration.java
@@ -27,7 +27,7 @@ import java.util.Set;
 
 /**
  * Immutable, type-checked configuration data.
- * <p/>
+ * <p>
  * Tang Configuration objects are constructed via
  * ConfigurationBuilders, and most applications interact with the
  * Configuration API much more than the one described here.  See
@@ -35,12 +35,12 @@ import java.util.Set;
  * semantics of configuration options.  The documentation provided
  * here is primarily for people that wish to extend Tang or implement
  * formats that export data from Configuration objects to other systems.
- * <p/>
+ * <p>
  * Conceptually, a configuration contains a set of key
  * value pairs.  Each pair either maps from an interface to an
  * implementation (a class) or from a configuration option to a
  * value (e.g., an integer or string).
- * <p/>
+ * <p>
  * Under the hood, Configuration objects carry much richer type
  * information than this, and also refer to the ClassHierarchy
  * object they were checked against.  Configurations can be
@@ -49,7 +49,7 @@ import java.util.Set;
  * Tang automatically merges the reflection data from the underlying
  * ClassHierarchy objects, and re-validates the merged configuration
  * data against the merged classpath.
- * <p/>
+ * <p>
  * Note that the left hand side of each configuration object (the
  * "key" in the key value pair) is unique.  Although there are many
  * APIs that take NamedParameterNode objects in this API, a given
@@ -64,21 +64,23 @@ public interface Configuration {
    * Create a new ConfigurationBuilder object based on the same classpath
    * as this Configuration, and populate it with the configuration options
    * of this object.
-   * <p/>
+   * <p>
    * This API is unstable and should be considered private.  Use the methods
    * in org.apache.reef.Tang instead.
+   *
+   * @return a new configuration builder
    */
   ConfigurationBuilder newBuilder();
 
   /**
    * Return the value of the given named parameter as an unparsed string.
-   * <p/>
+   * <p>
    * If nothing was explicitly bound, this method returns null (it does not
    * return default values).
    *
    * @param np A NamedParameter object from this Configuration's class hierarchy.
    * @return The validated string that this parameter is bound to, or null.
-   * @see getClassHierarchy()
+   * @see #getClassHierarchy()
    */
   String getNamedParameter(NamedParameterNode<?> np);
 
@@ -89,7 +91,7 @@ public interface Configuration {
    * @param np A NamedParameterNode from this Configuration's class hierarchy.
    * @return A set of ClassHierarchy Node objects or a set of strings, depending on
    * whether the NamedParameterNode refers to an interface or configuration options, respectively.
-   * @see getClassHierarchy()
+   * @see #getClassHierarchy()
    */
   Set<Object> getBoundSet(NamedParameterNode<Set<?>> np);
 
@@ -102,11 +104,19 @@ public interface Configuration {
   List<Object> getBoundList(NamedParameterNode<List<?>> np);
 
   /**
+   * Return the bound constructor.
+   *
+   * @param <T> a type
+   * @param cn a class node
    * @return the external constructor that cn has been explicitly bound to, or null.  Defaults are not returned.
    */
   <T> ClassNode<ExternalConstructor<T>> getBoundConstructor(ClassNode<T> cn);
 
   /**
+   * Returns the bound implementation.
+   *
+   * @param <T> a type
+   * @param cn a class node
    * @return the implementation that cn has been explicitly bound to, or null.  Defaults are not returned.
    */
   <T> ClassNode<T> getBoundImplementation(ClassNode<T> cn);
@@ -114,10 +124,14 @@ public interface Configuration {
   /**
    * Return the LegacyConstructor that has been bound to this Class.
    * Such constructors are defined in the class, but missing their @Inject annotation.
-   * <p/>
+   * <p>
    * For now, only one legacy constructor can be bound per class.
-   * <p/>
-   * TODO: Should this return Set<ConstructorDef<T>> instead?
+   * <p>
+   * TODO: Should this return {@code Set<ConstructorDef<T>>} instead?
+   *
+   * @param <T> a type
+   * @param cn a class node
+   * @return the legacy constructor
    */
   <T> ConstructorDef<T> getLegacyConstructor(ClassNode<T> cn);
 

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/ConfigurationBuilder.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/ConfigurationBuilder.java
@@ -32,7 +32,7 @@ import java.util.Set;
  * configurations are simply sets of bindings of various types.  The most
  * common bindings are of interfaces (or superclasses) to implementation
  * classes, and of configuration options ("NamedParameters") to values.
- * <p/>
+ * <p>
  * Implementations of this class type check the bindings against an underlying
  * ClassHierarchy implementation.  Typically, the backing ClassHierarchy will
  * be delegate to the default classloader (the one that loaded the code that is
@@ -42,12 +42,11 @@ import java.util.Set;
  * objects that are derived from reflection data from other languages, such as
  * C#.  This enables cross-language injection sessions, where Java code
  * configures C# code, or vice versa.
- * <p/>
- * <p/>
+ * <p>
  * When possible, the methods in this interface eagerly check for these
  * errors.  Methods that check for configuration and other runtime or
  * application-level errors are declared to throw BindException.
- * <p/>
+ * <p>
  * Furthermore, all methods in Tang, may throw RuntimeException if they
  * encounter inconsistencies in the underlying ClassHierarchy.  Such errors
  * reflect problems that existed when the application was compiled or
@@ -62,7 +61,7 @@ import java.util.Set;
  * @see JavaConfigurationBuilder for convenience methods that assume the
  * underlying ClassHierarchy object delegates to the default
  * classloader, and enable many compile time static checks.
- * @see ConfigurationModule which pushes additional type checks to class load
+ * @see org.apache.reef.tang.formats.ConfigurationModule which pushes additional type checks to class load
  * time.  This allows Tint, Tang's static analysis tool, to detect a wide
  * range of runtime configuration errors at build time.
  */
@@ -71,7 +70,7 @@ public interface ConfigurationBuilder {
   /**
    * Add all configuration parameters from the given Configuration object.
    *
-   * @param c
+   * @param c the configuration to be added
    */
   void addConfiguration(final Configuration c) throws BindException;
 
@@ -89,7 +88,7 @@ public interface ConfigurationBuilder {
   /**
    * Force Tang to treat the specified constructor as though it had an @Inject
    * annotation.
-   * <p/>
+   * <p>
    * This method takes ClassNode objects.  Like all of the methods in this
    * API, the ClassNode objects must come from the ClassHierarchy instance
    * returned by getClassHierarchy().
@@ -115,12 +114,12 @@ public interface ConfigurationBuilder {
   /**
    * Force Tang to treat the specified constructor as though it had an @Inject
    * annotation.
-   * <p/>
+   * <p>
    * This method takes ClassNode and ConstructorArg objects.  Like all of the
    * methods in this API, these objects must come from the ClassHierarchy
    * instance returned by getClassHierarchy().
    *
-   * @param cn   The class the constructor instantiates.
+   * @param c   The class the constructor instantiates.
    * @param args The parsed ConstructorArg objects corresponding to the types of the arguments taken by the constructor,
    *             in declaration order.
    * @throws BindException if the constructor does not exist, or if it has already been bound as a legacy constructor.
@@ -132,6 +131,7 @@ public interface ConfigurationBuilder {
    * Bind classes to each other, based on their full class names; alternatively,
    * bound a NamedParameter configuration option to a configuration value.
    *
+   * @param <T> a type
    * @param iface The full name of the interface that should resolve to impl,
    *              or the NamedParameter to be set.
    * @param impl  The full name of the implementation that will be used in
@@ -149,15 +149,15 @@ public interface ConfigurationBuilder {
   /**
    * Bind classes to each other, based on their full class names; alternatively,
    * bound a NamedParameter configuration option to a configuration value.
-   * <p/>
+   * <p>
    * This method takes Node objects.  Like all of the methods in this API,
    * these objects must come from the ClassHierarchy instance returned by
    * getClassHierarchy().
    *
-   * @param key   The interface / NamedParmaeter to be bound.
-   * @param value The implementation / value iface should be set to.
+   * @param iface   The interface / NamedParmaeter to be bound.
+   * @param impl The implementation / value iface should be set to.
    * @throws BindException if there is a type checking error
-   * @see bind(String, String) for a more complete description.
+   * See {@link #bind(String, String) bind(String,String)} for a more complete description.
    */
   void bind(Node iface, Node impl) throws BindException;
 
@@ -168,7 +168,7 @@ public interface ConfigurationBuilder {
    * constructors to classes that you cannot modify and (2) implementing
    * constructors that exmanine their arguments and return an instance of a
    * subclass of the requested object.
-   * <p/>
+   * <p>
    * To see how the second use case could be useful, consider a implementing a
    * URI interface with a distinct subclass for each valid URI prefix (e.g.,
    * http://, ssh://, etc...).  An ExternalConstructor could examine the prefix
@@ -177,15 +177,16 @@ public interface ConfigurationBuilder {
    * URI's external constructor would return the validated subclass of URI that
    * corresponds to the provided string, allowing instanceof and downcasts to
    * behave as expected in the code that invoked Tang.
-   * <p/>
+   * <p>
    * Both use cases should be avoided when possible, since they can
    * unnecessarily complicate object injections and undermine Tang's ability
    * to statically check a given configuration.
-   * <p/>
+   * <p>
    * This method takes ClassNode objects.  Like all of the methods in this API,
    * these objects must come from the ClassHierarchy instance returned by
    * getClassHierarchy().
    *
+   * @param <T> a type
    * @param iface The class or interface to be instantiated.
    * @param impl  The ExternalConstructor class that will be used to instantiate iface.
    * @throws BindException If impl does not instantiate a subclass of iface.
@@ -197,12 +198,20 @@ public interface ConfigurationBuilder {
   /**
    * Pretty print the default implementation / value of the provided class / NamedParamter.
    * This is used by Tang to produce human readable error messages.
+   *
+   * @param longName a name of class or parameter
+   * @return a pretty-formatted string for class or named parameter
+   * @throws BindException if name resolution fails
    */
   String classPrettyDefaultString(String longName) throws BindException;
 
   /**
    * Pretty print the human readable documentation of the provided class / NamedParamter.
    * This is used by Tang to produce human readable error messages.
+   *
+   * @param longName a name of class or parameter
+   * @return a pretty-formatted class description string
+   * @throws BindException if name resolution fails
    */
   String classPrettyDescriptionString(String longName)
       throws BindException;
@@ -212,12 +221,12 @@ public interface ConfigurationBuilder {
    * bindings and ClassHierarchy of this ConfigurationBuilder.  Future
    * changes to this ConfigurationBuilder will not be reflected in the
    * returned Configuration.
-   * <p/>
+   * <p>
    * Since Tang eagerly checks for configuration errors, this method does not
    * perform any additional validation, and does not throw any checkable
    * exceptions.
    *
-   * @return
+   * @return the Configuration
    */
   Configuration build();
 
@@ -235,15 +244,16 @@ public interface ConfigurationBuilder {
    * Bind an list of implementations(Class or String) to an given NamedParameter.
    * Unlike bindSetEntry, bindListEntry will bind a whole list to the parameter,
    * not an element of the list.
-   * <p/>
+   * <p>
    * Since ordering of the list is important, list binding cannot be repeated or
    * merged unlike set binding. If the elements of the list are Classes, the objects
    * created by the Classes will be injected. If the elements are Strings, the values
    * will be injected directly to a given list parameter.
    *
+   * @param <T> a type
    * @param iface    The list named parameter to be instantiated
    * @param implList The list of class or value will be used to instantiated the named parameter
-   * @throws BindException
+   * @throws BindException if implementation class does not fit to the named parameter
    */
   <T> void bindList(NamedParameterNode<List<T>> iface, List implList) throws BindException;
 

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Configurations.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Configurations.java
@@ -33,7 +33,7 @@ public final class Configurations {
   /**
    * Merge a set of Configurations.
    *
-   * @param configurations
+   * @param configurations the configuration to be merged
    * @return the merged configuration.
    * @throws org.apache.reef.tang.exceptions.BindException if the merge fails.
    */
@@ -44,7 +44,7 @@ public final class Configurations {
   /**
    * Merge a set of Configurations.
    *
-   * @param configurations
+   * @param configurations the configuration to be merged
    * @return the merged configuration.
    * @throws org.apache.reef.tang.exceptions.BindException if the merge fails.
    */

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/InjectionFuture.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/InjectionFuture.java
@@ -29,39 +29,37 @@ import java.util.concurrent.TimeUnit;
  * A future-based mechanism for cyclic object injections. Since Tang is a
  * constructor-based dependency injector, there is no way to directly create
  * cycles of objects.
- * <p/>
+ * <p>
  * In situations where you need to have two objects that point at each other, you
  * can use an InjectionFuture to break the cycle. Simply ask Tang to inject an
- * InjectionFuture<T> into your constructor.  Later (after your constructor
+ * {@code InjectionFuture<T>} into your constructor.  Later (after your constructor
  * returns) invoke the get() method of the injection future to get a reference
  * to an injected object of type T.
- * <p/>
+ * <p>
  * Note that InjectorFutures and singletons interact in subtle ways.
- * <p/>
+ * <p>
  * Normally, Tang never reuses a reference to an injected object unless the
  * object is a singleton or a volatile instance. If InjectionFutures followed
  * this convention, then a cyclic injection of two non-singleton classes would
  * result in an an infinite chain of objects of the two types. Tang addresses
  * this issue as follows:
- * <p/>
+ * <p>
  * 1) In the first pass, it injects a complete object tree, making note of
  * InjectionFuture objects that will need to be populated later. The injection
  * of this tree respects standard Tang singleton and volatile semantics.
- * <p/>
+ * <p>
  * 2) In a second pass, Tang populates each of the InjectionFutures with the
  * reference to the requested class that was instantiated in the first pass. If
  * this reference does not exist (or is non-unique) then an InjectionException
  * is thrown.
- * <p/>
+ * <p>
  * Note: The semantics of complex cyclic injections may change over time.
- * <p/>
+ * <p>
  * We haven't seen many complicated injections that involve cycles in practice.
  * A second approach would be to establish some scoping rules, so that each
  * InjectionFuture binds to the innermost matching parent in the InjectionPlan.
  * This would allow plans to inject multiple cycles involving distinct objects
  * of the same type.
- *
- * @param <T>
  */
 
 public final class InjectionFuture<T> implements Future<T> {

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Injector.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Injector.java
@@ -32,24 +32,36 @@ public interface Injector {
    * the existing instance will be returned. Otherwise, a new instance will be
    * returned, and registered in the current scope.
    *
-   * @param iface
-   * @return
-   * @throws NameResolutionException
-   * @throws ReflectiveOperationException
+   * @param <U> a type
+   * @param iface an interface
+   * @return an instance
+   * @throws InjectionException if it fails to find corresponding class
    */
   <U> U getInstance(Class<U> iface) throws InjectionException;
 
+  /**
+   * Gets an instance of iface, or the implementation that has been bound to it.
+   * If an instance has already been created in this (or a parent) scope, then
+   * the existing instance will be returned. Otherwise, a new instance will be
+   * returned, and registered in the current scope.
+   *
+   * @param <U> a type
+   * @param iface a name of interface
+   * @return an instance
+   * @throws InjectionException if it fails to find corresponding class
+   * @throws NameResolutionException if name resolution fails
+   */
   <U> U getInstance(String iface) throws InjectionException,
       NameResolutionException;
 
   /**
    * Gets the value stored for the given named parameter.
    *
-   * @param <U>
-   * @param iface
+   * @param <U> a type
+   * @param iface the name of interface
    * @return an Instance of the class configured as the implementation for the
    * given interface class.
-   * @throws InjectionException
+   * @throws InjectionException if name resolution fails
    */
   <U> U getNamedInstance(Class<? extends Name<U>> iface)
       throws InjectionException;
@@ -60,10 +72,10 @@ public interface Injector {
    * Injectors, none of those objects can be serialized back to a configuration
    * file).
    *
-   * @param iface
-   * @param inst
-   * @return A copy of this injector that reflects the new binding.
-   * @throws BindException
+   * @param <T> a type
+   * @param iface an interface cass
+   * @param inst an instance
+   * @throws BindException when trying to re-bind
    */
   <T> void bindVolatileInstance(Class<T> iface, T inst)
       throws BindException;
@@ -74,19 +86,20 @@ public interface Injector {
   /**
    * Binds a TANG Aspect to this injector.  Tang Aspects interpose on each
    * injection performed by an injector, and return an instance of their choosing.
-   * <p/>
+   * <p>
    * A given aspect will be invoked once for each object that Tang injects, and aspects
    * will be copied in a way that mirrors the scoping that Tang creates at runtime.
    *
-   * @param a
-   * @throws BindException
+   * @param <T> a type
+   * @param a aspect
+   * @throws BindException if there exists a bound aspect already
    */
   <T> void bindAspect(Aspect a) throws BindException;
 
   /**
    * Allows InjectionFuture to tell the aspect when get() is invoked.  Package private.
    *
-   * @return
+   * @return the aspect
    */
   Aspect getAspect();
 
@@ -95,8 +108,7 @@ public interface Injector {
    * created by this Injector, but reflects additional Configuration objects.
    * This can be used to create trees of Injectors that obey hierarchical
    * scoping rules.
-   * <p/>
-   * <p/>
+   * <p>
    * Except for the fact that the child Injector will have references to this
    * injector's instances, the returned Injector is equivalent to the one you
    * would get by using ConfigurationBuilder to build a merged Configuration,
@@ -104,6 +116,8 @@ public interface Injector {
    * returned by ConfigurationBuilders are always independent, and never
    * share references to the same instances of injected objects.
    *
+   * @param configurations configurations
+   * @return an injector
    * @throws BindException If any of the configurations conflict with each other, or the
    *                       existing Injector's Configuration.
    */
@@ -113,9 +127,9 @@ public interface Injector {
    * Returns true if this Injector is able to instantiate the object named by
    * name.
    *
-   * @param name
-   * @return
-   * @throws BindException
+   * @param name a name of object
+   * @return whether the name is injectable
+   * @throws BindException if there is a loop or the name is package name
    */
   boolean isInjectable(String name) throws BindException;
 

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/JavaClassHierarchy.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/JavaClassHierarchy.java
@@ -28,7 +28,7 @@ public interface JavaClassHierarchy extends ClassHierarchy {
    * Look up a class object in this ClassHierarchy. Unlike the version that
    * takes a string in ClassHierarchy, this version does not throw
    * NameResolutionException.
-   * <p/>
+   * <p>
    * The behavior of this method is undefined if the provided Class object is
    * not from the ClassLoader (or an ancestor of the ClassLoader) associated
    * with this JavaClassHierarchy. By default, Tang uses the default runtime
@@ -45,9 +45,10 @@ public interface JavaClassHierarchy extends ClassHierarchy {
   /**
    * Parse a string value that has been passed into a named parameter.
    *
+   * @param <T> A type
    * @param name  The named parameter that will receive the value.
    * @param value A string value to be validated and parsed.
-   * @return An instance of T, or a ClassNode<? extends T>.
+   * @return An instance of T, or a {@code ClassNode<? extends T>}.
    * @throws ParseException if the value failed to parse, or parsed to the
    *                        wrong type (such as when it specifies a class that does not implement
    *                        or extend T).
@@ -57,6 +58,7 @@ public interface JavaClassHierarchy extends ClassHierarchy {
   /**
    * Obtain a parsed instance of the default value of a named parameter.
    *
+   * @param <T> A type
    * @param name The named parameter that should be checked for a default instance.
    * @return The default instance or null, unless T is a set type.  If T is a set,
    * then this method returns a (potentially empty) set of default instances.

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/JavaConfigurationBuilder.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/JavaConfigurationBuilder.java
@@ -28,13 +28,13 @@ import java.util.Set;
 /**
  * Convenience methods that extend the ConfigurationBuilder but assume that
  * the underlying ClassHierarchy delegates to the default Java classloader.
- * <p/>
+ * <p>
  * In addition to being less verbose, this interface expresses many of Tang's
  * type checks in Java's generic type system.  This improves IDE
  * auto-completion.  It also allows the errors to be caught at compile time
  * instead of later on in the build process, or at runtime.
  *
- * @see ConfigurationModule which pushes additional type checks to class load
+ * @see org.apache.reef.tang.formats.ConfigurationModule which pushes additional type checks to class load
  * time.  This allows Tint, Tang's static analysis tool, to detect a wide
  * range of runtime configuration errors at build time.
  */
@@ -44,17 +44,20 @@ public interface JavaConfigurationBuilder extends ConfigurationBuilder {
    * Bind named parameters, implementations or external constructors, depending
    * on the types of the classes passed in.
    *
-   * @param iface
-   * @param impl
+   * @param <T> a type
+   * @param iface an interface class
+   * @param impl an implementation class
+   * @return the configuration builder
    */
   <T> JavaConfigurationBuilder bind(Class<T> iface, Class<?> impl) throws BindException;
 
   /**
    * Binds the Class impl as the implementation of the interface iface.
    *
-   * @param <T>
-   * @param iface
-   * @param impl
+   * @param <T> a type
+   * @param iface an interface class
+   * @param impl an implementation class
+   * @return the configuration builder
    */
   <T> JavaConfigurationBuilder bindImplementation(Class<T> iface, Class<? extends T> impl)
       throws BindException;
@@ -66,7 +69,8 @@ public interface JavaConfigurationBuilder extends ConfigurationBuilder {
    * @param name  The dummy class that serves as the name of this parameter.
    * @param value A string representing the value of the parameter. Reef must know
    *              how to parse the parameter's type.
-   * @throws org.apache.reef.tang.exceptions.NameResolutionException
+   * @return the configuration builder
+   * @throws org.apache.reef.tang.exceptions.NameResolutionException which occurs when name resolution fails
    */
   JavaConfigurationBuilder bindNamedParameter(Class<? extends Name<?>> name, String value)
       throws BindException;
@@ -84,15 +88,15 @@ public interface JavaConfigurationBuilder extends ConfigurationBuilder {
       throws BindException;
 
   /**
-   * Binds a specfic list to a named parameter. List's elements can be string values or class implementations.
+   * Binds a specific list to a named parameter. List's elements can be string values or class implementations.
    * Their type would be checked in this method. If their types are not applicable to the named parameter,
    * it will make an exception.
    *
    * @param iface The target named parameter to be injected into
    * @param impl  A concrete list
-   * @param <T>
-   * @return
-   * @throws BindException
+   * @param <T> A type
+   * @return the configuration builder
+   * @throws BindException It occurs when iface is not a named parameter or impl is not compatible to bind
    */
   <T> JavaConfigurationBuilder bindList(Class<? extends Name<List<T>>> iface, List impl)
       throws BindException;

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Tang.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/Tang.java
@@ -33,6 +33,8 @@ public interface Tang {
   /**
    * Returns an Injector for the given Configurations.
    *
+   * @param confs a configuration
+   * @return an injector
    * @throws BindException If the confs conflict, a BindException will be thrown.
    */
   Injector newInjector(final Configuration... confs)
@@ -40,11 +42,16 @@ public interface Tang {
 
   /**
    * Returns an Injector for the given Configuration.
+   *
+   * @param confs a configuration
+   * @return an injector
    */
   Injector newInjector(final Configuration confs);
 
   /**
    * Returns an Injector based on an empty Configuration.
+
+   * @return an injector
    */
   Injector newInjector();
 
@@ -65,6 +72,7 @@ public interface Tang {
    * then the first classpath entry / jar passed to this method, then the
    * second, and so on.
    *
+   * @param jars the locations of jar files
    * @return a new JavaConfigurationBuilder
    */
   JavaConfigurationBuilder newConfigurationBuilder(URL... jars);
@@ -72,12 +80,13 @@ public interface Tang {
   /**
    * Merge a set of configurations into a new JavaConfiurationBuilder.  If
    * the configurations conflict, this method will throw a bind exception.
-   * <p/>
+   * <p>
    * The underlying ClassHierarchies and parameter parsers of the
    * configurations will be checked for consistency.  The returned
    * configuration builder will be backed by a ClassHierachy that incorporates
    * the classpath and parsers from all of the provided Configurations.
    *
+   * @param confs configurations
    * @return a new ConfigurationBuilder
    * @throws BindException if any of the configurations contain duplicated or
    *                       conflicting bindings, or if the backing ClassHierarchy objects conflict
@@ -91,7 +100,11 @@ public interface Tang {
    * application-specific configuration values.  The returned
    * JavaConfigurationBuilder will be backed by the default classloader.
    *
+   * @param parameterParsers the parsers for parameters
    * @return a new ConfigurationBuilder
+   * @throws BindException if any of the configurations contain duplicated or
+   *                       conflicting bindings, or if the backing ClassHierarchy objects conflict
+   *                       in some way.
    */
   JavaConfigurationBuilder newConfigurationBuilder(
       @SuppressWarnings("unchecked") Class<? extends ExternalConstructor<?>>... parameterParsers)
@@ -102,9 +115,14 @@ public interface Tang {
    * incorporates existing configuration data and / or can parse
    * application-specific types.
    *
-   * @see The documentation for the other newConfigurationBuilder methods in
+   * See the documentation for the other newConfigurationBuilder methods in
    * this class for detailed information about each of the parameters to
    * this method.
+   *
+   * @param jars the locations of jar files
+   * @param confs configurations
+   * @param parameterParsers the parsers for parameters
+   * @return a configuration builder
    */
   JavaConfigurationBuilder newConfigurationBuilder(URL[] jars,
                                                    Configuration[] confs,
@@ -114,6 +132,8 @@ public interface Tang {
   /**
    * Create a new empty ConfigurationBuilder that is backed by the default
    * classloader.
+   *
+   * @return a configuration builder
    */
   JavaConfigurationBuilder newConfigurationBuilder();
 
@@ -125,10 +145,14 @@ public interface Tang {
   JavaClassHierarchy getDefaultClassHierarchy();
 
   /**
+   * Get a default class hierarchy.
+   *
+   * @param jars the locations of jar files
+   * @param parsers the parsers
    * @return a custom instance of JavaClassHierarchy.  ClassHierarchy objects
    * are immutable, so multiple invocations of this method may return the
    * same instance.
-   * @TODO Is the class hierarchy returned here backed by the default
+   * TODO Is the class hierarchy returned here backed by the default
    * classloader or not?  If not, then callers will need to merge it with
    * getDefaultClassHierarchy().  If so, we should add a new method like
    * getNonDefaultClassHiearchy() that takes the same options as this one.
@@ -142,7 +166,7 @@ public interface Tang {
     /**
      * Return an instance of the default implementation of Tang.
      *
-     * @return
+     * @return an instance of Tang.
      */
     public static Tang getTang() {
       return new TangImpl();

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/annotations/DefaultImplementation.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/annotations/DefaultImplementation.java
@@ -22,11 +22,11 @@ import java.lang.annotation.*;
 
 /**
  * Allows interfaces to specify a default implementation.
- * <p/>
+ * <p>
  * Note that the default can be overridden after the fact
  * by explicitly binding a different implementation to the
  * interface.
- * <p/>
+ * <p>
  * For "normal" injections of a given library, this reduces
  * the amount of boilerplate configuration code needed,
  * and also shrinks the Tang configuration objects that

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/annotations/Unit.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/annotations/Unit.java
@@ -26,15 +26,15 @@ import java.lang.annotation.Target;
 /**
  * A TANG Unit consists of an outer class and some non-static inner classes.
  * TANG injectors automatically treat all the classes in a unit as singletons.
- * <p/>
+ * <p>
  * In order to inject the singleton instance of each inner class, TANG first
  * instantiates the outer class and then uses the resulting instance to
  * instantiate each inner class.
- * <p/>
+ * <p>
  * Classes annotated in this way must have at least one non-static inner class
  * and no static inner classes. The inner classes must not declare any
  * constructors.
- * <p/>
+ * <p>
  * Furthermore, classes annotated with Unit may not have injectable (or Unit)
  * subclasses.
  *

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/exceptions/BindException.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/exceptions/BindException.java
@@ -20,7 +20,7 @@ package org.apache.reef.tang.exceptions;
 
 /**
  * Thrown when an illegal or contradictory configuration option is encountered.
- * <p/>
+ * <p>
  * While binding configuration values and merging Configuration objects, Tang
  * checks each configuration option to make sure that it is correctly typed,
  * and that it does not override some other setting (even if the two settings

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/exceptions/InjectionException.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/exceptions/InjectionException.java
@@ -23,7 +23,7 @@ package org.apache.reef.tang.exceptions;
  * The first is that the InjectionPlan that Tang produced is ambiguous or
  * infeasible.  The second is that a constructor invoked by Tang itself threw
  * an exception.
- * <p/>
+ * <p>
  * A third, less common issue arises when constructors obtain a handle to the
  * Tang Injector that created them, and then attempt to modify its state.
  * Doing so is illegal, and results in a runtime exception that Tang converts

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/exceptions/ParseException.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/exceptions/ParseException.java
@@ -21,7 +21,7 @@ package org.apache.reef.tang.exceptions;
 /**
  * Thrown when a string fails to parse as the requested type.
  *
- * @see ParameterParser for more information about string parsing.
+ * @see org.apache.reef.tang.formats.ParameterParser for more information about string parsing.
  */
 public class ParseException extends BindException {
   private static final long serialVersionUID = 1L;

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/AvroConfigurationSerializer.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/AvroConfigurationSerializer.java
@@ -46,14 +46,14 @@ import java.util.*;
 
 /**
  * (De-)Serializing Configuration to and from AvroConfiguration.
- * <p/>
+ * <p>
  * This class is stateless and is therefore safe to reuse.
  */
 public final class AvroConfigurationSerializer implements ConfigurationSerializer {
 
   /**
    * The Charset used for the JSON encoding.
-   * <p/>
+   * <p>
    * Copied from <code>org.apache.avro.io.JsonDecoder.CHARSET</code>
    */
   private static final String JSON_CHARSET = "ISO-8859-1";
@@ -241,7 +241,7 @@ public final class AvroConfigurationSerializer implements ConfigurationSerialize
   /**
    * Converts a given AvroConfiguration to Configuration.
    *
-   * @param avroConfiguration
+   * @param avroConfiguration a Avro configuration
    * @return a Configuration version of the given AvroConfiguration
    */
   public Configuration fromAvro(final AvroConfiguration avroConfiguration) throws BindException {
@@ -253,7 +253,7 @@ public final class AvroConfigurationSerializer implements ConfigurationSerialize
   /**
    * Converts a given AvroConfiguration to Configuration.
    *
-   * @param avroConfiguration
+   * @param avroConfiguration a Avro configuration
    * @param classHierarchy    the class hierarchy used for validation.
    * @return a Configuration version of the given AvroConfiguration
    */
@@ -326,10 +326,10 @@ public final class AvroConfigurationSerializer implements ConfigurationSerialize
   /**
    * Converts a given serialized string to ConfigurationBuilder from which Configuration can be produced.
    *
-   * @param theString
-   * @param configBuilder
-   * @throws IOException
-   * @throws BindException
+   * @param theString the String containing configuration
+   * @param configBuilder a configuration builder
+   * @throws IOException if the string is not Avro format
+   * @throws BindException if the content of configuration string is invalid to bind
    */
   public void configurationBuilderFromString(final String theString, final ConfigurationBuilder configBuilder)
       throws IOException, BindException {

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/CommandLine.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/CommandLine.java
@@ -115,11 +115,14 @@ public final class CommandLine {
   }
 
   /**
-   * @param args
+   * Process command line arguments.
+   *
+   * @param <T> a type
+   * @param args the command line arguments to be parsed
+   * @param argClasses the target named classes to be set
    * @return Selfie if the command line parsing succeeded, null (or exception) otherwise.
-   * @throws IOException
-   * @throws NumberFormatException
-   * @throws ParseException
+   * @throws IOException if parsing fails
+   * @throws BindException if a binding of short-named parameter fails
    */
   @SafeVarargs
   @SuppressWarnings("checkstyle:redundantmodifier")
@@ -168,7 +171,7 @@ public final class CommandLine {
 
   /**
    * Utility method to quickly parse a command line to a Configuration.
-   * <p/>
+   * <p>
    * This is equivalent to
    * <code>parseToConfigurationBuilder(args, argClasses).build()</code>
    *
@@ -185,7 +188,7 @@ public final class CommandLine {
 
   /**
    * Utility method to quickly parse a command line to a ConfigurationBuilder.
-   * <p/>
+   * <p>
    * This is equivalent to
    * <code>new CommandLine().processCommandLine(args, argClasses).getBuilder()</code>, but with additional checks.
    *

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationModule.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationModule.java
@@ -44,7 +44,7 @@ import java.util.Set;
  * ConfigurationModules store such information in static data structures that
  * can be statically discovered and sanity-checked.
  *
- * @see org.apache.reef.tang.formats.TestConfigurationModule for more information and examples.
+ * See org.apache.reef.tang.formats.TestConfigurationModule for more information and examples.
  */
 public class ConfigurationModule {
   private final ConfigurationModuleBuilder builder;
@@ -115,8 +115,8 @@ public class ConfigurationModule {
    *
    * @param opt      Target optional/required Impl
    * @param implList List object to be injected
-   * @param <T>
-   * @return
+   * @param <T> a type
+   * @return the configuration module
    */
   public final <T> ConfigurationModule set(final Impl<List> opt, final List implList) {
     final ConfigurationModule c = deepCopy();
@@ -153,8 +153,8 @@ public class ConfigurationModule {
    *
    * @param opt    Target Param
    * @param values Values to bind to the Param
-   * @param <T>
-   * @return
+   * @param <T> type
+   * @return the Configuration module
    */
   public final <T> ConfigurationModule setMultiple(final Param<T> opt, final Iterable<String> values) {
     ConfigurationModule c = deepCopy();
@@ -169,8 +169,8 @@ public class ConfigurationModule {
    *
    * @param opt    Target Param
    * @param values Values to bind to the Param
-   * @param <T>
-   * @return
+   * @param <T> type
+   * @return the Configuration module
    */
   public final <T> ConfigurationModule setMultiple(final Param<T> opt, final String... values) {
     ConfigurationModule c = deepCopy();
@@ -185,8 +185,8 @@ public class ConfigurationModule {
    *
    * @param opt      target optional/required Param
    * @param implList List object to be injected
-   * @param <T>
-   * @return
+   * @param <T>      type
+   * @return the Configuration module
    */
   public final <T> ConfigurationModule set(final Param<List> opt, final List implList) {
     final ConfigurationModule c = deepCopy();

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationModuleBuilder.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationModuleBuilder.java
@@ -127,6 +127,9 @@ public abstract class ConfigurationModuleBuilder {
   /**
    * TODO: It would be nice if this incorporated d by reference so that static analysis / documentation tools
    * could document the dependency between c and d.
+   *
+   * @param d a configuration module to merge
+   * @return the merged configuration module builder
    */
   public final ConfigurationModuleBuilder merge(final ConfigurationModule d) {
     if (d == null) {

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationSerializer.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/formats/ConfigurationSerializer.java
@@ -54,16 +54,16 @@ public interface ConfigurationSerializer {
   /**
    * Writes the Configuration to a byte[].
    *
-   * @param conf
-   * @return
-   * @throws IOException
+   * @param conf the Configuration to be converted
+   * @return the byte array
+   * @throws IOException if encoding fails to write
    */
   byte[] toByteArray(final Configuration conf) throws IOException;
 
   /**
    * Writes the Configuration as a String.
    *
-   * @param configuration
+   * @param configuration the Configuration to be converted
    * @return a String representation of the Configuration
    */
   String toString(final Configuration configuration);
@@ -92,10 +92,10 @@ public interface ConfigurationSerializer {
   /**
    * Loads a Configuration from a File created with toFile() with ClassHierarchy.
    *
-   * @param file
-   * @param classHierarchy
-   * @return
-   * @throws IOException
+   * @param file the File to read from.
+   * @param classHierarchy the class hierarchy to be used.
+   * @return the Configuration stored in the file.
+   * @throws IOException if the File can't be read or parsed
    */
   Configuration fromTextFile(final File file, final ClassHierarchy classHierarchy) throws IOException;
 

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/InjectionPlan.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/InjectionPlan.java
@@ -118,9 +118,9 @@ public abstract class InjectionPlan<T> implements Traversable<InjectionPlan<?>> 
 
   /**
    * Algorithm for generating cant inject string:
-   * <p/>
+   * <p>
    * For infeasible plans:
-   * <p/>
+   * <p>
    * Some node types are "leaves":
    * <ul>
    * <li>NamedParameterNode</li>
@@ -130,9 +130,9 @@ public abstract class InjectionPlan<T> implements Traversable<InjectionPlan<?>> 
    * most constructor arguments. When we encounter a constructor whose arguments
    * are all either injectable or non-injectable leaf nodes, we return the name
    * of its parent, and the name of the non-injectable leaves.
-   * <p/>
+   * <p>
    * For ambiguous plans:
-   * <p/>
+   * <p>
    * We perform a depth first search of the ambiguous constructors, as above. We
    * return the name of the first class that has multiple constructors that are
    * feasible or ambiguous (as opposed to having a single constructor with an

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/avro/AvroClassHierarchySerializer.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/avro/AvroClassHierarchySerializer.java
@@ -51,6 +51,7 @@ public final class AvroClassHierarchySerializer implements ClassHierarchySeriali
   /**
    * Serialize the ClassHierarchy into the AvroNode.
    * @param ch ClassHierarchy to serialize
+   * @return a Avro node having class hierarchy
    */
   public AvroNode toAvro(final ClassHierarchy ch) {
     return newAvroNode(ch.getNamespace());
@@ -59,6 +60,7 @@ public final class AvroClassHierarchySerializer implements ClassHierarchySeriali
   /**
    * Deserialize the ClassHierarchy from the AvroNode.
    * @param n AvroNode to deserialize
+   * @return a class hierarchy
    */
   public ClassHierarchy fromAvro(final AvroNode n) {
     return new AvroClassHierarchy(n);

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/ClassHierarchyImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/ClassHierarchyImpl.java
@@ -134,7 +134,7 @@ public class ClassHierarchyImpl implements JavaClassHierarchy {
 
   /**
    * Parse a string, assuming that it is of the type expected by a given NamedParameter.
-   * <p/>
+   * <p>
    * This method does not deal with sets; if the NamedParameter is set valued, then the provided
    * string should correspond to a single member of the set.  It is up to the caller to call parse
    * once for each value that should be parsed as a member of the set.

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/InjectorImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/InjectorImpl.java
@@ -155,16 +155,16 @@ public class InjectorImpl implements Injector {
 
   /**
    * Produce a list of "interesting" constructors from a set of ClassNodes.
-   * <p/>
+   * <p>
    * Tang Constructors expose a isMoreSpecificThan function that embeds all
    * a skyline query over the lattices.  Precisely:
-   * <p/>
+   * <p>
    * Let candidateConstructors be the union of all constructors defined by
    * ClassNodes in candidateImplementations.
-   * <p/>
+   * <p>
    * This function returns a set called filteredImplementations, defined as
    * follows:
-   * <p/>
+   * <p>
    * For each member f of filteredConstructors, there does not exist
    * a g in candidateConstructors s.t. g.isMoreSpecificThan(f).
    */
@@ -577,7 +577,7 @@ public class InjectorImpl implements Injector {
    * registered by callees after each recursive invocation of injectFromPlan or
    * constructor invocations. The error handling currently bails if the thing we
    * just instantiated should be discarded.
-   * <p/>
+   * <p>
    * This could happen if (for instance), a constructor did a
    * bindVolatileInstance of its own class to an instance, or somehow triggered
    * an injection of itself with a different plan (an injection of itself with

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/JavaConfigurationBuilderImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/JavaConfigurationBuilderImpl.java
@@ -191,7 +191,7 @@ public class JavaConfigurationBuilderImpl extends ConfigurationBuilderImpl
    * Binding list method for JavaConfigurationBuilder. It checks the type of a given named parameter,
    * and whether all the list's elements can be applied to the named parameter. The elements' type
    * should be either java Class or String.
-   * <p/>
+   * <p>
    * It does not check whether the list's String values can be parsed to T, like bindSetEntry.
    *
    * @param iface    target named parameter to be instantiated

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/types/ConstructorDefImpl.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/types/ConstructorDefImpl.java
@@ -94,7 +94,7 @@ public class ConstructorDefImpl<T> implements ConstructorDef<T> {
    * Check to see if two boundConstructors take indistinguishable arguments. If
    * so (and they are in the same class), then this would lead to ambiguous
    * injection targets, and we want to fail fast.
-   * <p/>
+   * <p>
    * TODO could be faster. Currently O(n^2) in number of parameters.
    *
    * @param def

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/ReflectionUtilities.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/ReflectionUtilities.java
@@ -49,11 +49,12 @@ public final class ReflectionUtilities {
 
   /**
    * Given a primitive type, return its boxed representation.
-   * <p/>
+   * <p>
    * Examples:
+   * <pre>{@code
    * boxClass(int.class) -> Integer.class
    * boxClass(String.class) -> String.class
-   *
+   * }</pre>
    * @param c The class to be boxed.
    * @return The boxed version of c, or c if it is not a primitive type.
    */
@@ -88,13 +89,15 @@ public final class ReflectionUtilities {
 
   /**
    * Given a Type, return all of the classes it extends and interfaces it implements (including the class itself).
-   * <p/>
+   * <p>
    * Examples:
+   * <pre>{@code
    * Integer.class -> {Integer.class, Number.class, Object.class}
    * T -> Object
    * ? -> Object
    * HashSet<T> -> {HashSet<T>, Set<T>, Collection<T>, Object}
    * FooEventHandler -> {FooEventHandler, EventHandler<Foo>, Object}
+   * }</pre>
    */
   public static Iterable<Type> classAndAncestors(final Type c) {
     final List<Type> workQueue = new ArrayList<>();
@@ -139,10 +142,10 @@ public final class ReflectionUtilities {
    * Check to see if one class can be coerced into another.  A class is
    * coercable to another if, once both are boxed, the target class is a
    * superclass or implemented interface of the source class.
-   * <p/>
+   * <p>
    * If both classes are numeric types, then this method returns true iff
    * the conversion will not result in a loss of precision.
-   * <p/>
+   * <p>
    * TODO: Float and double are currently coercible to int and long.  This is a bug.
    */
   public static boolean isCoercable(final Class<?> to, final Class<?> from) {
@@ -210,12 +213,12 @@ public final class ReflectionUtilities {
 
   /**
    * Return the full name of the raw type of the provided Type.
-   * <p/>
+   * <p>
    * Examples:
-   * <p/>
+   * <pre>{@code
    * java.lang.String.class -> "java.lang.String"
    * Set<String> -> "java.util.Set"  // such types can occur as constructor arguments, for example
-   *
+   * }</pre>
    * @param name
    * @return
    */
@@ -227,10 +230,11 @@ public final class ReflectionUtilities {
    * Return the full name of the provided field.  This will be globally
    * unique.  Following Java semantics, the full name will have all the
    * generic parameters stripped out of it.
-   * <p/>
+   * <p>
    * Example:
-   * <p/>
+   * <pre>{@code
    * Set<X> { int size; } -> java.util.Set.size
+   * }</pre>
    */
   public static String getFullName(final Field f) {
     return getFullName(f.getDeclaringClass()) + "." + f.getName();
@@ -239,9 +243,9 @@ public final class ReflectionUtilities {
   /**
    * This method takes a class called clazz that *directly* implements a generic interface or generic class, iface.
    * Iface should take a single parameter, which this method will return.
-   * <p/>
+   * <p>
    * TODO This is only tested for interfaces, and the type parameters associated with method arguments.
-   * TODO Not sure what we should do in the face of deeply nested generics (eg: Set<Set<String>)
+   * TODO Not sure what we should do in the face of deeply nested generics (eg: {@code Set<Set<String>})
    * TODO Recurse up the class hierarchy in case there are intermediate interfaces
    *
    * @param iface A generic interface; we're looking up it's first (and only) parameter.
@@ -291,7 +295,7 @@ public final class ReflectionUtilities {
 
   /**
    * @param clazz
-   * @return T if clazz implements Name<T>, null otherwise
+   * @return T if clazz implements {@code Name<T>}, null otherwise
    * @throws org.apache.reef.tang.exceptions.BindException
    * If clazz's definition incorrectly uses Name or @NamedParameter
    */
@@ -381,12 +385,14 @@ public final class ReflectionUtilities {
   /**
    * Coerce a Type into a Class.  This strips out any generic paramters, and
    * resolves wildcards and free parameters to Object.
-   * <p/>
+   * <p>
    * Examples:
+   * <pre>{@code
    * java.util.Set<String> -> java.util.Set
    * ? extends T -> Object
    * T -> Object
    * ? -> Object
+   * }</pre>
    */
   public static Class<?> getRawClass(final Type clazz) {
     if (clazz instanceof Class) {

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/graphviz/GraphvizConfigVisitor.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/graphviz/GraphvizConfigVisitor.java
@@ -80,9 +80,9 @@ public final class GraphvizConfigVisitor
   /**
    * Create a new TANG configuration visitor.
    *
-   * @param aConfig     Entire TANG configuration object.
-   * @param aShowImpl   If true, plot IS-A edges for know implementations.
-   * @param aShowLegend If true, add legend to the plot.
+   * @param config     Entire TANG configuration object.
+   * @param showImpl   If true, plot IS-A edges for know implementations.
+   * @param showLegend If true, add legend to the plot.
    */
   public GraphvizConfigVisitor(final Configuration config,
                                final boolean showImpl, final boolean showLegend) {

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/graphviz/GraphvizInjectionPlanVisitor.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/util/walk/graphviz/GraphvizInjectionPlanVisitor.java
@@ -54,7 +54,7 @@ public final class GraphvizInjectionPlanVisitor
   /**
    * Create a new visitor to build a graphviz string for the injection plan.
    *
-   * @param aShowLegend if true, show legend on the graph.
+   * @param showLegend if true, show legend on the graph.
    */
   public GraphvizInjectionPlanVisitor(final boolean showLegend) {
     if (showLegend) {

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/evaluatorreuse/package-info.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/evaluatorreuse/package-info.java
@@ -18,6 +18,6 @@
  */
 /**
  * This package contains a test of the Evaluator reuse. It submits the EchoTask several times to the same Evaluator.
- * This test also incidentially tests whether the memento is transferred correctly from and to the Task.
+ * This test also incidentally tests whether the memento is transferred correctly from and to the Task.
  */
 package org.apache.reef.tests.evaluatorreuse;

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/driver/package-info.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/fail/driver/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Tests for Driver-side failures.
  */
 package org.apache.reef.tests.fail.driver;

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/driver/package-info.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/driver/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Commonly used event handler implementations in our tests.
  */
 package org.apache.reef.tests.library.driver;

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/exceptions/package-info.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/exceptions/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Exceptions used in our tests.
  */
 package org.apache.reef.tests.library.exceptions;

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/tasks/package-info.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/library/tasks/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Commonly used task implementations in our tests.
  */
 package org.apache.reef.tests.library.tasks;

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/package-info.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Tests for REEF implementations.
  */
 package org.apache.reef.tests;

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/rack/awareness/package-info.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/rack/awareness/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Tests for Rack-awareness.
  */
 package org.apache.reef.tests.rack.awareness;

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/statepassing/package-info.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/statepassing/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Tests for State-passing.
  */
 package org.apache.reef.tests.statepassing;

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/yarn/failure/package-info.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/yarn/failure/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Tests for YARN failures.
  */
 package org.apache.reef.tests.yarn.failure;

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/TestEnvironment.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/TestEnvironment.java
@@ -23,7 +23,7 @@ import org.apache.reef.tang.Configuration;
 
 /**
  * Environment for REEF unit tests.
- * <p/>
+ * <p>
  * The idea is to use an instance of this class to gain access
  * to a REEF resource manager environment in order to make the tests
  * portable amongst REEF runtimes (e.g. YARN, Local, ...)

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/files/FileResourceTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/files/FileResourceTest.java
@@ -45,7 +45,7 @@ import java.util.logging.Logger;
 
 /**
  * Tests whether a set of files makes it to the Driver and from there to the Evaluator.
- * <p/>
+ * <p>
  * The test is shallow: It only makes sure that files with the same (random) names exist. It doesn't check for file
  * contents.
  */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/AbstractEStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/AbstractEStage.java
@@ -41,7 +41,7 @@ public abstract class AbstractEStage<T> implements EStage<T> {
   /**
    * Constructs an abstract estage.
    *
-   * @parm stageName the stage name
+   * @param stageName the stage name
    */
   public AbstractEStage(final String stageName) {
     this.closed = new AtomicBoolean(false);
@@ -70,7 +70,7 @@ public abstract class AbstractEStage<T> implements EStage<T> {
 
   /**
    * Updates the input meter.
-   * <p/>
+   * <p>
    * Stages that want to meter their
    * input must call this each time an event is input.
    */
@@ -80,7 +80,7 @@ public abstract class AbstractEStage<T> implements EStage<T> {
 
   /**
    * Updates the output meter.
-   * <p/>
+   * <p>
    * Stages that want to meter their
    * output must call this each time an event is output.
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/p2p/Pull2Push.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/examples/p2p/Pull2Push.java
@@ -27,11 +27,11 @@ import java.util.logging.Logger;
 
 /**
  * Performs a Pull-to-Push conversion in Wake.
- * <p/>
+ * <p>
  * The class pulls from a set of event sources, and pushes to a single
  * EventHandler. If the downstream event handler blocks, this will block,
  * providing a simple rate limiting scheme.
- * <p/>
+ * <p>
  * The EventSources are managed in a basic Queue.
  *
  * @param <T> the message type

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/BlockingEventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/BlockingEventHandler.java
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * An EventHandler that blocks until a set number of Events has been received.
  * Once they have been received, the downstream event handler is called with an
  * Iterable of the events spooled.
- * <p/>
+ * <p>
  * onNext is thread safe
  *
  * @param <T> type of events

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/BlockingSignalEventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/BlockingSignalEventHandler.java
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Once they have been received, the downstream event handler is called with
  * the <i>last event</i> received. The handler resets atomically to start
  * receiving the next batch of events.
- * <p/>
+ * <p>
  * onNext is thread safe
  *
  * @param <T> type of events

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/DefaultIdentifierFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/DefaultIdentifierFactory.java
@@ -32,7 +32,7 @@ import java.util.Map;
 /**
  * Default remote identifier factory that creates a specific remote identifier
  * from a string representation
- * <p/>
+ * <p>
  * A string representation is broken into two parts type and type-specific details separated by "://"
  * A remote identifier implementation should implement a constructor that accepts a string.
  * The factory invokes a proper constructor by reflection.

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/ForkPoolStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/ForkPoolStage.java
@@ -28,14 +28,14 @@ import java.util.concurrent.ForkJoinTask;
 import java.util.logging.Logger;
 
 /**
- * This Wake event handling stage uses a {@link ForkJoinPool}
+ * This Wake event handling stage uses a {@link java.util.concurrent.ForkJoinPool}
  * to submit tasks. The advantage is that underlying workers
  * have separate queues instead of sharing one. The queues are load
  * balanced with work stealing.
- * <p/>
+ * <p>
  * The pool is provided to the constructor, so multiple stages
  * may use the same pool.
- * <p/>
+ * <p>
  * Some advantage in throughput over other stage implementations should be seen
  * when one wake stage is submitting to another using the same
  * {@link WakeSharedPool}. In this case, the new event may be executed

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/MergingEventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/MergingEventHandler.java
@@ -28,7 +28,7 @@ import java.util.logging.Logger;
 /**
  * An EventHandler combines two events of different types into a single Pair of events.
  * Handler will block until both events are received.
- * <p/>
+ * <p>
  * onNext is thread safe
  *
  * @param <L> type of event

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/MultiEventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/MultiEventHandler.java
@@ -44,7 +44,7 @@ public class MultiEventHandler<T> implements EventHandler<T> {
   /**
    * Invokes a specific handler for the event class type if it exists.
    *
-   * @param an event
+   * @param event an event
    * @throws WakeRuntimeException
    */
   @Override

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/PubSubEventHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/PubSubEventHandler.java
@@ -51,7 +51,7 @@ public class PubSubEventHandler<T> implements EventHandler<T> {
   /**
    * Constructs a pub-sub event handler with initial subscribed event handlers.
    *
-   * @param map a map of event class types to lists of event handlers
+   * @param clazzToListOfHandlersMap a map of event class types to lists of event handlers
    */
   public PubSubEventHandler(final Map<Class<? extends T>, List<EventHandler<? extends T>>> clazzToListOfHandlersMap) {
     this.clazzToListOfHandlersMap = clazzToListOfHandlersMap;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/SyncStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/SyncStage.java
@@ -54,8 +54,8 @@ public final class SyncStage<T> extends AbstractEStage<T> {
   /**
    * Constructs a synchronous stage.
    *
+   * @param name the stage name
    * @param handler the event handler
-   * @name name the stage name
    */
   @Inject
   public SyncStage(@Parameter(StageName.class) final String name,
@@ -66,9 +66,9 @@ public final class SyncStage<T> extends AbstractEStage<T> {
   /**
    * Constructs a synchronous stage.
    *
+   * @param name the stage name
    * @param handler      the event handler
    * @param errorHandler the error handler
-   * @name name the stage name
    */
   @Inject
   public SyncStage(@Parameter(StageName.class) final String name,

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/ThreadPoolStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/ThreadPoolStage.java
@@ -195,8 +195,6 @@ public final class ThreadPoolStage<T> extends AbstractEStage<T> {
 
   /**
    * Closes resources.
-   *
-   * @return Exception
    */
   @Override
   public void close() throws Exception {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/TimerStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/impl/TimerStage.java
@@ -62,9 +62,9 @@ public final class TimerStage implements Stage {
   /**
    * Constructs a timer stage with no initial delay.
    *
+   * @param name the stage name
    * @param handler an event handler
    * @param period  a period in milli-seconds
-   * @name name the stage name
    */
   @Inject
   public TimerStage(@Parameter(StageName.class) final String name,

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/UniformHistogram.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/metrics/UniformHistogram.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongArray;
 
 /**
- * An {@link Histogram} that implements uniform binning of numbers (>=0).
+ * An {@link Histogram} that implements uniform binning of numbers ({@code >=0}).
  */
 public class UniformHistogram implements Histogram {
   private final AtomicLong count;

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteManager.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteManager.java
@@ -37,7 +37,7 @@ public interface RemoteManager extends Stage {
    * Returns an event handler that can be used to send messages of type T to the
    * given destination.
    *
-   * @param <T>
+   * @param <T> type of message
    * @param destinationIdentifier a destination identifier
    * @param messageType           a message class type
    * @return an event handler
@@ -47,10 +47,11 @@ public interface RemoteManager extends Stage {
   /**
    * Registers the given EventHandler to be invoked when messages of Type T
    * arrive from sourceIdentifier.
-   * <p/>
+   * <p>
    * Calling this method twice overrides the initial registration.
    *
-   * @param <T,              U extends T>
+   * @param <T> type of event
+   * @param <U> type of message
    * @param sourceIdentifier a source identifier
    * @param messageType      a message class type
    * @param theHandler       the event handler
@@ -63,10 +64,11 @@ public interface RemoteManager extends Stage {
   /**
    * Registers the given EventHandler to be called for the given message type
    * from any source.
-   * <p/>
+   * <p>
    * If there is an EventHandler registered for this EventType
    *
-   * @param <T,         U extends T>
+   * @param <T> a type of remote message of event
+   * @param <U> a type of message
    * @param messageType a message class type
    * @param theHandler  the event handler
    * @return the subscription that can be used to unsubscribe later

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteManagerFactory.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/RemoteManagerFactory.java
@@ -26,7 +26,7 @@ import org.apache.reef.wake.remote.ports.TcpPortProvider;
 
 /**
  * Injectable Factory for RemoteManager instances.
- * <p/>
+ * <p>
  * Use when direct injection of the RemoteManager is impossible.
  */
 @DefaultImplementation(DefaultRemoteManagerFactory.class)

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEventCodec.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/impl/RemoteEventCodec.java
@@ -44,7 +44,7 @@ public class RemoteEventCodec<T> implements Codec<RemoteEvent<T>> {
    * Encodes the remote event object to bytes.
    *
    * @param obj the remote event object
-   * @returns bytes
+   * @return bytes
    */
   @Override
   public byte[] encode(final RemoteEvent<T> obj) {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/RangeTcpPortProvider.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/ports/RangeTcpPortProvider.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/ChunkedReadWriteHandler.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/ChunkedReadWriteHandler.java
@@ -31,18 +31,18 @@ import java.util.logging.Logger;
 
 /**
  * Thin wrapper around ChunkedWriteHandler.
- * <p/>
+ * <p>
  * ChunkedWriteHandler only handles the down stream parts
  * and just emits the chunks up stream. So we add an upstream
  * handler that aggregates the chunks into its original form. This
  * is guaranteed to be thread serial so state can be shared.
- * <p/>
+ * <p>
  * On the down stream side, we just decorate the original message
  * with its size and allow the thread-serial base class to actually
  * handle the chunking. We need to be careful since the decoration
  * itself has to be thread-safe since netty does not guarantee thread
  * serial access to down stream handlers.
- * <p/>
+ * <p>
  * We do not need to tag the writes since the base class ChunkedWriteHandler
  * serializes access to the channel and first write will complete before
  * the second begins.
@@ -111,7 +111,7 @@ public class ChunkedReadWriteHandler extends ChunkedWriteHandler {
    * Just prepend size to the message and stream it through
    * a chunked stream and let the base method handle the actual
    * chunking.
-   * <p/>
+   * <p>
    * We do not need to tag the writes since the base class ChunkedWriteHandler
    * serializes access to the channel and first write will complete before
    * the second begins.

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyLink.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/remote/transport/netty/NettyLink.java
@@ -33,7 +33,7 @@ import java.util.logging.Logger;
 /**
  * Link implementation with Netty.
  *
- * If you set a LinkListener<T>, it keeps message until writeAndFlush operation completes
+ * If you set a {@code LinkListener<T>}, it keeps message until writeAndFlush operation completes
  * and notifies whether the sent message transferred successfully through the listener.
  */
 public class NettyLink<T> implements Link<T> {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/AbstractRxStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/AbstractRxStage.java
@@ -48,7 +48,7 @@ public abstract class AbstractRxStage<T> implements RxStage<T> {
 
   /**
    * Updates the input meter.
-   * <p/>
+   * <p>
    * Stages that want to meter their
    * input must call this each time an event is input.
    */
@@ -58,7 +58,7 @@ public abstract class AbstractRxStage<T> implements RxStage<T> {
 
   /**
    * Updates the output meter.
-   * <p/>
+   * <p>
    * Stages that want to meter their
    * output must call this each time an event is output.
    */

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/Subject.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/Subject.java
@@ -19,10 +19,10 @@
 package org.apache.reef.wake.rx;
 
 /**
- * A class implementing Observer<InType> and StaticObservable<OutType>.
+ * A class implementing {@code Observer<InType>} and {@code StaticObservable<OutType>}.
  *
- * @param <InType>
- * @param <OutType>
+ * @param <InType> type for in
+ * @param <OutType> type for out
  */
 public interface Subject<InType, OutType> extends Observer<InType>, StaticObservable {
   // intentionally empty

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/exception/ObserverCompletedException.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/exception/ObserverCompletedException.java
@@ -25,7 +25,7 @@ package org.apache.reef.wake.rx.exception;
  * an ObserverCompleted exception whenever this API is violated. Violating the
  * API leaves the Observer (and any resources that it holds) in an undefined
  * state, and throwing ObserverCompleted exceptions is optional.
- * <p/>
+ * <p>
  * Callers receiving this exception should simply pass it up the stack to the
  * Aura runtime. They should not attempt to forward it on to upstream or
  * downstream stages. The easiest way to do this is to ignore the exception

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/RxThreadPoolStage.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/RxThreadPoolStage.java
@@ -37,13 +37,13 @@ import java.util.logging.Logger;
 
 /**
  * Stage that executes the observer with a thread pool.
- * <p/>
+ * <p>
  * {@code onNext}'s will be arbitrarily subject to reordering, as with most stages.
- * <p/>
+ * <p>
  * All {@code onNext}'s for which returning from the method call
  * happens-before the call to {@code onComplete} will maintain
  * this relationship when passed to the observer.
- * <p/>
+ * <p>
  * Any {@code onNext} whose return is not ordered before
  * {@code onComplete} may or may not get dropped.
  *
@@ -167,8 +167,6 @@ public final class RxThreadPoolStage<T> extends AbstractRxStage<T> {
 
   /**
    * Closes the stage.
-   *
-   * @return Exception
    */
   @Override
   public void close() throws Exception {

--- a/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/TimeoutSubject.java
+++ b/lang/java/reef-wake/wake/src/main/java/org/apache/reef/wake/rx/impl/TimeoutSubject.java
@@ -24,9 +24,9 @@ import org.apache.reef.wake.rx.Subject;
 import java.util.concurrent.TimeoutException;
 
 /**
- * A class implementing Subject<T> with timeout.
+ * A class implementing {@code Subject<T>} with timeout.
  *
- * @param <T>
+ * @param <T> a type of subject
  * @deprecated in 0.14 as unused
  */
 @Deprecated

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpHandler.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/HttpHandler.java
@@ -27,16 +27,14 @@ import java.io.IOException;
  */
 public interface HttpHandler {
   /**
-   * return specification of the handler. e.g Reef
+   * Return specification of the handler. e.g Reef
    *
    * @return
    */
   String getUriSpecification();
 
   /**
-   * return specification of the handler. e.g Reef
-   *
-   * @return
+   * Set specification of the handler. e.g Reef
    */
   void setUriSpecification(final String s);
 

--- a/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/ParsedHttpRequest.java
+++ b/lang/java/reef-webserver/src/main/java/org/apache/reef/webserver/ParsedHttpRequest.java
@@ -45,7 +45,6 @@ public final class ParsedHttpRequest {
    *
    * @param request
    * @throws IOException
-   * @throws javax.servlet.ServletException
    */
   public ParsedHttpRequest(final HttpServletRequest request) throws IOException {
     this.pathInfo = request.getPathInfo() != null ? request.getPathInfo() : "";

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@ under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.1</version>
+                    <version>2.10.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This PR fixes the followings in order to get Javadoc results:
  * Upgrade maven-javadoc-plugin from 2.10.1 to 2.10.3.
  * Correct broken '@throws', '@links', and '@param'.
  * Add missing '@param'.
  * Use '@code' syntax for code snipet: e.g. {@code EventHandler<DriverMessage>}.
  * Replace `<p/>` into `<p>` and '&' into 'and'.
  * Fix usages of '@see' and use <a> tag for hyperlinks.

JIRA:
  [REEF-912](https://issues.apache.org/jira/browse/REEF-912)

Pull Request:
  This closes #