### PR TITLE
[REEF-913] FailedEvaluatorHandler Interop is broken

### DIFF
--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/generic/JobDriver.java
@@ -302,7 +302,7 @@ public final class JobDriver {
           failedEvaluatorBridge, JobDriver.this.interopLogger);
     } else {
       NativeInterop.clrSystemFailedEvaluatorHandlerOnNext(
-          JobDriver.this.handlerManager.getDriverRestartFailedEvaluatorHandler(),
+          JobDriver.this.handlerManager.getFailedEvaluatorHandler(),
           failedEvaluatorBridge,
           JobDriver.this.interopLogger);
     }


### PR DESCRIPTION
This addressed the issue by
  * Call the proper failed evaluator handler in the general case in Interop JobDriver.

JIRA:
  [REEF-913](https://issues.apache.org/jira/browse/REEF-913)