### PR TITLE
[REEF-917] Add Google Analytics on Apache REEF Websites

### DIFF
--- a/website/src/site/markdown/privacy-policy.md
+++ b/website/src/site/markdown/privacy-policy.md
@@ -1,0 +1,49 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+#Privacy Policy
+
+Information about your use of this website is collected using server
+access logs and a tracking cookie. The collected information consists of
+the following:
+
+1.  The IP address from which you access the website;
+
+2.  The type of browser and operating system you use to access our site;
+
+3.  The date and time you access our site;
+
+4.  The pages you visit; and
+
+5.  The addresses of pages from where you followed a link to our site.
+
+Part of this information is gathered using a tracking cookie set by the
+[Google Analytics](http://www.google.com/analytics/) service and handled
+by Google as described in their [privacy
+policy](http://www.google.com/privacy.html). See your browser
+documentation for instructions on how to disable the cookie if you
+prefer not to share this data with Google.
+
+We use the gathered information to help us make our site more useful to
+visitors and to better understand how and when our site is used. We do
+not track or collect personally identifiable information or associate
+gathered data with any personally identifying information from other
+sources.
+
+By using this website, you consent to the collection of this data in the
+manner and for the purpose described above.

--- a/website/src/site/site.xml
+++ b/website/src/site/site.xml
@@ -61,6 +61,15 @@ under the License.
     <body>   
         <head>
             <script src="js/release.js" type="text/javascript"></script>
+            <script>
+                (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+                })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+                ga('create', 'UA-69807635-1', 'auto');
+                ga('send', 'pageview');
+            </script>
         </head>
         
 	    <breadcrumbs>
@@ -76,6 +85,7 @@ under the License.
             <item name="FAQ" href="faq.html"/>
             <item name="License" href="license.html"/>
             <item name="Downloads" href="downloads.html"/>
+            <item name="Privacy Policy" href="privacy-policy.html"/>
         </menu>
 
         <menu name="Documentation">


### PR DESCRIPTION
This PR do the followings:
  * Add 'Privacy Policy' page and navigation menu for that.
  * Add a tracking javascript code in HEAD element.

JIRA:
  [REEF-917](https://issues.apache.org/jira/browse/REEF-917)

Pull request:
  This closes #