### PR TITLE
[REEF-910] Assemble entire driver configuration on driver instead of client

### DIFF
--- a/lang/cs/Org.Apache.REEF.Bridge/DriverLauncher.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/DriverLauncher.cpp
@@ -50,7 +50,7 @@ const char ClassPathSeparatorCharForWindows = ';';
 
 // we look for this to delineate java vm arguments from app arguments.
 // todo: be smarter about this. Accomodate arbitrary apps.
-const char* launcherClass = "org.apache.reef.runtime.common.REEFLauncher";
+const char* launcherClass = "org.apache.reef.bridge.client.BootstrapLauncher";
 
 // method to invoke
 const char* JavaMainMethodName = "main";

--- a/lang/cs/Org.Apache.REEF.Client/Common/DriverFolderPreparationHelper.cs
+++ b/lang/cs/Org.Apache.REEF.Client/Common/DriverFolderPreparationHelper.cs
@@ -52,7 +52,7 @@ namespace Org.Apache.REEF.Client.Common
         // We embed certain binaries in client dll.
         // Following items in tuples refer to resource names in Org.Apache.REEF.Client.dll
         // The first resource item contains the name of the file 
-        // such as "reef-bridge-java-0.13.0-incubating-SNAPSHOT-shaded.jar". The second resource
+        // such as "reef-bridge-java-0.14.0-incubating-SNAPSHOT-shaded.jar". The second resource
         // item contains the byte contents for said file.
         // Please note that the identifiers below need to be in sync with 2 other files
         // 1. $(SolutionDir)\Org.Apache.REEF.Client\Properties\Resources.xml
@@ -182,7 +182,8 @@ namespace Org.Apache.REEF.Client.Common
             var lowerCasePath = fileName.ToLower();
             return lowerCasePath.EndsWith(DLLFileNameExtension) ||
                    lowerCasePath.EndsWith(EXEFileNameExtension) ||
-                   lowerCasePath.StartsWith(ClientConstants.DriverJarFilePrefix);
+                   lowerCasePath.StartsWith(ClientConstants.DriverJarFilePrefix) ||
+                   lowerCasePath.StartsWith(ClientConstants.ClientJarFilePrefix);
         }
     }
 }

--- a/lang/java/reef-bridge-client/pom.xml
+++ b/lang/java/reef-bridge-client/pom.xml
@@ -115,6 +115,22 @@ under the License.
         </pluginManagement>
         <plugins>
             <plugin>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>schema</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirectory>${project.basedir}/src/main/avro/</sourceDirectory>
+                            <outputDirectory>${project.basedir}/target/generated-sources/avro/</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>

--- a/lang/java/reef-bridge-client/src/main/avro/YarnBootstrapArgs.avsc
+++ b/lang/java/reef-bridge-client/src/main/avro/YarnBootstrapArgs.avsc
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+[
+  {
+      "namespace": "org.apache.reef.reef.bridge.client",
+      "type": "record",
+      "name": "YarnBootstrapArgs",
+      "fields": [
+	    { "name": "jobId", "type": "string" },
+		{ "name": "driverMemory", "type": "int" },
+		{ "name": "tcpBeginPort", "type": "int" },
+		{ "name": "tcpRangeCount", "type": "int" },
+		{ "name": "tcpTryCount", "type": "int" },
+  	    { "name": "jobSubmissionFolder", "type": "string" },
+		{ "name": "jobSubmissionDirectoryPrefix", "type": "string" },
+  	    { "name": "driverRecoveryTimeout", "type": "int" }
+      ]
+  }
+]
+

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/BootstrapLauncher.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/BootstrapLauncher.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.bridge.client;
+
+import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.runtime.common.REEFLauncher;
+import org.apache.reef.tang.Tang;
+import org.apache.reef.tang.exceptions.InjectionException;
+
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * The bootstrap launcher that provides 2 ways to Launch a REEF driver, either
+ * directly or indirectly. This is generally called through Bridge.exe.
+ * The direct flag indicates that the Java Driver configuration is pre-generated, while
+ * an indirect method indicates that the Java Driver configuration is generated at
+ * runtime. This is to avoid Java dependencies for .NET clients.
+ * @see REEFLauncher
+ * @see org.apache.reef.runtime.common.launch.LauncherCommandFormatter
+ */
+@Private
+public final class BootstrapLauncher {
+  private static final Logger LOG = Logger.getLogger(BootstrapLauncher.class.getName());
+
+  /**
+   * Directly calls REEFLauncher with a pre-generated Java driver configuration.
+   */
+  public static final String DIRECT_LAUNCH = "direct";
+
+  /**
+   * Generates a Java driver config for YARN and calls REEFLauncher.
+   */
+  public static final String YARN_LAUNCH = "yarn";
+
+  public static void main(final String[] args) throws IOException, InjectionException {
+    LOG.log(Level.INFO, "Entering BootstrapLauncher.main().");
+
+    if (args.length != 2) {
+      final String message = "Bootstrap launcher should have two arguments specifying the launcher runtime and " +
+          "the argument configuration to use for the runtime";
+
+      throw fatal(message, new IllegalArgumentException(message));
+    }
+
+    try {
+      switch (args[0]) {
+      case DIRECT_LAUNCH:
+        REEFLauncher.main(new String[]{args[1]});
+        break;
+      case YARN_LAUNCH:
+        // TODO[JIRA REEF-922]: Test this path after YARN REST Submission is enabled.
+        final YarnBootstrapDriverConfigGenerator yarnDriverConfigurationGenerator =
+            Tang.Factory.getTang().newInjector().getInstance(YarnBootstrapDriverConfigGenerator.class);
+        REEFLauncher.main(new String[]{yarnDriverConfigurationGenerator.writeDriverConfiguration(args[1])});
+        break;
+      default:
+        throw fatal(args[0] + " is not a valid driver start option.");
+      }
+    } catch (final Exception exception) {
+      if (!(exception instanceof RuntimeException)) {
+        throw fatal("Failed to initialize configurations.", exception);
+      }
+
+      throw exception;
+    }
+  }
+
+  private static RuntimeException fatal(final String msg) {
+    LOG.log(Level.SEVERE, msg);
+    return new RuntimeException(msg);
+  }
+
+  private static RuntimeException fatal(final String msg, final Throwable t) {
+    LOG.log(Level.SEVERE, msg, t);
+    return new RuntimeException(msg, t);
+  }
+
+  private BootstrapLauncher(){
+  }
+}

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/BootstrapLauncherCommandFormatter.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/BootstrapLauncherCommandFormatter.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.bridge.client;
+
+import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.runtime.common.launch.LauncherCommandFormatter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Creates the Java command line for the bootstrap Launcher class.
+ * @see org.apache.reef.runtime.common.launch.LauncherCommandFormatter
+ */
+@Private
+public final class BootstrapLauncherCommandFormatter implements LauncherCommandFormatter {
+  private final List<String> flags = new ArrayList<>();
+  private String configFileName = "";
+
+  private BootstrapLauncherCommandFormatter() {
+  }
+
+  public static BootstrapLauncherCommandFormatter getLauncherCommand(){
+    return new BootstrapLauncherCommandFormatter();
+  }
+
+  @Override
+  public LauncherCommandFormatter addFlag(final String flag) {
+    flags.add(flag);
+    return this;
+  }
+
+  @Override
+  public String getLauncherClass() {
+    return BootstrapLauncher.class.getName();
+  }
+
+  @Override
+  public List<String> getFlags() {
+    return Collections.unmodifiableList(flags);
+  }
+
+  @Override
+  public LauncherCommandFormatter setConfigurationFileName(final String configurationFileName) {
+    configFileName = configurationFileName;
+    return this;
+  }
+
+  @Override
+  public String getConfigurationFileName() {
+    return configFileName;
+  }
+}

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/LocalClient.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/LocalClient.java
@@ -56,7 +56,8 @@ public final class LocalClient {
 
     configurationGenerator.writeConfiguration(localSubmissionFromCS.getJobFolder(),
         localSubmissionFromCS.getJobId(), CLIENT_REMOTE_ID);
-    launcher.launch(driverFolder, localSubmissionFromCS.getJobId(), CLIENT_REMOTE_ID);
+    launcher.launch(BootstrapLauncherCommandFormatter.getLauncherCommand().addFlag(BootstrapLauncher.DIRECT_LAUNCH),
+        driverFolder, localSubmissionFromCS.getJobId(), CLIENT_REMOTE_ID);
   }
 
   public static void main(final String[] args) throws InjectionException, IOException {

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/LocalSubmissionFromCS.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/LocalSubmissionFromCS.java
@@ -34,6 +34,7 @@ import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeTryCount;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Represents a job submission from the CS code.
@@ -83,11 +84,9 @@ final class LocalSubmissionFromCS {
         .set(LocalRuntimeConfiguration.RUNTIME_ROOT_FOLDER, runtimeRootFolder.getAbsolutePath())
         .build();
 
-    final ArrayList<String> driverLaunchCommandPrefixList = new ArrayList<>();
+    final List<String> driverLaunchCommandPrefixList = new ArrayList<>();
     driverLaunchCommandPrefixList.add(
-        new File(driverFolder,
-            new REEFFileNames().getDriverLauncherExeFile().toString()
-        ).toString());
+        new File(driverFolder, new REEFFileNames().getDriverLauncherExeFile().toString()).toString());
 
     final Configuration userProviderConfiguration = Tang.Factory.getTang().newConfigurationBuilder()
         .bindSetEntry(DriverConfigurationProviders.class, TcpPortConfigurationProvider.class)

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/YarnBootstrapDriverConfigGenerator.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/YarnBootstrapDriverConfigGenerator.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.bridge.client;
+
+import com.google.inject.Inject;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.reef.client.DriverRestartConfiguration;
+import org.apache.reef.client.parameters.DriverConfigurationProviders;
+import org.apache.reef.io.TcpPortConfigurationProvider;
+import org.apache.reef.javabridge.generic.JobDriver;
+import org.apache.reef.reef.bridge.client.YarnBootstrapArgs;
+import org.apache.reef.runtime.common.driver.parameters.ClientRemoteIdentifier;
+import org.apache.reef.runtime.common.files.REEFFileNames;
+import org.apache.reef.runtime.yarn.driver.YarnDriverConfiguration;
+import org.apache.reef.runtime.yarn.driver.YarnDriverRestartConfiguration;
+import org.apache.reef.runtime.yarn.driver.parameters.JobSubmissionDirectoryPrefix;
+import org.apache.reef.tang.*;
+import org.apache.reef.tang.formats.ConfigurationSerializer;
+import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeBegin;
+import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeCount;
+import org.apache.reef.wake.remote.ports.parameters.TcpPortRangeTryCount;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * This is the Java Driver configuration generator for .NET Drivers that generates
+ * the Driver configuration at runtime. This is used by the "yarn" flag of the
+ * {@link BootstrapLauncher} to avoid Java dependencies for .NET clients during REST submission
+ * to YARN clusters.
+ * TODO[JIRA REEF-922]: Make sure that the generated Avro configurations work without dependencies on Java.
+ */
+public final class YarnBootstrapDriverConfigGenerator {
+  private static final REEFFileNames REEF_FILE_NAMES = new REEFFileNames();
+  private static final Logger LOG = Logger.getLogger(YarnBootstrapDriverConfigGenerator.class.getName());
+
+  private final ConfigurationSerializer configurationSerializer;
+
+  @Inject
+  private YarnBootstrapDriverConfigGenerator(final ConfigurationSerializer configurationSerializer) {
+    this.configurationSerializer = configurationSerializer;
+  }
+
+  public String writeDriverConfiguration(final String bootstrapArgsLocation) throws IOException {
+    final File bootstrapArgsFile = new File(bootstrapArgsLocation);
+    final YarnBootstrapArgs yarnBootstrapArgs = getYarnBootstrapArgsFromFile(bootstrapArgsFile);
+    final String driverConfigPath = REEF_FILE_NAMES.getDriverConfigurationPath();
+
+    this.configurationSerializer.toFile(getYarnDriverConfiguration(yarnBootstrapArgs),
+        new File(driverConfigPath));
+
+    return driverConfigPath;
+  }
+
+  private static Configuration getYarnDriverConfiguration(final YarnBootstrapArgs yarnBootstrapArgs) {
+    final Configuration providerConfig = Tang.Factory.getTang().newConfigurationBuilder()
+        .bindSetEntry(DriverConfigurationProviders.class, TcpPortConfigurationProvider.class)
+        .bindNamedParameter(TcpPortRangeBegin.class, Integer.toString(yarnBootstrapArgs.getTcpBeginPort()))
+        .bindNamedParameter(TcpPortRangeCount.class, Integer.toString(yarnBootstrapArgs.getTcpRangeCount()))
+        .bindNamedParameter(TcpPortRangeTryCount.class, Integer.toString(yarnBootstrapArgs.getTcpTryCount()))
+        .bindNamedParameter(JobSubmissionDirectoryPrefix.class,
+            yarnBootstrapArgs.getJobSubmissionDirectoryPrefix().toString())
+        .build();
+
+    final Configuration yarnDriverConfiguration = YarnDriverConfiguration.CONF
+        .set(YarnDriverConfiguration.JOB_SUBMISSION_DIRECTORY, yarnBootstrapArgs.getJobSubmissionFolder().toString())
+        .set(YarnDriverConfiguration.JOB_IDENTIFIER, yarnBootstrapArgs.getJobId().toString())
+        .set(YarnDriverConfiguration.CLIENT_REMOTE_IDENTIFIER, ClientRemoteIdentifier.NONE)
+        .set(YarnDriverConfiguration.JVM_HEAP_SLACK, 0.0)
+        .build();
+
+    final Configuration driverConfiguration = Configurations.merge(
+        Constants.DRIVER_CONFIGURATION_WITH_HTTP_AND_NAMESERVER, yarnDriverConfiguration, providerConfig);
+
+    if (yarnBootstrapArgs.getDriverRecoveryTimeout() > 0) {
+      LOG.log(Level.FINE, "Driver restart is enabled.");
+
+      final Configuration yarnDriverRestartConfiguration =
+          YarnDriverRestartConfiguration.CONF.build();
+
+      final Configuration driverRestartConfiguration =
+          DriverRestartConfiguration.CONF
+              .set(DriverRestartConfiguration.ON_DRIVER_RESTARTED, JobDriver.RestartHandler.class)
+              .set(DriverRestartConfiguration.ON_DRIVER_RESTART_CONTEXT_ACTIVE,
+                  JobDriver.DriverRestartActiveContextHandler.class)
+              .set(DriverRestartConfiguration.ON_DRIVER_RESTART_TASK_RUNNING,
+                  JobDriver.DriverRestartRunningTaskHandler.class)
+              .set(DriverRestartConfiguration.DRIVER_RESTART_EVALUATOR_RECOVERY_SECONDS,
+                  yarnBootstrapArgs.getDriverRecoveryTimeout())
+              .set(DriverRestartConfiguration.ON_DRIVER_RESTART_COMPLETED,
+                  JobDriver.DriverRestartCompletedHandler.class)
+              .set(DriverRestartConfiguration.ON_DRIVER_RESTART_EVALUATOR_FAILED,
+                  JobDriver.DriverRestartFailedEvaluatorHandler.class)
+              .build();
+
+      return Configurations.merge(driverConfiguration, yarnDriverRestartConfiguration, driverRestartConfiguration);
+    }
+
+    return driverConfiguration;
+  }
+
+  private static YarnBootstrapArgs getYarnBootstrapArgsFromFile(final File file) throws IOException {
+    final YarnBootstrapArgs yarnBootstrapArgs;
+    try (final DataFileReader<YarnBootstrapArgs> dataFileReader =
+             new DataFileReader<>(file, new SpecificDatumReader<>(YarnBootstrapArgs.class))) {
+      yarnBootstrapArgs = dataFileReader.next();
+    }
+    return yarnBootstrapArgs;
+  }
+}

--- a/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/YarnJobSubmissionClient.java
+++ b/lang/java/reef-bridge-client/src/main/java/org/apache/reef/bridge/client/YarnJobSubmissionClient.java
@@ -144,6 +144,8 @@ public final class YarnJobSubmissionClient {
             .setQueue(yarnSubmission.getQueue())
             .setMaxApplicationAttempts(this.maxApplicationSubmissions)
             .setPreserveEvaluators(jobParamsInjector.getNamedInstance(ResourceManagerPreserveEvaluators.class))
+            .setLauncherCommandFormatter(
+                BootstrapLauncherCommandFormatter.getLauncherCommand().addFlag(BootstrapLauncher.DIRECT_LAUNCH))
             .submit();
       } catch (InjectionException ie) {
         throw new RuntimeException("Unable to submit job due to " + ie);

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/LauncherCommandFormatter.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/LauncherCommandFormatter.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runtime.common.launch;
+
+import org.apache.reef.annotations.audience.Private;
+
+import java.util.List;
+
+/**
+ * The formatter that creates and formats the Java command-line command.
+ * The configuration file name is always the last parameter and the Launcher class name is always the first.
+ * Flags are all the parameters between the Launcher class and the configuration file name.
+ * Currently there are 2 types of Launchers: BootstrapLauncher and REEFLauncher.
+ * The BootstrapLauncher is mainly used to launch the .NET Driver without Java dependencies and has a flag
+ * to internally create the Java Driver configuration and invoke REEFLauncher with the newly created
+ * configuration file.
+ */
+@Private
+public interface LauncherCommandFormatter {
+  /**
+   * @return the Launcher class name.
+   */
+  String getLauncherClass();
+
+  /**
+   * @param flag Adds a flag to the command line.
+   * @return LauncherCommandFormatter
+   */
+  LauncherCommandFormatter addFlag(final String flag);
+
+  /**
+   * @return List of flags for the command line.
+   */
+  List<String> getFlags();
+
+  /**
+   * @param configurationFileName The name of the configuration file.
+   * @return LauncherCommandFormatter
+   */
+  LauncherCommandFormatter setConfigurationFileName(final String configurationFileName);
+
+  /**
+   * @return The configuration file name.
+   */
+  String getConfigurationFileName();
+}

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/REEFLauncherCommandFormatter.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/launch/REEFLauncherCommandFormatter.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.reef.runtime.common.launch;
+
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.reef.annotations.audience.Private;
+import org.apache.reef.runtime.common.REEFLauncher;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The Java command formatting class for the REEFLauncher class.
+ * Directly launches the Driver, assuming a pre-generated Java Driver configuration.
+ * @see LauncherCommandFormatter
+ */
+@Private
+public final class REEFLauncherCommandFormatter implements LauncherCommandFormatter {
+  private final List<String> immutableFlags = Collections.unmodifiableList(new ArrayList<String>());
+  private String configFileName;
+
+  private REEFLauncherCommandFormatter(){
+  }
+
+  public static REEFLauncherCommandFormatter getLauncherCommand() {
+    return new REEFLauncherCommandFormatter();
+  }
+
+  @Override
+  public LauncherCommandFormatter addFlag(final String flag) {
+    throw new NotImplementedException("Launching with the REEFLauncher does not support flags.");
+  }
+
+  @Override
+  public String getLauncherClass() {
+    return REEFLauncher.class.getName();
+  }
+
+  @Override
+  public List<String> getFlags() {
+    return immutableFlags;
+  }
+
+  @Override
+  public LauncherCommandFormatter setConfigurationFileName(final String configurationFileName) {
+    configFileName = configurationFileName;
+    return this;
+  }
+
+  @Override
+  public String getConfigurationFileName() {
+    return configFileName;
+  }
+}

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/LocalJobSubmissionHandler.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/LocalJobSubmissionHandler.java
@@ -23,6 +23,7 @@ import org.apache.reef.annotations.audience.Private;
 import org.apache.reef.runtime.common.client.api.JobSubmissionEvent;
 import org.apache.reef.runtime.common.client.api.JobSubmissionHandler;
 import org.apache.reef.runtime.common.files.REEFFileNames;
+import org.apache.reef.runtime.common.launch.REEFLauncherCommandFormatter;
 import org.apache.reef.runtime.local.client.parameters.RootFolder;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.annotations.Parameter;
@@ -101,7 +102,8 @@ final class LocalJobSubmissionHandler implements JobSubmissionHandler {
 
         this.configurationSerializer.toFile(driverConfiguration,
             new File(driverFolder, this.fileNames.getDriverConfigurationPath()));
-        this.driverLauncher.launch(driverFolder, t.getIdentifier(), t.getRemoteId());
+        this.driverLauncher.launch(REEFLauncherCommandFormatter.getLauncherCommand(), driverFolder, t.getIdentifier(),
+            t.getRemoteId());
       } catch (final Exception e) {
         LOG.log(Level.SEVERE, "Unable to setup driver.", e);
         throw new RuntimeException("Unable to setup driver.", e);

--- a/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/PreparedDriverFolderLauncher.java
+++ b/lang/java/reef-runtime-local/src/main/java/org/apache/reef/runtime/local/client/PreparedDriverFolderLauncher.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.reef.runtime.common.files.ClasspathProvider;
 import org.apache.reef.runtime.common.files.REEFFileNames;
 import org.apache.reef.runtime.common.launch.JavaLaunchCommandBuilder;
+import org.apache.reef.runtime.common.launch.LauncherCommandFormatter;
 import org.apache.reef.runtime.local.process.LoggingRunnableProcessObserver;
 import org.apache.reef.runtime.local.process.RunnableProcess;
 import org.apache.reef.tang.annotations.Parameter;
@@ -73,10 +74,13 @@ public class PreparedDriverFolderLauncher {
    * @param jobId
    * @param clientRemoteId
    */
-  public void launch(final File driverFolder, final String jobId, final String clientRemoteId) {
+  public void launch(final LauncherCommandFormatter launcherCommandFormatter,
+                     final File driverFolder,
+                     final String jobId,
+                     final String clientRemoteId) {
     assert driverFolder.isDirectory();
 
-    final List<String> command = makeLaunchCommand(jobId, clientRemoteId);
+    final List<String> command = makeLaunchCommand(launcherCommandFormatter, jobId, clientRemoteId);
 
     final RunnableProcess process = new RunnableProcess(command,
         "driver",
@@ -88,9 +92,10 @@ public class PreparedDriverFolderLauncher {
     this.executor.shutdown();
   }
 
-  private List<String> makeLaunchCommand(final String jobId, final String clientRemoteId) {
+  private List<String> makeLaunchCommand(final LauncherCommandFormatter launcherCommandFormatter, final String jobId,
+                                         final String clientRemoteId) {
 
-    final List<String> command = new JavaLaunchCommandBuilder(commandPrefixList)
+    final List<String> command = new JavaLaunchCommandBuilder(launcherCommandFormatter, commandPrefixList)
         .setConfigurationFileName(this.fileNames.getDriverConfigurationPath())
         .setClassPath(this.classpath.getDriverClasspath())
         .setMemory(DRIVER_MEMORY)
@@ -99,6 +104,8 @@ public class PreparedDriverFolderLauncher {
     if (LOG.isLoggable(Level.FINEST)) {
       LOG.log(Level.FINEST, "REEF app command: {0}", StringUtils.join(command, ' '));
     }
+
+    LOG.log(Level.WARNING, "REEF app command: {0}", StringUtils.join(command, ' '));
     return command;
   }
 


### PR DESCRIPTION
This addressed the issue by
  * Creating a BootstrapLauncher that has the ability to indirectly generate a Java Driver config and invoke REEFLauncher.
  * Adding client JAR to the list of required JARs to run the .NET driver.
  * Use LauncherCommandFormatter to determine which class and format to launch the Driver with.

JIRA:
  [REEF-910](https://issues.apache.org/jira/browse/REEF-910)