### PR TITLE
[REEF-926] Add docker-based test environments

### DIFF
--- a/dev/docker/README.md
+++ b/dev/docker/README.md
@@ -1,0 +1,103 @@
+Apache REEF (incubator) Docker Tests
+====================================
+
+[Apache REEF (incubator)](http://reef.incubator.apache.org/) is
+an approach to simplify and unify the lower layers of big data systems
+on modern resource managers. This project maintains docker images
+to simulate the target underlying systems as similar as possible.
+
+Docker-based Test Cluster
+-------------------------
+
+| Environment | OS           | Hadoop Version            | Description   | alias     |
+|-------------|--------------|---------------------------|---------------|-----------|
+| YARN        | Ubuntu 12.04 | HDP 2.1.15 (Hadoop 2.4.0) | HDInsight 3.1 | hdi3.1    |
+| YARN        | Ubuntu 12.04 | HDP 2.2.7  (Hadoop 2.6.0) | HDInsight 3.2 | hdi3.2    |
+| YARN        | Ubuntu 12.04 | HDP 2.2.8  (Hadoop 2.6.0) |               | hdp2.2    |
+| YARN        | Ubuntu 12.04 | HDP 2.3.2  (Hadoop 2.7.1) |               | hdp2.3    |
+| YARN        | Ubuntu 12.04 | Apache Hadoop 2.7.1       |               | apache2.7 |
+| MESOS       | Ubuntu 12.04 | Apache Mesos 0.24.1       |               | mesos0.24 |
+| MESOS       | Ubuntu 12.04 | Apache Mesos 0.25.0       |               | mesos0.25 |
+
+Please note that all images use Oracle JDK 7u80.
+
+Requirements
+------------
+
+First, download and *build* Apache REEF. You can find a guide for this
+[here](https://cwiki.apache.org/confluence/display/REEF/Compiling+REEF).
+Second, set $REEF_HOME to the directory of Apache REEF for the script to know its location.
+Tests will use `$REEF_HOME/lang/java/reef-tests/target/reef-tests-*-test-jar-with-dependencies.jar`.
+
+Build docker images (Optional)
+------------------------------
+
+This step is optional. We provide pre-built docker images in DockerHub.
+Please go to next step if you do not want to build images.
+To build all images manually, run `build.sh`.
+
+```sh
+$ ./build.sh
+```
+
+Run a docker-based cluster
+--------------------------
+
+Run `run-cluster.sh reefrt/{alias}`. It will create a small cluster
+with 4 nodes and run a shell on the master node.
+For all cluster, Apache Hadoop (HDFS/YARN) is installed. The hostnames
+are `hnn-001-01` (master) and `hnn-001-01 ~ hnn-001-03` (slaves).
+
+```sh
+$ ./run-cluster.sh reefrt/hdi3.2
+$ root@hnn-001-01:~#
+```
+
+Test Apache REEF on a docker-based YARN cluster
+-----------------------------------------------
+
+Among reefrt/hdi3.1, reefrt/hdi3.2, reefrt/hdp2.2, reefrt/hdp2.3, and reefrt/apache2.7,
+choose one and run it as described in section _Run a docker-based cluster_.
+If you want to test on Hadoop 2.7.1, choose reefrt/apache2.7.
+To simulate HDInsight 3.2, choose reefrt/hdi3.2.
+After running a cluster, use the following commands.
+
+```sh
+$ root@hnn-001-01:~# cd /reef
+$ root@hnn-001-01:~# ./bin/runyarntests.sh
+...
+OK (# tests)
+$ root@hnn-001-01:~# exit
+```
+
+If you see 'OK', it means all tests are passed.
+`exit` command will terminate your cluster automatically.
+
+Test Apache REEF on a docker-based Mesos cluster
+-----------------------------------------------
+
+Among reefrt/mesos0.24 and reefrt/mesos0.25,
+choose one and run it as described in section _Run a docker-based cluster_.
+If you want to test on Mesos 0.25, choose reefrt/mesos0.25.
+After running a cluster, use the following commands.
+
+```sh
+$ root@hnn-001-01:~# cd /reef
+$ root@hnn-001-01:~# ./bin/runmesostests.sh hnn-001-01:5050
+...
+OK (# tests)
+$ root@hnn-001-01:~# exit
+```
+
+If you see 'OK', it means all tests are passed.
+`exit` command will terminate your cluster automatically.
+
+Reference
+---------
+* Ubuntu OS: https://hub.docker.com/_/ubuntu/
+* Java: https://github.com/dockerfile/java/tree/master/oracle-java7
+* Hadoop: https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/DockerContainerExecutor.html
+* Hadoop: https://github.com/sequenceiq/hadoop-docker
+* Mesos: https://mesos.apache.org/gettingstarted
+* Prebuilt Mesos: https://mesosphere.com/downloads
+

--- a/dev/docker/build.sh
+++ b/dev/docker/build.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+ORG=reefrt
+for DIR in `ls -d ubuntu12.04*`
+do
+    IMAGE=$DIR
+    TAG=${DIR##*-}
+    echo $DIR $ORG/$TAG
+    docker build -t $ORG/$IMAGE $DIR
+    docker tag -f $ORG/$IMAGE $ORG/$TAG
+done
+docker tag -f $ORG/ubuntu12.04-jdk7-hdp2.1.15 $ORG/hdi3.1
+docker tag -f $ORG/ubuntu12.04-jdk7-hdp2.2.7 $ORG/hdi3.2
+docker tag -f $ORG/ubuntu12.04-jdk7-hdp2.2.8 $ORG/hdp2.2
+docker tag -f $ORG/ubuntu12.04-jdk7-hdp2.3.2 $ORG/hdp2.3

--- a/dev/docker/run-cluster.sh
+++ b/dev/docker/run-cluster.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+IMAGE=${1:-reefrt/hdi3.2}
+echo "Using $IMAGE with $REEF_HOME"
+if [[ $IMAGE == *"mesos"* ]]
+then
+   PRIVILEGED='--privileged=true'
+fi
+
+LINK=""
+for i in {1..3}
+do
+    HOST=hdn-001-0$i
+    LINK="$LINK --link=$HOST:$HOST"
+    docker run $PRIVILEGED --name=$HOST -h $HOST -p 1001$i:22 -d $IMAGE /root/start.sh
+done
+
+HOST=hnn-001-01
+PORT="-p 5050:5050 -p 8088:8088 -p 10000:10000 -p 10010:22 -p 26002:26002 -p 26080:26080 -p 50070:50070"
+docker run $PRIVILEGED --name=$HOST -h $HOST $PORT $LINK -it --rm -v $REEF_HOME:/reef -e REEF_HOME=/reef $IMAGE /root/init-nn.sh
+
+for i in {1..3}
+do
+    docker rm -f hdn-001-0$i
+done

--- a/dev/docker/ubuntu12.04-jdk7-apache2.7/Dockerfile
+++ b/dev/docker/ubuntu12.04-jdk7-apache2.7/Dockerfile
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM reefrt/ubuntu12.04-jdk7
+MAINTAINER Apache REEF (incubator) <dev@reef.incubator.apache.org>
+
+# Apache Hadoop 2.7.1
+RUN \
+  cd /usr/local && wget -q http://www.us.apache.org/dist/hadoop/common/hadoop-2.7.1/hadoop-2.7.1.tar.gz && \
+  tar -xzf hadoop-2.7.1.tar.gz && \
+  ln -s ./hadoop-2.7.1 hadoop && \
+  rm hadoop-2.7.1.tar.gz
+
+ENV HADOOP_PREFIX /usr/local/hadoop
+ENV YARN_CONF_DIR /usr/local/hadoop/etc/hadoop
+RUN \
+  echo 'HADOOP_PREFIX="/usr/local/hadoop"' >> /etc/environment && \
+  echo 'HADOOP_COMMON_HOME="/usr/local/hadoop"' >> /etc/environment && \
+  echo 'HADOOP_HDFS_HOME="/usr/local/hadoop"' >> /etc/environment && \
+  echo 'HADOOP_MAPRED_HOME="/usr/local/hadoop"' >> /etc/environment && \
+  echo 'HADOOP_YARN_HOME="/usr/local/hadoop"' >> /etc/environment && \
+  echo 'HADOOP_CONF_DIR="/usr/local/hadoop/etc/hadoop"' >> /etc/environment && \
+  echo 'YARN_CONF_DIR="/usr/local/hadoop/etc/hadoop"' >> /etc/environment
+ENV PATH $PATH:$HADOOP_PREFIX/bin:$HADOOP_PREFIX/sbin:$HADOOP_PREFIX-yarn/bin:$HADOOP_PREFIX-yarn/sbin:$HADOOP_PREFIX-hdfs/bin:$HADOOP_PREFIX-hdfs/sbin
+
+RUN sed -i '/^export JAVA_HOME/ s:.*:export JAVA_HOME=$JAVA_HOME\nexport HADOOP_PREFIX=/usr/local/hadoop\nexport HADOOP_HOME=/usr/local/hadoop\n:' $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh
+RUN sed -i '/^export HADOOP_CONF_DIR/ s:.*:export HADOOP_CONF_DIR=/usr/local/hadoop/etc/hadoop/:' $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh
+
+COPY core-site.xml $HADOOP_PREFIX/etc/hadoop/
+COPY hdfs-site.xml $HADOOP_PREFIX/etc/hadoop/
+COPY mapred-site.xml $HADOOP_PREFIX/etc/hadoop/
+COPY yarn-site.xml $HADOOP_PREFIX/etc/hadoop/
+
+RUN chmod +x /usr/local/hadoop/etc/hadoop/*-env.sh
+COPY init-nn.sh /root/
+
+EXPOSE 22 7077 8020 8030 8031 8032 8033 8040 8042 8080 8088 10000 50010 50020 50060 50070 50075 50090

--- a/dev/docker/ubuntu12.04-jdk7-apache2.7/core-site.xml
+++ b/dev/docker/ubuntu12.04-jdk7-apache2.7/core-site.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration>
+    <property>
+        <name>fs.defaultFS</name>
+        <value>hdfs://hnn-001-01:9000</value>
+    </property>
+</configuration>

--- a/dev/docker/ubuntu12.04-jdk7-apache2.7/hdfs-site.xml
+++ b/dev/docker/ubuntu12.04-jdk7-apache2.7/hdfs-site.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration>
+    <property>
+        <name>dfs.replication</name>
+        <value>1</value>
+    </property>
+</configuration>

--- a/dev/docker/ubuntu12.04-jdk7-apache2.7/init-nn.sh
+++ b/dev/docker/ubuntu12.04-jdk7-apache2.7/init-nn.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+/usr/sbin/sshd
+
+grep hdn /etc/hosts | awk '{print $1}' | sort | uniq > $HADOOP_PREFIX/etc/hadoop/slaves
+for host in `cat $HADOOP_PREFIX/etc/hadoop/slaves`
+do
+    scp /etc/hosts $host:/etc/hosts
+    scp $HADOOP_PREFIX/etc/hadoop/slaves $host:$HADOOP_PREFIX/etc/hadoop/slaves
+done
+
+/usr/local/hadoop/bin/hdfs namenode -format
+/usr/local/hadoop/sbin/start-dfs.sh
+/usr/local/hadoop/sbin/start-yarn.sh
+
+cd ~ && /bin/bash

--- a/dev/docker/ubuntu12.04-jdk7-apache2.7/mapred-site.xml
+++ b/dev/docker/ubuntu12.04-jdk7-apache2.7/mapred-site.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration>
+    <property>
+        <name>mapreduce.framework.name</name>
+        <value>yarn</value>
+    </property>
+</configuration>

--- a/dev/docker/ubuntu12.04-jdk7-apache2.7/yarn-site.xml
+++ b/dev/docker/ubuntu12.04-jdk7-apache2.7/yarn-site.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration>
+    <property>
+        <name>yarn.resourcemanager.scheduler.address</name>
+        <value>hnn-001-01:8030</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.resource-tracker.address</name>
+        <value>hnn-001-01:8025</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.address</name>
+        <value>hnn-001-01:8050</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.admin.address</name>
+        <value>hnn-001-01:8141</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.webapp.address</name>
+        <value>hnn-001-01:8088</value>
+    </property>
+
+    <property>
+        <name>yarn.log.server.url</name>
+        <value>http://hnn-001-01:19888/jobhistory/logs/</value>
+        <description>URL for job history server</description>
+    </property>
+
+    <property>
+      <name>yarn.application.classpath</name>
+      <value>/usr/local/hadoop/etc/hadoop, /usr/local/hadoop/share/hadoop/common/*, /usr/local/hadoop/share/hadoop/common/lib/*, /usr/local/hadoop/share/hadoop/hdfs/*, /usr/local/hadoop/share/hadoop/hdfs/lib/*, /usr/local/hadoop/share/hadoop/mapreduce/*, /usr/local/hadoop/share/hadoop/mapreduce/lib/*, /usr/local/hadoop/share/hadoop/yarn/*, /usr/local/hadoop/share/hadoop/yarn/lib/*</value>
+    </property>
+
+    <property>
+        <name>yarn.scheduler.minimum-allocation-mb</name>
+        <value>1024</value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.aux-services</name>
+        <value>mapreduce_shuffle</value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.aux-services.mapreduce.shuffle.class</name>
+        <value>org.apache.hadoop.mapred.ShuffleHandler</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.scheduler.class</name>
+        <value>org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler</value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.resource.memory-mb</name>
+        <value>87040</value>
+    </property>
+</configuration>

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.1.15/Dockerfile
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.1.15/Dockerfile
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM reefrt/ubuntu12.04-jdk7
+MAINTAINER Apache REEF (incubator) <dev@reef.incubator.apache.org>
+
+# HDP 2.1.15
+RUN \
+  wget http://public-repo-1.hortonworks.com/HDP/ubuntu12/2.x/updates/2.1.15.0/hdp.list -O /etc/apt/sources.list.d/hdp.list && \
+  gpg --keyserver pgp.mit.edu --recv-keys B9733A7A07513CAD && \
+  gpg -a --export 07513CAD | apt-key add - && \
+  apt-get update && \
+  apt-get install -y hadoop hadoop-hdfs hadoop-yarn hadoop-mapreduce hadoop-client && \
+  apt-get clean
+ENV CLASSPATH $CLASSPATH:/usr/lib/hadoop/client/*
+ENV HADOOP_PREFIX /usr/lib/hadoop
+ENV HADOOP_LIBEXEC_DIR /usr/lib/hadoop/libexec
+
+ENV YARN_CONF_DIR $HADOOP_PREFIX/etc/hadoop
+RUN \
+  echo 'HADOOP_PREFIX="/usr/lib/hadoop"' >> /etc/environment && \
+  echo 'HADOOP_LIBEXEC_DIR="/usr/lib/hadoop/libexec"' >> /etc/environment && \
+  echo 'HADOOP_COMMON_HOME="/usr/lib/hadoop"' >> /etc/environment && \
+  echo 'HADOOP_HDFS_HOME="/usr/lib/hadoop-hdfs"' >> /etc/environment && \
+  echo 'HADOOP_MAPRED_HOME="/usr/lib/hadoop"' >> /etc/environment && \
+  echo 'HADOOP_YARN_HOME="/usr/lib/hadoop-yarn"' >> /etc/environment && \
+  echo 'HADOOP_CONF_DIR="/usr/lib/hadoop/etc/hadoop"' >> /etc/environment && \
+  echo 'YARN_CONF_DIR="/usr/lib/hadoop/etc/hadoop"' >> /etc/environment
+ENV PATH $PATH:$HADOOP_PREFIX/bin:$HADOOP_PREFIX/sbin:$HADOOP_PREFIX-yarn/bin:$HADOOP_PREFIX-yarn/sbin:$HADOOP_PREFIX-hdfs/bin:$HADOOP_PREFIX-hdfs/sbin
+
+COPY core-site.xml $HADOOP_PREFIX/etc/hadoop/
+COPY hdfs-site.xml $HADOOP_PREFIX/etc/hadoop/
+COPY mapred-site.xml $HADOOP_PREFIX/etc/hadoop/
+COPY yarn-site.xml $HADOOP_PREFIX/etc/hadoop/
+
+COPY init-nn.sh /root/
+
+EXPOSE 22 7077 8020 8030 8031 8032 8033 8040 8042 8080 8088 10000 50010 50020 50060 50070 50075 50090

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.1.15/core-site.xml
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.1.15/core-site.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration>
+    <property>
+        <name>fs.defaultFS</name>
+        <value>hdfs://hnn-001-01:9000</value>
+    </property>
+</configuration>

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.1.15/hdfs-site.xml
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.1.15/hdfs-site.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration>
+    <property>
+        <name>dfs.replication</name>
+        <value>1</value>
+    </property>
+</configuration>

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.1.15/init-nn.sh
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.1.15/init-nn.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+/usr/sbin/sshd
+
+grep hdn /etc/hosts | awk '{print $1}' | sort | uniq > $HADOOP_PREFIX/etc/hadoop/slaves
+for host in `cat $HADOOP_PREFIX/etc/hadoop/slaves`
+do
+    scp /etc/hosts $host:/etc/hosts
+    scp $HADOOP_PREFIX/etc/hadoop/slaves $host:$HADOOP_PREFIX/etc/hadoop/slaves
+done
+
+hdfs namenode -format
+
+hadoop-daemon.sh --script hdfs start namenode
+slaves.sh /usr/lib/hadoop/sbin/hadoop-daemon.sh --script hdfs start datanode
+
+yarn-daemon.sh start resourcemanager
+slaves.sh /usr/lib/hadoop-yarn/sbin/yarn-daemon.sh start nodemanager
+
+cd ~ && /bin/bash

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.1.15/mapred-site.xml
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.1.15/mapred-site.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration>
+    <property>
+        <name>mapreduce.framework.name</name>
+        <value>yarn</value>
+    </property>
+</configuration>

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.1.15/yarn-site.xml
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.1.15/yarn-site.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration>
+    <property>
+        <name>yarn.resourcemanager.scheduler.address</name>
+        <value>hnn-001-01:8030</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.resource-tracker.address</name>
+        <value>hnn-001-01:8025</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.address</name>
+        <value>hnn-001-01:8050</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.admin.address</name>
+        <value>hnn-001-01:8141</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.webapp.address</name>
+        <value>hnn-001-01:8088</value>
+    </property>
+
+    <property>
+        <name>yarn.log.server.url</name>
+        <value>http://hnn-001-01:19888/jobhistory/logs/</value>
+        <description>URL for job history server</description>
+    </property>
+
+    <property>
+      <name>yarn.application.classpath</name>
+      <value>/usr/lib/hadoop/etc/hadoop, /usr/lib/hadoop/*, /usr/lib/hadoop/lib/*, /usr/lib/hadoop/client/*, /usr/lib/hadoop-hdfs/*, /usr/lib/hadoop-hdfs/lib/*, /usr/lib/hadoop-mapreduce/*, /usr/lib/hadoop-mapreduce/lib/*, /usr/lib/hadoop-yarn/*, /usr/lib/hadoop-yarn/lib/*</value>
+    </property>
+
+    <property>
+        <name>yarn.scheduler.minimum-allocation-mb</name>
+        <value>1024</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.scheduler.class</name>
+        <value>org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler</value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.resource.memory-mb</name>
+        <value>87040</value>
+    </property>
+</configuration>

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.2.7/Dockerfile
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.2.7/Dockerfile
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM reefrt/ubuntu12.04-jdk7
+MAINTAINER Apache REEF (incubator) <dev@reef.incubator.apache.org>
+
+# HDP 2.2.7
+RUN \
+  wget http://public-repo-1.hortonworks.com/HDP/ubuntu12/2.x/updates/2.2.7.1/hdp.list -O /etc/apt/sources.list.d/hdp.list && \
+  gpg --keyserver pgp.mit.edu --recv-keys B9733A7A07513CAD && \
+  gpg -a --export 07513CAD | apt-key add - && \
+  apt-get update && \
+  apt-get install -y hadoop-2-2-7-1-33* && \
+  apt-get clean
+ENV HADOOP_PREFIX /usr/hdp/2.2.7.1-33/hadoop
+
+ENV YARN_CONF_DIR $HADOOP_PREFIX/etc/hadoop
+RUN \
+  echo 'HADOOP_PREFIX="/usr/hdp/2.2.7.1-33/hadoop"' >> /etc/environment && \
+  echo 'HADOOP_COMMON_HOME="/usr/hdp/2.2.7.1-33/hadoop"' >> /etc/environment && \
+  echo 'HADOOP_HDFS_HOME="/usr/hdp/2.2.7.1-33/hadoop"' >> /etc/environment && \
+  echo 'HADOOP_MAPRED_HOME="/usr/hdp/2.2.7.1-33/hadoop"' >> /etc/environment && \
+  echo 'HADOOP_YARN_HOME="/usr/hdp/2.2.7.1-33/hadoop-yarn"' >> /etc/environment && \
+  echo 'HADOOP_CONF_DIR="/usr/hdp/2.2.7.1-33/hadoop/etc/hadoop"' >> /etc/environment && \
+  echo 'YARN_CONF_DIR="/usr/hdp/2.2.7.1-33/hadoop/etc/hadoop"' >> /etc/environment
+ENV PATH $PATH:$HADOOP_PREFIX/bin:$HADOOP_PREFIX/sbin:$HADOOP_PREFIX-yarn/bin:$HADOOP_PREFIX-yarn/sbin:$HADOOP_PREFIX-hdfs/bin:$HADOOP_PREFIX-hdfs/sbin
+
+COPY core-site.xml $HADOOP_PREFIX/etc/hadoop/
+COPY hdfs-site.xml $HADOOP_PREFIX/etc/hadoop/
+COPY mapred-site.xml $HADOOP_PREFIX/etc/hadoop/
+COPY yarn-site.xml $HADOOP_PREFIX/etc/hadoop/
+
+COPY init-nn.sh /root/
+
+EXPOSE 22 7077 8020 8030 8031 8032 8033 8040 8042 8080 8088 10000 50010 50020 50060 50070 50075 50090

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.2.7/core-site.xml
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.2.7/core-site.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration>
+    <property>
+        <name>fs.defaultFS</name>
+        <value>hdfs://hnn-001-01:9000</value>
+    </property>
+</configuration>

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.2.7/hdfs-site.xml
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.2.7/hdfs-site.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration>
+    <property>
+        <name>dfs.replication</name>
+        <value>1</value>
+    </property>
+</configuration>

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.2.7/init-nn.sh
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.2.7/init-nn.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+/usr/sbin/sshd
+
+grep hdn /etc/hosts | awk '{print $1}' | sort | uniq > $HADOOP_PREFIX/etc/hadoop/slaves
+for host in `cat $HADOOP_PREFIX/etc/hadoop/slaves`
+do
+    scp /etc/hosts $host:/etc/hosts
+    scp $HADOOP_PREFIX/etc/hadoop/slaves $host:$HADOOP_PREFIX/etc/hadoop/slaves
+done
+
+hdfs namenode -format
+
+hadoop-daemon.sh --script hdfs start namenode
+slaves.sh /usr/hdp/2.2.7.1-33/hadoop/sbin/hadoop-daemon.sh --script hdfs start datanode
+
+yarn-daemon.sh start resourcemanager
+slaves.sh /usr/hdp/2.2.7.1-33/hadoop-yarn/sbin/yarn-daemon.sh start nodemanager
+
+cd ~ && /bin/bash

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.2.7/mapred-site.xml
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.2.7/mapred-site.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration>
+    <property>
+        <name>mapreduce.framework.name</name>
+        <value>yarn</value>
+    </property>
+</configuration>

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.2.7/yarn-site.xml
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.2.7/yarn-site.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration>
+    <property>
+        <name>yarn.resourcemanager.scheduler.address</name>
+        <value>hnn-001-01:8030</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.resource-tracker.address</name>
+        <value>hnn-001-01:8025</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.address</name>
+        <value>hnn-001-01:8050</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.admin.address</name>
+        <value>hnn-001-01:8141</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.webapp.address</name>
+        <value>hnn-001-01:8088</value>
+    </property>
+
+    <property>
+        <name>yarn.log.server.url</name>
+        <value>http://hnn-001-01:19888/jobhistory/logs/</value>
+        <description>URL for job history server</description>
+    </property>
+
+    <property>
+      <name>yarn.application.classpath</name>
+      <value>/usr/hdp/2.2.7.1-33/hadoop/etc/hadoop, /usr/hdp/2.2.7.1-33/hadoop/*, /usr/hdp/2.2.7.1-33/hadoop/lib/*, /usr/hdp/2.2.7.1-33/hadoop-hdfs/*, /usr/hdp/2.2.7.1-33/hadoop-hdfs/lib/*, /usr/hdp/2.2.7.1-33/hadoop-mapreduce/*, /usr/hdp/2.2.7.1-33/hadoop-mapreduce/lib/*, /usr/hdp/2.2.7.1-33/hadoop-yarn/*, /usr/hdp/2.2.7.1-33/hadoop-yarn/lib/*</value>
+    </property>
+
+    <property>
+        <name>yarn.scheduler.minimum-allocation-mb</name>
+        <value>1024</value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.aux-services</name>
+        <value>mapreduce_shuffle</value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.aux-services.mapreduce.shuffle.class</name>
+        <value>org.apache.hadoop.mapred.ShuffleHandler</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.scheduler.class</name>
+        <value>org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler</value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.resource.memory-mb</name>
+        <value>87040</value>
+    </property>
+</configuration>

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.2.8/Dockerfile
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.2.8/Dockerfile
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM reefrt/ubuntu12.04-jdk7
+MAINTAINER Apache REEF (incubator) <dev@reef.incubator.apache.org>
+
+# HDP 2.2.8
+RUN \
+  wget http://public-repo-1.hortonworks.com/HDP/ubuntu12/2.x/updates/2.2.8.0/hdp.list -O /etc/apt/sources.list.d/hdp.list && \
+  gpg --keyserver pgp.mit.edu --recv-keys B9733A7A07513CAD && \
+  gpg -a --export 07513CAD | apt-key add - && \
+  apt-get update && \
+  apt-get install -y hadoop-2-2-8-0-3150* && \
+  apt-get clean
+ENV HADOOP_PREFIX /usr/hdp/2.2.8.0-3150/hadoop
+
+ENV YARN_CONF_DIR $HADOOP_PREFIX/etc/hadoop
+RUN \
+  echo 'HADOOP_PREFIX="/usr/hdp/2.2.8.0-3150/hadoop"' >> /etc/environment && \
+  echo 'HADOOP_COMMON_HOME="/usr/hdp/2.2.8.0-3150/hadoop"' >> /etc/environment && \
+  echo 'HADOOP_HDFS_HOME="/usr/hdp/2.2.8.0-3150/hadoop"' >> /etc/environment && \
+  echo 'HADOOP_MAPRED_HOME="/usr/hdp/2.2.8.0-3150/hadoop"' >> /etc/environment && \
+  echo 'HADOOP_YARN_HOME="/usr/hdp/2.2.8.0-3150/hadoop-yarn"' >> /etc/environment && \
+  echo 'HADOOP_CONF_DIR="/usr/hdp/2.2.8.0-3150/hadoop/etc/hadoop"' >> /etc/environment && \
+  echo 'YARN_CONF_DIR="/usr/hdp/2.2.8.0-3150/hadoop/etc/hadoop"' >> /etc/environment
+ENV PATH $PATH:$HADOOP_PREFIX/bin:$HADOOP_PREFIX/sbin:$HADOOP_PREFIX-yarn/bin:$HADOOP_PREFIX-yarn/sbin:$HADOOP_PREFIX-hdfs/bin:$HADOOP_PREFIX-hdfs/sbin
+
+COPY core-site.xml $HADOOP_PREFIX/etc/hadoop/
+COPY hdfs-site.xml $HADOOP_PREFIX/etc/hadoop/
+COPY mapred-site.xml $HADOOP_PREFIX/etc/hadoop/
+COPY yarn-site.xml $HADOOP_PREFIX/etc/hadoop/
+
+COPY init-nn.sh /root/
+
+EXPOSE 22 7077 8020 8030 8031 8032 8033 8040 8042 8080 8088 10000 50010 50020 50060 50070 50075 50090

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.2.8/core-site.xml
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.2.8/core-site.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration>
+    <property>
+        <name>fs.defaultFS</name>
+        <value>hdfs://hnn-001-01:9000</value>
+    </property>
+</configuration>

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.2.8/hdfs-site.xml
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.2.8/hdfs-site.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration>
+    <property>
+        <name>dfs.replication</name>
+        <value>1</value>
+    </property>
+</configuration>

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.2.8/init-nn.sh
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.2.8/init-nn.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+/usr/sbin/sshd
+
+/root/sync-hosts.sh
+
+grep hdn /etc/hosts | awk '{print $1}' | sort | uniq > $HADOOP_PREFIX/etc/hadoop/slaves
+for host in `grep 172 /etc/hosts | awk '{print $1}'`
+do
+    scp /etc/hosts $host:/etc/hosts
+    scp $HADOOP_PREFIX/etc/hadoop/slaves $host:$HADOOP_PREFIX/etc/hadoop/slaves
+done
+
+hdfs namenode -format
+
+hadoop-daemon.sh --script hdfs start namenode
+slaves.sh /usr/hdp/2.2.8.0-3150/hadoop/sbin/hadoop-daemon.sh --script hdfs start datanode
+
+yarn-daemon.sh start resourcemanager
+slaves.sh /usr/hdp/2.2.8.0-3150/hadoop-yarn/sbin/yarn-daemon.sh start nodemanager
+
+cd ~ && /bin/bash

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.2.8/mapred-site.xml
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.2.8/mapred-site.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration>
+    <property>
+        <name>mapreduce.framework.name</name>
+        <value>yarn</value>
+    </property>
+</configuration>

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.2.8/yarn-site.xml
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.2.8/yarn-site.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration>
+    <property>
+        <name>yarn.resourcemanager.scheduler.address</name>
+        <value>hnn-001-01:8030</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.resource-tracker.address</name>
+        <value>hnn-001-01:8025</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.address</name>
+        <value>hnn-001-01:8050</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.admin.address</name>
+        <value>hnn-001-01:8141</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.webapp.address</name>
+        <value>hnn-001-01:8088</value>
+    </property>
+
+    <property>
+        <name>yarn.log.server.url</name>
+        <value>http://hnn-001-01:19888/jobhistory/logs/</value>
+        <description>URL for job history server</description>
+    </property>
+
+    <property>
+      <name>yarn.application.classpath</name>
+      <value>/usr/hdp/2.2.8.0-3150/hadoop/etc/hadoop, /usr/hdp/2.2.8.0-3150/hadoop/*, /usr/hdp/2.2.8.0-3150/hadoop/lib/*, /usr/hdp/2.2.8.0-3150/hadoop-hdfs/*, /usr/hdp/2.2.8.0-3150/hadoop-hdfs/lib/*, /usr/hdp/2.2.8.0-3150/hadoop-mapreduce/*, /usr/hdp/2.2.8.0-3150/hadoop-mapreduce/lib/*, /usr/hdp/2.2.8.0-3150/hadoop-yarn/*, /usr/hdp/2.2.8.0-3150/hadoop-yarn/lib/*</value>
+    </property>
+
+    <property>
+        <name>yarn.scheduler.minimum-allocation-mb</name>
+        <value>1024</value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.aux-services</name>
+        <value>mapreduce_shuffle</value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.aux-services.mapreduce.shuffle.class</name>
+        <value>org.apache.hadoop.mapred.ShuffleHandler</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.scheduler.class</name>
+        <value>org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler</value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.resource.memory-mb</name>
+        <value>87040</value>
+    </property>
+</configuration>

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.3.2/Dockerfile
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.3.2/Dockerfile
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM reefrt/ubuntu12.04-jdk7
+MAINTAINER Apache REEF (incubator) <dev@reef.incubator.apache.org>
+
+# HDP 2.3.2
+RUN \
+  wget http://public-repo-1.hortonworks.com/HDP/ubuntu12/2.x/updates/2.3.2.0/hdp.list -O /etc/apt/sources.list.d/hdp.list && \
+  gpg --keyserver pgp.mit.edu --recv-keys B9733A7A07513CAD && \
+  gpg -a --export 07513CAD | apt-key add - && \
+  apt-get update && \
+  apt-get install -y hadoop-2-3-2* && \
+  apt-get clean
+ENV HADOOP_PREFIX /usr/hdp/2.3.2.0-2950/hadoop
+
+ENV YARN_CONF_DIR $HADOOP_PREFIX/etc/hadoop
+RUN \
+  echo 'HADOOP_PREFIX="/usr/hdp/2.3.2.0-2950/hadoop"' >> /etc/environment && \
+  echo 'HADOOP_COMMON_HOME="/usr/hdp/2.3.2.0-2950/hadoop"' >> /etc/environment && \
+  echo 'HADOOP_HDFS_HOME="/usr/hdp/2.3.2.0-2950/hadoop"' >> /etc/environment && \
+  echo 'HADOOP_MAPRED_HOME="/usr/hdp/2.3.2.0-2950/hadoop"' >> /etc/environment && \
+  echo 'HADOOP_YARN_HOME="/usr/hdp/2.3.2.0-2950/hadoop-yarn"' >> /etc/environment && \
+  echo 'HADOOP_CONF_DIR="/usr/hdp/2.3.2.0-2950/hadoop/etc/hadoop"' >> /etc/environment && \
+  echo 'YARN_CONF_DIR="/usr/hdp/2.3.2.0-2950/hadoop/etc/hadoop"' >> /etc/environment
+ENV PATH $PATH:$HADOOP_PREFIX/bin:$HADOOP_PREFIX/sbin:$HADOOP_PREFIX-yarn/bin:$HADOOP_PREFIX-yarn/sbin:$HADOOP_PREFIX-hdfs/bin:$HADOOP_PREFIX-hdfs/sbin
+
+COPY core-site.xml $HADOOP_PREFIX/etc/hadoop/
+COPY hdfs-site.xml $HADOOP_PREFIX/etc/hadoop/
+COPY mapred-site.xml $HADOOP_PREFIX/etc/hadoop/
+COPY yarn-site.xml $HADOOP_PREFIX/etc/hadoop/
+
+COPY init-nn.sh /root/
+
+EXPOSE 22 7077 8020 8030 8031 8032 8033 8040 8042 8080 8088 10000 50010 50020 50060 50070 50075 50090

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.3.2/core-site.xml
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.3.2/core-site.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration>
+    <property>
+        <name>fs.defaultFS</name>
+        <value>hdfs://hnn-001-01:9000</value>
+    </property>
+</configuration>

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.3.2/hdfs-site.xml
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.3.2/hdfs-site.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration>
+    <property>
+        <name>dfs.replication</name>
+        <value>1</value>
+    </property>
+</configuration>

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.3.2/init-nn.sh
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.3.2/init-nn.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+/usr/sbin/sshd
+
+/root/sync-hosts.sh
+
+grep hdn /etc/hosts | awk '{print $1}' | sort | uniq > $HADOOP_PREFIX/etc/hadoop/slaves
+for host in `cat $HADOOP_PREFIX/etc/hadoop/slaves`
+do
+    scp /etc/hosts $host:/etc/hosts
+    scp $HADOOP_PREFIX/etc/hadoop/slaves $host:$HADOOP_PREFIX/etc/hadoop/slaves
+done
+
+hdfs namenode -format
+
+hadoop-daemon.sh --script hdfs start namenode
+slaves.sh /usr/hdp/2.3.2.0-2950/hadoop/sbin/hadoop-daemon.sh --script hdfs start datanode
+
+yarn-daemon.sh start resourcemanager
+slaves.sh /usr/hdp/2.3.2.0-2950/hadoop-yarn/sbin/yarn-daemon.sh start nodemanager
+
+cd ~ && /bin/bash

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.3.2/mapred-site.xml
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.3.2/mapred-site.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration>
+    <property>
+        <name>mapreduce.framework.name</name>
+        <value>yarn</value>
+    </property>
+</configuration>

--- a/dev/docker/ubuntu12.04-jdk7-hdp2.3.2/yarn-site.xml
+++ b/dev/docker/ubuntu12.04-jdk7-hdp2.3.2/yarn-site.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration>
+    <property>
+        <name>yarn.resourcemanager.scheduler.address</name>
+        <value>hnn-001-01:8030</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.resource-tracker.address</name>
+        <value>hnn-001-01:8025</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.address</name>
+        <value>hnn-001-01:8050</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.admin.address</name>
+        <value>hnn-001-01:8141</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.webapp.address</name>
+        <value>hnn-001-01:8088</value>
+    </property>
+
+    <property>
+        <name>yarn.log.server.url</name>
+        <value>http://hnn-001-01:19888/jobhistory/logs/</value>
+        <description>URL for job history server</description>
+    </property>
+
+    <property>
+      <name>yarn.application.classpath</name>
+      <value>/usr/hdp/2.3.2.0-2950/hadoop/etc/hadoop, /usr/hdp/2.3.2.0-2950/hadoop/*, /usr/hdp/2.3.2.0-2950/hadoop/lib/*, /usr/hdp/2.3.2.0-2950/hadoop-hdfs/*, /usr/hdp/2.3.2.0-2950/hadoop-hdfs/lib/*, /usr/hdp/2.3.2.0-2950/hadoop-mapreduce/*, /usr/hdp/2.3.2.0-2950/hadoop-mapreduce/lib/*, /usr/hdp/2.3.2.0-2950/hadoop-yarn/*, /usr/hdp/2.3.2.0-2950/hadoop-yarn/lib/*</value>
+    </property>
+
+    <property>
+        <name>yarn.scheduler.minimum-allocation-mb</name>
+        <value>1024</value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.aux-services</name>
+        <value>mapreduce_shuffle</value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.aux-services.mapreduce.shuffle.class</name>
+        <value>org.apache.hadoop.mapred.ShuffleHandler</value>
+    </property>
+
+    <property>
+        <name>yarn.resourcemanager.scheduler.class</name>
+        <value>org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler</value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.resource.memory-mb</name>
+        <value>87040</value>
+    </property>
+</configuration>

--- a/dev/docker/ubuntu12.04-jdk7-mesos0.24/Dockerfile
+++ b/dev/docker/ubuntu12.04-jdk7-mesos0.24/Dockerfile
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM reefrt/apache2.7
+MAINTAINER Apache REEF (incubator) <dev@reef.incubator.apache.org>
+
+RUN ln -s /usr/lib/jvm/java-7-oracle/jre/lib/amd64/server/libjvm.so /usr/bin/libjvm.so
+
+# Apache Mesos 0.24.1
+RUN \
+  apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
+  echo "deb http://repos.mesosphere.io/ubuntu precise main" > /etc/apt/sources.list.d/mesosphere.list && \
+  apt-get -y update && \
+  apt-get install -y mesos=0.24.1-0.2.35.ubuntu1204 && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+ENV HADOOP_HOME=$HADOOP_PREFIX
+RUN echo 'PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/hadoop/bin"' >> /etc/environment
+COPY init-nn.sh /root/
+
+EXPOSE 22 5050

--- a/dev/docker/ubuntu12.04-jdk7-mesos0.24/init-nn.sh
+++ b/dev/docker/ubuntu12.04-jdk7-mesos0.24/init-nn.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+/usr/sbin/sshd
+
+hostname > /usr/etc/mesos/masters
+grep hdn /etc/hosts | awk '{print $1}' | sort | uniq > $HADOOP_PREFIX/etc/hadoop/slaves
+cp $HADOOP_PREFIX/etc/hadoop/slaves /usr/etc/mesos/slaves
+for host in `cat $HADOOP_PREFIX/etc/hadoop/slaves`
+do
+    scp /etc/hosts $host:/etc/hosts
+    scp $HADOOP_PREFIX/etc/hadoop/slaves $host:$HADOOP_PREFIX/etc/hadoop/slaves
+    scp /usr/etc/mesos/masters $host:/usr/etc/mesos/masters
+    scp /usr/etc/mesos/slaves $host:/usr/etc/mesos/slaves
+    ssh $host nohup mesos-daemon.sh mesos-slave --master=hnn-001-01:5050 --docker_mesos_image=ubuntu12.04-jdk7-mesos0.24
+done
+
+/usr/local/hadoop/bin/hdfs namenode -format
+/usr/local/hadoop/sbin/start-dfs.sh
+mesos-daemon.sh mesos-master --cluster=REEF --work_dir=/var/lib/mesos --log_dir=/var/log/mesos
+
+cd ~ && /bin/bash

--- a/dev/docker/ubuntu12.04-jdk7-mesos0.25/Dockerfile
+++ b/dev/docker/ubuntu12.04-jdk7-mesos0.25/Dockerfile
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM reefrt/apache2.7
+MAINTAINER Apache REEF (incubator) <dev@reef.incubator.apache.org>
+
+RUN ln -s /usr/lib/jvm/java-7-oracle/jre/lib/amd64/server/libjvm.so /usr/bin/libjvm.so
+
+# Apache Mesos 0.25.0
+RUN \
+  apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
+  echo "deb http://repos.mesosphere.io/ubuntu precise main" > /etc/apt/sources.list.d/mesosphere.list && \
+  apt-get -y update && \
+  apt-get install -y mesos && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+ENV HADOOP_HOME=$HADOOP_PREFIX
+RUN echo 'PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/hadoop/bin"' >> /etc/environment
+COPY init-nn.sh /root/
+
+EXPOSE 22 5050

--- a/dev/docker/ubuntu12.04-jdk7-mesos0.25/init-nn.sh
+++ b/dev/docker/ubuntu12.04-jdk7-mesos0.25/init-nn.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+/usr/sbin/sshd
+
+hostname > /usr/etc/mesos/masters
+grep hdn /etc/hosts | awk '{print $1}' | sort | uniq > $HADOOP_PREFIX/etc/hadoop/slaves
+cp $HADOOP_PREFIX/etc/hadoop/slaves /usr/etc/mesos/slaves
+for host in `cat $HADOOP_PREFIX/etc/hadoop/slaves`
+do
+    scp /etc/hosts $host:/etc/hosts
+    scp $HADOOP_PREFIX/etc/hadoop/slaves $host:$HADOOP_PREFIX/etc/hadoop/slaves
+    scp /usr/etc/mesos/masters $host:/usr/etc/mesos/masters
+    scp /usr/etc/mesos/slaves $host:/usr/etc/mesos/slaves
+    ssh $host mesos-daemon.sh mesos-slave --master=hnn-001-01:5050
+done
+
+/usr/local/hadoop/bin/hdfs namenode -format
+/usr/local/hadoop/sbin/start-dfs.sh
+mesos-daemon.sh mesos-master --cluster=REEF --work_dir=/var/lib/mesos --log_dir=/var/log/mesos
+
+cd ~ && /bin/bash

--- a/dev/docker/ubuntu12.04-jdk7/Dockerfile
+++ b/dev/docker/ubuntu12.04-jdk7/Dockerfile
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM ubuntu:12.04
+MAINTAINER Apache REEF (incubator) <dev@reef.incubator.apache.org>
+
+RUN \
+  apt-get update && \
+  apt-get install -y openssh-server python-software-properties && \
+  apt-get clean
+
+RUN \
+  mkdir /var/run/sshd && \
+  ssh-keygen -q -N "" -t rsa -f /root/.ssh/id_rsa && \
+  cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
+  sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd && \
+  echo 'StrictHostKeyChecking no' > /root/.ssh/config
+COPY start.sh /root/
+
+# java
+RUN \
+  echo oracle-java7-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
+  add-apt-repository -y ppa:webupd8team/java && \
+  apt-get update && \
+  apt-get install -y oracle-java7-installer && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* && \
+  rm -rf /var/cache/oracle-jdk7-installer
+
+ENV JAVA_HOME /usr/lib/jvm/java-7-oracle
+ENV PATH $PATH:$JAVA_HOME/bin
+RUN echo 'JAVA_HOME="/usr/lib/jvm/java-7-oracle"' >> /etc/environment

--- a/dev/docker/ubuntu12.04-jdk7/start.sh
+++ b/dev/docker/ubuntu12.04-jdk7/start.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+/usr/sbin/sshd
+
+while true; do sleep 1000; done


### PR DESCRIPTION
This PR provides docker-related scripts in order to run `runyarntests.sh`
and `runmesostests.sh` in a development environment. Developers can verify
their newly developed codes in their own PCs.
The followings are the target test environments.
  * Apache Hadoop 2.7.1
  * HDInsight 3.1 and 3.2
  * HDP 2.2 and 2.3
  * Mesos 0.24 and 0.25

JIRA:
  [REEF-926](https://issues.apache.org/jira/browse/REEF-926)

Pull request:
  This closes #