### PR TITLE
[REEF-935] Close EvaluatorMessageDispatcher upon Evaluator completion…

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
@@ -306,6 +306,7 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
           this.messageDispatcher.onDriverRestartEvaluatorFailed(failedEvaluator);
         } else {
           this.messageDispatcher.onEvaluatorFailed(failedEvaluator);
+          this.messageDispatcher.close();
         }
 
       } catch (final Exception e) {
@@ -416,6 +417,11 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
     LOG.log(Level.FINEST, "Evaluator {0} done.", getId());
     this.stateManager.setDone();
     this.messageDispatcher.onEvaluatorCompleted(new CompletedEvaluatorImpl(this.evaluatorId));
+    try {
+      this.messageDispatcher.close();
+    } catch (Exception e) {
+      LOG.log(Level.SEVERE, "Exception while handling CompletedEvaluator", e);
+    }
     close();
   }
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorManager.java
@@ -253,6 +253,12 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
         }
       }
     }
+
+    try {
+      this.messageDispatcher.close();
+    } catch (Exception e) {
+      LOG.log(Level.SEVERE, "Exception while closing EvaluatorManager", e);
+    }
     this.idlenessSource.check();
   }
 
@@ -306,7 +312,6 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
           this.messageDispatcher.onDriverRestartEvaluatorFailed(failedEvaluator);
         } else {
           this.messageDispatcher.onEvaluatorFailed(failedEvaluator);
-          this.messageDispatcher.close();
         }
 
       } catch (final Exception e) {
@@ -417,11 +422,6 @@ public final class EvaluatorManager implements Identifiable, AutoCloseable {
     LOG.log(Level.FINEST, "Evaluator {0} done.", getId());
     this.stateManager.setDone();
     this.messageDispatcher.onEvaluatorCompleted(new CompletedEvaluatorImpl(this.evaluatorId));
-    try {
-      this.messageDispatcher.close();
-    } catch (Exception e) {
-      LOG.log(Level.SEVERE, "Exception while handling CompletedEvaluator", e);
-    }
     close();
   }
 

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorMessageDispatcher.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/evaluator/EvaluatorMessageDispatcher.java
@@ -41,7 +41,7 @@ import java.util.logging.Logger;
 /**
  * Central dispatcher for all Evaluator related events. This exists once per Evaluator.
  */
-public final class EvaluatorMessageDispatcher {
+public final class EvaluatorMessageDispatcher implements AutoCloseable {
 
   private static final Logger LOG = Logger.getLogger(EvaluatorMessageDispatcher.class.getName());
 
@@ -278,5 +278,13 @@ public final class EvaluatorMessageDispatcher {
   private <T, U extends T> void dispatchForRestartedDriver(final Class<T> type, final U message) {
     this.driverRestartServiceDispatcher.onNext(type, message);
     this.driverRestartApplicationDispatcher.onNext(type, message);
+  }
+
+  @Override
+  public void close() throws Exception {
+    /**
+     * This effectively closes all dispatchers as they share the same stage.
+     */
+    this.serviceDispatcher.close();
   }
 }


### PR DESCRIPTION
… and failure

This addressed the issue by
* Making EvaluatorMessageDispatcher AutoCloseable
* Closing the dispatcher in appropriate methods of EvaluatorManager

JIRA:
[REEF-935](https://issues.apache.org/jira/browse/REEF-935)