### PR TITLE
[REEF-938] Runtime folder path is too long in some tests

### DIFF
--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSimpleEventHandlers.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSimpleEventHandlers.cs
@@ -48,7 +48,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
         [Timeout(180 * 1000)]
         public void RunSimpleEventHandlerOnLocalRuntime()
         {
-            string testFolder = DefaultRuntimeFolder + Guid.NewGuid().ToString("N").Substring(4);
+            string testFolder = DefaultRuntimeFolder + Guid.NewGuid().ToString("N").Substring(0, 4);
             CleanUp(testFolder);
             TestRun(DriverConfigurations(), typeof(HelloSimpleEventHandlers), 2, "simpleHandler", "local", testFolder);
             ValidateSuccessForLocalRuntime(1, testFolder);

--- a/lang/cs/Org.Apache.REEF.Tests/Utility/TestDriverConfigGenerator.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Utility/TestDriverConfigGenerator.cs
@@ -33,7 +33,7 @@ namespace Org.Apache.REEF.Tests.Utility
             {
                 DriverMemory = 1024,
                 DriverIdentifier = "juliaDriverId",
-                SubmissionDirectory = "reefClrBridgeTmp/job_" + Guid.NewGuid().ToString("N").Substring(0, 8),
+                SubmissionDirectory = "reefClrBridgeTmp/job_" + Guid.NewGuid().ToString("N").Substring(0, 4),
                 IncludingHttpServer = true,
                 IncludingNameServer = true,
                 ClrFolder = ".",
@@ -50,7 +50,7 @@ namespace Org.Apache.REEF.Tests.Utility
             {
                 DriverMemory = 1024,
                 DriverIdentifier = "juliaDriverId",
-                SubmissionDirectory = "reefClrBridgeTmp/job_" + Guid.NewGuid().ToString("N").Substring(0, 8),
+                SubmissionDirectory = "reefClrBridgeTmp/job_" + Guid.NewGuid().ToString("N").Substring(0, 4),
                 IncludingHttpServer = false,
                 IncludingNameServer = true,
                 ClrFolder = ".",
@@ -67,7 +67,7 @@ namespace Org.Apache.REEF.Tests.Utility
             {
                 DriverMemory = 1024,
                 DriverIdentifier = "juliaDriverId",
-                SubmissionDirectory = "reefClrBridgeTmp/job_" + Guid.NewGuid().ToString("N").Substring(0, 8),
+                SubmissionDirectory = "reefClrBridgeTmp/job_" + Guid.NewGuid().ToString("N").Substring(0, 4),
                 IncludingHttpServer = true,
                 IncludingNameServer = false,
                 ClrFolder = ".",
@@ -84,7 +84,7 @@ namespace Org.Apache.REEF.Tests.Utility
             {
                 DriverMemory = 1024,
                 DriverIdentifier = "juliaDriverId",
-                SubmissionDirectory = "reefClrBridgeTmp/job_" + Guid.NewGuid().ToString("N").Substring(0, 8),
+                SubmissionDirectory = "reefClrBridgeTmp/job_" + Guid.NewGuid().ToString("N").Substring(0, 4),
                 IncludingHttpServer = false,
                 IncludingNameServer = false,
                 ClrFolder = ".",


### PR DESCRIPTION
Limit the folder name to have 4 sub strings from a GUID and fix issue in TestSimpleEventHandlers

JIRA: [REEF-938](https://issues.apache.org/jira/browse/REEF-938)

This closes #