### PR TITLE
[REEF-949] Remove unnecessary TODO comment in Mesos-runtime module

### DIFF
--- a/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/REEFScheduler.java
+++ b/lang/java/reef-runtime-mesos/src/main/java/org/apache/reef/runtime/mesos/driver/REEFScheduler.java
@@ -135,7 +135,7 @@ final class REEFScheduler implements Scheduler {
     this.schedulerDriverEStage = schedulerDriverEStage;
 
     final Protos.FrameworkInfo frameworkInfo = Protos.FrameworkInfo.newBuilder()
-        .setUser("") // TODO: make it configurable.
+        .setUser("")
         .setName(REEF_JOB_NAME_PREFIX + jobIdentifier)
         .build();
     this.mesosMaster = new MesosSchedulerDriver(this, frameworkInfo, masterIp);


### PR DESCRIPTION
Since the current code already submits its executing user to Mesos,
this PR simply remove the comment to prevent further confusion.

JIRA:
  [REEF-949](https://issues.apache.org/jira/browse/REEF-949)

Pull request:
  This closes #