### PR TITLE
[REEF-950] Make Tang allow empty string as a default value for String NamedParameter

### DIFF
--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/annotations/NamedParameter.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/annotations/NamedParameter.java
@@ -24,13 +24,15 @@ import java.lang.annotation.*;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 public @interface NamedParameter {
+  String REEF_UNINITIALIZED_VALUE = "__REEF_UNINITIALIZED_VALUE__";
+
   //Class<?> type() default String.class;
   String doc() default "";
 
   String short_name() default "";
 
   // One of the following should be set.
-  String default_value() default "";
+  String default_value() default REEF_UNINITIALIZED_VALUE;
 
   Class<?> default_class() default Void.class;
 

--- a/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/JavaNodeFactory.java
+++ b/lang/java/reef-tang/tang/src/main/java/org/apache/reef/tang/implementation/java/JavaNodeFactory.java
@@ -172,11 +172,11 @@ public final class JavaNodeFactory {
     final boolean hasStringDefault, hasClassDefault, hasStringSetDefault, hasClassSetDefault;
 
     int defaultCount = 0;
-    if (!namedParameter.default_value().isEmpty()) {
+    if (namedParameter.default_value().equals(NamedParameter.REEF_UNINITIALIZED_VALUE)) {
+      hasStringDefault = false;
+    } else {
       hasStringDefault = true;
       defaultCount++;
-    } else {
-      hasStringDefault = false;
     }
     if (namedParameter.default_class() != Void.class) {
       hasClassDefault = true;

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestTang.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestTang.java
@@ -27,6 +27,9 @@ import org.apache.reef.tang.exceptions.ClassHierarchyException;
 import org.apache.reef.tang.exceptions.InjectionException;
 import org.apache.reef.tang.exceptions.NameResolutionException;
 import org.apache.reef.tang.formats.AvroConfigurationSerializer;
+import org.apache.reef.tang.formats.ConfigurationModule;
+import org.apache.reef.tang.formats.ConfigurationModuleBuilder;
+import org.apache.reef.tang.formats.OptionalParameter;
 import org.apache.reef.tang.util.ReflectionUtilities;
 import org.junit.Assert;
 import org.junit.Before;
@@ -712,6 +715,27 @@ public class TestTang {
     final Injector i = Tang.Factory.getTang().newInjector(cb.build());
     final CheckChildIface o1 = i.getInstance(CheckChildIface.class);
     Assert.assertTrue(o1 instanceof CheckChildImpl);
+  }
+
+  /**
+   * Tang supports empty string, '', as a default value.
+   */
+  @Test
+  public void testEmptyStringAsDefaultValue() throws InjectionException {
+    final ConfigurationModule cm = new EmptyStringAsDefaultParamConf()
+        .bindNamedParameter(EmptyStringAsDefaultParam.class, EmptyStringAsDefaultParamConf.OPTIONAL_STRING)
+        .build();
+    final Configuration conf = cm.build();
+    String value = Tang.Factory.getTang().newInjector(conf).getNamedInstance(EmptyStringAsDefaultParam.class);
+    Assert.assertEquals("", value);
+  }
+
+  @NamedParameter(default_value = "")
+  class EmptyStringAsDefaultParam implements Name<String> {
+  }
+
+  public static class EmptyStringAsDefaultParamConf extends ConfigurationModuleBuilder {
+    public static final OptionalParameter<String> OPTIONAL_STRING = new OptionalParameter<>();
   }
 }
 

--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestTang.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/TestTang.java
@@ -722,10 +722,7 @@ public class TestTang {
    */
   @Test
   public void testEmptyStringAsDefaultValue() throws InjectionException {
-    final ConfigurationModule cm = new EmptyStringAsDefaultParamConf()
-        .bindNamedParameter(EmptyStringAsDefaultParam.class, EmptyStringAsDefaultParamConf.OPTIONAL_STRING)
-        .build();
-    final Configuration conf = cm.build();
+    final Configuration conf = EmptyStringAsDefaultParamConf.CONF.build();
     String value = Tang.Factory.getTang().newInjector(conf).getNamedInstance(EmptyStringAsDefaultParam.class);
     Assert.assertEquals("", value);
   }
@@ -736,6 +733,10 @@ public class TestTang {
 
   public static class EmptyStringAsDefaultParamConf extends ConfigurationModuleBuilder {
     public static final OptionalParameter<String> OPTIONAL_STRING = new OptionalParameter<>();
+
+    public static final ConfigurationModule CONF = new EmptyStringAsDefaultParamConf()
+        .bindNamedParameter(EmptyStringAsDefaultParam.class, EmptyStringAsDefaultParamConf.OPTIONAL_STRING)
+        .build();
   }
 }
 


### PR DESCRIPTION
  This PR resolves that Tang raises InjectionException for String NamedParameter
  whose default value is defined with "".

JIRA:
  [REEF-950](https://issues.apache.org/jira/browse/REEF-950)

Pull request:
  This closes #