### PR TITLE
[REEF-959] Add javadoc for 8 packages and fix documentation errors

### DIFF
--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/messaging/driver/package-info.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/messaging/driver/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Tests the messaging channel between client and driver.
  */
 package org.apache.reef.tests.messaging.driver;

--- a/lang/java/reef-tests/src/main/java/org/apache/reef/tests/messaging/task/package-info.java
+++ b/lang/java/reef-tests/src/main/java/org/apache/reef/tests/messaging/task/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Test message exchange between the Task and the Driver.
  */
 package org.apache.reef.tests.messaging.task;

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/FailureTest.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/FailureTest.java
@@ -29,8 +29,6 @@ import org.junit.Test;
 
 public class FailureTest {
 
-  private static final int JOB_TIMEOUT = 2 * 60 * 1000;
-
   private final TestEnvironment testEnvironment = TestEnvironmentFactory.getNewTestEnvironment();
 
   @Before

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/close_eval/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/close_eval/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Tests for evaluator allocation by asking for allocations that it immediately closes.
  */
 package org.apache.reef.tests.close_eval;

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/driver/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/driver/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Test for Driver start mechanism by launching noop driver.
  */
 package org.apache.reef.tests.driver;

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorreuse/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/evaluatorreuse/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Tests for Evaluator reusability across Tasks.
  */
 package org.apache.reef.tests.evaluatorreuse;

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/fail/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/fail/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Tests for failure handling mechanism.
  */
 package org.apache.reef.tests.fail;

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/multipleEventHandlerInstances/Client.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/multipleEventHandlerInstances/Client.java
@@ -40,7 +40,7 @@ public class Client {
   /**
    * Number of milliseconds to wait for the job to complete.
    */
-  private static final int JOB_TIMEOUT = 300000; // 10 sec.
+  private static final int JOB_TIMEOUT = 300000; // 300 sec.
 
   public static LauncherStatus runReefJob(final Configuration runtimeConf, final int timeOut)
       throws BindException, InjectionException {
@@ -61,7 +61,6 @@ public class Client {
   }
 
   /**
-   * @param args command line parameters.
    * @throws BindException      configuration error.
    * @throws InjectionException configuration error.
    */

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/multipleEventHandlerInstances/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/multipleEventHandlerInstances/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Tests for multiple event handler registration.
  */
 package org.apache.reef.tests.multipleEventHandlerInstances;

--- a/lang/java/reef-tests/src/test/java/org/apache/reef/tests/package-info.java
+++ b/lang/java/reef-tests/src/test/java/org/apache/reef/tests/package-info.java
@@ -17,6 +17,6 @@
  * under the License.
  */
 /**
- * TODO: Document.
+ * Tests for REEF implementations.
  */
 package org.apache.reef.tests;


### PR DESCRIPTION
This PR resolves the following items in reef-tests.
  * Add descriptions for 8 packages to remove all "TODO: Documents"
  * Remove unused variable
  * Fix documentation errors

JIRA:
  [REEF-959](https://issues.apache.org/jira/browse/REEF-959)

Pull request:
  This closes #