### PR TITLE
[REEF-951] Allow empty string as default for a named parameter

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common/Services/ServiceConfiguration.cs
+++ b/lang/cs/Org.Apache.REEF.Common/Services/ServiceConfiguration.cs
@@ -17,13 +17,10 @@
  * under the License.
  */
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Org.Apache.REEF.Tang.Annotations;
-using Org.Apache.REEF.Tang.Exceptions;
 using Org.Apache.REEF.Tang.Formats;
-using Org.Apache.REEF.Tang.Implementations.Configuration;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
@@ -47,7 +44,6 @@ namespace Org.Apache.REEF.Common.Services
         public static readonly OptionalParameter<IService> Services = new OptionalParameter<IService>();
 
         public ServiceConfiguration()
-            : base()
         {
         }
 
@@ -86,8 +82,9 @@ namespace Org.Apache.REEF.Common.Services
         public ISet<IService> Services { get; set; }
     }
 
-    [NamedParameter("Set of services", "servicesSet", "")]
+    [NamedParameter("Set of services", "servicesSet")]
     class ServicesSet : Name<ISet<IService>>
     {      
     }
 }
+

--- a/lang/cs/Org.Apache.REEF.Tang.Tests/Tang/TestTang.cs
+++ b/lang/cs/Org.Apache.REEF.Tang.Tests/Tang/TestTang.cs
@@ -23,6 +23,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Tang.Annotations;
 using Org.Apache.REEF.Tang.Examples;
 using Org.Apache.REEF.Tang.Exceptions;
+using Org.Apache.REEF.Tang.Formats;
 using Org.Apache.REEF.Tang.Implementations.InjectionPlan;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
@@ -546,6 +547,14 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
             IMultiLayer o = tang.NewInjector(cb.Build()).GetInstance<IMultiLayer>();
             Assert.IsNotNull(o);
         }
+
+        [TestMethod]
+        public void TestEmptyStringAsDefaultValue()
+        {
+            ICsConfigurationBuilder cb = tang.NewConfigurationBuilder(EmptyStringAsDefaultParamConf.ConfigurationModule.Build());
+            var value = tang.NewInjector(cb.Build()).GetNamedInstance<EmptyStringAsDefaultParam, string>();
+            Assert.IsNotNull(value.Equals(""));
+        }
     }
 
     internal class InjectInjector
@@ -831,8 +840,36 @@ namespace Org.Apache.REEF.Tang.Tests.Tang
             }
         }
     }
-    
-    class ThreeConstructors 
+
+    [NamedParameter(DefaultValue = "")]
+    public class EmptyStringAsDefaultParam : Name<string>
+    {
+    }
+
+    public class EmptyStringAsDefaultParamConf : ConfigurationModuleBuilder
+    {
+        public static readonly OptionalParameter<string> OptionalString = new OptionalParameter<string>();
+
+        public static ConfigurationModule ConfigurationModule = new EmptyStringAsDefaultParamConf()
+       .BindNamedParameter(GenericType<EmptyStringAsDefaultParam>.Class, OptionalString)
+       .Build();
+    }
+
+    [NamedParameter]
+    public class StringWithoutDefaultParam : Name<string>
+    {
+    }
+
+    public class StringWithoutDefaultParamConf : ConfigurationModuleBuilder
+    {
+        public static readonly OptionalParameter<string> OptionalString = new OptionalParameter<string>();
+
+        public static ConfigurationModule ConfigurationModule = new StringWithoutDefaultParamConf()
+       .BindNamedParameter(GenericType<StringWithoutDefaultParam>.Class, OptionalString)
+       .Build();
+    }
+
+    class ThreeConstructors
     {
         public int i;
         public string s;

--- a/lang/cs/Org.Apache.REEF.Tang/Annotations/NamedParameter.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Annotations/NamedParameter.cs
@@ -37,7 +37,7 @@ namespace Org.Apache.REEF.Tang.Annotations
         public string AliasLanguage { get; set; }
 
         public NamedParameterAttribute(string documentation = "", string shortName = "",
-            string defaultValue = "__REEF_UNINITIALIZED_VALUE__", Type defaultClass = null, string[] defaultValues = null, Type[] defaultClasses = null, string alias = null, string aliasLanguage = AvroConfigurationSerializer.Java)
+            string defaultValue = ReefUninitializedValue, Type defaultClass = null, string[] defaultValues = null, Type[] defaultClasses = null, string alias = null, string aliasLanguage = AvroConfigurationSerializer.Java)
         {
             this.Documentation = documentation;
             this.ShortName = shortName;

--- a/lang/cs/Org.Apache.REEF.Tang/Annotations/NamedParameter.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Annotations/NamedParameter.cs
@@ -25,6 +25,8 @@ namespace Org.Apache.REEF.Tang.Annotations
     [System.AttributeUsage(System.AttributeTargets.Class)]
     public class NamedParameterAttribute : System.Attribute
     {
+        public const string ReefUninitializedValue = "__REEF_UNINITIALIZED_VALUE__";
+
         public string Documentation { get; set; }
         public string ShortName { get; set; }
         public string DefaultValue { get; set; }
@@ -35,7 +37,7 @@ namespace Org.Apache.REEF.Tang.Annotations
         public string AliasLanguage { get; set; }
 
         public NamedParameterAttribute(string documentation = "", string shortName = "",
-            string defaultValue = "", Type defaultClass = null, string[] defaultValues = null, Type[] defaultClasses = null, string alias = null, string aliasLanguage = AvroConfigurationSerializer.Java)
+            string defaultValue = "__REEF_UNINITIALIZED_VALUE__", Type defaultClass = null, string[] defaultValues = null, Type[] defaultClasses = null, string alias = null, string aliasLanguage = AvroConfigurationSerializer.Java)
         {
             this.Documentation = documentation;
             this.ShortName = shortName;

--- a/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/NodeFactory.cs
+++ b/lang/cs/Org.Apache.REEF.Tang/Implementations/ClassHierarchy/NodeFactory.cs
@@ -200,15 +200,14 @@ namespace Org.Apache.REEF.Tang.Implementations.ClassHierarchy
 
             bool hasStringDefault, hasClassDefault, hasStringSetDefault, hasClassSetDefault;
             int default_count = 0;
-            //if(!namedParameter.default_value().isEmpty()) {  //QUESTION: difference from below? 
-            if (namedParameter.DefaultValue != null && namedParameter.DefaultValue.Length > 0)
+            if (namedParameter.DefaultValue == null || namedParameter.DefaultValue.Equals(NamedParameterAttribute.ReefUninitializedValue))
             {
-                hasStringDefault = true;
-                default_count++;
+                hasStringDefault = false;
             }
             else
             {
-                hasStringDefault = false;
+                hasStringDefault = true;
+                default_count++;
             }
 
             if (namedParameter.DefaultClass != null /*Void.class*/)


### PR DESCRIPTION
Similar change as in REEF-950
Redefine internally used default and allow the user to use empty string as default
Add test cases
Fix default setting for serviceSet

JIRA: [REEF-951](https://issues.apache.org/jira/browse/REEF-951)

This closes #