### PR TITLE
[REEF-969] Fix FailedEvaluatorHandlerTest

### DIFF
--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedEvaluatorEventHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestFailedEvaluatorEventHandler.cs
@@ -18,8 +18,6 @@
  */
 
 using System;
-using System.IO;
-using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.Driver;
@@ -54,7 +52,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
             CleanUp(testFolder);
             TestRun(DriverConfigurations(), typeof(FailedEvaluatorDriver), 1, "failedEvaluatorTest", "local", testFolder);
             ValidateSuccessForLocalRuntime(0, numberOfEvaluatorsToFail: 1, testFolder: testFolder);
-            ValidateSuccessForFailedEvaluator(testFolder);
+            ValidateMessageSuccessfullyLogged(FailedEvaluatorMessage, testFolder);
             CleanUp(testFolder);
         }
 
@@ -70,13 +68,6 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
             return TangFactory.GetTang().NewConfigurationBuilder(driverConfig)
                 .BindSetEntry<DriverBridgeConfigurationOptions.SetOfAssemblies, string>(typeof(FailEvaluatorTask).Assembly.GetName().Name)
                 .Build();
-        }
-
-        private void ValidateSuccessForFailedEvaluator(string testFolder)
-        {
-            string[] lines = File.ReadAllLines(GetLogFile(_stdout, testFolder));
-            string[] successIndicators = lines.Where(s => s.Contains(FailedEvaluatorMessage)).ToArray();
-            Assert.IsTrue(successIndicators.Any());
         }
 
         private sealed class FailedEvaluatorDriver : IObserver<IDriverStarted>, IObserver<IAllocatedEvaluator>, 
@@ -107,7 +98,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
 
             public void OnNext(ICompletedEvaluator value)
             {
-                throw new Exception("Did not expecte completed evaluator.");
+                throw new Exception("Did not expect completed evaluator.");
             }
 
             public void OnNext(IFailedEvaluator value)

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSimpleEventHandlers.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/Bridge/TestSimpleEventHandlers.cs
@@ -52,7 +52,7 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
             CleanUp(testFolder);
             TestRun(DriverConfigurations(), typeof(HelloSimpleEventHandlers), 2, "simpleHandler", "local", testFolder);
             ValidateSuccessForLocalRuntime(1, testFolder: testFolder);
-            ValidateEvaluatorSetting(testFolder);
+            ValidateMessageSuccessfullyLogged("Evaluator is assigned with 3072 MB of memory and 1 cores.", testFolder);
             CleanUp(testFolder);
         }
 
@@ -80,14 +80,6 @@ namespace Org.Apache.REEF.Tests.Functional.Bridge
                 .BindNamedParameter<IsRetain, bool>(GenericType<IsRetain>.Class, "false")
                 .BindNamedParameter<NumberOfEvaluators, Int32>(GenericType<NumberOfEvaluators>.Class, "1")
                 .Build();
-        }
-
-        private void ValidateEvaluatorSetting(string testFolder)
-        {
-            const string successIndication = "Evaluator is assigned with 3072 MB of memory and 1 cores.";
-            string[] lines = File.ReadAllLines(GetLogFile(_stdout, testFolder));
-            string[] successIndicators = lines.Where(s => s.Contains(successIndication)).ToArray();
-            Assert.IsTrue(successIndicators.Any());
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
@@ -161,8 +161,8 @@ namespace Org.Apache.REEF.Tests.Functional
                 string[] failedTaskIndicators = lines.Where(s => s.Contains(failedTaskIndication)).ToArray();
                 string[] failedIndicators = lines.Where(s => s.Contains(failedEvaluatorIndication)).ToArray();
                 Assert.AreEqual(numberOfEvaluatorsToClose, successIndicators.Length);
-                Assert.AreEqual(numberOfTasksToFail * 3, failedTaskIndicators.Length);
-                Assert.AreEqual(numberOfEvaluatorsToFail * 3, failedIndicators.Length);
+                Assert.AreEqual(numberOfTasksToFail, failedTaskIndicators.Length);
+                Assert.AreEqual(numberOfEvaluatorsToFail, failedIndicators.Length);
             }
             else
             {

--- a/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Functional/ReefFunctionalTest.cs
@@ -171,6 +171,13 @@ namespace Org.Apache.REEF.Tests.Functional
             }
         }
 
+        protected void ValidateMessageSuccessfullyLogged(string message, string testFolder)
+        {
+            string[] lines = File.ReadAllLines(GetLogFile(_stdout, testFolder));
+            string[] successIndicators = lines.Where(s => s.Contains(message)).ToArray();
+            Assert.IsTrue(successIndicators.Any());
+        }
+
         protected void PeriodicUploadLog(object source, ElapsedEventArgs e)
         {
             try


### PR DESCRIPTION
This addressed the issue by
  * Adding a verification message to check for FailedEvaluatorHandler being called.
  * Fix count to check for in ReefFunctionalTest.

JIRA:
  [REEF-969](https://issues.apache.org/jira/browse/REEF-969)