### PR TITLE
[REEF-981] Adjust logging in ResourceManageStatus#isLegalStateTransition

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceManagerStatus.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/resourcemanager/ResourceManagerStatus.java
@@ -160,7 +160,7 @@ public final class ResourceManagerStatus implements EventHandler<RuntimeStatusEv
 
     // handle diagonal elements of the transition matrix
     if (from.equals(to)){
-      LOG.warning("Transition from " + from + " state to the same state. This shouldn't happen.");
+      LOG.finest("Transition from " + from + " state to the same state.");
       return true;
     }
 


### PR DESCRIPTION
This patch:
 * Decreases the level of the logging statement in isLegalStateTransition() from 'warning' to 'finest'

JIRA:
 [REEF-981] (https://issues.apache.org/jira/browse/REEF-981)