### PR TITLE
[REEF-1001] Replace deprecated junit.framework.Assert with org.junit.Assert

### DIFF
--- a/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/formats/TestCommandLine.java
+++ b/lang/java/reef-tang/tang/src/test/java/org/apache/reef/tang/formats/TestCommandLine.java
@@ -18,13 +18,13 @@
  */
 package org.apache.reef.tang.formats;
 
-import junit.framework.Assert;
 import org.apache.commons.cli.ParseException;
 import org.apache.reef.tang.Configuration;
 import org.apache.reef.tang.ConfigurationBuilder;
 import org.apache.reef.tang.Tang;
 import org.apache.reef.tang.exceptions.BindException;
 import org.apache.reef.tang.exceptions.InjectionException;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;


### PR DESCRIPTION
Since JUnit 4.0, junit.framework.Assert is replaced with org.junit.Assert.
This PR replaces the existing `import` statement of junit.framework.Assert.

JIRA:
  [REEF-1001](https://issues.apache.org/jira/browse/REEF-1001)

Pull Request:
  This closes #