### PR TITLE
[REEF-1013] C# Evaluator does not work on HDInsight

### DIFF
--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/EvaluatorConfiguration.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/evaluator/EvaluatorConfiguration.java
@@ -18,6 +18,8 @@
  */
 package org.apache.reef.runtime.common.evaluator;
 
+import org.apache.reef.io.TempFileCreator;
+import org.apache.reef.io.WorkingDirectoryTempFileCreator;
 import org.apache.reef.runtime.common.evaluator.parameters.*;
 import org.apache.reef.runtime.common.launch.parameters.ErrorHandlerRID;
 import org.apache.reef.runtime.common.launch.parameters.LaunchID;
@@ -67,6 +69,7 @@ public final class EvaluatorConfiguration extends ConfigurationModuleBuilder {
    * This is ConfigurationModule for Java Evaluator.
    */
   public static final ConfigurationModule CONF = EVALUATOR_CONFIG_MODULE_BUILDER
+      .bindImplementation(TempFileCreator.class, WorkingDirectoryTempFileCreator.class)
       .bindSetEntry(Clock.RuntimeStartHandler.class, EvaluatorRuntime.RuntimeStartHandler.class)
       .bindSetEntry(Clock.RuntimeStopHandler.class, EvaluatorRuntime.RuntimeStopHandler.class)
       .bindConstructor(ExecutorService.class, ExecutorServiceConstructor.class)

--- a/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/EvaluatorSetupHelper.java
+++ b/lang/java/reef-runtime-yarn/src/main/java/org/apache/reef/runtime/yarn/driver/EvaluatorSetupHelper.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.api.records.LocalResource;
 import org.apache.reef.annotations.audience.DriverSide;
 import org.apache.reef.io.TempFileCreator;
-import org.apache.reef.io.WorkingDirectoryTempFileCreator;
 import org.apache.reef.runtime.common.driver.api.ResourceLaunchEvent;
 import org.apache.reef.runtime.common.files.JobJarMaker;
 import org.apache.reef.runtime.common.files.REEFFileNames;
@@ -141,7 +140,6 @@ final class EvaluatorSetupHelper {
       throws IOException {
     return Tang.Factory.getTang()
         .newConfigurationBuilder(resourceLaunchEvent.getEvaluatorConf())
-        .bindImplementation(TempFileCreator.class, WorkingDirectoryTempFileCreator.class)
         .build();
   }
 }


### PR DESCRIPTION
This addressed the issue by
  * Adding an alias parameter to identify ``TempFileCreator``, which is used in the Hadoop runtime evaluator.conf.

JIRA:
  [REEF-1013](https://issues.apache.org/jira/browse/REEF-1013)