### PR TITLE
[REEF-1015] Fix NSubstitute package version used by o.a.r.IO.Tests

### DIFF
--- a/lang/cs/Org.Apache.REEF.IO.Tests/packages.config
+++ b/lang/cs/Org.Apache.REEF.IO.Tests/packages.config
@@ -18,7 +18,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 <packages>
-  <package id="NSubstitute" version="1.9.2.0" targetFramework="net45" />
+  <package id="NSubstitute" version="1.8.2.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />


### PR DESCRIPTION
This version downgrages NSubstitute version in o.a.r.IO.Tests
to 1.8.2.0 to be consistent across tests.

JIRA:
  [REEF-1015](https://issues.apache.org/jira/browse/REEF-1015)

Pull request:
  This closes #