### PR TITLE
[REEF-998] Migrate unit tests which use only simple attributes to xUnit

### DIFF
--- a/lang/cs/Org.Apache.REEF.Common.Tests/TestHttpSerialization.cs
+++ b/lang/cs/Org.Apache.REEF.Common.Tests/TestHttpSerialization.cs
@@ -18,17 +18,16 @@
  */
 
 using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Common.Avro;
 using Org.Apache.REEF.Utilities;
 using Org.Apache.REEF.Utilities.Logging;
+using Xunit;
 
 namespace Org.Apache.REEF.Common.Tests
 {
     /// <summary>
     /// Class TestHttpSerialization. This class contains unit tests for HttpRequest serailization and deserialization.
     /// </summary>
-    [TestClass]
     public class TestHttpSerialization
     {
         private static readonly Logger LOGGER = Logger.GetLogger(typeof(TestHttpSerialization));
@@ -36,7 +35,7 @@ namespace Org.Apache.REEF.Common.Tests
         /// <summary>
         /// Tests the HTTP request serialization jason round trip.
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void TestHttpRequestSerializationJasonRoundTrip()
         {
             AvroHttpRequest r = CreateAvroHttpRequest();
@@ -47,14 +46,14 @@ namespace Org.Apache.REEF.Common.Tests
 
             var ri = ByteUtilities.ByteArraysToString(r.InputStream);
             var ri1 = ByteUtilities.ByteArraysToString(r1.InputStream);
-            Assert.AreEqual(ri, ri1);
-            Assert.AreEqual(r.QueryString, r1.QueryString);
+            Assert.Equal(ri, ri1);
+            Assert.Equal(r.QueryString, r1.QueryString);
         }
 
         /// <summary>
         /// Tests the HTTP request serialization round trip.
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void TestHttpRequestSerializationBytesRoundTrip()
         {
             AvroHttpRequest r = CreateAvroHttpRequest();
@@ -64,8 +63,8 @@ namespace Org.Apache.REEF.Common.Tests
 
             var ri = ByteUtilities.ByteArraysToString(r.InputStream);
             var ri1 = ByteUtilities.ByteArraysToString(r1.InputStream);
-            Assert.AreEqual(ri, ri1);
-            Assert.AreEqual(r.QueryString, r1.QueryString);
+            Assert.Equal(ri, ri1);
+            Assert.Equal(r.QueryString, r1.QueryString);
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.IMRU.Tests/MapInputWithControlMessageTests.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Tests/MapInputWithControlMessageTests.cs
@@ -27,7 +27,6 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.IMRU.OnREEF;
 using Org.Apache.REEF.IMRU.OnREEF.MapInputWithControlMessage;
 using Org.Apache.REEF.Network.Group.Config;
@@ -39,16 +38,16 @@ using Org.Apache.REEF.Wake.Remote;
 using Org.Apache.REEF.Wake.Remote.Impl;
 using Org.Apache.REEF.Wake.StreamingCodec;
 using Org.Apache.REEF.Wake.StreamingCodec.CommonStreamingCodecs;
+using Xunit;
 
 namespace Org.Apache.REEF.IMRU.Tests
 {
-    [TestClass]
     public class MapInputWithControlMessageTests
     {
         /// <summary>
         /// Tests the codec for TMapInputWithControlMessage
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void TestMapInputWithControlMessageCodec()
         {
             float[] baseMessage = { 0, 1 };
@@ -73,17 +72,17 @@ namespace Org.Apache.REEF.IMRU.Tests
             var message1 = codec.Read(reader);
             var message2 = codec.Read(reader);
 
-            Assert.AreEqual(message1.Message[0], baseMessage[0]);
-            Assert.AreEqual(message1.Message[1], baseMessage[1]);
-            Assert.IsNull(message2.Message);
-            Assert.AreEqual(message1.ControlMessage, MapControlMessage.AnotherRound);
-            Assert.AreEqual(message2.ControlMessage, MapControlMessage.Stop);
+            Assert.Equal(message1.Message[0], baseMessage[0]);
+            Assert.Equal(message1.Message[1], baseMessage[1]);
+            Assert.Null(message2.Message);
+            Assert.Equal(message1.ControlMessage, MapControlMessage.AnotherRound);
+            Assert.Equal(message2.ControlMessage, MapControlMessage.Stop);
         }
 
         /// <summary>
         /// Tests the pipelining Data converter for TMapInputWithControlMessage
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void TestMapInputPipelining()
         {
             int chunkSize = 2;
@@ -108,31 +107,31 @@ namespace Org.Apache.REEF.IMRU.Tests
 
             var chunks2 = dataConverter.PipelineMessage(new MapInputWithControlMessage<int[]>(MapControlMessage.Stop));
 
-            Assert.AreEqual(chunks1.Count, 2);
-            Assert.IsTrue(chunks1[0].Data.Message.Length == 2);
-            Assert.IsTrue(chunks1[1].Data.Message.Length == 1);
-            Assert.AreEqual(chunks1[0].Data.Message[0], baseMessage[0]);
-            Assert.AreEqual(chunks1[0].Data.Message[1], baseMessage[1]);
-            Assert.AreEqual(chunks1[1].Data.Message[0], baseMessage[2]);
-            Assert.AreEqual(chunks1[0].Data.ControlMessage, MapControlMessage.AnotherRound);
-            Assert.AreEqual(chunks1[1].Data.ControlMessage, MapControlMessage.AnotherRound);
-            Assert.AreEqual(chunks1[0].IsLast, false);
-            Assert.AreEqual(chunks1[1].IsLast, true);
+            Assert.Equal(chunks1.Count, 2);
+            Assert.True(chunks1[0].Data.Message.Length == 2);
+            Assert.True(chunks1[1].Data.Message.Length == 1);
+            Assert.Equal(chunks1[0].Data.Message[0], baseMessage[0]);
+            Assert.Equal(chunks1[0].Data.Message[1], baseMessage[1]);
+            Assert.Equal(chunks1[1].Data.Message[0], baseMessage[2]);
+            Assert.Equal(chunks1[0].Data.ControlMessage, MapControlMessage.AnotherRound);
+            Assert.Equal(chunks1[1].Data.ControlMessage, MapControlMessage.AnotherRound);
+            Assert.Equal(chunks1[0].IsLast, false);
+            Assert.Equal(chunks1[1].IsLast, true);
 
-            Assert.AreEqual(chunks2.Count, 1);
-            Assert.IsNull(chunks2[0].Data.Message);
-            Assert.AreEqual(chunks2[0].Data.ControlMessage, MapControlMessage.Stop);
-            Assert.AreEqual(chunks2[0].IsLast, true);
+            Assert.Equal(chunks2.Count, 1);
+            Assert.Null(chunks2[0].Data.Message);
+            Assert.Equal(chunks2[0].Data.ControlMessage, MapControlMessage.Stop);
+            Assert.Equal(chunks2[0].IsLast, true);
 
             var fullMessage1 = dataConverter.FullMessage(chunks1);
             var fullMessage2 = dataConverter.FullMessage(chunks2);
 
-            Assert.AreEqual(fullMessage1.Message[0], baseMessage[0]);
-            Assert.AreEqual(fullMessage1.Message[1], baseMessage[1]);
-            Assert.AreEqual(fullMessage1.Message[2], baseMessage[2]);
-            Assert.AreEqual(fullMessage1.ControlMessage, chunks1[0].Data.ControlMessage);
-            Assert.IsNull(fullMessage2.Message);
-            Assert.AreEqual(fullMessage2.ControlMessage, chunks2[0].Data.ControlMessage);
+            Assert.Equal(fullMessage1.Message[0], baseMessage[0]);
+            Assert.Equal(fullMessage1.Message[1], baseMessage[1]);
+            Assert.Equal(fullMessage1.Message[2], baseMessage[2]);
+            Assert.Equal(fullMessage1.ControlMessage, chunks1[0].Data.ControlMessage);
+            Assert.Null(fullMessage2.Message);
+            Assert.Equal(fullMessage2.ControlMessage, chunks2[0].Data.ControlMessage);
         }
 
         [NamedParameter("Chunk size.")]

--- a/lang/cs/Org.Apache.REEF.IMRU.Tests/MapperCountTest.cs
+++ b/lang/cs/Org.Apache.REEF.IMRU.Tests/MapperCountTest.cs
@@ -17,17 +17,16 @@
  * under the License.
  */
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.IMRU.Examples.MapperCount;
 using Org.Apache.REEF.IMRU.InProcess;
 using Org.Apache.REEF.Tang.Implementations.Tang;
+using Xunit;
 
 namespace Org.Apache.REEF.IMRU.Tests
 {
     /// <summary>
     /// Tests of the mapper counting job.
     /// </summary>
-    [TestClass]
     public class MapperCountTest
     {
         private const int NumberOfMappers = 7;
@@ -35,7 +34,7 @@ namespace Org.Apache.REEF.IMRU.Tests
         /// <summary>
         /// Tests the mapper counting job using the in-process IMRU implementation.
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void TestMapperCountInProcess()
         {
             var tested =
@@ -46,7 +45,7 @@ namespace Org.Apache.REEF.IMRU.Tests
                             .Build())
                     .GetInstance<MapperCount>();
             var result = tested.Run(NumberOfMappers, "", TangFactory.GetTang().NewConfigurationBuilder().Build());
-            Assert.AreEqual(NumberOfMappers, result, "The result of the run should be the number of Mappers.");
+            Assert.True(NumberOfMappers == result, "The result of the run should be the number of Mappers.");
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network.Tests/BlockingCollectionExtensionTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/BlockingCollectionExtensionTests.cs
@@ -19,28 +19,27 @@
 
 using System;
 using System.Collections.Concurrent;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Network.Utilities;
+using Xunit;
 
 namespace Org.Apache.REEF.Network.Tests
 {
-    [TestClass]
     public class BlockingCollectionExtensionTests
     {
-        [TestMethod]
+        [Fact]
         public void TestCollectionContainsElement()
         {
             string item = "abc";
             BlockingCollection<string> collection = new BlockingCollection<string>();
             collection.Add(item);
 
-            Assert.AreEqual(item, collection.Take(item));
+            Assert.Equal(item, collection.Take(item));
 
             // Check that item is no longer in collection
-            Assert.AreEqual(0, collection.Count);
+            Assert.Equal(0, collection.Count);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestCollectionContainsElement2()
         {
             string item = "abc";
@@ -49,16 +48,15 @@ namespace Org.Apache.REEF.Network.Tests
             collection.Add(item);
             collection.Add("dog");
 
-            Assert.AreEqual(item, collection.Take(item));
+            Assert.Equal(item, collection.Take(item));
 
             // Remove remaining items, check that item is not there
-            Assert.AreNotEqual(item, collection.Take());
-            Assert.AreNotEqual(item, collection.Take());
-            Assert.AreEqual(0, collection.Count);
+            Assert.NotEqual(item, collection.Take());
+            Assert.NotEqual(item, collection.Take());
+            Assert.Equal(0, collection.Count);
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(InvalidOperationException))]
+        [Fact]
         public void TestCollectionDoesNotContainsElement()
         {
             string item1 = "abc";
@@ -68,7 +66,7 @@ namespace Org.Apache.REEF.Network.Tests
             collection.Add(item2);
 
             // Should throw InvalidOperationException since item1 is not in collection
-            collection.Take(item1);
+            Assert.Throws<InvalidOperationException>(() => collection.Take(item1));
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommuDriverTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommuDriverTests.cs
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Common.Services;
 using Org.Apache.REEF.Network.Group.Config;
 using Org.Apache.REEF.Tang.Exceptions;
@@ -27,13 +26,13 @@ using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Wake.Remote.Impl;
+using Xunit;
 
 namespace Org.Apache.REEF.Network.Tests.GroupCommunication
 {
-    [TestClass]
     public class GroupCommuDriverTests
     {
-        [TestMethod]
+        [Fact]
         public void TestServiceConfiguration()
         {
             string groupName = "group1";
@@ -66,7 +65,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             // the configuration string is received at Evaluator side
             var serviceConfig2 = new ServiceConfiguration(serviceConfigString);
 
-            Assert.AreEqual(serializer.ToString(serviceConfig), serializer.ToString(serviceConfig2.TangConfig));
+            Assert.Equal(serializer.ToString(serviceConfig), serializer.ToString(serviceConfig2.TangConfig));
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTests.cs
@@ -27,7 +27,6 @@ using System.Net;
 using System.Reactive;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Common.Io;
 using Org.Apache.REEF.Common.Tasks;
 using Org.Apache.REEF.Network.Examples.GroupCommunication;
@@ -53,13 +52,13 @@ using Org.Apache.REEF.Wake.Remote;
 using Org.Apache.REEF.Wake.Remote.Impl;
 using Org.Apache.REEF.Wake.StreamingCodec;
 using Org.Apache.REEF.Wake.StreamingCodec.CommonStreamingCodecs;
+using Xunit;
 
 namespace Org.Apache.REEF.Network.Tests.GroupCommunication
 {
-    [TestClass]
     public class GroupCommunicationTests
     {
-        [TestMethod]
+        [Fact]
         public void TestSender()
         {
             using (var nameServer = NameServerTests.BuildNameServer())
@@ -96,15 +95,15 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
                 string msg1 = (messages2.Take() as GroupCommunicationMessage<string>).Data[0];
                 string msg2 = (messages2.Take() as GroupCommunicationMessage<string>).Data[0];
 
-                Assert.AreEqual("abc", msg1);
-                Assert.AreEqual("def", msg2);
+                Assert.Equal("abc", msg1);
+                Assert.Equal("def", msg2);
 
                 string msg3 = (messages1.Take() as GroupCommunicationMessage<string>).Data[0];
-                Assert.AreEqual("ghi", msg3);
+                Assert.Equal("ghi", msg3);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestBroadcastReduceOperators()
         {
             string groupName = "group1";
@@ -148,8 +147,8 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
 
                 int n1 = broadcastReceiver1.Receive();
                 int n2 = broadcastReceiver2.Receive();
-                Assert.AreEqual(j, n1);
-                Assert.AreEqual(j, n2);
+                Assert.Equal(j, n1);
+                Assert.Equal(j, n2);
 
                 int triangleNum1 = TriangleNumber(n1);
                 triangleNumberSender1.Send(triangleNum1);
@@ -158,14 +157,14 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
 
                 int sum = sumReducer.Reduce();
                 int expected = TriangleNumber(j) * (numTasks - 1);
-                Assert.AreEqual(sum, expected);
+                Assert.Equal(sum, expected);
             }
         }
 
         /// <summary>
         /// This is to test operator injection in CommunicationGroupClient with int[] as message type
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void TestGetBroadcastReduceOperatorsForIntArrayMessageType()
         {
             const string groupName = "group1";
@@ -221,15 +220,15 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IBroadcastReceiver<int[]> broadcastReceiver2 = commGroups[2].GetBroadcastReceiver<int[]>(broadcastOperatorName);
             IReduceSender<int[]> triangleNumberSender2 = commGroups[2].GetReduceSender<int[]>(reduceOperatorName);
 
-            Assert.IsNotNull(broadcastSender);
-            Assert.IsNotNull(sumReducer);
-            Assert.IsNotNull(broadcastReceiver1);
-            Assert.IsNotNull(triangleNumberSender1);
-            Assert.IsNotNull(broadcastReceiver2);
-            Assert.IsNotNull(triangleNumberSender2);
+            Assert.NotNull(broadcastSender);
+            Assert.NotNull(sumReducer);
+            Assert.NotNull(broadcastReceiver1);
+            Assert.NotNull(triangleNumberSender1);
+            Assert.NotNull(broadcastReceiver2);
+            Assert.NotNull(triangleNumberSender2);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestScatterReduceOperators()
         {
             string groupName = "group1";
@@ -273,11 +272,11 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IScatterReceiver<int> receiver4 = commGroups[4].GetScatterReceiver<int>(scatterOperatorName);
             IReduceSender<int> sumSender4 = commGroups[4].GetReduceSender<int>(reduceOperatorName);
 
-            Assert.IsNotNull(sender);
-            Assert.IsNotNull(receiver1);
-            Assert.IsNotNull(receiver2);
-            Assert.IsNotNull(receiver3);
-            Assert.IsNotNull(receiver4);
+            Assert.NotNull(sender);
+            Assert.NotNull(receiver1);
+            Assert.NotNull(receiver2);
+            Assert.NotNull(receiver3);
+            Assert.NotNull(receiver4);
 
             List<int> data = Enumerable.Range(1, 100).ToList();
             List<string> order = new List<string> { "task4", "task3", "task2", "task1" };
@@ -291,10 +290,10 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
 
             int sum = sumReducer.Reduce();
 
-            Assert.AreEqual(sum, data.Sum());
+            Assert.Equal(sum, data.Sum());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestBroadcastOperator()
         {
             string groupName = "group1";
@@ -317,16 +316,16 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IBroadcastReceiver<int> receiver1 = commGroups[1].GetBroadcastReceiver<int>(operatorName);
             IBroadcastReceiver<int> receiver2 = commGroups[2].GetBroadcastReceiver<int>(operatorName);
 
-            Assert.IsNotNull(sender);
-            Assert.IsNotNull(receiver1);
-            Assert.IsNotNull(receiver2);
+            Assert.NotNull(sender);
+            Assert.NotNull(receiver1);
+            Assert.NotNull(receiver2);
 
             sender.Send(value);
-            Assert.AreEqual(value, receiver1.Receive());
-            Assert.AreEqual(value, receiver2.Receive());
+            Assert.Equal(value, receiver1.Receive());
+            Assert.Equal(value, receiver2.Receive());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestBroadcastOperatorWithDefaultCodec()
         {
             INameServer nameServer = NameServerTests.BuildNameServer();
@@ -351,16 +350,16 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IBroadcastReceiver<int> receiver1 = commGroups[1].GetBroadcastReceiver<int>(operatorName);
             IBroadcastReceiver<int> receiver2 = commGroups[2].GetBroadcastReceiver<int>(operatorName);
 
-            Assert.IsNotNull(sender);
-            Assert.IsNotNull(receiver1);
-            Assert.IsNotNull(receiver2);
+            Assert.NotNull(sender);
+            Assert.NotNull(receiver1);
+            Assert.NotNull(receiver2);
 
             sender.Send(value);
-            Assert.AreEqual(value, receiver1.Receive());
-            Assert.AreEqual(value, receiver2.Receive());
+            Assert.Equal(value, receiver1.Receive());
+            Assert.Equal(value, receiver2.Receive());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestBroadcastOperator2()
         {
             string groupName = "group1";
@@ -385,24 +384,24 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IBroadcastReceiver<int> receiver1 = commGroups[1].GetBroadcastReceiver<int>(operatorName);
             IBroadcastReceiver<int> receiver2 = commGroups[2].GetBroadcastReceiver<int>(operatorName);
 
-            Assert.IsNotNull(sender);
-            Assert.IsNotNull(receiver1);
-            Assert.IsNotNull(receiver2);
+            Assert.NotNull(sender);
+            Assert.NotNull(receiver1);
+            Assert.NotNull(receiver2);
 
             sender.Send(value1);
-            Assert.AreEqual(value1, receiver1.Receive());
-            Assert.AreEqual(value1, receiver2.Receive());
+            Assert.Equal(value1, receiver1.Receive());
+            Assert.Equal(value1, receiver2.Receive());
 
             sender.Send(value2);
-            Assert.AreEqual(value2, receiver1.Receive());
-            Assert.AreEqual(value2, receiver2.Receive());
+            Assert.Equal(value2, receiver1.Receive());
+            Assert.Equal(value2, receiver2.Receive());
 
             sender.Send(value3);
-            Assert.AreEqual(value3, receiver1.Receive());
-            Assert.AreEqual(value3, receiver2.Receive());
+            Assert.Equal(value3, receiver1.Receive());
+            Assert.Equal(value3, receiver2.Receive());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestReduceOperator()
         {
             string groupName = "group1";
@@ -425,19 +424,19 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IReduceSender<int> sender2 = commGroups[2].GetReduceSender<int>(operatorName);
             IReduceSender<int> sender3 = commGroups[3].GetReduceSender<int>(operatorName);
 
-            Assert.IsNotNull(receiver);
-            Assert.IsNotNull(sender1);
-            Assert.IsNotNull(sender2);
-            Assert.IsNotNull(sender3);
+            Assert.NotNull(receiver);
+            Assert.NotNull(sender1);
+            Assert.NotNull(sender2);
+            Assert.NotNull(sender3);
 
             sender3.Send(5);
             sender1.Send(1);
             sender2.Send(3);
 
-            Assert.AreEqual(9, receiver.Reduce());
+            Assert.Equal(9, receiver.Reduce());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestReduceOperator2()
         {
             string groupName = "group1";
@@ -460,28 +459,28 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IReduceSender<int> sender2 = commGroups[2].GetReduceSender<int>(operatorName);
             IReduceSender<int> sender3 = commGroups[3].GetReduceSender<int>(operatorName);
 
-            Assert.IsNotNull(receiver);
-            Assert.IsNotNull(sender1);
-            Assert.IsNotNull(sender2);
-            Assert.IsNotNull(sender3);
+            Assert.NotNull(receiver);
+            Assert.NotNull(sender1);
+            Assert.NotNull(sender2);
+            Assert.NotNull(sender3);
 
             sender3.Send(5);
             sender1.Send(1);
             sender2.Send(3);
-            Assert.AreEqual(9, receiver.Reduce());
+            Assert.Equal(9, receiver.Reduce());
 
             sender3.Send(6);
             sender1.Send(2);
             sender2.Send(4);
-            Assert.AreEqual(12, receiver.Reduce());
+            Assert.Equal(12, receiver.Reduce());
 
             sender3.Send(9);
             sender1.Send(3);
             sender2.Send(6);
-            Assert.AreEqual(18, receiver.Reduce());
+            Assert.Equal(18, receiver.Reduce());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestScatterOperator()
         {
             string groupName = "group1";
@@ -505,22 +504,22 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IScatterReceiver<int> receiver3 = commGroups[3].GetScatterReceiver<int>(operatorName);
             IScatterReceiver<int> receiver4 = commGroups[4].GetScatterReceiver<int>(operatorName);
 
-            Assert.IsNotNull(sender);
-            Assert.IsNotNull(receiver1);
-            Assert.IsNotNull(receiver2);
-            Assert.IsNotNull(receiver3);
-            Assert.IsNotNull(receiver4);
+            Assert.NotNull(sender);
+            Assert.NotNull(receiver1);
+            Assert.NotNull(receiver2);
+            Assert.NotNull(receiver3);
+            Assert.NotNull(receiver4);
 
             List<int> data = new List<int> { 1, 2, 3, 4 };
 
             sender.Send(data);
-            Assert.AreEqual(1, receiver1.Receive().Single());
-            Assert.AreEqual(2, receiver2.Receive().Single());
-            Assert.AreEqual(3, receiver3.Receive().Single());
-            Assert.AreEqual(4, receiver4.Receive().Single());
+            Assert.Equal(1, receiver1.Receive().Single());
+            Assert.Equal(2, receiver2.Receive().Single());
+            Assert.Equal(3, receiver3.Receive().Single());
+            Assert.Equal(4, receiver4.Receive().Single());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestScatterOperatorWithDefaultCodec()
         {
             string groupName = "group1";
@@ -544,22 +543,22 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IScatterReceiver<int> receiver3 = commGroups[3].GetScatterReceiver<int>(operatorName);
             IScatterReceiver<int> receiver4 = commGroups[4].GetScatterReceiver<int>(operatorName);
 
-            Assert.IsNotNull(sender);
-            Assert.IsNotNull(receiver1);
-            Assert.IsNotNull(receiver2);
-            Assert.IsNotNull(receiver3);
-            Assert.IsNotNull(receiver4);
+            Assert.NotNull(sender);
+            Assert.NotNull(receiver1);
+            Assert.NotNull(receiver2);
+            Assert.NotNull(receiver3);
+            Assert.NotNull(receiver4);
 
             List<int> data = new List<int> { 1, 2, 3, 4 };
 
             sender.Send(data);
-            Assert.AreEqual(1, receiver1.Receive().Single());
-            Assert.AreEqual(2, receiver2.Receive().Single());
-            Assert.AreEqual(3, receiver3.Receive().Single());
-            Assert.AreEqual(4, receiver4.Receive().Single());
+            Assert.Equal(1, receiver1.Receive().Single());
+            Assert.Equal(2, receiver2.Receive().Single());
+            Assert.Equal(3, receiver3.Receive().Single());
+            Assert.Equal(4, receiver4.Receive().Single());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestScatterOperator2()
         {
             string groupName = "group1";
@@ -583,33 +582,33 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IScatterReceiver<int> receiver3 = commGroups[3].GetScatterReceiver<int>(operatorName);
             IScatterReceiver<int> receiver4 = commGroups[4].GetScatterReceiver<int>(operatorName);
 
-            Assert.IsNotNull(sender);
-            Assert.IsNotNull(receiver1);
-            Assert.IsNotNull(receiver2);
-            Assert.IsNotNull(receiver3);
-            Assert.IsNotNull(receiver4);
+            Assert.NotNull(sender);
+            Assert.NotNull(receiver1);
+            Assert.NotNull(receiver2);
+            Assert.NotNull(receiver3);
+            Assert.NotNull(receiver4);
 
             List<int> data = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8 };
 
             sender.Send(data);
             var data1 = receiver1.Receive();
-            Assert.AreEqual(1, data1.First());
-            Assert.AreEqual(2, data1.Last());
+            Assert.Equal(1, data1.First());
+            Assert.Equal(2, data1.Last());
 
             var data2 = receiver2.Receive();
-            Assert.AreEqual(3, data2.First());
-            Assert.AreEqual(4, data2.Last());
+            Assert.Equal(3, data2.First());
+            Assert.Equal(4, data2.Last());
 
             var data3 = receiver3.Receive();
-            Assert.AreEqual(5, data3.First());
-            Assert.AreEqual(6, data3.Last());
+            Assert.Equal(5, data3.First());
+            Assert.Equal(6, data3.Last());
 
             var data4 = receiver4.Receive();
-            Assert.AreEqual(7, data4.First());
-            Assert.AreEqual(8, data4.Last());
+            Assert.Equal(7, data4.First());
+            Assert.Equal(8, data4.Last());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestScatterOperator3()
         {
             string groupName = "group1";
@@ -632,31 +631,31 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IScatterReceiver<int> receiver2 = commGroups[2].GetScatterReceiver<int>(operatorName);
             IScatterReceiver<int> receiver3 = commGroups[3].GetScatterReceiver<int>(operatorName);
 
-            Assert.IsNotNull(sender);
-            Assert.IsNotNull(receiver1);
-            Assert.IsNotNull(receiver2);
-            Assert.IsNotNull(receiver3);
+            Assert.NotNull(sender);
+            Assert.NotNull(receiver1);
+            Assert.NotNull(receiver2);
+            Assert.NotNull(receiver3);
 
             List<int> data = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8 };
 
             sender.Send(data);
 
             var data1 = receiver1.Receive().ToArray();
-            Assert.AreEqual(1, data1[0]);
-            Assert.AreEqual(2, data1[1]);
-            Assert.AreEqual(3, data1[2]);
+            Assert.Equal(1, data1[0]);
+            Assert.Equal(2, data1[1]);
+            Assert.Equal(3, data1[2]);
 
             var data2 = receiver2.Receive().ToArray();
-            Assert.AreEqual(4, data2[0]);
-            Assert.AreEqual(5, data2[1]);
-            Assert.AreEqual(6, data2[2]);
+            Assert.Equal(4, data2[0]);
+            Assert.Equal(5, data2[1]);
+            Assert.Equal(6, data2[2]);
 
             var data3 = receiver3.Receive().ToArray();
-            Assert.AreEqual(7, data3[0]);
-            Assert.AreEqual(8, data3[1]);
+            Assert.Equal(7, data3[0]);
+            Assert.Equal(8, data3[1]);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestScatterOperator4()
         {
             string groupName = "group1";
@@ -678,10 +677,10 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IScatterReceiver<int> receiver2 = commGroups[2].GetScatterReceiver<int>(operatorName);
             IScatterReceiver<int> receiver3 = commGroups[3].GetScatterReceiver<int>(operatorName);
 
-            Assert.IsNotNull(sender);
-            Assert.IsNotNull(receiver1);
-            Assert.IsNotNull(receiver2);
-            Assert.IsNotNull(receiver3);
+            Assert.NotNull(sender);
+            Assert.NotNull(receiver1);
+            Assert.NotNull(receiver2);
+            Assert.NotNull(receiver3);
 
             List<int> data = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8 };
             List<string> order = new List<string> { "task3", "task2", "task1" };
@@ -689,21 +688,21 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             sender.Send(data, order);
 
             var data3 = receiver3.Receive().ToArray();
-            Assert.AreEqual(1, data3[0]);
-            Assert.AreEqual(2, data3[1]);
-            Assert.AreEqual(3, data3[2]);
+            Assert.Equal(1, data3[0]);
+            Assert.Equal(2, data3[1]);
+            Assert.Equal(3, data3[2]);
 
             var data2 = receiver2.Receive().ToArray();
-            Assert.AreEqual(4, data2[0]);
-            Assert.AreEqual(5, data2[1]);
-            Assert.AreEqual(6, data2[2]);
+            Assert.Equal(4, data2[0]);
+            Assert.Equal(5, data2[1]);
+            Assert.Equal(6, data2[2]);
 
             var data1 = receiver1.Receive().ToArray();
-            Assert.AreEqual(7, data1[0]);
-            Assert.AreEqual(8, data1[1]);
+            Assert.Equal(7, data1[0]);
+            Assert.Equal(8, data1[1]);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestConfigurationBroadcastSpec()
         {
             FlatTopology<int> topology = new FlatTopology<int>("Operator", "Operator", "task1", "driverid",
@@ -720,10 +719,10 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             stream.Position = 0;
             IDataReader reader = new StreamDataReader(stream);
             int res = codec.Read(reader);
-            Assert.AreEqual(3, res);
+            Assert.Equal(3, res);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestConfigurationReduceSpec()
         {
             FlatTopology<int> topology = new FlatTopology<int>("Operator", "Group", "task1", "driverid",
@@ -733,7 +732,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             var conf2 = topology.GetTaskConfiguration("task1");
 
             IReduceFunction<int> reduceFunction = TangFactory.GetTang().NewInjector(conf2).GetInstance<IReduceFunction<int>>();
-            Assert.AreEqual(10, reduceFunction.Reduce(new int[] { 1, 2, 3, 4 }));
+            Assert.Equal(10, reduceFunction.Reduce(new int[] { 1, 2, 3, 4 }));
         }
 
         public static IGroupCommDriver GetInstanceOfGroupCommDriver(string driverId, string masterTaskId, string groupName, int fanOut, int numTasks)
@@ -751,7 +750,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             return groupCommDriver;
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestCodecToStreamingCodecConfiguration()
         {
             var config = CodecToStreamingCodecConfiguration<int>.Conf
@@ -775,10 +774,10 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IDataReader reader = new StreamDataReader(stream);
             var res1 = streamingCodec.Read(reader);
             var res2 = await streamingCodec.ReadAsync(reader, token);
-            Assert.AreEqual(obj, res1.Data);
-            Assert.AreEqual(obj + 1, res2.Data);
-            Assert.AreEqual(true, res1.IsLast);
-            Assert.AreEqual(false, res2.IsLast);
+            Assert.Equal(obj, res1.Data);
+            Assert.Equal(obj + 1, res2.Data);
+            Assert.Equal(true, res1.IsLast);
+            Assert.Equal(false, res2.IsLast);
         }
 
         public static List<ICommunicationGroupClient> CommGroupClients(string groupName, int numTasks, IGroupCommDriver groupCommDriver, ICommunicationGroupDriver commGroupDriver, IConfiguration userServiceConfig)

--- a/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTreeTopologyTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/GroupCommunicationTreeTopologyTests.cs
@@ -19,7 +19,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Network.Group.Config;
 using Org.Apache.REEF.Network.Group.Driver;
 using Org.Apache.REEF.Network.Group.Operators;
@@ -29,13 +28,13 @@ using Org.Apache.REEF.Network.Group.Topology;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Wake.StreamingCodec.CommonStreamingCodecs;
+using Xunit;
 
 namespace Org.Apache.REEF.Network.Tests.GroupCommunication
 {
-    [TestClass]
     public class GroupCommunicationTreeTopologyTests
     {
-        [TestMethod]
+        [Fact]
         public void TestTreeTopology()
         {
             TreeTopology<int> topology = new TreeTopology<int>("Operator", "Operator", "task1", "driverid",
@@ -52,7 +51,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestReduceOperator()
         {
             string groupName = "group1";
@@ -81,16 +80,16 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IReduceSender<int> sender8 = commGroups[8].GetReduceSender<int>(operatorName);
             IReduceSender<int> sender9 = commGroups[9].GetReduceSender<int>(operatorName);
 
-            Assert.IsNotNull(receiver);
-            Assert.IsNotNull(sender1);
-            Assert.IsNotNull(sender2);
-            Assert.IsNotNull(sender3);
-            Assert.IsNotNull(sender4);
-            Assert.IsNotNull(sender5);
-            Assert.IsNotNull(sender6);
-            Assert.IsNotNull(sender7);
-            Assert.IsNotNull(sender8);
-            Assert.IsNotNull(sender9);
+            Assert.NotNull(receiver);
+            Assert.NotNull(sender1);
+            Assert.NotNull(sender2);
+            Assert.NotNull(sender3);
+            Assert.NotNull(sender4);
+            Assert.NotNull(sender5);
+            Assert.NotNull(sender6);
+            Assert.NotNull(sender7);
+            Assert.NotNull(sender8);
+            Assert.NotNull(sender9);
 
             sender9.Send(9);
             sender8.Send(8);
@@ -102,10 +101,10 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             sender2.Send(2);
             sender1.Send(1);
 
-            Assert.AreEqual(45, receiver.Reduce());
+            Assert.Equal(45, receiver.Reduce());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestBroadcastOperator()
         {
             string groupName = "group1";
@@ -137,53 +136,53 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IBroadcastReceiver<int> receiver8 = commGroups[8].GetBroadcastReceiver<int>(operatorName);
             IBroadcastReceiver<int> receiver9 = commGroups[9].GetBroadcastReceiver<int>(operatorName);
 
-            Assert.IsNotNull(sender);
-            Assert.IsNotNull(receiver1);
-            Assert.IsNotNull(receiver2);
-            Assert.IsNotNull(receiver3);
-            Assert.IsNotNull(receiver4);
-            Assert.IsNotNull(receiver5);
-            Assert.IsNotNull(receiver6);
-            Assert.IsNotNull(receiver7);
-            Assert.IsNotNull(receiver8);
-            Assert.IsNotNull(receiver9);
+            Assert.NotNull(sender);
+            Assert.NotNull(receiver1);
+            Assert.NotNull(receiver2);
+            Assert.NotNull(receiver3);
+            Assert.NotNull(receiver4);
+            Assert.NotNull(receiver5);
+            Assert.NotNull(receiver6);
+            Assert.NotNull(receiver7);
+            Assert.NotNull(receiver8);
+            Assert.NotNull(receiver9);
 
             sender.Send(value1);
-            Assert.AreEqual(value1, receiver1.Receive());
-            Assert.AreEqual(value1, receiver2.Receive());
-            Assert.AreEqual(value1, receiver3.Receive());
-            Assert.AreEqual(value1, receiver4.Receive());
-            Assert.AreEqual(value1, receiver5.Receive());
-            Assert.AreEqual(value1, receiver6.Receive());
-            Assert.AreEqual(value1, receiver7.Receive());
-            Assert.AreEqual(value1, receiver8.Receive());
-            Assert.AreEqual(value1, receiver9.Receive());
+            Assert.Equal(value1, receiver1.Receive());
+            Assert.Equal(value1, receiver2.Receive());
+            Assert.Equal(value1, receiver3.Receive());
+            Assert.Equal(value1, receiver4.Receive());
+            Assert.Equal(value1, receiver5.Receive());
+            Assert.Equal(value1, receiver6.Receive());
+            Assert.Equal(value1, receiver7.Receive());
+            Assert.Equal(value1, receiver8.Receive());
+            Assert.Equal(value1, receiver9.Receive());
 
             sender.Send(value2);
-            Assert.AreEqual(value2, receiver1.Receive());
-            Assert.AreEqual(value2, receiver2.Receive());
-            Assert.AreEqual(value2, receiver3.Receive());
-            Assert.AreEqual(value2, receiver4.Receive());
-            Assert.AreEqual(value2, receiver5.Receive());
-            Assert.AreEqual(value2, receiver6.Receive());
-            Assert.AreEqual(value2, receiver7.Receive());
-            Assert.AreEqual(value2, receiver8.Receive());
-            Assert.AreEqual(value2, receiver9.Receive());
+            Assert.Equal(value2, receiver1.Receive());
+            Assert.Equal(value2, receiver2.Receive());
+            Assert.Equal(value2, receiver3.Receive());
+            Assert.Equal(value2, receiver4.Receive());
+            Assert.Equal(value2, receiver5.Receive());
+            Assert.Equal(value2, receiver6.Receive());
+            Assert.Equal(value2, receiver7.Receive());
+            Assert.Equal(value2, receiver8.Receive());
+            Assert.Equal(value2, receiver9.Receive());
 
             sender.Send(value3);
-            Assert.AreEqual(value3, receiver1.Receive());
-            Assert.AreEqual(value3, receiver2.Receive());
-            Assert.AreEqual(value3, receiver3.Receive());
-            Assert.AreEqual(value3, receiver4.Receive());
-            Assert.AreEqual(value3, receiver5.Receive());
-            Assert.AreEqual(value3, receiver6.Receive());
-            Assert.AreEqual(value3, receiver7.Receive());
-            Assert.AreEqual(value3, receiver8.Receive());
-            Assert.AreEqual(value3, receiver9.Receive());
+            Assert.Equal(value3, receiver1.Receive());
+            Assert.Equal(value3, receiver2.Receive());
+            Assert.Equal(value3, receiver3.Receive());
+            Assert.Equal(value3, receiver4.Receive());
+            Assert.Equal(value3, receiver5.Receive());
+            Assert.Equal(value3, receiver6.Receive());
+            Assert.Equal(value3, receiver7.Receive());
+            Assert.Equal(value3, receiver8.Receive());
+            Assert.Equal(value3, receiver9.Receive());
         }
 
 
-        [TestMethod]
+        [Fact]
         public void TestBroadcastReduceOperators()
         {
             string groupName = "group1";
@@ -256,15 +255,15 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
                 int n7 = broadcastReceiver7.Receive();
                 int n8 = broadcastReceiver8.Receive();
                 int n9 = broadcastReceiver9.Receive();
-                Assert.AreEqual(i, n1);
-                Assert.AreEqual(i, n2);
-                Assert.AreEqual(i, n3);
-                Assert.AreEqual(i, n4);
-                Assert.AreEqual(i, n5);
-                Assert.AreEqual(i, n6);
-                Assert.AreEqual(i, n7);
-                Assert.AreEqual(i, n8);
-                Assert.AreEqual(i, n9);
+                Assert.Equal(i, n1);
+                Assert.Equal(i, n2);
+                Assert.Equal(i, n3);
+                Assert.Equal(i, n4);
+                Assert.Equal(i, n5);
+                Assert.Equal(i, n6);
+                Assert.Equal(i, n7);
+                Assert.Equal(i, n8);
+                Assert.Equal(i, n9);
 
                 int triangleNum9 = GroupCommunicationTests.TriangleNumber(n9);
                 triangleNumberSender9.Send(triangleNum9);
@@ -295,11 +294,11 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
 
                 int sum = sumReducer.Reduce();
                 int expected = GroupCommunicationTests.TriangleNumber(i) * (numTasks - 1);
-                Assert.AreEqual(sum, expected);
+                Assert.Equal(sum, expected);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestScatterOperator()
         {
             string groupName = "group1";
@@ -323,28 +322,28 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IScatterReceiver<int> receiver3 = commGroups[3].GetScatterReceiver<int>(operatorName);
             IScatterReceiver<int> receiver4 = commGroups[4].GetScatterReceiver<int>(operatorName);
 
-            Assert.IsNotNull(sender);
-            Assert.IsNotNull(receiver1);
-            Assert.IsNotNull(receiver2);
-            Assert.IsNotNull(receiver3);
-            Assert.IsNotNull(receiver4);
+            Assert.NotNull(sender);
+            Assert.NotNull(receiver1);
+            Assert.NotNull(receiver2);
+            Assert.NotNull(receiver3);
+            Assert.NotNull(receiver4);
 
             List<int> data = new List<int> { 1, 2, 3, 4 };
 
             sender.Send(data);
             var receved1 = receiver1.Receive().ToArray();
-            Assert.AreEqual(1, receved1[0]);
-            Assert.AreEqual(2, receved1[1]);
+            Assert.Equal(1, receved1[0]);
+            Assert.Equal(2, receved1[1]);
 
             var receved2 = receiver2.Receive().ToArray();
-            Assert.AreEqual(3, receved2[0]);
-            Assert.AreEqual(4, receved2[1]);
+            Assert.Equal(3, receved2[0]);
+            Assert.Equal(4, receved2[1]);
 
-            Assert.AreEqual(1, receiver3.Receive().Single());
-            Assert.AreEqual(2, receiver4.Receive().Single());
+            Assert.Equal(1, receiver3.Receive().Single());
+            Assert.Equal(2, receiver4.Receive().Single());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestScatterOperator2()
         {
             string groupName = "group1";
@@ -368,37 +367,37 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IScatterReceiver<int> receiver3 = commGroups[3].GetScatterReceiver<int>(operatorName);
             IScatterReceiver<int> receiver4 = commGroups[4].GetScatterReceiver<int>(operatorName);
 
-            Assert.IsNotNull(sender);
-            Assert.IsNotNull(receiver1);
-            Assert.IsNotNull(receiver2);
-            Assert.IsNotNull(receiver3);
-            Assert.IsNotNull(receiver4);
+            Assert.NotNull(sender);
+            Assert.NotNull(receiver1);
+            Assert.NotNull(receiver2);
+            Assert.NotNull(receiver3);
+            Assert.NotNull(receiver4);
 
             List<int> data = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8 };
 
             sender.Send(data);
             var data1 = receiver1.Receive().ToArray();
-            Assert.AreEqual(1, data1[0]);
-            Assert.AreEqual(2, data1[1]);
-            Assert.AreEqual(3, data1[2]);
-            Assert.AreEqual(4, data1[3]);
+            Assert.Equal(1, data1[0]);
+            Assert.Equal(2, data1[1]);
+            Assert.Equal(3, data1[2]);
+            Assert.Equal(4, data1[3]);
 
             var data2 = receiver2.Receive().ToArray();
-            Assert.AreEqual(5, data2[0]);
-            Assert.AreEqual(6, data2[1]);
-            Assert.AreEqual(7, data2[2]);
-            Assert.AreEqual(8, data2[3]);
+            Assert.Equal(5, data2[0]);
+            Assert.Equal(6, data2[1]);
+            Assert.Equal(7, data2[2]);
+            Assert.Equal(8, data2[3]);
 
             var data3 = receiver3.Receive();
-            Assert.AreEqual(1, data3.First());
-            Assert.AreEqual(2, data3.Last());
+            Assert.Equal(1, data3.First());
+            Assert.Equal(2, data3.Last());
 
             var data4 = receiver4.Receive();
-            Assert.AreEqual(3, data4.First());
-            Assert.AreEqual(4, data4.Last());
+            Assert.Equal(3, data4.First());
+            Assert.Equal(4, data4.Last());
         }
 
-        [TestMethod]
+        [Fact]
         public void TestScatterOperator3()
         {
             string groupName = "group1";
@@ -421,35 +420,35 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IScatterReceiver<int> receiver2 = commGroups[2].GetScatterReceiver<int>(operatorName);
             IScatterReceiver<int> receiver3 = commGroups[3].GetScatterReceiver<int>(operatorName);
 
-            Assert.IsNotNull(sender);
-            Assert.IsNotNull(receiver1);
-            Assert.IsNotNull(receiver2);
-            Assert.IsNotNull(receiver3);
+            Assert.NotNull(sender);
+            Assert.NotNull(receiver1);
+            Assert.NotNull(receiver2);
+            Assert.NotNull(receiver3);
 
             List<int> data = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8 };
 
             sender.Send(data);
 
             var data1 = receiver1.Receive().ToArray();
-            Assert.AreEqual(1, data1[0]);
-            Assert.AreEqual(2, data1[1]);
-            Assert.AreEqual(3, data1[2]);
-            Assert.AreEqual(4, data1[3]);
+            Assert.Equal(1, data1[0]);
+            Assert.Equal(2, data1[1]);
+            Assert.Equal(3, data1[2]);
+            Assert.Equal(4, data1[3]);
 
             var data2 = receiver2.Receive().ToArray();
-            Assert.AreEqual(5, data2[0]);
-            Assert.AreEqual(6, data2[1]);
-            Assert.AreEqual(7, data2[2]);
-            Assert.AreEqual(8, data2[3]);
+            Assert.Equal(5, data2[0]);
+            Assert.Equal(6, data2[1]);
+            Assert.Equal(7, data2[2]);
+            Assert.Equal(8, data2[3]);
 
             var data3 = receiver3.Receive().ToArray();
-            Assert.AreEqual(1, data3[0]);
-            Assert.AreEqual(2, data3[1]);
-            Assert.AreEqual(3, data3[2]);
-            Assert.AreEqual(4, data3[3]);
+            Assert.Equal(1, data3[0]);
+            Assert.Equal(2, data3[1]);
+            Assert.Equal(3, data3[2]);
+            Assert.Equal(4, data3[3]);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestScatterOperator4()
         {
             string groupName = "group1";
@@ -472,10 +471,10 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IScatterReceiver<int> receiver2 = commGroups[2].GetScatterReceiver<int>(operatorName);
             IScatterReceiver<int> receiver3 = commGroups[3].GetScatterReceiver<int>(operatorName);
 
-            Assert.IsNotNull(sender);
-            Assert.IsNotNull(receiver1);
-            Assert.IsNotNull(receiver2);
-            Assert.IsNotNull(receiver3);
+            Assert.NotNull(sender);
+            Assert.NotNull(receiver1);
+            Assert.NotNull(receiver2);
+            Assert.NotNull(receiver3);
 
             List<int> data = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8 };
             List<string> order = new List<string> { "task2", "task1" };
@@ -483,25 +482,25 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             sender.Send(data, order);
 
             var data2 = receiver2.Receive().ToArray();
-            Assert.AreEqual(1, data2[0]);
-            Assert.AreEqual(2, data2[1]);
-            Assert.AreEqual(3, data2[2]);
-            Assert.AreEqual(4, data2[3]);
+            Assert.Equal(1, data2[0]);
+            Assert.Equal(2, data2[1]);
+            Assert.Equal(3, data2[2]);
+            Assert.Equal(4, data2[3]);
 
             var data1 = receiver1.Receive().ToArray();
-            Assert.AreEqual(5, data1[0]);
-            Assert.AreEqual(6, data1[1]);
-            Assert.AreEqual(7, data1[2]);
-            Assert.AreEqual(8, data1[3]);
+            Assert.Equal(5, data1[0]);
+            Assert.Equal(6, data1[1]);
+            Assert.Equal(7, data1[2]);
+            Assert.Equal(8, data1[3]);
 
             var data3 = receiver3.Receive().ToArray();
-            Assert.AreEqual(5, data3[0]);
-            Assert.AreEqual(6, data3[1]);
-            Assert.AreEqual(7, data3[2]);
-            Assert.AreEqual(8, data3[3]);
+            Assert.Equal(5, data3[0]);
+            Assert.Equal(6, data3[1]);
+            Assert.Equal(7, data3[2]);
+            Assert.Equal(8, data3[3]);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestScatterOperator5()
         {
             string groupName = "group1";
@@ -526,45 +525,45 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IScatterReceiver<int> receiver4 = commGroups[4].GetScatterReceiver<int>(operatorName);
             IScatterReceiver<int> receiver5 = commGroups[5].GetScatterReceiver<int>(operatorName);
 
-            Assert.IsNotNull(sender);
-            Assert.IsNotNull(receiver1);
-            Assert.IsNotNull(receiver2);
-            Assert.IsNotNull(receiver3);
-            Assert.IsNotNull(receiver4);
-            Assert.IsNotNull(receiver5);
+            Assert.NotNull(sender);
+            Assert.NotNull(receiver1);
+            Assert.NotNull(receiver2);
+            Assert.NotNull(receiver3);
+            Assert.NotNull(receiver4);
+            Assert.NotNull(receiver5);
 
             List<int> data = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8 };
 
             sender.Send(data);
 
             var data1 = receiver1.Receive().ToArray();
-            Assert.AreEqual(1, data1[0]);
-            Assert.AreEqual(2, data1[1]);
-            Assert.AreEqual(3, data1[2]);
-            Assert.AreEqual(4, data1[3]);
+            Assert.Equal(1, data1[0]);
+            Assert.Equal(2, data1[1]);
+            Assert.Equal(3, data1[2]);
+            Assert.Equal(4, data1[3]);
 
             var data2 = receiver2.Receive().ToArray();
-            Assert.AreEqual(5, data2[0]);
-            Assert.AreEqual(6, data2[1]);
-            Assert.AreEqual(7, data2[2]);
-            Assert.AreEqual(8, data2[3]);
+            Assert.Equal(5, data2[0]);
+            Assert.Equal(6, data2[1]);
+            Assert.Equal(7, data2[2]);
+            Assert.Equal(8, data2[3]);
 
             var data3 = receiver3.Receive().ToArray();
-            Assert.AreEqual(1, data3[0]);
-            Assert.AreEqual(2, data3[1]);
+            Assert.Equal(1, data3[0]);
+            Assert.Equal(2, data3[1]);
             
             var data4 = receiver4.Receive().ToArray();
-            Assert.AreEqual(3, data4[0]);
-            Assert.AreEqual(4, data4[1]);
+            Assert.Equal(3, data4[0]);
+            Assert.Equal(4, data4[1]);
 
             var data5 = receiver5.Receive().ToArray();
-            Assert.AreEqual(5, data5[0]);
-            Assert.AreEqual(6, data5[1]);
-            Assert.AreEqual(7, data5[2]);
-            Assert.AreEqual(8, data5[3]);
+            Assert.Equal(5, data5[0]);
+            Assert.Equal(6, data5[1]);
+            Assert.Equal(7, data5[2]);
+            Assert.Equal(8, data5[3]);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestScatterReduceOperators()
         {
             string groupName = "group1";
@@ -607,11 +606,11 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IScatterReceiver<int> receiver4 = commGroups[4].GetScatterReceiver<int>(scatterOperatorName);
             IReduceSender<int> sumSender4 = commGroups[4].GetReduceSender<int>(reduceOperatorName);
 
-            Assert.IsNotNull(sender);
-            Assert.IsNotNull(receiver1);
-            Assert.IsNotNull(receiver2);
-            Assert.IsNotNull(receiver3);
-            Assert.IsNotNull(receiver4);
+            Assert.NotNull(sender);
+            Assert.NotNull(receiver1);
+            Assert.NotNull(receiver2);
+            Assert.NotNull(receiver3);
+            Assert.NotNull(receiver4);
 
             List<int> data = Enumerable.Range(1, 100).ToList();
 
@@ -636,7 +635,7 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             sumSender1.Send(sum1);
 
             int sum = sumReducer.Reduce();
-            Assert.AreEqual(sum, 6325);
+            Assert.Equal(sum, 6325);
         }
 
         private IConfiguration GetDefaultCodecConfig()

--- a/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/StreamingCodecTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/GroupCommunication/StreamingCodecTests.cs
@@ -21,7 +21,6 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
@@ -29,16 +28,16 @@ using Org.Apache.REEF.Wake.Remote;
 using Org.Apache.REEF.Wake.Remote.Impl;
 using Org.Apache.REEF.Wake.StreamingCodec;
 using Org.Apache.REEF.Wake.StreamingCodec.CommonStreamingCodecs;
+using Xunit;
 
 namespace Org.Apache.REEF.Network.Tests.GroupCommunication
 {
     /// <summary>
     /// Defines streaming codec tests
     /// </summary>
-    [TestClass]
     public class StreamingCodecTests
     {
-        [TestMethod]
+        [Fact]
         public async Task TestCommonStreamingCodecs()
         {
             IInjector injector = TangFactory.GetTang().NewInjector();
@@ -94,76 +93,72 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             string resArr7 = stringCodec.Read(reader);
             string resArr8 = await stringCodec.ReadAsync(reader, token);
 
-            Assert.AreEqual(obj, res1);
-            Assert.AreEqual(obj + 1, res2);
-            Assert.AreEqual(obj + 2, res3);
-            Assert.AreEqual(obj + 3, res4);
-            Assert.AreEqual(obj + 4, res5);
-            Assert.AreEqual(obj + 5, res6);
-            Assert.AreEqual(stringObj, resArr7);
-            Assert.AreEqual(stringObj, resArr8);
+            Assert.Equal(obj, res1);
+            Assert.Equal(obj + 1, res2);
+            Assert.Equal(obj + 2, res3);
+            Assert.Equal(obj + 3, res4);
+            Assert.Equal(obj + 4, res5);
+            Assert.Equal(obj + 5, res6);
+            Assert.Equal(stringObj, resArr7);
+            Assert.Equal(stringObj, resArr8);
 
             for (int i = 0; i < intArr.Length; i++)
             {
-                Assert.AreEqual(intArr[i], resArr1[i]);
-                Assert.AreEqual(intArr[i], resArr2[i]);
+                Assert.Equal(intArr[i], resArr1[i]);
+                Assert.Equal(intArr[i], resArr2[i]);
             }
 
             for (int i = 0; i < doubleArr.Length; i++)
             {
-                Assert.AreEqual(doubleArr[i], resArr3[i]);
-                Assert.AreEqual(doubleArr[i], resArr4[i]);
+                Assert.Equal(doubleArr[i], resArr3[i]);
+                Assert.Equal(doubleArr[i], resArr4[i]);
             }
 
             for (int i = 0; i < floatArr.Length; i++)
             {
-                Assert.AreEqual(floatArr[i], resArr5[i]);
-                Assert.AreEqual(floatArr[i], resArr6[i]);
+                Assert.Equal(floatArr[i], resArr5[i]);
+                Assert.Equal(floatArr[i], resArr6[i]);
             }
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void TestIntArrayStreamingCodecsNullException()
         {
             IInjector injector = TangFactory.GetTang().NewInjector();
             IStreamingCodec<int[]> intArrCodec = injector.GetInstance<IntArrayStreamingCodec>();
             var stream = new MemoryStream();
             IDataWriter writer = new StreamDataWriter(stream);
-            intArrCodec.Write(null, writer);
+            Assert.Throws<ArgumentNullException>(() => intArrCodec.Write(null, writer));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void TestFloatArrayStreamingCodecsNullException()
         {
             IInjector injector = TangFactory.GetTang().NewInjector();
             IStreamingCodec<float[]> floatArrCodec = injector.GetInstance<FloatArrayStreamingCodec>();
             var stream = new MemoryStream();
             IDataWriter writer = new StreamDataWriter(stream);
-            floatArrCodec.Write(null, writer);
+            Assert.Throws<ArgumentNullException>(() => floatArrCodec.Write(null, writer));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void TestDoubleArrayStreamingCodecsNullException()
         {
             IInjector injector = TangFactory.GetTang().NewInjector();
             IStreamingCodec<double[]> doubleArrCodec = injector.GetInstance<DoubleArrayStreamingCodec>();
             var stream = new MemoryStream();
             IDataWriter writer = new StreamDataWriter(stream);
-            doubleArrCodec.Write(null, writer);
+            Assert.Throws<ArgumentNullException>(() => doubleArrCodec.Write(null, writer));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void TestNullStreamException()
         {
-            IDataWriter writer = new StreamDataWriter(null);
-            writer.WriteFloat(2.0f);
+            IDataWriter writer;
+            Assert.Throws<ArgumentNullException>(() => writer = new StreamDataWriter(null));
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestCodecToStreamingCodec()
         {
             var config = TangFactory.GetTang().NewConfigurationBuilder()
@@ -187,8 +182,8 @@ namespace Org.Apache.REEF.Network.Tests.GroupCommunication
             IDataReader reader = new StreamDataReader(stream);
             int res1 = streamingCodec.Read(reader);
             int res2 = await streamingCodec.ReadAsync(reader, token);
-            Assert.AreEqual(obj, res1);
-            Assert.AreEqual(obj + 1, res2);
+            Assert.Equal(obj, res1);
+            Assert.Equal(obj + 1, res2);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Network.Tests/NamingService/NameServerTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/NamingService/NameServerTests.cs
@@ -22,7 +22,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Net;
 using System.Threading;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Common.Io;
 using Org.Apache.REEF.Examples.Tasks.StreamingTasks;
 using Org.Apache.REEF.Network.Naming;
@@ -32,13 +31,13 @@ using Org.Apache.REEF.Tang.Implementations.Tang;
 using Org.Apache.REEF.Tang.Interface;
 using Org.Apache.REEF.Tang.Util;
 using Org.Apache.REEF.Wake.Remote.Parameters;
+using Xunit;
 
 namespace Org.Apache.REEF.Network.Tests.NamingService
 {
-    [TestClass]
     public class NameServerTests
     {
-        [TestMethod]
+        [Fact]
         public void TestNameServerNoRequests()
         {
            using (var server = BuildNameServer())
@@ -46,7 +45,7 @@ namespace Org.Apache.REEF.Network.Tests.NamingService
            }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestNameServerNoRequestsTwoClients()
         {
            using (var server = BuildNameServer())
@@ -58,7 +57,7 @@ namespace Org.Apache.REEF.Network.Tests.NamingService
            }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestNameServerNoRequestsTwoClients2()
         {
            using (var server = BuildNameServer())
@@ -70,7 +69,7 @@ namespace Org.Apache.REEF.Network.Tests.NamingService
            }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestNameServerMultipleRequestsTwoClients()
         {
            using (var server = BuildNameServer())
@@ -82,7 +81,7 @@ namespace Org.Apache.REEF.Network.Tests.NamingService
            }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestRegister()
         {
             using (INameServer server = BuildNameServer())
@@ -94,9 +93,9 @@ namespace Org.Apache.REEF.Network.Tests.NamingService
                     IPEndPoint endpoint3 = new IPEndPoint(IPAddress.Parse("100.0.0.3"), 300);
 
                     // Check that no endpoints have been registered
-                    Assert.IsNull(client.Lookup("a"));
-                    Assert.IsNull(client.Lookup("b"));
-                    Assert.IsNull(client.Lookup("c"));
+                    Assert.Null(client.Lookup("a"));
+                    Assert.Null(client.Lookup("b"));
+                    Assert.Null(client.Lookup("c"));
                 
                     // Register endpoints
                     client.Register("a", endpoint1);
@@ -104,14 +103,14 @@ namespace Org.Apache.REEF.Network.Tests.NamingService
                     client.Register("c", endpoint3);
 
                     // Check that they can be looked up correctly
-                    Assert.AreEqual(endpoint1, client.Lookup("a"));
-                    Assert.AreEqual(endpoint2, client.Lookup("b"));
-                    Assert.AreEqual(endpoint3, client.Lookup("c"));
+                    Assert.Equal(endpoint1, client.Lookup("a"));
+                    Assert.Equal(endpoint2, client.Lookup("b"));
+                    Assert.Equal(endpoint3, client.Lookup("c"));
                 }
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestUnregister()
         {
             using (INameServer server = BuildNameServer())
@@ -124,19 +123,19 @@ namespace Org.Apache.REEF.Network.Tests.NamingService
                     client.Register("a", endpoint1);
 
                     // Check that it can be looked up correctly
-                    Assert.AreEqual(endpoint1, client.Lookup("a"));
+                    Assert.Equal(endpoint1, client.Lookup("a"));
 
                     // Unregister endpoints
                     client.Unregister("a");
                     Thread.Sleep(1000);
 
                     // Make sure they were unregistered correctly
-                    Assert.IsNull(client.Lookup("a"));
+                    Assert.Null(client.Lookup("a"));
                 }
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestLookup()
         {
             using (INameServer server = BuildNameServer())
@@ -148,16 +147,16 @@ namespace Org.Apache.REEF.Network.Tests.NamingService
                 
                     // Register endpoint1
                     client.Register("a", endpoint1);
-                    Assert.AreEqual(endpoint1, client.Lookup("a"));
+                    Assert.Equal(endpoint1, client.Lookup("a"));
 
                     // Reregister identifer a
                     client.Register("a", endpoint2);
-                    Assert.AreEqual(endpoint2, client.Lookup("a"));
+                    Assert.Equal(endpoint2, client.Lookup("a"));
                 }
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestLookupList()
         {
             using (INameServer server = BuildNameServer())
@@ -178,20 +177,20 @@ namespace Org.Apache.REEF.Network.Tests.NamingService
                     List<NameAssignment> assignments = client.Lookup(ids);
 
                     // Check that a, b, and c are registered
-                    Assert.AreEqual("a", assignments[0].Identifier);
-                    Assert.AreEqual(endpoint1, assignments[0].Endpoint);
-                    Assert.AreEqual("b", assignments[1].Identifier);
-                    Assert.AreEqual(endpoint2, assignments[1].Endpoint);
-                    Assert.AreEqual("c", assignments[2].Identifier);
-                    Assert.AreEqual(endpoint3, assignments[2].Endpoint);
+                    Assert.Equal("a", assignments[0].Identifier);
+                    Assert.Equal(endpoint1, assignments[0].Endpoint);
+                    Assert.Equal("b", assignments[1].Identifier);
+                    Assert.Equal(endpoint2, assignments[1].Endpoint);
+                    Assert.Equal("c", assignments[2].Identifier);
+                    Assert.Equal(endpoint3, assignments[2].Endpoint);
 
                     // Check that d is not registered
-                    Assert.AreEqual(3, assignments.Count);
+                    Assert.Equal(3, assignments.Count);
                 }
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestNameClientRestart()
         {
             int oldPort = 6666;
@@ -203,7 +202,7 @@ namespace Org.Apache.REEF.Network.Tests.NamingService
                 IPEndPoint endpoint = new IPEndPoint(IPAddress.Parse("100.0.0.1"), 100);
             
                 client.Register("a", endpoint);
-                Assert.AreEqual(endpoint, client.Lookup("a"));
+                Assert.Equal(endpoint, client.Lookup("a"));
 
                 server.Dispose();
 
@@ -211,13 +210,13 @@ namespace Org.Apache.REEF.Network.Tests.NamingService
                 client.Restart(server.LocalEndpoint);
 
                 client.Register("b", endpoint);
-                Assert.AreEqual(endpoint, client.Lookup("b"));
+                Assert.Equal(endpoint, client.Lookup("b"));
 
                 server.Dispose();
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestConstructorInjection()
         {
             int port = 6666;
@@ -232,11 +231,11 @@ namespace Org.Apache.REEF.Network.Tests.NamingService
                     .NewInjector(nameClientConfiguration)
                     .GetInstance<ConstructorInjection>();
 
-                Assert.IsNotNull(c);
+                Assert.NotNull(c);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestNameCache()
         {
             double interval = 50;
@@ -254,13 +253,13 @@ namespace Org.Apache.REEF.Network.Tests.NamingService
             cache.Set("dst1", new IPEndPoint(IPAddress.Any, 0));
             Thread.Sleep(100);
             var value = cache.Get("dst1");
-            Assert.IsNull(value);
+            Assert.Null(value);
 
             IPAddress address = new IPAddress(1234);
             cache.Set("dst1", new IPEndPoint(address, 0));
             value = cache.Get("dst1");
-            Assert.IsNotNull(value);
-            Assert.AreEqual(address, value.Address);
+            Assert.NotNull(value);
+            Assert.Equal(address, value.Address);
         }
 
         public static INameServer BuildNameServer(int listenPort = 0)

--- a/lang/cs/Org.Apache.REEF.Network.Tests/NetworkService/NetworkServiceTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/NetworkService/NetworkServiceTests.cs
@@ -22,7 +22,6 @@ using System.Collections.Concurrent;
 using System.Globalization;
 using System.Linq;
 using System.Net;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Common.Io;
 using Org.Apache.REEF.Network.Naming;
 using Org.Apache.REEF.Network.NetworkService;
@@ -34,13 +33,13 @@ using Org.Apache.REEF.Wake;
 using Org.Apache.REEF.Wake.Remote;
 using Org.Apache.REEF.Wake.Remote.Impl;
 using Org.Apache.REEF.Wake.Util;
+using Xunit;
 
 namespace Org.Apache.REEF.Network.Tests.NetworkService
 {
-    [TestClass]
     public class NetworkServiceTests
     {
-        [TestMethod]
+        [Fact]
         public void TestNetworkServiceOneWayCommunication()
         {
             int networkServicePort1 = NetworkUtils.GenerateRandomPort(6000, 7000);
@@ -68,15 +67,15 @@ namespace Org.Apache.REEF.Network.Tests.NetworkService
                         connection.Write("def");
                         connection.Write("ghi");
 
-                        Assert.AreEqual("abc", queue.Take());
-                        Assert.AreEqual("def", queue.Take());
-                        Assert.AreEqual("ghi", queue.Take());
+                        Assert.Equal("abc", queue.Take());
+                        Assert.Equal("def", queue.Take());
+                        Assert.Equal("ghi", queue.Take());
                     }
                 }
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void TestNetworkServiceTwoWayCommunication()
         {
             int networkServicePort1 = NetworkUtils.GenerateRandomPort(6000, 7000);
@@ -110,12 +109,12 @@ namespace Org.Apache.REEF.Network.Tests.NetworkService
                         connection2.Write("jkl");
                         connection2.Write("mno");
 
-                        Assert.AreEqual("abc", queue2.Take());
-                        Assert.AreEqual("def", queue2.Take());
-                        Assert.AreEqual("ghi", queue2.Take());
+                        Assert.Equal("abc", queue2.Take());
+                        Assert.Equal("def", queue2.Take());
+                        Assert.Equal("ghi", queue2.Take());
 
-                        Assert.AreEqual("jkl", queue1.Take());
-                        Assert.AreEqual("mno", queue1.Take());
+                        Assert.Equal("jkl", queue1.Take());
+                        Assert.Equal("mno", queue1.Take());
                     }
                 }
             }

--- a/lang/cs/Org.Apache.REEF.Network.Tests/NetworkService/StreamingNetworkServiceTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/NetworkService/StreamingNetworkServiceTests.cs
@@ -25,7 +25,6 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Common.Io;
 using Org.Apache.REEF.Network.Naming;
 using Org.Apache.REEF.Network.NetworkService;
@@ -41,19 +40,19 @@ using Org.Apache.REEF.Wake.Remote.Impl;
 using Org.Apache.REEF.Wake.StreamingCodec;
 using Org.Apache.REEF.Wake.StreamingCodec.CommonStreamingCodecs;
 using Org.Apache.REEF.Wake.Util;
+using Xunit;
 
 namespace Org.Apache.REEF.Network.Tests.NetworkService
 {
     /// <summary>
     /// Tests for Streaming Network Service
     /// </summary>
-    [TestClass]
     public class StreamingNetworkServiceTests
     {
         /// <summary>
         /// Tests one way communication between two network services
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void TestStreamingNetworkServiceOneWayCommunication()
         {
             int networkServicePort1 = NetworkUtils.GenerateRandomPort(6000, 7000);
@@ -103,9 +102,9 @@ namespace Org.Apache.REEF.Network.Tests.NetworkService
                         connection.Write("def");
                         connection.Write("ghi");
 
-                        Assert.AreEqual("abc", queue.Take());
-                        Assert.AreEqual("def", queue.Take());
-                        Assert.AreEqual("ghi", queue.Take());
+                        Assert.Equal("abc", queue.Take());
+                        Assert.Equal("def", queue.Take());
+                        Assert.Equal("ghi", queue.Take());
                     }
                 }
             }
@@ -114,7 +113,7 @@ namespace Org.Apache.REEF.Network.Tests.NetworkService
         /// <summary>
         /// Tests two way communication between two network services
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void TestStreamingNetworkServiceTwoWayCommunication()
         {
             int networkServicePort1 = NetworkUtils.GenerateRandomPort(6000, 7000);
@@ -165,12 +164,12 @@ namespace Org.Apache.REEF.Network.Tests.NetworkService
                         connection2.Write("jkl");
                         connection2.Write("nop");
 
-                        Assert.AreEqual("abc", queue2.Take());
-                        Assert.AreEqual("def", queue2.Take());
-                        Assert.AreEqual("ghi", queue2.Take());
+                        Assert.Equal("abc", queue2.Take());
+                        Assert.Equal("def", queue2.Take());
+                        Assert.Equal("ghi", queue2.Take());
 
-                        Assert.AreEqual("jkl", queue1.Take());
-                        Assert.AreEqual("nop", queue1.Take());
+                        Assert.Equal("jkl", queue1.Take());
+                        Assert.Equal("nop", queue1.Take());
                     }
                 }
             }
@@ -179,7 +178,7 @@ namespace Org.Apache.REEF.Network.Tests.NetworkService
         /// <summary>
         /// Tests StreamingCodecFunctionCache
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void TestStreamingCodecFunctionCache()
         {
             IConfiguration conf = TangFactory.GetTang().NewConfigurationBuilder()
@@ -219,10 +218,10 @@ namespace Org.Apache.REEF.Network.Tests.NetworkService
             res = readAsyncFunc.EndInvoke(asyncResult);
             B resB2 = res as B;
             
-            Assert.AreEqual("hello", resB1.Value1);
-            Assert.AreEqual("reef", resB1.Value2);
-            Assert.AreEqual("helloasync", resB2.Value1);
-            Assert.AreEqual("reefasync", resB2.Value2);
+            Assert.Equal("hello", resB1.Value1);
+            Assert.Equal("reef", resB1.Value2);
+            Assert.Equal("helloasync", resB2.Value1);
+            Assert.Equal("reefasync", resB2.Value2);
         }
 
         /// <summary>

--- a/lang/cs/Org.Apache.REEF.Tests/Utility/TestDriverConfigGenerator.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Utility/TestDriverConfigGenerator.cs
@@ -18,15 +18,14 @@
  */
 
 using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Driver;
+using Xunit;
 
 namespace Org.Apache.REEF.Tests.Utility
 {
-    [TestClass]
     public class TestDriverConfigGenerator
     {
-        [TestMethod]
+        [Fact]
         public void TestGeneratingFullDriverConfigFile()
         {
             DriverConfigurationSettings driverSubmissionSettings = new DriverConfigurationSettings()
@@ -43,7 +42,7 @@ namespace Org.Apache.REEF.Tests.Utility
             DriverConfigGenerator.DriverConfigurationBuilder(driverSubmissionSettings);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestGeneratingDriverConfigFileWithoutHttp()
         {
             DriverConfigurationSettings driverSubmissionSettings = new DriverConfigurationSettings()
@@ -60,7 +59,7 @@ namespace Org.Apache.REEF.Tests.Utility
             DriverConfigGenerator.DriverConfigurationBuilder(driverSubmissionSettings);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestGeneratingDriverConfigFileWithoutNameServer()
         {
             DriverConfigurationSettings driverSubmissionSettings = new DriverConfigurationSettings()
@@ -77,7 +76,7 @@ namespace Org.Apache.REEF.Tests.Utility
             DriverConfigGenerator.DriverConfigurationBuilder(driverSubmissionSettings);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestGeneratingDriverConfigFileDriverOnly()
         {
             DriverConfigurationSettings driverSubmissionSettings = new DriverConfigurationSettings()

--- a/lang/cs/Org.Apache.REEF.Tests/Utility/TestExceptions.cs
+++ b/lang/cs/Org.Apache.REEF.Tests/Utility/TestExceptions.cs
@@ -18,18 +18,17 @@
  */
 
 using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Org.Apache.REEF.Utilities.Diagnostics;
 using Org.Apache.REEF.Utilities.Logging;
+using Xunit;
 
 namespace Org.Apache.REEF.Tests.Utility
 {
-    [TestClass]
     public class TestExceptions
     {
         private static readonly Logger LOGGER = Logger.GetLogger(typeof(TestExceptions));
 
-        [TestMethod]
+        [Fact]
         public void TestThrowCaught()
         {
             string msg = null;
@@ -37,13 +36,13 @@ namespace Org.Apache.REEF.Tests.Utility
             {
                 Exceptions.Throw(new ApplicationException("test"), LOGGER);
                 msg = "not supposed to reach here";
-                Assert.Fail(msg);
+                Assert.True(false, msg);
             }
             catch (ApplicationException e)
             {
                 Exceptions.Caught(e, Level.Info, LOGGER);
             }
-            Assert.IsNull(msg);
+            Assert.Null(msg);
         }
     }
 }


### PR DESCRIPTION
This migrates the following tests:

 * Org.Apache.REEF.Common.Tests
 * Org.Apache.REEF.IMRU.Tests
 * Org.Apache.REEF.Network.Tests
 * Org.Apache.REEF.Tests\Utility

JIRA:
  [REEF-998](https://issues.apache.org/jira/browse/REEF-998)

Pull request:
  This closes #